### PR TITLE
fix: force to use fgpu-rdc to compile

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,12 +196,15 @@ def get_common_flags():
     extra_link_args = [
         "-Wl,-rpath,/opt/rocm/lib",
         f"-L/usr/lib/{arch}-linux-gnu",
+        "-fgpu-rdc",
+        "--hip-link",
     ]
 
     cxx_flags = [
         "-O3",
         "-fvisibility=hidden",
         "-std=c++20",
+        "-fgpu-rdc",
     ]
 
     nvcc_flags = [
@@ -220,9 +223,10 @@ def get_common_flags():
         "-enable-post-misched=0",
         "-mllvm",
         "-amdgpu-early-inline-all=true",
-        "-mllvm",
-        "-amdgpu-function-calls=false",
+        # "-mllvm",
+        # "-amdgpu-function-calls=false",
         "-std=c++20",
+        "-fgpu-rdc",
     ]
 
     # Check and add optional compiler flags (for ROCm version compatibility)


### PR DESCRIPTION
From JIRA [AIMA-212](https://amd.atlassian.net/browse/AIMA-212), it shows that DeepEP intranode-combine timeout on rocm7.2 docker image, but works well on rocm7.1.

I found a workaround to solve the timeout which forcely add `-fgpu-rdc` to compile and disable `-amdgpu-function-calls=false`