### PR TITLE
feat(token_dispatcher): add TurboDeepEPTokenDispatcher/Combiner and TurboTokenPermuter/Unpermuter of MoE.

### DIFF
--- a/primus_turbo/pytorch/modules/__init__.py
+++ b/primus_turbo/pytorch/modules/__init__.py
@@ -2,4 +2,5 @@ from .attention import *
 from .grouped_linear import *
 from .linear import *
 from .linear_fp8 import *
+from .moe import *
 from .normalization import *

--- a/primus_turbo/pytorch/modules/moe/__init__.py
+++ b/primus_turbo/pytorch/modules/moe/__init__.py
@@ -1,0 +1,6 @@
+from .token_dispatcher import (
+    TurboDeepEPTokenCombiner,
+    TurboDeepEPTokenDispatcher,
+    TurboTokenPermuter,
+    TurboTokenUnpermuter,
+)

--- a/primus_turbo/pytorch/ops/__init__.py
+++ b/primus_turbo/pytorch/ops/__init__.py
@@ -15,5 +15,6 @@ from .gemm import *
 from .gemm_fp8 import *
 from .grouped_gemm import *
 from .grouped_gemm_fp8 import *
+from .moe import *
 from .normalization import *
 from .quantization import *

--- a/primus_turbo/pytorch/ops/moe/__init__.py
+++ b/primus_turbo/pytorch/ops/moe/__init__.py
@@ -1,0 +1,3 @@
+from .deepep_dispatch_combine import *
+from .fused_indices_converter import *
+from .permutation import *

--- a/primus_turbo/pytorch/ops/moe/deepep_dispatch_combine.py
+++ b/primus_turbo/pytorch/ops/moe/deepep_dispatch_combine.py
@@ -1,5 +1,6 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################

--- a/primus_turbo/pytorch/ops/moe/deepep_dispatch_combine.py
+++ b/primus_turbo/pytorch/ops/moe/deepep_dispatch_combine.py
@@ -1,0 +1,252 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+
+from typing import List, Optional, Tuple, Union
+
+import torch
+import torch.distributed as dist
+
+from primus_turbo.pytorch.deep_ep import Buffer, Config
+from primus_turbo.pytorch.deep_ep.utils import EventHandle, EventOverlap
+
+__all__ = [
+    "init_deepep_buffer",
+    "deepep_is_initialized",
+    "DeepEPDispatch",
+    "DeepEPCombine",
+    "deepep_dispatch",
+    "deepep_combine",
+]
+
+_buffer = None
+
+
+def init_deepep_buffer(
+    group: dist.ProcessGroup,
+    hidden_bytes: int,
+    use_default_stream_as_comm_stream: bool = True,
+    autotune_config: Optional[Tuple[Config, Config]] = None,
+    num_use_cu: Optional[int] = None,
+) -> Buffer:
+    global _buffer
+
+    if num_use_cu:
+        Buffer.set_num_sms(num_use_cu)
+
+    num_nvl_bytes, num_rdma_bytes = 0, 0
+    ep_size = group.size()
+    dispatch_config, combine_config = autotune_config or (
+        Buffer.get_dispatch_config(ep_size),
+        Buffer.get_combine_config(ep_size),
+    )
+
+    for config in (dispatch_config, combine_config):
+        num_nvl_bytes = max(config.get_nvl_buffer_size_hint(hidden_bytes, group.size()), num_nvl_bytes)
+        try:
+            num_rdma_bytes = max(config.get_rdma_buffer_size_hint(hidden_bytes, group.size()), num_rdma_bytes)
+        except:
+            pass
+
+    # Allocate buffer if not existed or not enough buffer size
+    if (
+        _buffer is None
+        or _buffer.group != group
+        or _buffer.num_nvl_bytes < num_nvl_bytes
+        or _buffer.num_rdma_bytes < num_rdma_bytes
+    ):
+        _buffer = Buffer(
+            group,
+            num_nvl_bytes,
+            num_rdma_bytes,
+            use_default_stream_as_comm_stream=use_default_stream_as_comm_stream,
+        )
+    return _buffer
+
+
+def deepep_is_initialized():
+    global _buffer
+    return _buffer is not None
+
+
+class DeepEPDispatch(torch.autograd.Function):
+
+    @staticmethod
+    def forward(
+        ctx,
+        x: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+        token_indices: torch.Tensor,
+        token_weights: torch.Tensor,
+        num_experts: int,
+        async_finish=False,
+        allocate_on_comm_stream=False,
+        use_cuda_num_token_per_expert: bool = True,
+        num_worst_tokens: int = 0,
+    ) -> Tuple[
+        Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+        torch.Tensor,
+        torch.Tensor,
+        Union[List, torch.Tensor],
+        Tuple,
+    ]:
+        global _buffer
+        assert deepep_is_initialized(), "Please check DeepEP buffer has been initialized."
+
+        previous_event = None
+        if async_finish:
+            previous_event = EventOverlap(EventHandle())
+
+        # Calculate layout before actual dispatch
+        (
+            num_tokens_per_rank,
+            num_tokens_per_rdma_rank,
+            num_tokens_per_expert,
+            is_token_in_rank,
+            previous_event,
+        ) = _buffer.get_dispatch_layout(
+            token_indices,
+            num_experts,
+            previous_event=previous_event,
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+        )
+
+        # Do MoE dispatch
+        # NOTES: the CPU will wait for GPU's signal to arrive,
+        # so this is not compatible with CUDA graph
+        (
+            recv_x,
+            recv_token_indices,
+            recv_token_probs,
+            tokens_per_expert,
+            handle,
+            after_event_overlap,
+        ) = _buffer.dispatch(
+            x,
+            topk_idx=token_indices,
+            topk_weights=token_weights,  # DeepEP only supports float32 probs
+            num_tokens_per_rank=num_tokens_per_rank,
+            num_tokens_per_rdma_rank=num_tokens_per_rdma_rank,
+            is_token_in_rank=is_token_in_rank,
+            num_tokens_per_expert=num_tokens_per_expert,
+            previous_event=previous_event,
+            async_finish=async_finish,
+            allocate_on_comm_stream=allocate_on_comm_stream,
+            num_recv_tokens_per_expert_as_cuda=use_cuda_num_token_per_expert,
+            num_worst_tokens=num_worst_tokens,
+        )
+
+        # Make sure current stream is synchronized
+        if async_finish:
+            after_event_overlap.current_stream_wait()
+
+        ctx.handle = handle
+        ctx.async_finish = async_finish
+        ctx.allocate_on_comm_stream = allocate_on_comm_stream
+
+        if not use_cuda_num_token_per_expert:
+            assert isinstance(tokens_per_expert, list)
+            tokens_per_expert = torch.tensor(tokens_per_expert)
+
+        return (recv_x, recv_token_indices, recv_token_probs, tokens_per_expert, handle)
+
+    @staticmethod
+    def backward(ctx, grad_output, grad_token_indices, grad_token_probs, grad_tokens_per_expert, grad_handle):
+        global _buffer
+        handle = ctx.handle
+        previous_event = None
+        if ctx.async_finish:
+            previous_event = EventOverlap(EventHandle())
+        grad_x, grad_token_probs, after_event = _buffer.combine(
+            grad_output.contiguous(),
+            handle,
+            topk_weights=grad_token_probs.float(),
+            previous_event=previous_event,
+            async_finish=ctx.async_finish,
+            allocate_on_comm_stream=ctx.allocate_on_comm_stream,
+        )
+        # Make sure current stream is synchronized
+        if ctx.async_finish:
+            after_event.current_stream_wait()
+        return grad_x, None, grad_token_probs, None, None, None, None, None
+
+
+class DeepEPCombine(torch.autograd.Function):
+
+    @staticmethod
+    def forward(
+        ctx, x: torch.Tensor, handle: Tuple, async_finish=False, allocate_on_comm_stream=False
+    ) -> torch.Tensor:
+        global _buffer
+        assert deepep_is_initialized(), "Please check DeepEP buffer has been initialized."
+        previous_event = None
+        if async_finish:
+            previous_event = EventOverlap(EventHandle())
+        combined_x, _, after_event = _buffer.combine(
+            x,
+            handle=handle,
+            async_finish=True,
+            previous_event=previous_event,
+            allocate_on_comm_stream=previous_event is not None,
+        )
+        # Make sure current stream is synchronized
+        if async_finish:
+            after_event.current_stream_wait()
+
+        ctx.handle = handle
+
+        ctx.async_finish = async_finish
+        ctx.allocate_on_comm_stream = allocate_on_comm_stream
+        return combined_x
+
+    @staticmethod
+    def backward(ctx, grad_x: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]):
+        global _buffer
+        previous_event = None
+        if ctx.async_finish:
+            previous_event = EventOverlap(EventHandle())
+        grad_x, _, _, _, _, after_event = _buffer.dispatch(
+            grad_x,
+            handle=ctx.handle,
+            previous_event=previous_event,
+            async_finish=ctx.async_finish,
+            allocate_on_comm_stream=ctx.allocate_on_comm_stream,
+        )
+        # Make sure current stream is synchronized
+        if ctx.async_finish:
+            after_event.current_stream_wait()
+        return grad_x, None, None, None
+
+
+def deepep_dispatch(
+    x: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
+    token_indices: torch.Tensor,
+    token_weights: torch.Tensor,
+    num_experts: int,
+    async_finish=False,
+    allocate_on_comm_stream=False,
+    use_cuda_num_token_per_expert: bool = False,
+    num_worst_tokens: int = 0,
+):
+    return DeepEPDispatch.apply(
+        x,
+        token_indices,
+        token_weights,
+        num_experts,
+        async_finish,
+        allocate_on_comm_stream,
+        use_cuda_num_token_per_expert,
+        num_worst_tokens,
+    )
+
+
+def deepep_combine(
+    x,
+    handle,
+    async_finish=False,
+    allocate_on_comm_stream=False,
+):
+    return DeepEPCombine.apply(x, handle, async_finish, allocate_on_comm_stream)

