### PR TITLE
chore(attn): rename q_scale, k_scale, do_scale

### DIFF
--- a/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
@@ -263,8 +263,8 @@ def _attention_triton_forward_impl_fake(
     k: torch.Tensor,
     v: torch.Tensor,
     p_scale: float,
-    q_scale: torch.Tensor,
-    k_scale: torch.Tensor,
+    q_descale: torch.Tensor,
+    k_descale: torch.Tensor,
     v_scale: torch.Tensor,
     dropout_p: float,
     softmax_scale: float,
@@ -309,8 +309,8 @@ def attention_triton_backward_impl(
     k: torch.Tensor,
     v: torch.Tensor,
     o: torch.Tensor,
-    q_scale: torch.Tensor,
-    k_scale: torch.Tensor,
+    q_descale: torch.Tensor,
+    k_descale: torch.Tensor,
     v_scale: torch.Tensor,
     p_scale: float,
     softmax_lse_delta: torch.Tensor,
@@ -424,8 +424,8 @@ def attention_triton_backward_impl(
     assert v.is_contiguous()
     assert o.is_contiguous()
     assert softmax_lse_delta.is_contiguous()
-    assert q_scale.is_contiguous()
-    assert k_scale.is_contiguous()
+    assert q_descale.is_contiguous()
+    assert k_descale.is_contiguous()
 
     # # init delta
     # delta = torch.empty_like(softmax_lse)
@@ -438,10 +438,10 @@ def attention_triton_backward_impl(
     if use_fp8:
         do_fp8 = torch.empty_like(do, dtype=get_f8_bwd_dtype())
         _shape = (batch, nheads_q, triton.cdiv(max_seqlen_q, FIXED_BLOCK_M))
-        do_scale = torch.empty(_shape, dtype=torch.float32, device=q.device)
-        stride_descalez, stride_descaleh, stride_descalem = do_scale.stride()
-        stride_qscalez, stride_qscaleh, stride_qscalem = q_scale.stride()
-        stride_kscalez, stride_kscaleh, stride_kscalem = k_scale.stride()
+        do_descale = torch.empty(_shape, dtype=torch.float32, device=q.device)
+        stride_descalez, stride_descaleh, stride_descalem = do_descale.stride()
+        stride_qscalez, stride_qscaleh, stride_qscalem = q_descale.stride()
+        stride_kscalez, stride_kscaleh, stride_kscalem = k_descale.stride()
 
         padded_doscale_block_num = 1 << (stride_descaleh - 1).bit_length()
         padded_qscale_block_num = 1 << (stride_qscaleh - 1).bit_length()
@@ -449,7 +449,7 @@ def attention_triton_backward_impl(
 
     else:
         do_fp8 = None
-        do_scale = None
+        do_descale = None
         stride_descalez, stride_descaleh, stride_descalem = None, None, None
         stride_qscalez, stride_qscaleh, stride_qscalem = None, None, None
         stride_kscalez, stride_kscaleh, stride_kscalem = None, None, None
@@ -460,7 +460,7 @@ def attention_triton_backward_impl(
         o,
         do,
         do_fp8,
-        do_scale,
+        do_descale,
         softmax_lse_delta,
         use_fp8,
         stride_oz,
@@ -528,11 +528,11 @@ def attention_triton_backward_impl(
         k,
         v,
         softmax_scale,
-        q_scale,
-        k_scale,
+        q_descale,
+        k_descale,
         v_scale,
         p_scale,
-        do_scale,
+        do_descale,
         o,
         do_fp8 if use_fp8 else do,
         dq,
@@ -613,11 +613,11 @@ def attention_triton_backward_impl(
         k,
         v,
         softmax_scale,
-        q_scale,
-        k_scale,
+        q_descale,
+        k_descale,
         v_scale,
         p_scale,
-        do_scale,
+        do_descale,
         o,
         do_fp8 if use_fp8 else do,
         dq,
@@ -716,8 +716,8 @@ def _attention_triton_backward_impl_fake(
     k: torch.Tensor,
     v: torch.Tensor,
     out: torch.Tensor,
-    q_scale: torch.Tensor,
-    k_scale: torch.Tensor,
+    q_descale: torch.Tensor,
+    k_descale: torch.Tensor,
     v_scale: torch.Tensor,
     p_scale: float,
     softmax_lse: torch.Tensor,

--- a/primus_turbo/triton/attention/attention_kernel.py
+++ b/primus_turbo/triton/attention/attention_kernel.py
@@ -1038,7 +1038,7 @@ def _bwd_kernel_dkdv(
     K,
     V,
     sm_scale: tl.constexpr,
-    q_scale_ptr,
+    q_descale_ptr,
     k_descale_ptr,
     v_scale_ptr,
     p_scale: tl.constexpr,
@@ -1149,7 +1149,7 @@ def _bwd_kernel_dkdv(
         # while q, k, do in per-block scaling
         v_scale = tl.load(v_scale_ptr)  # + tl.arange(0, num_block_n)
         q_descale_offset = (
-            q_scale_ptr + off_z * stride_qscalez + off_h_q * stride_qscaleh + q_start * stride_qscalem
+            q_descale_ptr + off_z * stride_qscalez + off_h_q * stride_qscaleh + q_start * stride_qscalem
         )
         do_descale_offset = (
             do_descale_ptr + off_z * stride_doscalez + off_h_q * stride_doscaleh + q_start * stride_doscalem
@@ -1392,7 +1392,7 @@ def _bwd_kernel_dq(
     K,
     V,
     sm_scale: tl.constexpr,
-    q_scale_ptr,
+    q_descale_ptr,
     k_descale_ptr,
     v_scale_ptr,
     p_scale: tl.constexpr,
@@ -1544,7 +1544,7 @@ def _bwd_kernel_dq(
 
     if USE_FP8:
         q_descale_offset = (
-            q_scale_ptr + off_z * stride_qscalez + off_h_q * stride_qscaleh + start_m * stride_qscalem
+            q_descale_ptr + off_z * stride_qscalez + off_h_q * stride_qscaleh + start_m * stride_qscalem
         )
         blk_q_descale = tl.load(q_descale_offset)
 
@@ -1703,7 +1703,7 @@ def _attn_bwd_dq(
         _dq = tl.dot(ds, k, out_dtype=tl.float32, allow_tf32=False)
 
         if USE_FP8:
-            dq_descale = blk_k_descale / ds_scale  # ds_scale # 1. / k_scale
+            dq_descale = blk_k_descale / ds_scale
             _dq = _dq * dq_descale
 
         dq += _dq


### PR DESCRIPTION
Changes:
* rename q_scale, k_scale, do_scale to q_descale, k_descale, do_descale to avoid confusion with v_scale, p_scale.

Reasons:
* `block_scaling_node` returns the reciprocal of q_scale, k_scale.
  - see https://github.com/AMD-AIG-AIMA/Primus-Turbo/blob/f2cb11778e9dbe72f540b5d453406a55fcd392b2/primus_turbo/pytorch/ops/attention/attention_utils.py#L49
* `_bwd_preprocess_use_o` stores the reciprocal of do_scale.
  - see https://github.com/AMD-AIG-AIMA/Primus-Turbo/blob/f2cb11778e9dbe72f540b5d453406a55fcd392b2/primus_turbo/triton/attention/attention_kernel.py#L1008