### PR TITLE
update csrc/pytorch/deep_ep/event.hpp for hipify v2

### DIFF
--- a/csrc/pytorch/deep_ep/event.hpp
+++ b/csrc/pytorch/deep_ep/event.hpp
@@ -10,6 +10,18 @@
 
 #include "primus_turbo/macros.h"
 #include <ATen/hip/HIPContext.h>
+#include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
+
+// NOTE: pytorch hipify v2 support
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// We needed to create overloads of the inline functions here for CUDAStream.
+//
+// HIPStreamMasqueradingAsCUDA is no longer needed but exists for backward
+// compatibility. In hipify v1 behavior, it used to be necessary to use
+// HIPStreamMasqueradingAsCUDA instead of HIPStream for proper functioning of
+// ROCm builds. When pytorch switched to v2 of the hipify strategy, HIPStream
+// no longer exists and HIPStreamMasqueradingAsCUDA inherits from CUDAStream.
+// Functions like getCurrentHIPStreamMasqueradingAsCUDA now return CUDAStream.
 
 namespace primus_turbo::pytorch::deep_ep {
 
@@ -39,13 +51,29 @@ inline torch::Event create_event(const at::hip::HIPStreamMasqueradingAsCUDA &s) 
     return event;
 }
 
+inline torch::Event create_event(const c10::cuda::CUDAStream &s) {
+    auto event = torch::Event(torch::kCUDA);
+    event.record(s);
+    return event;
+}
+
 inline void stream_wait(const at::hip::HIPStreamMasqueradingAsCUDA &s_0,
                         const at::hip::HIPStreamMasqueradingAsCUDA &s_1) {
     PRIMUS_TURBO_CHECK(s_0.id() != s_1.id());
     s_0.unwrap().wait(create_event(s_1));
 }
 
+inline void stream_wait(const c10::cuda::CUDAStream &s_0,
+                        const c10::cuda::CUDAStream &s_1) {
+    PRIMUS_TURBO_CHECK(s_0.id() != s_1.id());
+    s_0.unwrap().wait(create_event(s_1));
+}
+
 inline void stream_wait(const at::hip::HIPStreamMasqueradingAsCUDA &s, const EventHandle &event) {
+    s.unwrap().wait(*event.event);
+}
+
+inline void stream_wait(const c10::cuda::CUDAStream &s, const EventHandle &event) {
     s.unwrap().wait(*event.event);
 }
 

--- a/csrc/pytorch/deep_ep/event.hpp
+++ b/csrc/pytorch/deep_ep/event.hpp
@@ -11,6 +11,7 @@
 #include "primus_turbo/macros.h"
 #include <ATen/hip/HIPContext.h>
 #include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
+#include <c10/cuda/CUDAStream.h>
 
 // NOTE: pytorch hipify v2 support
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/csrc/pytorch/deep_ep/event.hpp
+++ b/csrc/pytorch/deep_ep/event.hpp
@@ -11,7 +11,6 @@
 #include "primus_turbo/macros.h"
 #include <ATen/hip/HIPContext.h>
 #include <ATen/hip/impl/HIPStreamMasqueradingAsCUDA.h>
-#include <c10/cuda/CUDAStream.h>
 
 // NOTE: pytorch hipify v2 support
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We needed to create overloads of the inline functions here for CUDAStream.

HIPStreamMasqueradingAsCUDA is no longer needed but exists for backward compatibility. In hipify v1 behavior, it used to be necessary to use HIPStreamMasqueradingAsCUDA instead of HIPStream for proper functioning of ROCm builds. When pytorch switched to v2 of the hipify strategy, HIPStream no longer exists and HIPStreamMasqueradingAsCUDA inherits from CUDAStream. Functions like getCurrentHIPStreamMasqueradingAsCUDA now return CUDAStream.