--- a/primus_turbo/pytorch/ops/moe/fused_indices_converter.py
+++ b/primus_turbo/pytorch/ops/moe/fused_indices_converter.py
@@ -1,0 +1,112 @@
+import math
+
+import torch
+
+from primus_turbo.triton.moe.multihot_to_indices import (
+    _indices_to_multihot_kernel,
+    _multihot_to_indices_kernel,
+)
+
+
+class IndicesToMultihot(torch.autograd.Function):
+    """Convert moe topk indices to multihot representation.
+
+    This class implements a custom forward and backward propagation
+    operation for efficiently converting indices to multihot
+    representation.
+    It is an experimental feature and may change in future versions.
+    """
+
+    @staticmethod
+    def forward(ctx, indices, probs_indices, num_of_local_experts):
+        """Forward function for IndicesToMultihot
+
+        Convert indices to multihot representation.
+
+        Args:
+            indices: [num_of_tokens, topk]
+            probs_indices: [num_of_tokens, topk]
+            num_of_local_experts: int
+
+        Returns:
+            multihot_indices: [num_of_tokens, num_of_local_experts]
+            probs_in_multihot: [num_of_tokens, num_of_local_experts]
+        """
+        num_of_tokens = indices.shape[0]
+        assert indices.shape == probs_indices.shape, "indices and probs_indices must have the same shape"
+        topk = indices.shape[1]
+        multihot_indices = torch.empty((num_of_tokens, num_of_local_experts), dtype=torch.bool, device="cuda")
+        probs_in_multihot = torch.empty(
+            (num_of_tokens, num_of_local_experts), dtype=probs_indices.dtype, device="cuda"
+        )
+        position_map = torch.empty((num_of_tokens, num_of_local_experts), dtype=torch.int32, device="cuda")
+        # Compute the next power of 2 for the topk and num_of_local_experts
+        topk_next_power_of_2 = 2 ** int(math.ceil(math.log2(topk)))
+        num_of_local_experts_next_power_of_2 = 2 ** int(math.ceil(math.log2(num_of_local_experts)))
+        grid = (num_of_tokens,)
+        _indices_to_multihot_kernel[grid](
+            indices,
+            probs_indices,
+            multihot_indices,
+            probs_in_multihot,
+            position_map,
+            num_of_local_experts,
+            num_of_local_experts_next_power_of_2,
+            topk,
+            topk_next_power_of_2,
+            BLOCK_SIZE=32,  # use only 1 warp per block
+            num_warps=1,
+        )
+
+        ctx.save_for_backward(position_map)
+        ctx.num_of_tokens = num_of_tokens
+        ctx.num_of_local_experts = num_of_local_experts
+        ctx.topk = topk
+        return multihot_indices, probs_in_multihot
+
+    @staticmethod
+    def backward(ctx, grad_multihot_indices, grad_probs_in_multihot):
+        """Backward function for IndicesToMultihot
+
+        Convert multihot probs representation to indices.
+        indices is ignored in the backward function.
+
+        Args:
+            grad_multihot_indices: [num_of_tokens, num_of_local_experts]
+            grad_probs_in_multihot: [num_of_tokens, num_of_local_experts]
+
+        Returns:
+            grad_probs_indices: [num_of_tokens, topk]
+        """
+        position_map = ctx.saved_tensors[0]
+        num_of_tokens = ctx.num_of_tokens
+        num_of_local_experts = ctx.num_of_local_experts
+        topk = ctx.topk
+
+        # Initialize the gradient of the indices and probs_indices
+        grad_probs_indices = torch.empty(
+            (num_of_tokens, topk), dtype=grad_probs_in_multihot.dtype, device="cuda"
+        )
+        # Compute the next power of 2 for the topk and num_of_local_experts
+        topk_next_power_of_2 = 2 ** int(math.ceil(math.log2(topk)))
+        num_of_local_experts_next_power_of_2 = 2 ** int(math.ceil(math.log2(num_of_local_experts)))
+
+        grid = (num_of_tokens,)
+        _multihot_to_indices_kernel[grid](
+            # if the grad_probs_in_multihot is all-one/all-zero,
+            # overlapping stride will cause error without contiguous()
+            grad_probs_in_multihot.contiguous(),
+            position_map,
+            grad_probs_indices,
+            num_of_local_experts,
+            num_of_local_experts_next_power_of_2,
+            topk,
+            topk_next_power_of_2,
+            BLOCK_SIZE=32,  # use only 1 warp per block
+            num_warps=1,
+        )
+        return None, grad_probs_indices, None, None
+
+
+def fused_indices_to_multihot(indices, probs_indices, num_of_local_experts):
+    return IndicesToMultihot.apply(indices, probs_indices, num_of_local_experts)

--- a/primus_turbo/pytorch/ops/moe/fused_indices_converter.py
+++ b/primus_turbo/pytorch/ops/moe/fused_indices_converter.py
@@ -1,3 +1,10 @@
+###############################################################################
+# Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 import math
 
 import torch

