### PR TITLE
feat(mxfp4/mxfp8): optimize mxfp4 performance and add 2D block quantization for mxfp8

### DIFF
--- a/primus_turbo/pytorch/ops/gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/gemm_fp8.py
@@ -368,6 +368,7 @@ class FP8GemmMXFunction(torch.autograd.Function):
             block_size=config.block_size,
             axis=1,
             padding_align_size=__class__.HIPBLASLT_K_MULTIPLE,
+            scaling_recipe=config.scaling_recipe["a_fwd"],
         )
         b_fp8, b_scale_inv = quantize_fp8(
             b,
@@ -376,6 +377,7 @@ class FP8GemmMXFunction(torch.autograd.Function):
             block_size=config.block_size,
             axis=1,
             padding_align_size=__class__.HIPBLASLT_K_MULTIPLE,
+            scaling_recipe=config.scaling_recipe["b_fwd"],
         )
 
         # NT layout
@@ -417,6 +419,7 @@ class FP8GemmMXFunction(torch.autograd.Function):
             block_size=ctx.config.block_size,
             axis=1,
             padding_align_size=__class__.HIPBLASLT_K_MULTIPLE,
+            scaling_recipe=ctx.config.scaling_recipe["grad_bwd"],
         )
         grad_out_t_fp8, grad_out_t_scale_inv = quantize_fp8(
             grad_out,
@@ -425,6 +428,7 @@ class FP8GemmMXFunction(torch.autograd.Function):
             block_size=ctx.config.block_size,
             axis=0,
             padding_align_size=__class__.HIPBLASLT_K_MULTIPLE,
+            scaling_recipe=ctx.config.scaling_recipe["grad_bwd"],
         )
 
         # TODO(ruibin): cache a_t and b_t for backward pass
@@ -435,6 +439,7 @@ class FP8GemmMXFunction(torch.autograd.Function):
             block_size=ctx.config.block_size,
             axis=0,
             padding_align_size=__class__.HIPBLASLT_K_MULTIPLE,
+            scaling_recipe=ctx.config.scaling_recipe["a_bwd"],
         )
         b_t_fp8, b_t_scale_inv = quantize_fp8(
             b,
@@ -443,6 +448,7 @@ class FP8GemmMXFunction(torch.autograd.Function):
             block_size=ctx.config.block_size,
             axis=0,
             padding_align_size=__class__.HIPBLASLT_K_MULTIPLE,
+            scaling_recipe=ctx.config.scaling_recipe["b_bwd"],
         )
 
         # NOTE: convert NN layout to NT layout because MXFP8 only supports NT layout on hipblaslt.

--- a/primus_turbo/pytorch/ops/quantization.py
+++ b/primus_turbo/pytorch/ops/quantization.py
@@ -8,10 +8,7 @@ from typing import Optional, Tuple
 
 import torch
 
-from primus_turbo.pytorch.core.low_precision import (
-    Float4ScalingRecipe,
-    ScalingGranularity,
-)
+from primus_turbo.pytorch.core.low_precision import MXScalingRecipe, ScalingGranularity
 from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
     dequantize_fp8_rowwise_impl,
     dequantize_fp8_tensorwise_impl,
