### PR TITLE
feat(gemm): gemm kernel set transB=True as default

### DIFF
--- a/primus_turbo/pytorch/ops/gemm.py
+++ b/primus_turbo/pytorch/ops/gemm.py
@@ -48,7 +48,7 @@ def gemm(
     a: torch.Tensor,
     b: torch.Tensor,
     transA: bool = False,
-    transB: bool = False,
+    transB: bool = True,
     out_dtype: torch.dtype | None = None,
 ) -> torch.Tensor:
     assert a.ndim == 2 and b.ndim == 2, "Only 2D tensors are supported"


### PR DESCRIPTION
The default setting for gemm_fp8_blockwise is trans_b=true, making it consistent with the default configuration of gemm and gemm_fp8_blockwise.