--- a/primus_turbo/pytorch/ops/moe/permutation.py
+++ b/primus_turbo/pytorch/ops/moe/permutation.py
@@ -1,0 +1,308 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+import warnings
+from typing import Optional, Tuple, Union
+
+import torch
+
+from primus_turbo.pytorch.core.float8_tensor import Float8Tensor
+from primus_turbo.triton.moe import permutation
+
+__all__ = ["token_permute", "token_unpermute", "TokenPermuteMaskMap", "TokenUnpermuteMaskMap"]
+
+
+class TokenPermuteMaskMap(torch.autograd.Function):
+
+    @staticmethod
+    def forward(
+        ctx,
+        inp: Union[torch.Tensor, Float8Tensor],
+        routing_map: torch.Tensor,
+        num_out_tokens: int,
+        probs: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if not inp.numel():
+            ctx.probs = probs
+            return inp, torch.tensor([], device=inp.device), torch.tensor([], device=inp.device)
+
+        assert inp.is_cuda, "TransformerEngine needs CUDA."
+        assert routing_map.is_cuda, "TransformerEngine needs CUDA."
+        if probs is not None:
+            assert probs.is_cuda, "TransformerEngine needs CUDA."
+
+        assert inp.size(0) == routing_map.size(0), "Permute not possible"
+        num_tokens, hidden_size = inp.size()
+        num_experts = routing_map.size(1)
+        assert num_out_tokens is not None, "num_out_tokens must be provided to the fused permute function."
+
+        row_id_map = permutation.make_row_id_map(routing_map, num_tokens, num_experts)
+
+        use_fp8 = isinstance(inp, Float8Tensor)
+
+        if use_fp8:
+            fp8_scale = inp._scale
+            fp8_dtype = inp._fp8_dtype
+            scale_hidden_dim = fp8_scale.shape[1]
+        else:
+            fp8_scale = None
+            fp8_dtype = None
+            scale_hidden_dim = None
+
+        output, permuted_scale, permuted_probs = permutation.permute_with_mask_map(
+            inp,
+            row_id_map,
+            probs,
+            fp8_scale,
+            num_tokens,
+            num_experts,
+            num_out_tokens,
+            hidden_size,
+            scale_hidden_dim,
+        )
+
+        if use_fp8:
+            output = Float8Tensor(
+                data=output,
+                scale=permuted_scale,
+                orig_dtype=inp._orig_dtype,
+                fp8_dtype=fp8_dtype,
+                config=inp._config,
+            )
+
+        ctx.save_for_backward(row_id_map)
+        ctx.num_experts = num_experts
+        ctx.num_tokens = num_tokens
+        ctx.hidden_size = hidden_size
+        return output, row_id_map, permuted_probs
+
+    @staticmethod
+    def backward(
+        ctx,
+        permuted_act_grad: torch.Tensor,
+        _,
+        permuted_probs_grad: torch.Tensor,
+    ) -> Tuple[torch.Tensor, ...]:
+        if not permuted_act_grad.numel():
+            return permuted_act_grad, None, None, ctx.probs
+
+        act_grad = None
+        probs_grad = None
+        if ctx.needs_input_grad[0]:
+            (row_id_map,) = ctx.saved_tensors
+            assert not isinstance(
+                permuted_act_grad, Float8Tensor
+            ), "The backward of token_permute does not support FP8."
+            act_grad, probs_grad = permutation.unpermute_with_mask_map(
+                permuted_act_grad,
+                row_id_map,
+                None,
+                permuted_probs_grad,
+                ctx.num_tokens,
+                ctx.num_experts,
+                ctx.hidden_size,
+            )
+        if not ctx.needs_input_grad[3]:
+            probs_grad = None
+        return act_grad, None, None, probs_grad
+
+
+class TokenUnpermuteMaskMap(torch.autograd.Function):
+
+    @staticmethod
+    def forward(
+        ctx,
+        inp: torch.Tensor,
+        row_id_map: torch.Tensor,
+        merging_probs: Optional[torch.Tensor],
+        restore_shape: Optional[torch.Size],
+    ) -> torch.Tensor:
+
+        if not inp.numel():
+            ctx.merging_probs = merging_probs
+            return inp
+
+        if restore_shape is None:
+            restore_shape = inp.shape
+        num_tokens, hidden_size = restore_shape
+        num_experts = (row_id_map.size(1) - 1) // 2
+
+        with_probs = merging_probs is not None
+        if with_probs:
+            assert merging_probs.is_cuda, "Tensor device needs be CUDA."
+
+        # Device check
+        assert inp.is_cuda, "Tensor device needs be CUDA."
+        assert row_id_map.is_cuda, "Tensor device needs be CUDA."
+
+        assert not isinstance(inp, Float8Tensor), "The forward of moe_unpermute does not support FP8."
+        unpermuted_output, _ = permutation.unpermute_with_mask_map(
+            inp,
+            row_id_map,
+            merging_probs,
+            None,
+            num_tokens,
+            num_experts,
+            hidden_size,
+        )
+
+        if with_probs:
+            ctx.save_for_backward(inp, row_id_map, merging_probs)
+        else:
+            ctx.save_for_backward(row_id_map)
+        ctx.num_experts = num_experts
+        ctx.num_tokens = num_tokens
+        ctx.num_permuted_tokens = inp.size(0)
+        ctx.hidden_size = hidden_size
+        ctx.with_probs = with_probs
+        return unpermuted_output
+
+    @staticmethod
+    def backward(ctx, unpermuted_act_grad):
+        if not unpermuted_act_grad.numel():
+            return unpermuted_act_grad, None, ctx.merging_probs, None
+
+        act_grad = None
+        probs_grad = None
+        if ctx.needs_input_grad[0]:
+            if ctx.with_probs:
+                fwd_input, row_id_map, merging_probs = ctx.saved_tensors
+            else:
+                (row_id_map,) = ctx.saved_tensors
+
+            use_fp8 = isinstance(unpermuted_act_grad, Float8Tensor)
+
+            if use_fp8:
+                fp8_scale = unpermuted_act_grad._scale
+                fp8_dtype = unpermuted_act_grad._fp8_dtype
+                scale_hidden_dim = fp8_scale.shape[1]
+            else:
+                fp8_scale = None
+                fp8_dtype = None
+                scale_hidden_dim = None
+
+            if ctx.with_probs:
+                assert (
+                    not use_fp8
+                ), "The backward of TokenUnpermutation with merging probs does not support FP8."
+                act_grad, probs_grad = permutation.unpermute_with_mask_map_bwd_with_merging_probs(
+                    unpermuted_act_grad,
+                    row_id_map,
+                    fwd_input,
+                    merging_probs,
+                    ctx.num_tokens,
+                    ctx.num_experts,
+                    ctx.num_permuted_tokens,
+                    ctx.hidden_size,
+                )
+            else:
+                act_grad, permuted_scale, _ = permutation.permute_with_mask_map(
+                    unpermuted_act_grad,
+                    row_id_map,
+                    None,
+                    fp8_scale,
+                    ctx.num_tokens,
+                    ctx.num_experts,
+                    ctx.num_permuted_tokens,
+                    ctx.hidden_size,
+                    scale_hidden_dim,
+                )
+
+            if use_fp8:
+                act_grad = Float8Tensor(
+                    data=act_grad,
+                    scale=permuted_scale,
+                    orig_dtype=unpermuted_act_grad._orig_dtype,
+                    fp8_dtype=fp8_dtype,
+                    config=unpermuted_act_grad._config,
+                )
+
+        if not ctx.needs_input_grad[2]:
+            probs_grad = None
+        return act_grad, None, probs_grad, None
+
+
+def token_permute(
+    inp: torch.Tensor,
+    probs: Optional[torch.Tensor] = None,
+    routing_map: Optional[torch.Tensor] = None,
+    topk_indices: Optional[torch.Tensor] = None,
+    num_out_tokens: int = -1,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Permute the tokens based on the routing_map. Token with the same index will be grouped together.
+    Tokens with the same designated expert will be grouped together.
+    The routing_map indicates which experts were selected by each token.
+
+    Parameters
+    ----------
+    inp: torch.Tensor
+        Input tensor of shape `[num_tokens, hidden_size]`, on which permutation will be applied.
+    routing_map: torch.Tensor
+        The token to expert mapping tensor.
+        routing_map is of shape [num_tokens, num_experts] and dtype 'int32'.
+        The values in it: 1 means the token is routed to this expert and 0 means not.
+    topk_indices: torch.Tensor
+        The token to expert mapping tensor.
+        topk_indices is of shape [num_tokens, topK] and dtype 'int32'.
+        The values in it are the routed expert indices.
+    max_token_num: int, default = -1
+        The maximum number of tokens, used for workspace allocation.
+        By default, set to '-1', meaning the calculation of the size of workspace is
+        automatically taken over by the operator.
+    """
+    if topk_indices != None:
+        raise NotImplementedError("not support topk_indices")
+    if routing_map != None:
+        output, row_id_map, permuted_probs = TokenPermuteMaskMap.apply(
+            inp, routing_map, num_out_tokens, probs
+        )
+        return output, permuted_probs, row_id_map
+    raise ValueError("must be set topk_indices or routing_map")
+
+
+def token_unpermute(
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    merging_probs: Optional[torch.Tensor] = None,
+    restore_shape: Optional[torch.Size] = None,
+    map_type: str = "mask",
+    probs: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """
+    Unpermute a tensor with permuted tokens, and optionally merge the tokens with their
+    corresponding probabilities.
+
+    Parameters
+    ----------
+    inp: torch.Tensor
+        Input tensor with permuted tokens of shape `[num_tokens, hidden_size]` to be unpermuted.
+    row_id_map: torch.Tensor
+        The tensor of a mapping table for sorted indices used to unpermute the tokens,
+        which is the second output tensor of `Permute`.
+    merging_probs: torch.Tensor, default = None
+        The tensor of probabilities corresponding to the permuted tokens. If provided,
+        the unpermuted tokens will be merged with their respective probabilities.
+        By default, set to an empty tensor, which means that the tokens are directly merged by accumulation.
+    restore_shape: torch.Size, default = None
+        The output shape after the unpermute operation.
+    map_type: str, default = 'mask'
+        Type of the routing map tensor. Should be the same as the value passed to moe_permute.
+        Options are: 'mask', 'index'.
+    probs: torch.Tensor, default = None
+        Renamed to merging_probs. Keep for backward compatibility.
+    """
+    if probs is not None:
+        if merging_probs is not None:
+            raise ValueError("Both merging_probs and probs kwarg are provided. probs is deprecated.")
+        warnings.warn("probs kwarg is deprecated. Use merging_probs kwarg instead.")
+        merging_probs = probs
+    if map_type == "index":
+        if map_type == "index":
+            raise NotImplementedError("map_type not support 'index'")
+    if map_type == "mask":
+        return TokenUnpermuteMaskMap.apply(inp, row_id_map, merging_probs, restore_shape)
+    raise ValueError("map_type should be one of 'mask' or 'index'")

--- a/primus_turbo/triton/moe/multihot_to_indices.py
+++ b/primus_turbo/triton/moe/multihot_to_indices.py
@@ -1,0 +1,155 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+
+import triton
+import triton.language as tl
+
+
+# Assign a block to a row([1,topk]), generate a local routing map([1,num_of_local_experts])
+@triton.jit
+def _indices_to_multihot_kernel(
+    indices_ptr,
+    probs_in_indices_ptr,
+    multihot_indices_ptr,  # bool
+    probs_in_multihot_ptr,
+    position_map_ptr,
+    num_of_local_experts: tl.constexpr,
+    num_of_local_experts_next_power_of_2: tl.constexpr,
+    topk: tl.constexpr,
+    topk_next_power_of_2: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    Triton kernel for converting indices to multihot representation.
+
+    Input:
+        indices: [num_of_tokens, topk]
+        probs_in_indices: [num_of_tokens, topk]
+    Output:
+        multihot_indices: [num_of_tokens, num_of_local_experts]
+        probs_in_multihot: [num_of_tokens, num_of_local_experts]
+
+    Assume that topk = 2 , num_of_local_experts = 4, num_of_tokens = 2,
+    then the kernel can process the following conversion:
+
+    Input Example:
+        indices = [
+                [0, 1],
+                [1, 2]
+            ]
+        probs_in_indices = [
+                [0.1, 0.2],
+                [0.3, 0.4]
+            ]
+    Output Example:
+        multihot_indices = [
+                [1, 1, -1, -1],
+                [-1, 1, 1, -1]
+            ]
+        probs_in_multihot = [
+                [0.1, 0.2, 0.0, 0.0],
+                [0.0, 0.3, 0.4, 0.0]
+            ]
+    """
+    # Prepare the [0, topk) row
+    topk_row = tl.arange(0, topk_next_power_of_2)
+    topk_row = tl.where(topk_row < topk, topk_row, -1)
+    topk_row_mask = topk_row != -1
+    # Prepare the [0, num_of_local_experts) row
+    num_exp_row = tl.arange(0, num_of_local_experts_next_power_of_2)
+    num_exp_row = tl.where(num_exp_row < num_of_local_experts, num_exp_row, -1)
+    num_exp_row_mask = num_exp_row != -1
+
+    # Load a [1, topk] row from the indices buffer
+    row_idx = tl.program_id(0)
+    indices_row = tl.load(indices_ptr + row_idx * topk + topk_row, mask=topk_row_mask)
+    indices_row = tl.where(topk_row_mask, indices_row, -1)
+    probs_row = tl.load(probs_in_indices_ptr + row_idx * topk + topk_row, mask=topk_row_mask)
+
+    # Get the position of the each index in the indices_row, which is saved for backwards
+    position_row = tl.where(indices_row != -1, topk_row, -1)
+    # Mask of the valid indices
+    mask = (indices_row != -1) & (indices_row < num_of_local_experts)
+
+    row_idx_offset = row_idx * num_of_local_experts
+    # Store to initialize
+    tl.store(multihot_indices_ptr + row_idx_offset + num_exp_row, 0, mask=num_exp_row_mask)
+    tl.store(probs_in_multihot_ptr + row_idx_offset + num_exp_row, 0, mask=num_exp_row_mask)
+    tl.store(position_map_ptr + row_idx_offset + num_exp_row, -1, mask=num_exp_row_mask)
+    # Use barrier to make sure the initialization is done
+    tl.debug_barrier()
+    # Store the indices and probs_in_indices
+    tl.store(multihot_indices_ptr + row_idx_offset + indices_row, 1, mask)
+    tl.store(probs_in_multihot_ptr + row_idx_offset + indices_row, probs_row, mask)
+    # Store the position of the position_row for backwards
+    tl.store(position_map_ptr + row_idx_offset + indices_row, position_row, mask)
+
+
+# Assign a block to a row([1,topk]), generate a probs_indices([1,topk])
+@triton.jit
+def _multihot_to_indices_kernel(
+    probs_in_multihot_ptr,
+    position_map_ptr,
+    probs_indices_ptr,
+    num_of_local_experts: tl.constexpr,
+    num_of_local_experts_next_power_of_2: tl.constexpr,
+    topk: tl.constexpr,
+    topk_next_power_of_2: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    Triton kernel for converting multihot representation to indices.
+
+    Input:
+        probs_in_multihot: [num_of_tokens, num_of_local_experts]
+        position_map: [num_of_tokens, num_of_local_experts]
+    Output:
+        probs_indices: [num_of_tokens, topk]
+
+    Assume that topk = 2 , num_of_local_experts = 4, num_of_tokens = 2,
+    then the kernel can process the following conversion:
+
+    Input Example:
+        probs_in_multihot = [
+                [0.7, 0.8, 0.0, 0.0],
+                [0.0, 0.1, 0.9, 0.0]
+            ]
+        position_map = [
+                [1, 1, -1, -1],
+                [-1, 1, 1, -1]
+            ]
+    Output Example:
+        probs_indices = [
+                [0.7, 0.8],
+                [0.1, 0.9]
+            ]
+    """
+    # Prepare the [0, topk) row
+    topk_row = tl.arange(0, topk_next_power_of_2)
+    topk_row = tl.where(topk_row < topk, topk_row, -1)
+    topk_row_mask = topk_row != -1
+    # Prepare the [0, num_of_local_experts) row
+    num_exp_row = tl.arange(0, num_of_local_experts_next_power_of_2)
+    num_exp_row = tl.where(num_exp_row < num_of_local_experts, num_exp_row, -1)
+    num_exp_row_mask = num_exp_row != -1
+
+    # Load a [1, num_of_local_experts] row from the local routing map
+    row_idx = tl.program_id(0)
+    ptr_offset = row_idx * num_of_local_experts + num_exp_row
+    probs_in_multihot_row = tl.load(probs_in_multihot_ptr + ptr_offset, mask=num_exp_row_mask)
+
+    # Get the original position of the valid value in the the indices
+    position_map_row = tl.load(position_map_ptr + ptr_offset, mask=num_exp_row_mask)
+    position_map_row = tl.where(num_exp_row_mask, position_map_row, -1)
+    mask = position_map_row != -1
+
+    # Store to initialize
+    tl.store(probs_indices_ptr + row_idx * topk + topk_row, 0, mask=topk_row_mask)
+    # Use barrier to make sure the initialization is done
+    tl.debug_barrier()
+    # Restore the indices and probs_indices
+    tl.store(probs_indices_ptr + row_idx * topk + position_map_row, probs_in_multihot_row, mask)

--- a/primus_turbo/triton/moe/multihot_to_indices.py
+++ b/primus_turbo/triton/moe/multihot_to_indices.py
@@ -1,5 +1,6 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################

--- a/primus_turbo/triton/moe/permutation.py
+++ b/primus_turbo/triton/moe/permutation.py
@@ -1,5 +1,6 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################

--- a/primus_turbo/triton/moe/permutation.py
+++ b/primus_turbo/triton/moe/permutation.py
@@ -1,0 +1,952 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+from typing import Union
+
+import torch
+import triton
+import triton.language as tl
+from triton.language import core
+from triton.language.standard import _log2
+
+# The following three argsort related kernels are adapted from
+# the issue https://github.com/triton-lang/triton/issues/3698
+
+
+@triton.jit
+def _compare_and_swap(x, indices, flip, i: tl.constexpr, n_dims: tl.constexpr):
+    n_outer: tl.constexpr = x.numel >> n_dims
+    shape: tl.constexpr = [n_outer * (2**i), 2, 2 ** (n_dims - i - 1)]
+    y = tl.reshape(x, shape)
+    z = tl.reshape(indices, shape)
+
+    mask = tl.arange(0, 2)[None, :, None]
+
+    l_value = tl.reshape(tl.broadcast_to(tl.sum(y * (1 - mask), 1)[:, None, :], shape), x.shape).to(x.dtype)
+    r_value = tl.reshape(tl.broadcast_to(tl.sum(y * mask, 1)[:, None, :], shape), x.shape).to(x.dtype)
+
+    l_indice = tl.reshape(tl.broadcast_to(tl.sum(z * (1 - mask), 1)[:, None, :], shape), x.shape)
+    r_indice = tl.reshape(tl.broadcast_to(tl.sum(z * mask, 1)[:, None, :], shape), x.shape)
+
+    idtype = core.get_int_dtype(bitwidth=x.dtype.primitive_bitwidth, signed=True)
+
+    il_value = l_value.to(idtype, bitcast=True)
+    ir_value = r_value.to(idtype, bitcast=True)
+    ix = x.to(idtype, bitcast=True)
+
+    flag1 = tl.where(((l_value > r_value) ^ flip) != 0, il_value ^ ir_value, tl.zeros_like(ix))
+    ret = ix ^ flag1
+    flag2 = tl.where(((l_value > r_value) ^ flip) != 0, l_indice ^ r_indice, tl.zeros_like(ix))
+    ind = indices ^ flag2
+
+    return ret.to(x.dtype, bitcast=True), ind
+
+
+@triton.jit
+def _bitonic_merge(x, indices, stage: tl.constexpr, order: tl.constexpr, n_dims: tl.constexpr):
+    n_outer: tl.constexpr = x.numel >> n_dims
+    tl.static_assert(stage <= n_dims)
+    """
+    order_type 0 == ascending
+    order_type 1 == descending
+    order_type 2 == alternating
+    """
+    if order == 2:
+        shape: tl.constexpr = [n_outer * (2 ** (n_dims - 1 - stage)), 2, 2**stage]
+        flip = tl.reshape(tl.broadcast_to(tl.arange(0, 2)[None, :, None], shape), x.shape)
+    else:
+        flip = tl.full(x.shape, value=order, dtype=tl.int32)
+    for i in tl.static_range(stage):
+        x, indices = _compare_and_swap(x, indices, flip, i + (n_dims - stage), n_dims)
+    return x, indices
+
+
+@triton.jit
+def _argsort(x, indices, n_dims: tl.constexpr):
+    for i in tl.static_range(1, n_dims + 1):
+        x, indices = _bitonic_merge(x, indices, i, 2 if i < n_dims else 1, n_dims)
+    return x, indices
+
+
+@triton.jit
+def _row_id_map_pass_1_kernel(
+    # pointers
+    routing_map_ptr,
+    row_id_map_ptr,
+    workspace_ptr,
+    # sizes
+    num_tokens,
+    # strides
+    stride_routing_map_token,
+    stride_routing_map_expert,
+    stride_row_id_map_token,
+    stride_row_id_map_expert,
+    # metas
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offset = pid_n * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    expert_token_mask = tl.load(
+        routing_map_ptr + pid_m * stride_routing_map_expert + offset * stride_routing_map_token,
+        mask=(offset < num_tokens),
+        other=0,
+    ).to(tl.int32)
+    row_id_within_token_block = tl.cumsum(expert_token_mask) * expert_token_mask
+    tl.store(
+        row_id_map_ptr + pid_m * stride_row_id_map_expert + offset * stride_row_id_map_token,
+        row_id_within_token_block,
+        mask=offset < num_tokens,
+    )
+    n_tokens_per_block = tl.sum(expert_token_mask)
+    tl.store(workspace_ptr + pid_m * tl.cdiv(num_tokens, BLOCK_SIZE) + pid_n, n_tokens_per_block)
+
+
+@triton.jit
+def _row_id_map_pass_2_kernel(
+    # pointers
+    row_id_map_ptr,
+    workspace_ptr,
+    # sizes
+    num_tokens,
+    # strides
+    stride_row_id_map_token,
+    stride_row_id_map_expert,
+    # metas
+    WORKSPACE_LOAD_WIDTH: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    chunk_idx = pid_m * tl.cdiv(num_tokens, BLOCK_SIZE) + pid_n
+    offset = pid_n * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    row_id_within_token_block = tl.load(
+        row_id_map_ptr + pid_m * stride_row_id_map_expert + offset * stride_row_id_map_token,
+        mask=(offset < num_tokens),
+        other=0,
+    )
+
+    workspace_off = tl.arange(0, WORKSPACE_LOAD_WIDTH)
+    n_tokens_per_chunk = tl.load(workspace_ptr + workspace_off, mask=workspace_off < chunk_idx)
+    row_id = tl.where(
+        row_id_within_token_block == 0,
+        -1,
+        row_id_within_token_block + tl.sum(n_tokens_per_chunk) - 1,
+    )
+    tl.store(
+        row_id_map_ptr + pid_m * stride_row_id_map_expert + offset * stride_row_id_map_token,
+        row_id,
+        mask=(offset < num_tokens),
+    )
+
+
+@triton.jit
+def _row_id_map_pass_3_kernel(
+    # pointers
+    row_id_map_ptr,
+    # sizes
+    num_experts: tl.constexpr,
+    # strides
+    stride_row_id_map_token,
+    stride_row_id_map_expert,
+    # metas
+    LOAD_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    n_dims: tl.constexpr = _log2(LOAD_SIZE)
+    off = tl.arange(0, LOAD_SIZE)
+    row_id_map = tl.load(
+        row_id_map_ptr + pid * stride_row_id_map_token + stride_row_id_map_expert * off,
+        mask=off < num_experts,
+        other=-1,
+    )
+    n_routed = tl.sum(tl.where(row_id_map != -1, 1, 0))
+    indices = off
+    sorted_map, indices = _argsort(row_id_map, indices, n_dims=n_dims)
+    tl.store(
+        row_id_map_ptr + pid * stride_row_id_map_token + off * stride_row_id_map_expert,
+        sorted_map,
+        mask=off < n_routed,
+    )
+    tl.store(
+        row_id_map_ptr + pid * stride_row_id_map_token + (num_experts + off) * stride_row_id_map_expert,
+        indices,
+        mask=off < n_routed,
+    )
+    tl.store(
+        row_id_map_ptr + pid * stride_row_id_map_token + num_experts * 2 * stride_row_id_map_expert,
+        n_routed,
+    )
+
+
+def make_row_id_map(
+    routing_map: torch.Tensor,
+    num_tokens: int,
+    num_experts: int,
+):
+    """
+    Prepare the row_id_map for the permutation.
+
+    Parameters
+    ----------
+    routing_map: torch.Tensor
+        Input tensor of shape `[num_tokens, num_experts]`. It is a mask tensor that indicates
+        which experts are routed to which tokens. The values in it: 1 means the token is routed to
+        this expert and 0 means not.
+    num_tokens: int
+        Number of tokens in the input tensor.
+    num_experts: int
+        Number of experts in the input tensor.
+
+    Returns
+    -------
+    row_id_map: torch.Tensor
+        The row_id_map for the permutation of shape `[num_tokens, num_experts * 2 + 1]`.
+        For each token, the last item is the number of experts that are routed (n_routed).
+        The first n_routed items are the destination row indices in the permuted tokens.
+        The [num_experts, num_experts + n_routed) items are the indices of the experts corresponding
+        to the first n_routed row indices above.
+    """
+    row_id_map = torch.empty((num_tokens, num_experts * 2 + 1), dtype=torch.int32, device="cuda")
+    block_size = 1024
+    grid = (num_experts, triton.cdiv(num_tokens, block_size))
+    workspace_tensor = torch.empty(grid, dtype=torch.int32, device="cuda")
+
+    # supposing num_tokens == 5, num_experts == 3, block_size == 3
+    # and we have a routing_map like this:
+    # [[1, 1, 0],
+    #  [1, 0, 1],
+    #  [0, 0, 1],
+    #  [1, 1, 0],
+    #  [0, 0, 0]]
+
+    # pass 1: block cumsum
+    # for each expert, compute the cumsum of every block_size tokens
+    # the row_id_map will be like this after pass 1 (r means useless values):
+    # [[1, 1, 0, r, r, r, r],
+    #  [2, 0, 1, r, r, r, r],
+    #  [0, 0, 2, r, r, r, r],
+    #  [1, 1, 0, r, r, r, r],
+    #  [0, 0, 0, r, r, r, r]]
+    _row_id_map_pass_1_kernel[grid](
+        routing_map,
+        row_id_map,
+        workspace_tensor,
+        num_tokens,
+        routing_map.stride(0),
+        routing_map.stride(1),
+        row_id_map.stride(0),
+        row_id_map.stride(1),
+        block_size,
+    )
+
+    # pass 2: cumsum all and process the mask
+    # process the block cumsum into the global cumsum and then into the dst row indices
+    # the row_id_map will be like this after pass 2 (r means useless value):
+    # [[ 0,  3, -1, r, r, r, r],
+    #  [ 1, -1,  5, r, r, r, r],
+    #  [-1, -1,  6, r, r, r, r],
+    #  [ 2,  4, -1, r, r, r, r],
+    #  [-1, -1, -1, r, r, r, r]]
+    _row_id_map_pass_2_kernel[grid](
+        row_id_map,
+        workspace_tensor,
+        num_tokens,
+        row_id_map.stride(0),
+        row_id_map.stride(1),
+        triton.next_power_of_2(num_experts * triton.cdiv(num_tokens, block_size)),
+        block_size,
+    )
+
+    # pass 3: make the row_id_map from the sparse structure to the dense structure
+    # the row_id_map will be like this after pass 3 (r means useless value):
+    # [[3, 0, r, 1, 0, r, 2],
+    #  [5, 1, r, 2, 0, r, 2],
+    #  [6, r, r, 2, r, r, 1],
+    #  [4, 2, r, 1, 0, r, 2],
+    #  [r, r, r, r, r, r, 0]]
+    grid = (num_tokens,)
+    _row_id_map_pass_3_kernel[grid](
+        row_id_map,
+        num_experts,
+        row_id_map.stride(0),
+        row_id_map.stride(1),
+        triton.next_power_of_2(num_experts),
+    )
+    return row_id_map
+
+
+@triton.jit
+def _permute_kernel(
+    # pointers
+    input_ptr,
+    output_ptr,
+    row_id_map_ptr,
+    probs_ptr,
+    scale_ptr,
+    permuted_probs_ptr,
+    permuted_scale_ptr,
+    # sizes
+    num_experts: tl.constexpr,
+    hidden_size: tl.constexpr,
+    scale_hidden_dim,
+    # strides
+    stride_row_id_map_token,
+    stride_row_id_map_expert,
+    stride_input_token,
+    stride_input_hidden,
+    stride_output_token,
+    stride_output_hidden,
+    stride_probs_token,
+    stride_probs_expert,
+    stride_scale_token,
+    stride_scale_hidden,
+    stride_permuted_probs_token,
+    stride_permuted_scale_token,
+    stride_permuted_scale_hidden,
+    # metas
+    PERMUTE_PROBS: tl.constexpr,
+    PERMUTE_SCALE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    cur_off = pid_h * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = cur_off < hidden_size
+    input_off = pid_t * stride_input_token + cur_off * stride_input_hidden
+    inp = tl.load(input_ptr + input_off, mask=mask)
+    if PERMUTE_SCALE:
+        mask_scale = cur_off < scale_hidden_dim
+        scale_off = pid_t * stride_scale_token + cur_off * stride_scale_hidden
+        scale = tl.load(scale_ptr + scale_off, mask=mask_scale)
+    n_routed = tl.load(
+        row_id_map_ptr + pid_t * stride_row_id_map_token + num_experts * 2 * stride_row_id_map_expert
+    )
+    for idx in tl.range(n_routed):
+        dst_row = tl.load(row_id_map_ptr + pid_t * stride_row_id_map_token + idx * stride_row_id_map_expert)
+        output_off = dst_row * stride_output_token + cur_off * stride_output_hidden
+        if PERMUTE_SCALE:
+            permuted_scale_off = (
+                dst_row * stride_permuted_scale_token + cur_off * stride_permuted_scale_hidden
+            )
+            tl.store(permuted_scale_ptr + permuted_scale_off, scale, mask=mask_scale)
+        if PERMUTE_PROBS:
+            expert_idx = tl.load(
+                row_id_map_ptr
+                + pid_t * stride_row_id_map_token
+                + (num_experts + idx) * stride_row_id_map_expert
+            )
+            prob_off = pid_t * stride_probs_token + expert_idx * stride_probs_expert
+            prob = tl.load(probs_ptr + prob_off)
+            if pid_h == 0:
+                permuted_prob_off = dst_row * stride_permuted_probs_token
+                tl.store(permuted_probs_ptr + permuted_prob_off, prob)
+            if prob == 0.0:
+                # for routing_map padding
+                # dst_row != -1 and prob == 0.0 means that this slot is padded
+                tl.store(output_ptr + output_off, 0.0, mask=mask)
+            else:
+                tl.store(output_ptr + output_off, inp, mask=mask)
+        else:
+            tl.store(output_ptr + output_off, inp, mask=mask)
+
+
+try:
+    _permute_kernel = triton.autotune(
+        configs=[
+            triton.Config({"BLOCK_SIZE": 64}),
+            triton.Config({"BLOCK_SIZE": 128}),
+            triton.Config({"BLOCK_SIZE": 256}),
+            triton.Config({"BLOCK_SIZE": 512}),
+            triton.Config({"BLOCK_SIZE": 1024}),
+            triton.Config({"BLOCK_SIZE": 2048}),
+            triton.Config({"BLOCK_SIZE": 4096}),
+        ],
+        key=["hidden_size"],
+    )(_permute_kernel)
+except RuntimeError:
+    pass
+
+
+def permute_with_mask_map(
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    probs: torch.Tensor,
+    scale: torch.Tensor,
+    num_tokens: int,
+    num_experts: int,
+    num_out_tokens: int,
+    hidden_size: int,
+    scale_hidden_dim: int,
+):
+    """
+    Permute the input tensor based on the row_id_map.
+
+    Parameters
+    ----------
+    inp: torch.Tensor
+        Input tensor of shape `[num_tokens, hidden_size]`, on which permutation will be applied.
+    row_id_map: torch.Tensor
+        The token to expert mapping tensor of shape `[num_tokens, num_experts * 2 + 1]`.
+    probs: torch.Tensor
+        The probabilities of the input tensor. If it is not None, it will be permuted.
+    scale: torch.Tensor
+        The scale of the input tensor. If it is not None, it will be permuted.
+    num_tokens: int
+        Number of tokens in the input tensor.
+    num_experts: int
+        Number of experts in the input tensor.
+    num_out_tokens: int
+        Number of tokens in the permuted tensor.
+    hidden_size: int
+        Hidden size of the input tensor.
+    scale_hidden_dim: int
+        Hidden size of the scale tensor.
+    """
+    output = torch.empty((num_out_tokens, hidden_size), dtype=inp.dtype, device="cuda")
+    if probs is not None:
+        permuted_probs = torch.empty((num_out_tokens,), dtype=probs.dtype, device="cuda")
+    else:
+        permuted_probs = None
+
+    if scale is not None:
+        permuted_scale = torch.empty((num_out_tokens, scale_hidden_dim), dtype=scale.dtype, device="cuda")
+    else:
+        permuted_scale = None
+
+    # pylint: disable=unnecessary-lambda-assignment
+    def grid(META):
+        return (num_tokens, triton.cdiv(hidden_size, META["BLOCK_SIZE"]))
+
+    _permute_kernel[grid](
+        inp,
+        output,
+        row_id_map,
+        probs,
+        scale,
+        permuted_probs,
+        permuted_scale,
+        num_experts,
+        hidden_size,
+        scale_hidden_dim,
+        row_id_map.stride(0),
+        row_id_map.stride(1),
+        inp.stride(0),
+        inp.stride(1),
+        output.stride(0),
+        output.stride(1),
+        probs.stride(0) if probs is not None else None,
+        probs.stride(1) if probs is not None else None,
+        scale.stride(0) if scale is not None else None,
+        scale.stride(1) if scale is not None else None,
+        permuted_probs.stride(0) if permuted_probs is not None else None,
+        permuted_scale.stride(0) if permuted_scale is not None else None,
+        permuted_scale.stride(1) if permuted_scale is not None else None,
+        PERMUTE_PROBS=probs is not None,
+        PERMUTE_SCALE=scale is not None,
+    )
+    return output, permuted_scale, permuted_probs
+
+
+@triton.jit
+def _unpermute_kernel(
+    # pointers
+    input_ptr,
+    output_ptr,
+    row_id_map_ptr,
+    merging_probs_ptr,
+    permuted_probs_ptr,
+    unpermuted_probs_ptr,
+    # sizes
+    num_experts: tl.constexpr,
+    hidden_size: tl.constexpr,
+    # strides
+    stride_row_id_map_token,
+    stride_row_id_map_expert,
+    stride_input_token,
+    stride_input_hidden,
+    stride_output_token,
+    stride_output_hidden,
+    stride_merging_probs_token,
+    stride_merging_probs_expert,
+    stride_permuted_probs_token,
+    stride_unpermuted_probs_token,
+    stride_unpermuted_probs_expert,
+    # metas
+    PROBS_LOAD_WIDTH: tl.constexpr,
+    WITH_MERGING_PROBS: tl.constexpr,
+    PERMUTE_PROBS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    data_type = input_ptr.dtype.element_ty
+    compute_type = tl.float32
+
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    current_offset = pid_h * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = current_offset < hidden_size
+    if PERMUTE_PROBS:
+        # write 0.0 to probs_grad that are not routed
+        if pid_h == 0:
+            map_load_off = tl.arange(0, PROBS_LOAD_WIDTH)
+            unpermuted_prob_off = (
+                pid_t * stride_unpermuted_probs_token + stride_unpermuted_probs_expert * map_load_off
+            )
+            tl.store(unpermuted_probs_ptr + unpermuted_prob_off, 0.0, mask=map_load_off < num_experts)
+    accumulator = tl.zeros((BLOCK_SIZE,), dtype=compute_type)
+    n_routed = tl.load(
+        row_id_map_ptr + pid_t * stride_row_id_map_token + num_experts * 2 * stride_row_id_map_expert
+    )
+    for idx in tl.range(n_routed):
+        src_row = tl.load(row_id_map_ptr + pid_t * stride_row_id_map_token + idx * stride_row_id_map_expert)
+        input_off = src_row * stride_input_token + current_offset * stride_input_hidden
+        inp = tl.load(input_ptr + input_off, mask=mask)
+        inp = inp.to(compute_type)
+        if WITH_MERGING_PROBS:
+            expert_idx = tl.load(
+                row_id_map_ptr
+                + pid_t * stride_row_id_map_token
+                + (num_experts + idx) * stride_row_id_map_expert
+            )
+            merging_prob_off = pid_t * stride_merging_probs_token + expert_idx * stride_merging_probs_expert
+            merging_prob = tl.load(merging_probs_ptr + merging_prob_off).to(compute_type)
+            inp *= merging_prob
+        accumulator += inp
+        if PERMUTE_PROBS:
+            if pid_h == 0:
+                expert_idx = tl.load(
+                    row_id_map_ptr
+                    + pid_t * stride_row_id_map_token
+                    + (num_experts + idx) * stride_row_id_map_expert
+                )
+                unpermuted_prob_off = (
+                    pid_t * stride_unpermuted_probs_token + expert_idx * stride_unpermuted_probs_expert
+                )
+                permuted_prob_off = src_row * stride_permuted_probs_token
+                prob = tl.load(permuted_probs_ptr + permuted_prob_off)
+                tl.store(unpermuted_probs_ptr + unpermuted_prob_off, prob)
+    accumulator = accumulator.to(data_type)
+    output_off = pid_t * stride_output_token + current_offset * stride_output_hidden
+    tl.store(output_ptr + output_off, accumulator, mask=mask)
+
+
+try:
+    _unpermute_kernel = triton.autotune(
+        configs=[
+            triton.Config({"BLOCK_SIZE": 64}),
+            triton.Config({"BLOCK_SIZE": 128}),
+            triton.Config({"BLOCK_SIZE": 256}),
+            triton.Config({"BLOCK_SIZE": 512}),
+            triton.Config({"BLOCK_SIZE": 1024}),
+            triton.Config({"BLOCK_SIZE": 2048}),
+            triton.Config({"BLOCK_SIZE": 4096}),
+        ],
+        key=["hidden_size"],
+    )(_unpermute_kernel)
+except RuntimeError:
+    pass
+
+
+def unpermute_with_mask_map(
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    merging_probs: Union[torch.Tensor, None],
+    permuted_probs: Union[torch.Tensor, None],
+    num_tokens: int,
+    num_experts: int,
+    hidden_size: int,
+):
+    """
+    Unpermute the input tensor based on the row_id_map.
+
+    Parameters
+    ----------
+    inp: torch.Tensor
+        Input tensor of shape `[num_out_tokens, hidden_size]`.
+    row_id_map: torch.Tensor
+        The token to expert mapping tensor of shape `[num_tokens, num_experts * 2 + 1]`.
+    merging_probs: torch.Tensor
+        The merging probabilities of the input tensor. If it is not None, it will be used as weights
+        to reduce the unpermuted tokens.
+    permuted_probs: torch.Tensor
+        The permuted probabilities of the input tensor. If it is not None, it will be unpermuted.
+    num_tokens: int
+        Number of tokens in the permuted tensor.
+    num_experts: int
+        Number of experts in the permuted tensor.
+    hidden_size: int
+        Hidden size of the permuted tensor.
+    """
+    output = torch.empty((num_tokens, hidden_size), dtype=inp.dtype, device="cuda")
+    if permuted_probs is not None:
+        unpermuted_probs = torch.empty((num_tokens, num_experts), dtype=permuted_probs.dtype, device="cuda")
+    else:
+        unpermuted_probs = None
+
+    # pylint: disable=unnecessary-lambda-assignment
+    def grid(META):
+        return (num_tokens, triton.cdiv(hidden_size, META["BLOCK_SIZE"]))
+
+    _unpermute_kernel[grid](
+        inp,
+        output,
+        row_id_map,
+        merging_probs,
+        permuted_probs,
+        unpermuted_probs,
+        num_experts,
+        hidden_size,
+        row_id_map.stride(0),
+        row_id_map.stride(1),
+        inp.stride(0),
+        inp.stride(1),
+        output.stride(0),
+        output.stride(1),
+        merging_probs.stride(0) if merging_probs is not None else None,
+        merging_probs.stride(1) if merging_probs is not None else None,
+        permuted_probs.stride(0) if permuted_probs is not None else None,
+        unpermuted_probs.stride(0) if unpermuted_probs is not None else None,
+        unpermuted_probs.stride(1) if unpermuted_probs is not None else None,
+        PROBS_LOAD_WIDTH=triton.next_power_of_2(num_experts),
+        WITH_MERGING_PROBS=merging_probs is not None,
+        PERMUTE_PROBS=permuted_probs is not None,
+    )
+    return output, unpermuted_probs
+
+
+@triton.jit
+def _unpermute_bwd_with_merging_probs_kernel(
+    # pointers
+    fwd_output_grad_ptr,
+    fwd_input_grad_ptr,
+    fwd_input_ptr,
+    merging_probs_ptr,
+    merging_probs_grad_ptr,
+    row_id_map_ptr,
+    # sizes
+    num_experts: tl.constexpr,
+    hidden_size: tl.constexpr,
+    # strides
+    stride_row_id_map_token,
+    stride_row_id_map_expert,
+    stride_fwd_output_grad_token,
+    stride_fwd_output_grad_hidden,
+    stride_fwd_input_grad_token,
+    stride_fwd_input_grad_hidden,
+    stride_fwd_input_token,
+    stride_fwd_input_hidden,
+    stride_merging_probs_token,
+    stride_merging_probs_expert,
+    stride_merging_probs_grad_token,
+    stride_merging_probs_grad_expert,
+    # metas
+    PROBS_LOAD_WIDTH: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    data_type = fwd_output_grad_ptr.dtype.element_ty
+    compute_type = tl.float32
+
+    pid = tl.program_id(0)
+    map_load_off = tl.arange(0, PROBS_LOAD_WIDTH)
+    token_probs_grad_off = (
+        pid * stride_merging_probs_grad_token + stride_merging_probs_grad_expert * map_load_off
+    )
+    tl.store(merging_probs_grad_ptr + token_probs_grad_off, 0.0, mask=map_load_off < num_experts)
+    n_routed = tl.load(
+        row_id_map_ptr + pid * stride_row_id_map_token + num_experts * 2 * stride_row_id_map_expert
+    )
+    for idx in tl.range(n_routed):
+        dst_row = tl.load(row_id_map_ptr + pid * stride_row_id_map_token + idx * stride_row_id_map_expert)
+        expert_idx = tl.load(
+            row_id_map_ptr + pid * stride_row_id_map_token + (num_experts + idx) * stride_row_id_map_expert
+        )
+        prob_grad_accum = tl.zeros((BLOCK_SIZE,), dtype=compute_type)
+        current_start = 0
+        while current_start < hidden_size:
+            current_offset = current_start + tl.arange(0, BLOCK_SIZE)
+            mask = current_offset < hidden_size
+            input_off = pid * stride_fwd_output_grad_token + current_offset * stride_fwd_output_grad_hidden
+            inp = tl.load(fwd_output_grad_ptr + input_off, mask=mask)
+            inp = inp.to(compute_type)
+            merging_prob_off = pid * stride_merging_probs_token + expert_idx * stride_merging_probs_expert
+            merging_prob = tl.load(merging_probs_ptr + merging_prob_off).to(compute_type)
+            output = inp * merging_prob
+            output = output.to(data_type)
+            output_off = dst_row * stride_fwd_input_grad_token + current_offset * stride_fwd_input_grad_hidden
+            tl.store(fwd_input_grad_ptr + output_off, output, mask=mask)
+
+            fwd_input_off = dst_row * stride_fwd_input_token + current_offset * stride_fwd_input_hidden
+            fwd_input = tl.load(fwd_input_ptr + fwd_input_off, mask=mask)
+            prob_grad_accum += fwd_input.to(compute_type) * inp
+            current_start += BLOCK_SIZE
+        probs_grad = tl.sum(prob_grad_accum).to(merging_probs_grad_ptr.dtype.element_ty)
+        probs_grad_off = pid * stride_merging_probs_grad_token + expert_idx * stride_merging_probs_grad_expert
+        tl.store(merging_probs_grad_ptr + probs_grad_off, probs_grad)
+
+
+try:
+    _unpermute_bwd_with_merging_probs_kernel = triton.autotune(
+        configs=[
+            triton.Config({"BLOCK_SIZE": 64}),
+            triton.Config({"BLOCK_SIZE": 128}),
+            triton.Config({"BLOCK_SIZE": 256}),
+            triton.Config({"BLOCK_SIZE": 512}),
+            triton.Config({"BLOCK_SIZE": 1024}),
+            triton.Config({"BLOCK_SIZE": 2048}),
+            triton.Config({"BLOCK_SIZE": 4096}),
+        ],
+        key=["hidden_size"],
+    )(_unpermute_bwd_with_merging_probs_kernel)
+except RuntimeError:
+    pass
+
+
+def unpermute_with_mask_map_bwd_with_merging_probs(
+    fwd_output_grad: torch.Tensor,
+    row_id_map: torch.Tensor,
+    fwd_input: torch.Tensor,
+    merging_probs: torch.Tensor,
+    num_tokens: int,
+    num_experts: int,
+    num_out_tokens: int,
+    hidden_size: int,
+):
+    """
+    Unpermute backward pass kernel with merging probs.
+
+    Parameters
+    ----------
+    fwd_output_grad: torch.Tensor
+        The gradient of the output tensor of shape `[num_tokens, hidden_size]`.
+    row_id_map: torch.Tensor
+        The token to expert mapping tensor of shape `[num_tokens, num_experts * 2 + 1]`.
+    fwd_input: torch.Tensor
+        The input tensor of the forward pass of shape `[num_out_tokens, hidden_size]`.
+    merging_probs: torch.Tensor
+        The merging probabilities of the input tensor of shape `[num_tokens, num_experts]`.
+    num_tokens: int
+        Number of tokens in the permuted tensor.
+    num_experts: int
+        Number of experts in the permuted tensor.
+    num_out_tokens: int
+        Number of tokens in the output tensor.
+    hidden_size: int
+        Hidden size of the output tensor.
+    """
+    act_grad = torch.empty((num_out_tokens, hidden_size), dtype=fwd_output_grad.dtype, device="cuda")
+    merging_probs_grad = torch.empty((num_tokens, num_experts), dtype=merging_probs.dtype, device="cuda")
+    grid = (num_tokens,)
+    _unpermute_bwd_with_merging_probs_kernel[grid](
+        fwd_output_grad,
+        act_grad,
+        fwd_input,
+        merging_probs,
+        merging_probs_grad,
+        row_id_map,
+        num_experts,
+        hidden_size,
+        row_id_map.stride(0),
+        row_id_map.stride(1),
+        fwd_output_grad.stride(0),
+        fwd_output_grad.stride(1),
+        act_grad.stride(0),
+        act_grad.stride(1),
+        fwd_input.stride(0),
+        fwd_input.stride(1),
+        merging_probs.stride(0),
+        merging_probs.stride(1),
+        merging_probs_grad.stride(0),
+        merging_probs_grad.stride(1),
+        PROBS_LOAD_WIDTH=triton.next_power_of_2(num_experts),
+    )
+    return act_grad, merging_probs_grad
+
+
+@triton.jit
+def _make_chunk_sort_map_kernel(
+    # pointers
+    split_sizes_ptr,
+    sorted_indices_ptr,
+    dst_rows_ptr,
+    # sizes
+    num_splits: tl.constexpr,
+    # metas
+    IDX_LOAD_WIDTH: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    load_split_offset = tl.arange(0, IDX_LOAD_WIDTH)
+    sorted_indices = tl.load(sorted_indices_ptr + load_split_offset, mask=load_split_offset < num_splits)
+
+    # get chunk idx of the current token in the input tensor
+    input_split_sizes = tl.load(
+        split_sizes_ptr + load_split_offset, mask=load_split_offset < num_splits, other=0
+    ).to(tl.int32)
+    input_split_sizes_cumsum = tl.cumsum(input_split_sizes)
+    input_split_sizes_mask = tl.where(input_split_sizes_cumsum <= pid, 1, 0)
+    input_chunk_idx = tl.sum(input_split_sizes_mask)
+    input_split_sizes_presum = tl.sum(input_split_sizes * input_split_sizes_mask)
+    in_chunk_offset = pid - input_split_sizes_presum
+
+    # get chunk idx of the current token in the output tensor
+    output_chunk_mask = tl.where(sorted_indices == input_chunk_idx, 1, 0)
+    output_chunk_idx = tl.argmax(output_chunk_mask, axis=-1)
+
+    # make row_id_map
+    output_split_sizes = tl.load(split_sizes_ptr + sorted_indices, mask=load_split_offset < num_splits).to(
+        tl.int32
+    )
+    output_pre_split_sizes = tl.where(load_split_offset < output_chunk_idx, output_split_sizes, 0)
+    dst_row = tl.sum(output_pre_split_sizes) + in_chunk_offset
+    tl.store(dst_rows_ptr + pid, dst_row)
+
+
+def make_chunk_sort_map(
+    split_sizes: torch.Tensor,
+    sorted_indices: torch.Tensor,
+    num_tokens: int,
+    num_splits: int,
+):
+    """
+    Make a row_id_map for chunk sort.
+
+    Parameters
+    ----------
+    split_sizes: torch.Tensor
+        The sizes of the chunks of shape `[num_splits,]`.
+    sorted_indices: torch.Tensor
+        The indices of the sorted chunks of shape `[num_splits,]`.
+    num_tokens: int
+        Number of tokens in the input tensor.
+    num_splits: int
+        Number of splits of split_sizes and sorted_indices.
+    """
+    row_id_map = torch.empty((num_tokens,), dtype=torch.int32, device="cuda")
+    grid = (num_tokens,)
+    _make_chunk_sort_map_kernel[grid](
+        split_sizes,
+        sorted_indices,
+        row_id_map,
+        num_splits,
+        IDX_LOAD_WIDTH=triton.next_power_of_2(num_splits),
+    )
+    return row_id_map
+
+
+@triton.jit
+def _sort_chunks_by_map_kernel(
+    # pointers
+    input_ptr,
+    output_ptr,
+    row_id_map_ptr,
+    probs_ptr,
+    permuted_probs_ptr,
+    # sizes
+    hidden_size: tl.constexpr,
+    # strides
+    stride_input_token,
+    stride_input_hidden,
+    stride_output_token,
+    stride_output_hidden,
+    stride_probs_token,
+    stride_permuted_probs_token,
+    # metas
+    PERMUTE_PROBS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    FORWARD: tl.constexpr,
+):
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    if FORWARD:
+        src_row = pid_t
+        dst_row = tl.load(row_id_map_ptr + pid_t)
+    else:
+        src_row = tl.load(row_id_map_ptr + pid_t)
+        dst_row = pid_t
+    current_offset = pid_h * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = current_offset < hidden_size
+    input_offsets = src_row * stride_input_token + current_offset * stride_input_hidden
+    output_offsets = dst_row * stride_output_token + current_offset * stride_output_hidden
+    inp = tl.load(input_ptr + input_offsets, mask=mask)
+    tl.store(output_ptr + output_offsets, inp, mask=mask)
+    if PERMUTE_PROBS:
+        if pid_h == 0:
+            prob_off = src_row * stride_probs_token
+            prob = tl.load(probs_ptr + prob_off)
+            permuted_prob_off = dst_row * stride_permuted_probs_token
+            tl.store(permuted_probs_ptr + permuted_prob_off, prob)
+
+
+try:
+    _sort_chunks_by_map_kernel = triton.autotune(
+        configs=[
+            triton.Config({"BLOCK_SIZE": 64}),
+            triton.Config({"BLOCK_SIZE": 128}),
+            triton.Config({"BLOCK_SIZE": 256}),
+            triton.Config({"BLOCK_SIZE": 512}),
+            triton.Config({"BLOCK_SIZE": 1024}),
+            triton.Config({"BLOCK_SIZE": 2048}),
+            triton.Config({"BLOCK_SIZE": 4096}),
+        ],
+        key=["hidden_size"],
+    )(_sort_chunks_by_map_kernel)
+except RuntimeError:
+    pass
+
+
+def sort_chunks_by_map(
+    inp: torch.Tensor,
+    row_id_map: torch.Tensor,
+    probs: torch.Tensor,
+    num_tokens: int,
+    hidden_size: int,
+    is_forward: bool,
+):
+    """
+    Sort chunks with row_id_map.
+
+    Parameters
+    ----------
+    inp: torch.Tensor
+        Input tensor of shape `[num_tokens, hidden_size]`.
+    row_id_map: torch.Tensor
+        The token to expert mapping tensor of shape `[num_tokens,]`.
+    probs: torch.Tensor
+        The probabilities of the input tensor. If it is not None, it will be permuted.
+    num_tokens: int
+        Number of tokens in the input tensor.
+    hidden_size: int
+        Hidden size of the input tensor.
+    is_forward: bool
+        Whether the sort is for forward or backward.
+    """
+    output = torch.empty((num_tokens, hidden_size), dtype=inp.dtype, device="cuda")
+    if probs is not None:
+        permuted_probs = torch.empty((num_tokens,), dtype=probs.dtype, device="cuda")
+    else:
+        permuted_probs = None
+    # pylint: disable=unnecessary-lambda-assignment
+
+    def grid(META):
+        return (num_tokens, triton.cdiv(hidden_size, META["BLOCK_SIZE"]))
+
+    _sort_chunks_by_map_kernel[grid](
+        inp,
+        output,
+        row_id_map,
+        probs,
+        permuted_probs,
+        hidden_size,
+        inp.stride(0),
+        inp.stride(1),
+        output.stride(0),
+        output.stride(1),
+        probs.stride(0) if probs is not None else None,
+        permuted_probs.stride(0) if permuted_probs is not None else None,
+        PERMUTE_PROBS=probs is not None,
+        FORWARD=is_forward,
+    )
+    return output, permuted_probs

--- a/tests/pytorch/modules/test_token_dispatcher.py
+++ b/tests/pytorch/modules/test_token_dispatcher.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+
+from dataclasses import dataclass
+
+import torch
+import torch.distributed as dist
+from torch.testing._internal.common_distributed import MultiProcessTestCase
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    run_tests,
+)
+
+import primus_turbo.pytorch as turbo
+
+
+@dataclass
+class TokenDispatcherTestConfig:
+    num_tokens: int
+    hidden_size: int
+    dtype: torch.dtype
+    router_topk: int
+    num_experts: int
+
+
+_deepep_token_dispatcher_config = [
+    TokenDispatcherTestConfig(
+        num_tokens=4096, hidden_size=4096, dtype=torch.bfloat16, router_topk=8, num_experts=16
+    )
+]
+
+
+@instantiate_parametrized_tests
+class TokenDispatcherTestBase(MultiProcessTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._spawn_processes()
+
+    @property
+    def world_size(self) -> int:
+        return torch.cuda.device_count()
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("cuda", self.rank)
+
+    def _init_process(self):
+        torch.cuda.set_device(self.device)
+        store = dist.FileStore(self.file_name, self.world_size)
+        dist.init_process_group(
+            backend="nccl",
+            world_size=self.world_size,
+            rank=self.rank,
+            store=store,
+        )
+        torch.manual_seed(42 + self.rank)
+
+    def _init_dispatcher(self, kwargs):
+        ep_group = dist.group.WORLD
+        return turbo.modules.TurboDeepEPTokenDispatcher(ep_group, **kwargs)
+
+    def test_token_dispatcher_dropless(self):
+        self._init_process()
+        ep_group = dist.group.WORLD
+
+        for cfg in _deepep_token_dispatcher_config:
+            dispatcher = turbo.modules.TurboDeepEPTokenDispatcher(
+                ep_group, cfg.router_topk, cfg.num_experts, cfg.hidden_size, cfg.dtype
+            )
+            combiner = turbo.modules.TurboDeepEPTokenCombiner()
+
+            hidden_states = torch.randn((cfg.num_tokens, cfg.hidden_size), dtype=cfg.dtype, device="cuda")
+            ans = hidden_states
+            hidden_states.requires_grad = True
+
+            probs = (
+                torch.ones((cfg.num_tokens, cfg.num_experts), dtype=torch.float32, device="cuda")
+                / cfg.router_topk
+            )
+
+            (permuted_local_hidden_states, tokens_per_expert, permuted_probs, handle) = dispatcher(
+                hidden_states, probs, token_indices=None
+            )
+
+            permuted_local_hidden_states = permuted_local_hidden_states * permuted_probs.unsqueeze(-1)
+
+            permuted_local_hidden_states = permuted_local_hidden_states.to(hidden_states.dtype)
+
+            restored_hidden_states, _ = combiner(permuted_local_hidden_states, handle)
+
+            assert torch.allclose(
+                restored_hidden_states, ans
+            ), f"Restored hidden states do not match original hidden states, {restored_hidden_states} {ans}"
+
+            # check if the grad of the hidden states is same as the hidden states
+            torch.autograd.backward(restored_hidden_states, hidden_states)
+            assert torch.allclose(
+                hidden_states.grad, ans
+            ), "Restored hidden states do not match original hidden states"
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/pytorch/ops/test_permutation.py
+++ b/tests/pytorch/ops/test_permutation.py
@@ -1,5 +1,6 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -106,7 +107,7 @@ def _test_permutation_mask_map(
     turbo_unpermute_bwd_input = pytorch_unpermute_bwd_input.detach()
 
     turbo_unpermute_output = turbo.ops.token_unpermute(
-        turbo_unpermute_fwd_input, row_id_map, turbo_probs, restore_shape, map_type="mask"
+        turbo_unpermute_fwd_input, row_id_map, turbo_probs, restore_shape
     )
     turbo_unpermute_output.backward(turbo_unpermute_bwd_input, retain_graph=True)
 
@@ -115,12 +116,6 @@ def _test_permutation_mask_map(
     # Results Check
     #
     ###################################################################################################################################
-
-    # turbo_permute_output_float = turbo_permute_output.float()
-    # turbo_permute_fwd_input_grad = turbo_permute_fwd_input.grad.float()
-    # turbo_unpermute_output_float = turbo_unpermute_output.float()
-    # turbo_unpermute_fwd_input_grad = turbo_unpermute_fwd_input.grad.float()
-
     # TODO: can't pass turbo tolerances
     tol = get_tolerances(dtype)
     torch.testing.assert_close(
@@ -155,7 +150,7 @@ def _test_permutation_mask_map(
         )
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
 @pytest.mark.parametrize("num_tokens", [4096])
 @pytest.mark.parametrize("num_expert", [7, 16])
 @pytest.mark.parametrize("hidden_size", [4096])
@@ -182,7 +177,7 @@ def test_permutation_mask_map(
     )
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
 def test_permutation_mask_map_empty_input(dtype):
     with_probs = True
     _test_permutation_mask_map(

--- a/tests/pytorch/ops/test_permutation.py
+++ b/tests/pytorch/ops/test_permutation.py
@@ -1,0 +1,196 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+
+import random
+
+import pytest
+import torch
+
+import primus_turbo.pytorch as turbo
+from tests.pytorch.ref.permuatation_ref import (
+    pytorch_permute_mask_map,
+    pytorch_unpermute_mask_map,
+)
+from tests.test_utils import get_tolerances
+
+# TODO: add FP8 test
+
+
+def manual_seed(seed):
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    random.seed = seed
+
+
+def _test_permutation_mask_map(
+    dtype: torch.dtype,
+    num_tokens,
+    num_expert,
+    hidden_size,
+    topK,
+    num_out_tokens,
+    with_probs,
+):
+    if topK > num_expert:
+        pytest.skip("topK should be smaller than the number of experts.")
+
+    if num_out_tokens == None:
+        num_out_tokens = num_tokens * topK
+
+    manual_seed(1234)
+    print(
+        "mask map:" f" token:{num_tokens} hidden_size:{hidden_size} expert:{num_expert} topK:{topK} {dtype}"
+    )
+
+    pytorch_permute_fwd_input = torch.rand((num_tokens, hidden_size), dtype=dtype).cuda()
+    pytorch_permute_bwd_input = torch.rand((num_out_tokens, hidden_size), dtype=dtype).cuda()
+    pytorch_unpermute_bwd_input = torch.rand((num_tokens, hidden_size), dtype=dtype).cuda()
+
+    pytorch_permute_fwd_input.requires_grad_(True)
+
+    restore_shape = pytorch_permute_fwd_input.shape
+
+    _tmp_tensor = torch.zeros((num_tokens * num_expert,))
+    _tmp_tensor[: int(num_out_tokens)] = 1.0
+    _tmp_idx = torch.randperm(num_tokens * num_expert)
+    routing_map = torch.reshape(_tmp_tensor[_tmp_idx], (num_tokens, num_expert)).bool().cuda()
+
+    probs = None
+    if with_probs:
+        probs = torch.rand(num_tokens, num_expert).cuda() * routing_map
+        row_sums = probs.sum(dim=1, keepdim=True)
+        probs = probs / row_sums
+        probs = probs.to(dtype)
+        probs.requires_grad_(True)
+
+    ###################################################################################################################################
+    #
+    # PyTorch Permutation
+    #
+    ###################################################################################################################################
+    pytorch_permute_output, sorted_indices = pytorch_permute_mask_map(pytorch_permute_fwd_input, routing_map)
+    pytorch_permute_output.backward(pytorch_permute_bwd_input, retain_graph=True)
+
+    pytorch_unpermute_fwd_input = pytorch_permute_output.detach()
+    pytorch_unpermute_fwd_input.requires_grad_(True)
+
+    pytorch_unpermute_output = pytorch_unpermute_mask_map(
+        pytorch_unpermute_fwd_input, sorted_indices, restore_shape, probs, routing_map
+    )
+    pytorch_unpermute_output.backward(pytorch_unpermute_bwd_input, retain_graph=True)
+
+    ###################################################################################################################################
+    #
+    # Turbo Permutation
+    #
+    ###################################################################################################################################
+    turbo_permute_fwd_input = pytorch_permute_fwd_input.detach()
+    turbo_permute_fwd_input.requires_grad_(True)
+    turbo_permute_bwd_input = pytorch_permute_bwd_input.detach()
+
+    turbo_permute_output, _, row_id_map = turbo.ops.token_permute(
+        turbo_permute_fwd_input, routing_map=routing_map, num_out_tokens=num_out_tokens
+    )
+    turbo_permute_output.backward(turbo_permute_bwd_input, retain_graph=True)
+
+    turbo_probs = None
+    if with_probs:
+        turbo_probs = probs.detach()
+        turbo_probs.requires_grad_(True)
+    turbo_unpermute_fwd_input = turbo_permute_output.detach()
+    turbo_unpermute_fwd_input.requires_grad_(True)
+    turbo_unpermute_bwd_input = pytorch_unpermute_bwd_input.detach()
+
+    turbo_unpermute_output = turbo.ops.token_unpermute(
+        turbo_unpermute_fwd_input, row_id_map, turbo_probs, restore_shape, map_type="mask"
+    )
+    turbo_unpermute_output.backward(turbo_unpermute_bwd_input, retain_graph=True)
+
+    ###################################################################################################################################
+    #
+    # Results Check
+    #
+    ###################################################################################################################################
+
+    # turbo_permute_output_float = turbo_permute_output.float()
+    # turbo_permute_fwd_input_grad = turbo_permute_fwd_input.grad.float()
+    # turbo_unpermute_output_float = turbo_unpermute_output.float()
+    # turbo_unpermute_fwd_input_grad = turbo_unpermute_fwd_input.grad.float()
+
+    # TODO: can't pass turbo tolerances
+    tol = get_tolerances(dtype)
+    torch.testing.assert_close(
+        pytorch_permute_output,
+        turbo_permute_output,
+        msg=f"Mismatch in turbo_permute fwd",
+        **tol,
+    )
+    torch.testing.assert_close(
+        pytorch_permute_fwd_input.grad,
+        turbo_permute_fwd_input.grad,
+        **tol,
+    )
+    torch.testing.assert_close(
+        pytorch_unpermute_output,
+        turbo_unpermute_output,
+        msg=f"Mismatch in turbo_unpermute fwd",
+        **tol,
+    )
+    torch.testing.assert_close(
+        pytorch_unpermute_fwd_input.grad,
+        turbo_unpermute_fwd_input.grad,
+        msg=f"Mismatch in turbo_unpermute bwd",
+        **tol,
+    )
+    if with_probs:
+        torch.testing.assert_close(
+            probs.grad,
+            turbo_probs.grad,
+            msg=f"Mismatch in turbo_unpermute bwd",
+            **tol,
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("num_tokens", [4096])
+@pytest.mark.parametrize("num_expert", [7, 16])
+@pytest.mark.parametrize("hidden_size", [4096])
+@pytest.mark.parametrize("topK", [1, 2, 5])
+@pytest.mark.parametrize("num_out_tokens", [None, 2039])
+def test_permutation_mask_map(
+    dtype,
+    num_tokens,
+    num_expert,
+    hidden_size,
+    topK,
+    num_out_tokens,
+):
+    with_probs = True
+
+    _test_permutation_mask_map(
+        dtype=dtype,
+        num_tokens=num_tokens,
+        num_expert=num_expert,
+        hidden_size=hidden_size,
+        topK=topK,
+        num_out_tokens=num_out_tokens,
+        with_probs=with_probs,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_permutation_mask_map_empty_input(dtype):
+    with_probs = True
+    _test_permutation_mask_map(
+        dtype=dtype,
+        num_tokens=0,
+        num_expert=8,
+        hidden_size=4096,
+        topK=2,
+        num_out_tokens=0,
+        with_probs=with_probs,
+    )

--- a/tests/pytorch/ref/permuatation_ref.py
+++ b/tests/pytorch/ref/permuatation_ref.py
@@ -1,0 +1,69 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+import torch
+
+
+def pytorch_permute_mask_map(tokens, routing_map):
+    """Permute the tokens and probs based on the mask.
+    Tokens with the same designated expert will be grouped together.
+    The shape of mask is [tokens, num_experts], it indicates which experts were selected
+    by each token.
+
+    Args:
+        tokens (torch.Tensor): The input token tensor, [num_tokens, hidden].
+        routing_map (torch.Tensor): The sparse token to expert mapping, [num_tokens, num_experts].
+    """
+    num_tokens, _ = tokens.shape
+    num_experts = routing_map.shape[1]
+
+    # mask [num_tokens, num_experts] -> [num_experts, num_tokens]
+    routing_map = routing_map.bool().T.contiguous()
+
+    # Create a dense expert-to-token mapping from the sparse token-to-expert mapping
+    token_indices = torch.arange(num_tokens, device=routing_map.device).unsqueeze(0).expand(num_experts, -1)
+    sorted_indices = token_indices.masked_select(routing_map)
+
+    # use the mapping to permute the tokens
+    permuted_input = tokens.index_select(0, sorted_indices)
+
+    return permuted_input, sorted_indices
+
+
+def pytorch_unpermute_mask_map(
+    permuted_tokens: torch.Tensor,
+    sorted_indices: torch.Tensor,
+    restore_shape: torch.Size,
+    probs: torch.Tensor = None,
+    routing_map: torch.Tensor = None,
+):
+    """
+    Restore the original order of tokens after permutation. If probs are provided, it
+    will also apply them to the tokens before restoring the order.
+
+    Args:
+        permuted_tokens (torch.Tensor): The permuted token tensor.
+        sorted_indices (torch.Tensor): The indices used to sort the tokens.
+        restore_shape (torch.Size): The shape of the unpermuted tensor.
+        probs (torch.Tensor, optional): The unpermuted probs tensor,
+        routing_map (torch.Tensor, optional): Token to expert mapping, shape
+            [num_tokens, num_experts].
+
+    Returns:
+        torch.Tensor: The tokens restored to their original order.
+    """
+    _, hidden = restore_shape
+
+    if probs is not None:
+        assert routing_map is not None, "Mask must be provided to permute the probs."
+        permuted_probs = probs.T.contiguous().masked_select(routing_map.T.contiguous())
+        permuted_tokens = permuted_tokens * permuted_probs.unsqueeze(-1)
+
+    # Create an output tensor filled with zeros
+    output_tokens = torch.zeros(restore_shape, device=permuted_tokens.device, dtype=permuted_tokens.dtype)
+    # Scatter add the permuted_input back to the original positions
+    output_tokens.scatter_add_(0, sorted_indices.unsqueeze(1).expand(-1, hidden), permuted_tokens)
+    return output_tokens


### PR DESCRIPTION
## TurboDeepEPTokenDispatcher/Combiner

The `TurboDeepEPTokenDispatcher/Combiner` torch modules provide MoE dispatch/combine modules for user.  Megatron's `MoETokenDispatcher` has a nice API, but it's not a torch module. We can inherits MoETokenDispatcher and torch module, but it's weird when we use `MoETokenDispatcher` api instead of torch module's `forward`.

The capability of both dispatcher and combiner are similar to Megatron's `MoETokenDispatcher` . The dispatcher is equivalent to dispatch + permute, and the combiner is equivalent to unpermute + combine.

The main differences are:
- dispatcher/combiner are parameterless torch modules, making them simpler to use with other modules.
- support for Sync-Free MoE, allowing the dispatcher to avoid host sync via options.

If we want to implement shared experts overlap just like Megatron's `MoEAlltoAllTokenDispatcher`, we can add forward and backward hooks to dispatcher/combine and permuter/unpermute to achieve overlap, or just use turbo's ops.