@@ -37,6 +34,7 @@ def quantize_fp8(
     axis: Optional[int] = None,
     scale: Optional[torch.Tensor] = None,
     padding_align_size: Optional[int] = None,
+    scaling_recipe: Optional[MXScalingRecipe] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     FP8 Quantize
@@ -61,7 +59,7 @@ def quantize_fp8(
         assert block_size == MX_BLOCK_SIZE, f"The block size must be {MX_BLOCK_SIZE} for MXFP8 quantization"
         assert scale is None, "The scale is not supported for MXFP8 quantization"
 
-        return quantize_mxfp8_impl(x, out_dtype, axis, block_size, padding_align_size)
+        return quantize_mxfp8_impl(x, out_dtype, axis, block_size, padding_align_size, scaling_recipe)
     else:
         raise NotImplementedError(f"Unknown granularity {granularity}")
 
@@ -74,6 +72,7 @@ def dequantize_fp8(
     block_size: Optional[int] = None,
     axis: Optional[int] = None,
     scale_inv: torch.Tensor,
+    scaling_recipe: Optional[MXScalingRecipe] = None,
 ):
     """
     FP8 DeQuantize
@@ -111,7 +110,7 @@ def quantize_fp4(
     axis: Optional[int] = None,
     scale: Optional[torch.Tensor] = None,
     padding_align_size: Optional[int] = None,
-    scaling_recipe: Optional[Float4ScalingRecipe] = None,
+    scaling_recipe: Optional[MXScalingRecipe] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     FP4 Quantize
@@ -141,7 +140,7 @@ def dequantize_fp4(
     block_size: Optional[int] = None,
     axis: Optional[int] = None,
     scale_inv: torch.Tensor,
-    scaling_recipe: Optional[Float4ScalingRecipe] = None,
+    scaling_recipe: Optional[MXScalingRecipe] = None,
 ) -> torch.Tensor:
     """
     FP4 DeQuantize
@@ -156,6 +155,6 @@ def dequantize_fp4(
     if granularity == ScalingGranularity.MX_BLOCKWISE:
         assert block_size == MX_BLOCK_SIZE, f"The block size must be {MX_BLOCK_SIZE} for MXFP8 quantization"
 
-        return dequantize_mxfp4_impl(x, out_dtype, axis, block_size, scale_inv, scaling_recipe)
+        return dequantize_mxfp4_impl(x, out_dtype, axis, block_size, scale_inv)
     else:
         raise NotImplementedError(f"Unknown granularity {granularity}")

--- a/tests/pytorch/ops/test_gemm_fp4.py
+++ b/tests/pytorch/ops/test_gemm_fp4.py
@@ -10,8 +10,8 @@ import torch
 from primus_turbo.pytorch.core.backend import BackendType, GlobalBackendManager
 from primus_turbo.pytorch.core.low_precision import (
     Float4QuantConfig,
-    Float4ScalingRecipe,
     Format,
+    MXScalingRecipe,
     ScaleDtype,
     ScalingGranularity,
 )
@@ -41,7 +41,7 @@ torch.manual_seed(42)
 @pytest.mark.parametrize("granularity", [ScalingGranularity.MX_BLOCKWISE])
 @pytest.mark.parametrize("backend", [None, BackendType.HIPBLASLT])
 @pytest.mark.parametrize("auto_tune", [False, True])
-def test_gemm_mxfp4(m, n, k, layout, format, dtype, granularity, backend, auto_tune):
+def test_gemm_fp4_mx_blockwise(m, n, k, layout, format, dtype, granularity, backend, auto_tune):
     # Skip redundant test: auto_tune is ignored when backend is explicitly specified
     if backend is not None and auto_tune:
         pytest.skip("auto_tune is ignored when backend is explicitly specified")
@@ -92,11 +92,11 @@ def test_gemm_mxfp4(m, n, k, layout, format, dtype, granularity, backend, auto_t
     config = Float4QuantConfig(
         granularity=granularity, format=format, block_size=32, scale_dtype=ScaleDtype.E8M0
     )
-    config.scaling_recipe["a_fwd"] = Float4ScalingRecipe(use_2d_block=False, use_sr=False)
-    config.scaling_recipe["b_fwd"] = Float4ScalingRecipe(use_2d_block=True, use_sr=False)
-    config.scaling_recipe["grad_bwd"] = Float4ScalingRecipe(use_2d_block=False, use_sr=True)
-    config.scaling_recipe["a_bwd"] = Float4ScalingRecipe(use_2d_block=False, use_sr=False)
-    config.scaling_recipe["b_bwd"] = Float4ScalingRecipe(use_2d_block=True, use_sr=True)
+    config.scaling_recipe["a_fwd"] = MXScalingRecipe(use_2d_block=False, use_sr=False)
+    config.scaling_recipe["b_fwd"] = MXScalingRecipe(use_2d_block=True, use_sr=False)
+    config.scaling_recipe["grad_bwd"] = MXScalingRecipe(use_2d_block=False, use_sr=True)
+    config.scaling_recipe["a_bwd"] = MXScalingRecipe(use_2d_block=False, use_sr=False)
+    config.scaling_recipe["b_bwd"] = MXScalingRecipe(use_2d_block=True, use_sr=True)
     print(config)
     c = gemm_fp4(a, b, trans_a, trans_b, dtype, config)
     c.backward(torch.ones_like(c))


### PR DESCRIPTION
* Remove `replicate_scale_inv` aten ops call to optimize perf.
* MXFP8 support 2D block quantization.
* Rename `Float4ScalingRecipe` to `MXScalingRecipe` to support mxfp4 and mxfp8.