### PR TITLE
feat: Make DeepEP CPU timeout configurable and increase default timeout

### DIFF
--- a/csrc/include/primus_turbo/deep_ep/configs.h
+++ b/csrc/include/primus_turbo/deep_ep/configs.h
@@ -23,7 +23,7 @@
 #define FINISHED_SUM_TAG 1024
 
 #define NUM_CPU_TIMEOUT_SECS 300
-#define NUM_TIMEOUT_CYCLES 300000000000ll // 300G cycles ~= 150s
+#define NUM_TIMEOUT_CYCLES 600000000000ll // 600G cycles ~= 300s
 
 #define NUM_WAIT_NANOSECONDS 500
 
@@ -68,9 +68,16 @@ static constexpr uint64_t kSecondHalfMask   = 0xffffffff00000000;
 #endif
 
 static inline auto get_num_cpu_timeout_secs() {
-    const char *env = getenv("PRIMUS_TURBO_DEEPEP_TIMEOUT");
+    const char *env = getenv("PRIMUS_TURBO_DEEPEP_CPU_TIMEOUT");
     if (!env || env[0] == '\0')
         return NUM_CPU_TIMEOUT_SECS;
 
     return std::stoi(env);
+}
+
+inline static bool is_enable_cheap_fence() {
+    char const *v = std::getenv("PRIMUS_TURBO_DEEPEP_DISABLE_CHEAP_FENCE");
+    if (!v || v[0] == '\0')
+        return true;
+    return std::stoi(v) == 0;
 }

--- a/csrc/include/primus_turbo/deep_ep/configs.h
+++ b/csrc/include/primus_turbo/deep_ep/configs.h
@@ -22,8 +22,8 @@
 
 #define FINISHED_SUM_TAG 1024
 
-#define NUM_CPU_TIMEOUT_SECS 100
-#define NUM_TIMEOUT_CYCLES 200000000000ll // 200G cycles ~= 100s
+#define NUM_CPU_TIMEOUT_SECS 300
+#define NUM_TIMEOUT_CYCLES 300000000000ll // 300G cycles ~= 150s
 
 #define NUM_WAIT_NANOSECONDS 500
 
@@ -66,3 +66,11 @@ static constexpr uint64_t kSecondHalfMask   = 0xffffffff00000000;
 #ifdef __HIP_NO_HALF_OPERATORS__
 #undef __HIP_NO_HALF_OPERATORS__
 #endif
+
+static inline auto get_num_cpu_timeout_secs() {
+    const char *env = getenv("PRIMUS_TURBO_DEEPEP_TIMEOUT");
+    if (!env || env[0] == '\0')
+        return NUM_CPU_TIMEOUT_SECS;
+
+    return std::stoi(env);
+}

--- a/csrc/include/primus_turbo/deep_ep/configs.h
+++ b/csrc/include/primus_turbo/deep_ep/configs.h
@@ -67,12 +67,19 @@ static constexpr uint64_t kSecondHalfMask   = 0xffffffff00000000;
 #undef __HIP_NO_HALF_OPERATORS__
 #endif
 
-static inline auto get_num_cpu_timeout_secs() {
-    const char *env = getenv("PRIMUS_TURBO_DEEPEP_CPU_TIMEOUT");
-    if (!env || env[0] == '\0')
-        return NUM_CPU_TIMEOUT_SECS;
-
-    return std::stoi(env);
+static inline int get_num_cpu_timeout_secs() {
+    static int timeout = []() {
+        const char *env = std::getenv("PRIMUS_TURBO_DEEPEP_CPU_TIMEOUT");
+        if (!env || env[0] == '\0') {
+            return NUM_CPU_TIMEOUT_SECS;
+        }
+        try {
+            return std::stoi(env);
+        } catch (...) {
+            return NUM_CPU_TIMEOUT_SECS;
+        }
+    }();
+    return timeout;
 }
 
 inline static bool is_enable_cheap_fence() {

--- a/csrc/jax/deep_ep/deep_ep.cpp
+++ b/csrc/jax/deep_ep/deep_ep.cpp
@@ -341,7 +341,7 @@ void Buffer::IntranodeDispatch(
                 // Timeout check
                 if (std::chrono::duration_cast<std::chrono::seconds>(
                         std::chrono::high_resolution_clock::now() - start_time)
-                        .count() > NUM_CPU_TIMEOUT_SECS)
+                        .count() > get_num_cpu_timeout_secs())
                     throw std::runtime_error("DeepEP error: CPU recv timeout");
             }
         }

--- a/csrc/kernels/deep_ep/utils.cuh
+++ b/csrc/kernels/deep_ep/utils.cuh
@@ -377,11 +377,4 @@ __device__ __forceinline__ dtype_t ld_acquire_sys_global(const dtype_t *ptr) {
     }
     return ret;
 }
-
-inline static bool is_enable_cheap_fence() {
-    char const *v = std::getenv("PRIMUS_TURBO_DEEPEP_DISABLE_CHEAP_FENCE");
-    if (!v || v[0] == '\0')
-        return true;
-    return std::stoi(v) == 0;
-}
 } // namespace primus_turbo::deep_ep

--- a/csrc/pytorch/deep_ep/deep_ep.cpp
+++ b/csrc/pytorch/deep_ep/deep_ep.cpp
@@ -543,7 +543,7 @@ Buffer::intranode_dispatch(
                 // Timeout check
                 if (std::chrono::duration_cast<std::chrono::seconds>(
                         std::chrono::high_resolution_clock::now() - start_time)
-                        .count() > NUM_CPU_TIMEOUT_SECS)
+                        .count() > get_num_cpu_timeout_secs())
                     throw std::runtime_error("DeepEP error: CPU recv timeout");
             }
             num_recv_tokens_per_expert_list = std::vector<int>(
@@ -1004,7 +1004,7 @@ Buffer::internode_dispatch(const torch::Tensor &x, const std::optional<torch::Te
                 // Timeout check
                 if (std::chrono::duration_cast<std::chrono::seconds>(
                         std::chrono::high_resolution_clock::now() - start_time)
-                        .count() > NUM_CPU_TIMEOUT_SECS) {
+                        .count() > get_num_cpu_timeout_secs()) {
                     printf("Global rank: %d, num_recv_tokens: %d, num_rdma_recv_tokens: %d\n", rank,
                            num_recv_tokens, num_rdma_recv_tokens);
                     for (int i = 0; i < num_local_experts; ++i)


### PR DESCRIPTION
This PR makes the DeepEP CPU timeout configurable via an environment variable and increases the default timeout values to improve stability in large-scale deployments.

## Motivation

The previous 100s default CPU timeout was too aggressive for certain large-scale or high-contention scenarios, causing spurious timeout errors. Increasing the default to 300s and making it configurable allows users to tune the timeout for their specific workloads without code changes.

## Usage

To override the default CPU timeout (in seconds):
export PRIMUS_TURBO_DEEPEP_CPU_TIMEOUT=600  # Set to 600 seconds
