### PR TITLE
Improve MI355 tensorwise FP8 quant path for DeepSeek V2/V3 grouped GEMM

### DIFF
--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -17,18 +17,15 @@ from primus_turbo.triton.quantization.quant_blockwise import (
     quant_fp8_blockwise_segment_m_kernel,
 )
 from primus_turbo.triton.quantization.quant_fp8_tensorwise import (
-    _should_use_triton_fp8_tensorwise,
-    quantize_fp8_tensorwise as _triton_quantize_fp8_tensorwise,
+    should_use_triton_fp8_tensorwise,
+    triton_quantize_fp8_tensorwise_impl,
 )
-from primus_turbo.triton.quantization.quantization_mxfp4 import (
-    dequantize_mxfp4_kernel,
-    quantize_mxfp4_kernel,
-)
+from primus_turbo.triton.quantization.quantization_mxfp4 import dequantize_mxfp4_kernel
 from primus_turbo.triton.quantization.quantization_mxfp8 import (
     dequantize_mxfp8_kernel,
     quantize_mxfp8_kernel,
 )
-from primus_turbo.triton.utils.hardware_helper import _is_mi355_quant_device
+from primus_turbo.triton.utils.hardware_helper import is_mi355_quant_device
 
 
 def ceil_div(a, b):
@@ -45,8 +42,8 @@ def quantize_fp8_tensorwise_impl(
     tuned from the MI355X sweep data. Other targets keep the original C++
     implementation.
     """
-    if _should_use_triton_fp8_tensorwise(x) and _is_mi355_quant_device(x.device):
-        return _triton_quantize_fp8_tensorwise(x, out_dtype, scale)
+    if should_use_triton_fp8_tensorwise(x) and is_mi355_quant_device(x.device):
+        return triton_quantize_fp8_tensorwise_impl(x, out_dtype, scale)
 
     return quantize_fp8_tensorwise_cpp_impl(x, out_dtype, scale)
 

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -17,6 +17,7 @@ from primus_turbo.triton.quantization.quant_blockwise import (
     quant_fp8_blockwise_segment_m_kernel,
 )
 from primus_turbo.triton.quantization.quant_fp8_tensorwise import (
+    _should_use_triton_fp8_tensorwise,
     quantize_fp8_tensorwise as _triton_quantize_fp8_tensorwise,
 )
 from primus_turbo.triton.quantization.quantization_mxfp4 import (
@@ -44,9 +45,16 @@ def quantize_fp8_tensorwise_impl(
     tuned from the MI355X sweep data. Other targets keep the original C++
     implementation.
     """
-    if _is_mi355_quant_device(x.device):
+    if _should_use_triton_fp8_tensorwise(x) and _is_mi355_quant_device(x.device):
         return _triton_quantize_fp8_tensorwise(x, out_dtype, scale)
 
+    return quantize_fp8_tensorwise_cpp_impl(x, out_dtype, scale)
+
+
+def quantize_fp8_tensorwise_cpp_impl(
+    x: torch.Tensor, out_dtype: torch.dtype, scale: Optional[torch.Tensor] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Force the original C++ tensorwise FP8 quantization path."""
     x_fp8, scale_inv = torch.ops.primus_turbo_cpp_extension.quantize_fp8_tensorwise(x, out_dtype, scale)
     return x_fp8, scale_inv
 

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -16,11 +16,18 @@ from primus_turbo.triton.quantization.quant_blockwise import (
     quant_fp8_blockwise_kernel,
     quant_fp8_blockwise_segment_m_kernel,
 )
-from primus_turbo.triton.quantization.quantization_mxfp4 import dequantize_mxfp4_kernel
+from primus_turbo.triton.quantization.quant_fp8_tensorwise import (
+    quantize_fp8_tensorwise as _triton_quantize_fp8_tensorwise,
+)
+from primus_turbo.triton.quantization.quantization_mxfp4 import (
+    dequantize_mxfp4_kernel,
+    quantize_mxfp4_kernel,
+)
 from primus_turbo.triton.quantization.quantization_mxfp8 import (
     dequantize_mxfp8_kernel,
     quantize_mxfp8_kernel,
 )
+from primus_turbo.triton.utils.hardware_helper import _is_mi355_quant_device
 
 
 def ceil_div(a, b):
@@ -31,8 +38,15 @@ def quantize_fp8_tensorwise_impl(
     x: torch.Tensor, out_dtype: torch.dtype, scale: Optional[torch.Tensor] = None
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
-    Quantize FP8 Tensor-Wise
+    Quantize FP8 Tensor-Wise.
+
+    On MI355X we route tensorwise quant through the Triton implementation
+    tuned from the MI355X sweep data. Other targets keep the original C++
+    implementation.
     """
+    if _is_mi355_quant_device(x.device):
+        return _triton_quantize_fp8_tensorwise(x, out_dtype, scale)
+
     x_fp8, scale_inv = torch.ops.primus_turbo_cpp_extension.quantize_fp8_tensorwise(x, out_dtype, scale)
     return x_fp8, scale_inv
 

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -24,25 +24,12 @@ from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
     quant_fp8_blockwise_for_weight_impl,
     quant_fp8_blockwise_impl,
     quant_fp8_blockwise_segment_m_impl,
-    quantize_fp8_tensorwise_cpp_impl,
 )
 from primus_turbo.pytorch.ops.quantization import quantize_fp8
-from primus_turbo.triton.quantization.quant_fp8_tensorwise import _BufferCache
-from primus_turbo.triton.quantization.quant_fp8_tensorwise import (
-    quantize_fp8_tensorwise as triton_quantize_fp8_tensorwise,
-)
-from primus_turbo.triton.quantization.quant_fp8_tensorwise import (
-    should_use_triton_fp8_tensorwise,
-)
-from primus_turbo.triton.utils.hardware_helper import is_mi355_quant_device
 
 __all__ = [
     "grouped_gemm_fp8",
 ]
-
-_tw_cache_a = _BufferCache()
-_tw_cache_b = _BufferCache()
-_tw_cache_grad = _BufferCache()
 
 
 def _ensure_contiguous_grad_out(grad_out: torch.Tensor) -> torch.Tensor:
@@ -332,18 +319,8 @@ class GroupedGemmFP8TensorFunc(torch.autograd.Function):
         assert b.ndim == 3, "Weight tensor must be 3-dimensional."
         a_dtype = GroupedGemmFP8TensorFunc.get_fp8_dtype(config.format, True)
         b_dtype = GroupedGemmFP8TensorFunc.get_fp8_dtype(config.format, True)
-        use_triton_shape_gate = should_use_triton_fp8_tensorwise(a) and should_use_triton_fp8_tensorwise(b)
-        use_mi355_quant = use_triton_shape_gate and is_mi355_quant_device(a.device)
-        if use_mi355_quant:
-            (a_fp8, a_scale_inv), (b_fp8, b_scale_inv) = (
-                triton_quantize_fp8_tensorwise(a, a_dtype, buf_cache=_tw_cache_a),
-                triton_quantize_fp8_tensorwise(b, b_dtype, buf_cache=_tw_cache_b),
-            )
-        else:
-            (a_fp8, a_scale_inv), (b_fp8, b_scale_inv) = (
-                quantize_fp8_tensorwise_cpp_impl(a, a_dtype),
-                quantize_fp8_tensorwise_cpp_impl(b, b_dtype),
-            )
+        a_fp8, a_scale_inv = quantize_fp8(a, a_dtype, config.granularity)
+        b_fp8, b_scale_inv = quantize_fp8(b, b_dtype, config.granularity)
 
         out = grouped_gemm_fp8_impl(
             a_fp8,
@@ -358,7 +335,7 @@ class GroupedGemmFP8TensorFunc(torch.autograd.Function):
             granularity=config.granularity.value,
             num_cu=num_cu,
             default_backend=BackendType.CK.value,
-            maybe_pre_sync=not use_mi355_quant,
+            maybe_pre_sync=True,
         )
 
         ctx.save_for_backward(a_fp8, b_fp8, a_scale_inv, b_scale_inv, group_lens, group_offs)
@@ -367,7 +344,6 @@ class GroupedGemmFP8TensorFunc(torch.autograd.Function):
         ctx.config = config
         ctx.out_dtype = a.dtype
         ctx.num_cu = num_cu
-        ctx.use_mi355_quant = use_mi355_quant
         return out
 
     @staticmethod
@@ -377,13 +353,7 @@ class GroupedGemmFP8TensorFunc(torch.autograd.Function):
 
         # For grad_a
         grad_out_dtype = GroupedGemmFP8TensorFunc.get_fp8_dtype(ctx.config.format, False)
-        use_triton_quant_grad = ctx.use_mi355_quant and should_use_triton_fp8_tensorwise(grad_out)
-        if use_triton_quant_grad:
-            grad_out_fp8, grad_out_scale_inv = triton_quantize_fp8_tensorwise(
-                grad_out, grad_out_dtype, buf_cache=_tw_cache_grad
-            )
-        else:
-            grad_out_fp8, grad_out_scale_inv = quantize_fp8_tensorwise_cpp_impl(grad_out, grad_out_dtype)
+        grad_out_fp8, grad_out_scale_inv = quantize_fp8(grad_out, grad_out_dtype, ctx.config.granularity)
         grad_a = grouped_gemm_fp8_impl(
             grad_out_fp8,
             b_fp8,

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -27,12 +27,14 @@ from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
     quantize_fp8_tensorwise_cpp_impl,
 )
 from primus_turbo.pytorch.ops.quantization import quantize_fp8
+from primus_turbo.triton.quantization.quant_fp8_tensorwise import _BufferCache
 from primus_turbo.triton.quantization.quant_fp8_tensorwise import (
-    _BufferCache,
-    _should_use_triton_fp8_tensorwise,
-    quantize_fp8_tensorwise as _quant_fp8_tw,
+    quantize_fp8_tensorwise as triton_quantize_fp8_tensorwise,
 )
-from primus_turbo.triton.utils.hardware_helper import _is_mi355_quant_device
+from primus_turbo.triton.quantization.quant_fp8_tensorwise import (
+    should_use_triton_fp8_tensorwise,
+)
+from primus_turbo.triton.utils.hardware_helper import is_mi355_quant_device
 
 __all__ = [
     "grouped_gemm_fp8",
@@ -330,12 +332,12 @@ class GroupedGemmFP8TensorFunc(torch.autograd.Function):
         assert b.ndim == 3, "Weight tensor must be 3-dimensional."
         a_dtype = GroupedGemmFP8TensorFunc.get_fp8_dtype(config.format, True)
         b_dtype = GroupedGemmFP8TensorFunc.get_fp8_dtype(config.format, True)
-        use_triton_shape_gate = _should_use_triton_fp8_tensorwise(a) and _should_use_triton_fp8_tensorwise(b)
-        use_mi355_quant = use_triton_shape_gate and _is_mi355_quant_device(a.device)
+        use_triton_shape_gate = should_use_triton_fp8_tensorwise(a) and should_use_triton_fp8_tensorwise(b)
+        use_mi355_quant = use_triton_shape_gate and is_mi355_quant_device(a.device)
         if use_mi355_quant:
             (a_fp8, a_scale_inv), (b_fp8, b_scale_inv) = (
-                _quant_fp8_tw(a, a_dtype, buf_cache=_tw_cache_a),
-                _quant_fp8_tw(b, b_dtype, buf_cache=_tw_cache_b),
+                triton_quantize_fp8_tensorwise(a, a_dtype, buf_cache=_tw_cache_a),
+                triton_quantize_fp8_tensorwise(b, b_dtype, buf_cache=_tw_cache_b),
             )
         else:
             (a_fp8, a_scale_inv), (b_fp8, b_scale_inv) = (
@@ -375,9 +377,9 @@ class GroupedGemmFP8TensorFunc(torch.autograd.Function):
 
         # For grad_a
         grad_out_dtype = GroupedGemmFP8TensorFunc.get_fp8_dtype(ctx.config.format, False)
-        use_triton_quant_grad = ctx.use_mi355_quant and _should_use_triton_fp8_tensorwise(grad_out)
+        use_triton_quant_grad = ctx.use_mi355_quant and should_use_triton_fp8_tensorwise(grad_out)
         if use_triton_quant_grad:
-            grad_out_fp8, grad_out_scale_inv = _quant_fp8_tw(
+            grad_out_fp8, grad_out_scale_inv = triton_quantize_fp8_tensorwise(
                 grad_out, grad_out_dtype, buf_cache=_tw_cache_grad
             )
         else:

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -24,10 +24,12 @@ from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
     quant_fp8_blockwise_for_weight_impl,
     quant_fp8_blockwise_impl,
     quant_fp8_blockwise_segment_m_impl,
+    quantize_fp8_tensorwise_cpp_impl,
 )
 from primus_turbo.pytorch.ops.quantization import quantize_fp8
 from primus_turbo.triton.quantization.quant_fp8_tensorwise import (
     _BufferCache,
+    _should_use_triton_fp8_tensorwise,
     quantize_fp8_tensorwise as _quant_fp8_tw,
 )
 from primus_turbo.triton.utils.hardware_helper import _is_mi355_quant_device
@@ -328,13 +330,18 @@ class GroupedGemmFP8TensorFunc(torch.autograd.Function):
         assert b.ndim == 3, "Weight tensor must be 3-dimensional."
         a_dtype = GroupedGemmFP8TensorFunc.get_fp8_dtype(config.format, True)
         b_dtype = GroupedGemmFP8TensorFunc.get_fp8_dtype(config.format, True)
-        use_mi355_quant = _is_mi355_quant_device(a.device)
+        use_triton_shape_gate = _should_use_triton_fp8_tensorwise(a) and _should_use_triton_fp8_tensorwise(b)
+        use_mi355_quant = use_triton_shape_gate and _is_mi355_quant_device(a.device)
         if use_mi355_quant:
-            a_fp8, a_scale_inv = _quant_fp8_tw(a, a_dtype, buf_cache=_tw_cache_a)
-            b_fp8, b_scale_inv = _quant_fp8_tw(b, b_dtype, buf_cache=_tw_cache_b)
+            (a_fp8, a_scale_inv), (b_fp8, b_scale_inv) = (
+                _quant_fp8_tw(a, a_dtype, buf_cache=_tw_cache_a),
+                _quant_fp8_tw(b, b_dtype, buf_cache=_tw_cache_b),
+            )
         else:
-            a_fp8, a_scale_inv = quantize_fp8(a, a_dtype, config.granularity)
-            b_fp8, b_scale_inv = quantize_fp8(b, b_dtype, config.granularity)
+            (a_fp8, a_scale_inv), (b_fp8, b_scale_inv) = (
+                quantize_fp8_tensorwise_cpp_impl(a, a_dtype),
+                quantize_fp8_tensorwise_cpp_impl(b, b_dtype),
+            )
 
         out = grouped_gemm_fp8_impl(
             a_fp8,
@@ -368,14 +375,13 @@ class GroupedGemmFP8TensorFunc(torch.autograd.Function):
 
         # For grad_a
         grad_out_dtype = GroupedGemmFP8TensorFunc.get_fp8_dtype(ctx.config.format, False)
-        if ctx.use_mi355_quant:
+        use_triton_quant_grad = ctx.use_mi355_quant and _should_use_triton_fp8_tensorwise(grad_out)
+        if use_triton_quant_grad:
             grad_out_fp8, grad_out_scale_inv = _quant_fp8_tw(
                 grad_out, grad_out_dtype, buf_cache=_tw_cache_grad
             )
         else:
-            grad_out_fp8, grad_out_scale_inv = quantize_fp8(
-                grad_out, grad_out_dtype, ctx.config.granularity
-            )
+            grad_out_fp8, grad_out_scale_inv = quantize_fp8_tensorwise_cpp_impl(grad_out, grad_out_dtype)
         grad_a = grouped_gemm_fp8_impl(
             grad_out_fp8,
             b_fp8,

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -26,10 +26,19 @@ from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
     quant_fp8_blockwise_segment_m_impl,
 )
 from primus_turbo.pytorch.ops.quantization import quantize_fp8
+from primus_turbo.triton.quantization.quant_fp8_tensorwise import (
+    _BufferCache,
+    quantize_fp8_tensorwise as _quant_fp8_tw,
+)
+from primus_turbo.triton.utils.hardware_helper import _is_mi355_quant_device
 
 __all__ = [
     "grouped_gemm_fp8",
 ]
+
+_tw_cache_a = _BufferCache()
+_tw_cache_b = _BufferCache()
+_tw_cache_grad = _BufferCache()
 
 
 def _ensure_contiguous_grad_out(grad_out: torch.Tensor) -> torch.Tensor:
@@ -315,12 +324,17 @@ class GroupedGemmFP8TensorFunc(torch.autograd.Function):
     ):
 
         assert config.granularity == ScalingGranularity.TENSORWISE
-        assert a.ndim == 2, "Input tensor must be 3-dimensions."
+        assert a.ndim == 2, "Input tensor must be 2-dimensional."
         assert b.ndim == 3, "Weight tensor must be 3-dimensional."
         a_dtype = GroupedGemmFP8TensorFunc.get_fp8_dtype(config.format, True)
         b_dtype = GroupedGemmFP8TensorFunc.get_fp8_dtype(config.format, True)
-        a_fp8, a_scale_inv = quantize_fp8(a, a_dtype, config.granularity)
-        b_fp8, b_scale_inv = quantize_fp8(b, b_dtype, config.granularity)
+        use_mi355_quant = _is_mi355_quant_device(a.device)
+        if use_mi355_quant:
+            a_fp8, a_scale_inv = _quant_fp8_tw(a, a_dtype, buf_cache=_tw_cache_a)
+            b_fp8, b_scale_inv = _quant_fp8_tw(b, b_dtype, buf_cache=_tw_cache_b)
+        else:
+            a_fp8, a_scale_inv = quantize_fp8(a, a_dtype, config.granularity)
+            b_fp8, b_scale_inv = quantize_fp8(b, b_dtype, config.granularity)
 
         out = grouped_gemm_fp8_impl(
             a_fp8,
@@ -335,7 +349,7 @@ class GroupedGemmFP8TensorFunc(torch.autograd.Function):
             granularity=config.granularity.value,
             num_cu=num_cu,
             default_backend=BackendType.CK.value,
-            maybe_pre_sync=True,
+            maybe_pre_sync=not use_mi355_quant,
         )
 
         ctx.save_for_backward(a_fp8, b_fp8, a_scale_inv, b_scale_inv, group_lens, group_offs)
@@ -344,6 +358,7 @@ class GroupedGemmFP8TensorFunc(torch.autograd.Function):
         ctx.config = config
         ctx.out_dtype = a.dtype
         ctx.num_cu = num_cu
+        ctx.use_mi355_quant = use_mi355_quant
         return out
 
     @staticmethod
@@ -353,7 +368,14 @@ class GroupedGemmFP8TensorFunc(torch.autograd.Function):
 
         # For grad_a
         grad_out_dtype = GroupedGemmFP8TensorFunc.get_fp8_dtype(ctx.config.format, False)
-        grad_out_fp8, grad_out_scale_inv = quantize_fp8(grad_out, grad_out_dtype, ctx.config.granularity)
+        if ctx.use_mi355_quant:
+            grad_out_fp8, grad_out_scale_inv = _quant_fp8_tw(
+                grad_out, grad_out_dtype, buf_cache=_tw_cache_grad
+            )
+        else:
+            grad_out_fp8, grad_out_scale_inv = quantize_fp8(
+                grad_out, grad_out_dtype, ctx.config.granularity
+            )
         grad_a = grouped_gemm_fp8_impl(
             grad_out_fp8,
             b_fp8,

--- a/primus_turbo/triton/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_fp8_kernel.py
@@ -43,10 +43,7 @@ from primus_turbo.triton.gemm.gemm_kernel import (
     _get_hardware,
     _select_params_origami,
 )
-from primus_turbo.triton.utils.hardware_helper import (
-    _is_gfx950,
-    _set_knobs_gfx950,
-)
+from primus_turbo.triton.utils.hardware_helper import is_gfx950, set_knobs_gfx950
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # AMD knobs helper (blockwise-specific)
@@ -315,8 +312,8 @@ def gemm_fp8_tensorwise_triton_kernel(
     s_ak = A_view.stride(1)
     s_bk = B_view.stride(0)
 
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
 
         # gfx950 FP8: uniform 256×256×128 / stages=2 across all layouts (164-entry tuning).
         block_m, block_n, block_k = 256, 256, 128
@@ -621,8 +618,8 @@ def gemm_fp8_rowwise_triton_kernel(
     s_ak = A_view.stride(1)
     s_bk = B_view.stride(0)
 
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
 
         # gfx950 FP8: uniform 256×256×128 / stages=2 across all layouts.
         block_m, block_n, block_k = 256, 256, 128
@@ -962,8 +959,8 @@ def _blockwise_nt(
     trans_c: bool,
 ) -> torch.Tensor:
     """NT/RCR forward: C = A[M,K] @ B[N,K].T, 2D B_scales."""
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
     else:
         _set_amd_knobs(enable=True)
 
@@ -1022,8 +1019,8 @@ def _blockwise_nn(
     trans_c: bool,
 ) -> torch.Tensor:
     """NN/RRR grad_X: C = A[M,K] @ B[K,N], 2D B_scales (transposed internally)."""
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
     else:
         _set_amd_knobs(enable=True)
 
@@ -1089,8 +1086,8 @@ def _blockwise_tn(
       a_scale_inv: [K//128, M]
       b_scale_inv: [K//128, N]
     """
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
     else:
         _set_amd_knobs(enable=False)
 

--- a/primus_turbo/triton/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_fp8_kernel.py
@@ -41,8 +41,10 @@ from primus_turbo.triton.gemm.gemm_kernel import (
     _chiplet_transform_chunked,
     _compute_sk_grid,
     _get_hardware,
-    _is_gfx950,
     _select_params_origami,
+)
+from primus_turbo.triton.utils.hardware_helper import (
+    _is_gfx950,
     _set_knobs_gfx950,
 )
 

--- a/primus_turbo/triton/gemm/gemm_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_kernel.py
@@ -32,10 +32,8 @@ import origami
 import torch
 import triton
 import triton.language as tl
-from primus_turbo.triton.utils.hardware_helper import (
-    _is_gfx950,
-    _set_knobs_gfx950,
-)
+
+from primus_turbo.triton.utils.hardware_helper import is_gfx950, set_knobs_gfx950
 
 # Map torch dtypes to origami string (for problem_t). Align with TensorAtlas heuristics/selector.py.
 _ORIGAMI_DTYPE_TO_STR = {
@@ -275,7 +273,7 @@ def _estimate_lds_bytes_async_copy(block_m, block_n, block_k, elem_bytes_a, elem
 
 def _calculate_lds_usage(block_m, block_n, block_k, elem_bytes_a, elem_bytes_b, num_stages):
     """LDS usage with auto-detection of async_copy mode."""
-    if _is_gfx950():
+    if is_gfx950():
         return _estimate_lds_bytes_async_copy(
             block_m, block_n, block_k, elem_bytes_a, elem_bytes_b, num_stages
         )
@@ -313,7 +311,7 @@ def _get_valid_tiles(hardware, block_mn_range, block_k_range, mi_dim, elem_bytes
     should verify with _calculate_lds_usage for their actual num_stages.
     """
     lds_cap = hardware.lds_capacity
-    use_async = _is_gfx950()
+    use_async = is_gfx950()
     valid = []
     for bm, bn, bk in (
         (bm, bn, bk) for bm in block_mn_range for bn in block_mn_range for bk in block_k_range
@@ -606,8 +604,8 @@ def gemm_triton_kernel(
     s_ak = A_view.stride(1)
     s_bk = B_view.stride(0)
 
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
 
         # gfx950 BF16 config from 164-entry tuning data.
         # TN layout with large K → BLK_K=64, stages=2; all other cases → 32/3.

--- a/primus_turbo/triton/gemm/gemm_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_kernel.py
@@ -27,12 +27,15 @@ from __future__ import annotations
 
 import functools
 import math
-import os
 
 import origami
 import torch
 import triton
 import triton.language as tl
+from primus_turbo.triton.utils.hardware_helper import (
+    _is_gfx950,
+    _set_knobs_gfx950,
+)
 
 # Map torch dtypes to origami string (for problem_t). Align with TensorAtlas heuristics/selector.py.
 _ORIGAMI_DTYPE_TO_STR = {
@@ -153,35 +156,6 @@ def _compute_sk_grid(M, N, K, BLK_M, BLK_N, BLK_K, cu_count, elem_bytes_out=2):
             sk_grid = 256 if cu_count == 304 else 64
 
     return sk_grid
-
-
-@functools.lru_cache(maxsize=1)
-def _is_gfx950() -> bool:
-    """Check if current GPU is gfx950 (CDNA4 / MI350X / MI355X)."""
-    try:
-        target = triton.runtime.driver.active.get_current_target()
-        return target is not None and target.backend == "hip" and target.arch == "gfx950"
-    except (AttributeError, TypeError):
-        return False
-
-
-_KNOBS_SET = False
-
-
-def _set_knobs_gfx950():
-    """Enable AMD compiler knobs for gfx950 (async_copy, block_pingpong, scalarize)."""
-    global _KNOBS_SET
-    if _KNOBS_SET:
-        return
-    _KNOBS_SET = True
-    if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
-        triton.knobs.amd.use_async_copy = True
-        triton.knobs.amd.scalarize_packed_fops = True
-        triton.knobs.amd.use_block_pingpong = True
-    else:
-        os.environ.setdefault("TRITON_HIP_USE_ASYNC_COPY", "1")
-        os.environ.setdefault("AMDGCN_SCALARIZE_PACKED_FOPS", "1")
-        os.environ.setdefault("TRITON_HIP_USE_BLOCK_PINGPONG", "1")
 
 
 @triton.jit

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -39,15 +39,17 @@ import triton.language as tl
 from primus_turbo.triton.gemm.gemm_kernel import (
     _calculate_lds_usage,
     _get_hardware,
-    _is_gfx950,
     _select_params_origami,
-    _set_knobs_gfx950,
 )
 from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
     NUM_XCDS,
     _chiplet_transform_chunked,
     _get_num_cus,
     _grouped_variable_k_gemm_kernel,
+)
+from primus_turbo.triton.utils.hardware_helper import (
+    _is_gfx950,
+    _set_knobs_gfx950,
 )
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -47,10 +47,7 @@ from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
     _get_num_cus,
     _grouped_variable_k_gemm_kernel,
 )
-from primus_turbo.triton.utils.hardware_helper import (
-    _is_gfx950,
-    _set_knobs_gfx950,
-)
+from primus_turbo.triton.utils.hardware_helper import is_gfx950, set_knobs_gfx950
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # AMD knobs helper
@@ -115,7 +112,7 @@ def _get_gg_fp8_tw_fwd_config(
     stride_bk,
 ):
     """Cached kernel config for FP8 tensorwise grouped GEMM forward."""
-    if _is_gfx950():
+    if is_gfx950():
         blk_m, blk_n = 256, 256
         blk_k = 128
         num_stages_val = 2
@@ -177,7 +174,7 @@ def _get_gg_fp8_tw_fwd_config(
 @functools.lru_cache(maxsize=256)
 def _get_gg_fp8_tw_vk_config(OUT_M, OUT_N, avg_k, a_dtype, b_dtype, G, num_sms):
     """Cached kernel config for FP8 tensorwise grouped GEMM variable-K backward."""
-    if _is_gfx950():
+    if is_gfx950():
         blk_m, blk_n = 256, 256
         blk_k, num_stages_val = 64, 3
         group_m = 4
@@ -235,7 +232,7 @@ def _get_gg_fp8_rw_fwd_config(
     stride_bk,
 ):
     """Cached kernel config for FP8 rowwise grouped GEMM forward."""
-    if _is_gfx950():
+    if is_gfx950():
         blk_m, blk_n = 256, 256
         blk_k = 128
         num_stages_val = 2
@@ -284,7 +281,7 @@ def _get_gg_fp8_rw_fwd_config(
 @functools.lru_cache(maxsize=256)
 def _get_gg_fp8_rw_vk_config(OUT_M, OUT_N, avg_k, a_dtype, b_dtype, G, num_sms):
     """Cached kernel config for FP8 rowwise grouped GEMM variable-K backward."""
-    if _is_gfx950():
+    if is_gfx950():
         blk_m, blk_n = 256, 256
         blk_k, num_stages_val = 64, 3
         group_m = 4
@@ -546,8 +543,8 @@ def grouped_gemm_fp8_tensorwise_triton_kernel(
     # Kernel config (cached — origami + LDS check run only on first call per shape)
     num_sms = _get_num_cus()
     avg_m = max(M_total // max(G, 1), 256)
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
     blk_m, blk_n, blk_k, group_m, cache_a, cache_b, num_stages_val, chunk_size, num_sms = (
         _get_gg_fp8_tw_fwd_config(
             avg_m,
@@ -638,8 +635,8 @@ def grouped_gemm_fp8_tensorwise_variable_k_triton_kernel(
     out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)
     num_sms = _get_num_cus()
 
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
     avg_m_g = max(lhs.shape[0] // max(G, 1), 256)
     blk_m, blk_n, blk_k, group_m, cache_a, cache_b, num_stages_val, chunk_size = _get_gg_fp8_tw_vk_config(
         OUT_M, OUT_N, avg_m_g, lhs.dtype, rhs.dtype, G, num_sms
@@ -900,8 +897,8 @@ def grouped_gemm_fp8_rowwise_triton_kernel(
     # Kernel config (cached — origami + LDS check run only on first call per shape)
     num_sms = _get_num_cus()
     avg_m = max(M_total // max(G, 1), 256)
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
     blk_m, blk_n, blk_k, group_m, cache_a, cache_b, num_stages_val, chunk_size = _get_gg_fp8_rw_fwd_config(
         avg_m,
         N,
@@ -1141,8 +1138,8 @@ def grouped_gemm_fp8_rowwise_variable_k_triton_kernel(
     out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)
     num_sms = _get_num_cus()
 
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
     avg_m_g = max(lhs.shape[0] // max(G, 1), 256)
     blk_m, blk_n, blk_k, group_m, cache_a, cache_b, num_stages_val, chunk_size = _get_gg_fp8_rw_vk_config(
         OUT_M, OUT_N, avg_m_g, lhs.dtype, rhs.dtype, G, num_sms
@@ -1544,8 +1541,8 @@ def grouped_gemm_fp8_blockwise_triton_kernel(
     Returns:
         [M_total, N] output in out_dtype.
     """
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
     else:
         _set_amd_knobs(enable=True)
 
@@ -1655,8 +1652,8 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
     Returns:
         [G, OUT_M, OUT_N] output.
     """
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
     else:
         _set_amd_knobs(enable=False)
 

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
@@ -28,9 +28,9 @@ import torch
 import triton
 import triton.language as tl
 
-from primus_turbo.triton.gemm.gemm_kernel import (
+from primus_turbo.triton.gemm.gemm_kernel import _select_params_origami
+from primus_turbo.triton.utils.hardware_helper import (
     _is_gfx950,
-    _select_params_origami,
     _set_knobs_gfx950,
 )
 

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
@@ -29,10 +29,7 @@ import triton
 import triton.language as tl
 
 from primus_turbo.triton.gemm.gemm_kernel import _select_params_origami
-from primus_turbo.triton.utils.hardware_helper import (
-    _is_gfx950,
-    _set_knobs_gfx950,
-)
+from primus_turbo.triton.utils.hardware_helper import is_gfx950, set_knobs_gfx950
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Hardware constants (lazy init)
@@ -58,7 +55,7 @@ def _get_num_cus() -> int:
 @functools.lru_cache(maxsize=256)
 def _get_gg_bf16_fwd_config(avg_m, N, K, dtype_a, dtype_b, trans_b, G, num_sms):
     """Cached kernel config for BF16 grouped GEMM forward."""
-    if _is_gfx950():
+    if is_gfx950():
         is_tn = not trans_b
         BLOCK_M, BLOCK_N = 256, 256
         if is_tn:
@@ -112,7 +109,7 @@ def _get_gg_bf16_fwd_config(avg_m, N, K, dtype_a, dtype_b, trans_b, G, num_sms):
 @functools.lru_cache(maxsize=256)
 def _get_gg_bf16_vk_config(OUT_M, OUT_N, avg_k, dtype_lhs, dtype_rhs, G, num_sms):
     """Cached kernel config for BF16 grouped GEMM variable-K backward."""
-    if _is_gfx950():
+    if is_gfx950():
         BLOCK_M, BLOCK_N = 256, 256
         BLOCK_K, num_stages_val = 32, 3
         group_m = 4
@@ -381,8 +378,8 @@ def grouped_gemm_triton_kernel(
     # Kernel config (cached — origami + LDS check run only on first call per shape)
     num_sms = _get_num_cus()
     avg_m = max(M_total // max(G, 1), 256)
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
     BLOCK_M, BLOCK_N, BLOCK_K, group_m, cache_a, cache_b, num_stages_val, chunk_size = (
         _get_gg_bf16_fwd_config(avg_m, N, K, a.dtype, b.dtype, trans_b, G, num_sms)
     )
@@ -618,8 +615,8 @@ def grouped_gemm_variable_k_triton_kernel(
     num_sms = _get_num_cus()
     dummy_scale = torch.empty(1, device=lhs.device, dtype=torch.float32)
 
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_knobs_gfx950()
     avg_m_g = max(lhs.shape[0] // max(G, 1), 256)
     BLOCK_M, BLOCK_N, BLOCK_K, group_m, cache_a, cache_b, num_stages_val, chunk_size = _get_gg_bf16_vk_config(
         OUT_M, OUT_N, avg_m_g, lhs.dtype, rhs.dtype, G, num_sms

--- a/primus_turbo/triton/quantization/quant_fp8_tensorwise.py
+++ b/primus_turbo/triton/quantization/quant_fp8_tensorwise.py
@@ -13,10 +13,12 @@ prototype: use the fused 2-kernel path for small/medium tensors, switch to the
 MI355X-specific `waves_per_eu` tuning in the profitable ranges.
 """
 
+from typing import Optional, Tuple
+
 import torch
 import triton
 import triton.language as tl
-
+from torch.library import custom_op
 
 FP8_MAX_MAP = {
     torch.float8_e4m3fn: 448.0,
@@ -28,6 +30,7 @@ FP8_MAX_MAP = {
 FUSE_THRESHOLD = 70_000_000
 TRITON_USE_MIN_NUMEL = 8_000_000
 TRITON_USE_MAX_NUMEL = 600_000_000
+
 
 @triton.jit
 def _amax_partial_kernel(
@@ -145,11 +148,7 @@ class _BufferCache:
         self.max_tiles = 0
 
     def get(self, device, num_tiles):
-        if (
-            self.partial_buf is None
-            or self.max_tiles < num_tiles
-            or self.partial_buf.device != device
-        ):
+        if self.partial_buf is None or self.max_tiles < num_tiles or self.partial_buf.device != device:
             self.max_tiles = max(num_tiles, 1024)
             self.partial_buf = torch.empty(self.max_tiles, dtype=torch.float32, device=device)
             self.scale_buf = torch.empty(2, dtype=torch.float32, device=device)
@@ -159,10 +158,28 @@ class _BufferCache:
 _cache = _BufferCache()
 
 
-def _should_use_triton_fp8_tensorwise(x: torch.Tensor) -> bool:
+def should_use_triton_fp8_tensorwise(x: torch.Tensor) -> bool:
     """Conservative MI355 gate from direct C++ vs Triton quant sweeps."""
     n = x.numel()
     return TRITON_USE_MIN_NUMEL <= n <= TRITON_USE_MAX_NUMEL
+
+
+@custom_op("primus_turbo::quantize_fp8_tensorwise_triton_impl", mutates_args=())
+def triton_quantize_fp8_tensorwise_impl(
+    x: torch.Tensor, out_dtype: torch.dtype, scale: Optional[torch.Tensor] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    # Avoid the module-global cache here so torch.compile / cudagraph bookkeeping
+    # sees only the actual op outputs, not persistent scratch buffers.
+    return quantize_fp8_tensorwise(x, out_dtype, scale, buf_cache=_BufferCache())
+
+
+@triton_quantize_fp8_tensorwise_impl.register_fake
+def triton_quantize_fp8_tensorwise_impl_meta(
+    x: torch.Tensor, out_dtype: torch.dtype, scale: Optional[torch.Tensor] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    x_fp8 = torch.empty_like(x, dtype=out_dtype)
+    scale_inv = torch.empty((), dtype=torch.float32, device=x.device)
+    return x_fp8, scale_inv
 
 
 def _select_strategy(n: int):

--- a/primus_turbo/triton/quantization/quant_fp8_tensorwise.py
+++ b/primus_turbo/triton/quantization/quant_fp8_tensorwise.py
@@ -1,0 +1,287 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Triton FP8 tensorwise quantization kernels optimized for MI355X.
+
+This implementation is kept aligned with the sweep-backed `fp8_quant_opt`
+prototype: use the fused 2-kernel path for small/medium tensors, switch to the
+3-kernel path when partial-buffer rereads become expensive, and apply
+MI355X-specific `waves_per_eu` tuning in the profitable ranges.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+
+FP8_MAX_MAP = {
+    torch.float8_e4m3fn: 448.0,
+    torch.float8_e4m3fnuz: 240.0,
+    torch.float8_e5m2: 57344.0,
+    torch.float8_e5m2fnuz: 57344.0,
+}
+
+FUSE_THRESHOLD = 70_000_000
+
+@triton.jit
+def _amax_partial_kernel(
+    x_ptr,
+    partial_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0).to(tl.int64)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(tl.int64)
+    mask = offs < n_elements
+    x = tl.load(x_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+    tile_max = tl.max(tl.abs(x))
+    tl.store(partial_ptr + pid, tile_max)
+
+
+@triton.jit
+def _reduce_and_quant_kernel(
+    x_ptr,
+    out_ptr,
+    partial_ptr,
+    scale_inv_ptr,
+    n_elements,
+    num_partials,
+    FP8_MAX: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    RED_BS: tl.constexpr,
+):
+    pid = tl.program_id(0).to(tl.int64)
+    global_max = tl.zeros([1], dtype=tl.float32)
+    for start in range(0, num_partials, RED_BS):
+        idx = start + tl.arange(0, RED_BS)
+        mask = idx < num_partials
+        partials = tl.load(partial_ptr + idx, mask=mask, other=0.0)
+        block_max = tl.max(partials)
+        global_max = tl.maximum(global_max, tl.full([1], block_max, tl.float32))
+    amax = tl.reshape(global_max, [])
+    amax = tl.maximum(amax, 1e-12)
+    scale = FP8_MAX / amax
+    if pid == 0:
+        tl.store(scale_inv_ptr, 1.0 / scale)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(tl.int64)
+    mask = offs < n_elements
+    x = tl.load(x_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+    x_q = tl.clamp(x * scale, min=-FP8_MAX, max=FP8_MAX)
+    tl.store(out_ptr + offs, x_q.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+@triton.jit
+def _reduce_scale_kernel(
+    partial_ptr,
+    scale_ptr,
+    scale_inv_ptr,
+    num_partials,
+    FP8_MAX: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offs = tl.arange(0, BLOCK_SIZE)
+    global_max = tl.zeros([1], dtype=tl.float32)
+    for start in range(0, num_partials, BLOCK_SIZE):
+        idx = start + offs
+        mask = idx < num_partials
+        partials = tl.load(partial_ptr + idx, mask=mask, other=0.0)
+        block_max = tl.max(partials)
+        global_max = tl.maximum(global_max, tl.full([1], block_max, tl.float32))
+    amax = tl.reshape(global_max, [])
+    amax = tl.maximum(amax, 1e-12)
+    scale = FP8_MAX / amax
+    tl.store(scale_ptr, scale)
+    tl.store(scale_inv_ptr, 1.0 / scale)
+
+
+@triton.jit
+def _quant_scaled_kernel(
+    x_ptr,
+    out_ptr,
+    scale_ptr,
+    n_elements,
+    FP8_MAX: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0).to(tl.int64)
+    scale = tl.load(scale_ptr)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(tl.int64)
+    mask = offs < n_elements
+    x = tl.load(x_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+    x_q = tl.clamp(x * scale, min=-FP8_MAX, max=FP8_MAX)
+    tl.store(out_ptr + offs, x_q.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+@triton.jit
+def _quant_with_known_scale_kernel(
+    x_ptr,
+    out_ptr,
+    scale_ptr,
+    n_elements,
+    FP8_MAX: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0).to(tl.int64)
+    scale = tl.load(scale_ptr)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(tl.int64)
+    mask = offs < n_elements
+    x = tl.load(x_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+    x_q = tl.clamp(x * scale, min=-FP8_MAX, max=FP8_MAX)
+    tl.store(out_ptr + offs, x_q.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+class _BufferCache:
+    __slots__ = ("partial_buf", "scale_buf", "max_tiles")
+
+    def __init__(self):
+        self.partial_buf = None
+        self.scale_buf = None
+        self.max_tiles = 0
+
+    def get(self, device, num_tiles):
+        if (
+            self.partial_buf is None
+            or self.max_tiles < num_tiles
+            or self.partial_buf.device != device
+        ):
+            self.max_tiles = max(num_tiles, 1024)
+            self.partial_buf = torch.empty(self.max_tiles, dtype=torch.float32, device=device)
+            self.scale_buf = torch.empty(2, dtype=torch.float32, device=device)
+        return self.partial_buf[:num_tiles], self.scale_buf
+
+
+_cache = _BufferCache()
+
+
+def _select_strategy(n: int):
+    """Select path + launch config from MI355X sweep data."""
+    if n <= 3_000_000:
+        return "2k", 8192, 8, 1, 0
+    if n <= 6_000_000:
+        return "2k", 16384, 16, 1, 0
+    if n <= 12_000_000:
+        return "2k", 8192, 4, 1, 0
+    if n <= FUSE_THRESHOLD:
+        return "2k", 16384, 8, 1, 1
+    if n <= 80_000_000:
+        return "3k", 16384, 16, 2, 1
+    if n <= 140_000_000:
+        return "3k", 8192, 16, 1, 1
+    if n <= 210_000_000:
+        return "3k", 16384, 16, 2, 0
+    if n < 350_000_000:
+        return "3k", 16384, 16, 1, 1
+    if n < 600_000_000:
+        return "3k", 16384, 16, 2, 1
+    return "3k", 8192, 8, 1, 1
+
+
+def quantize_fp8_tensorwise(
+    x: torch.Tensor,
+    out_dtype: torch.dtype = torch.float8_e4m3fn,
+    scale=None,
+    out: torch.Tensor = None,
+    buf_cache: _BufferCache = None,
+):
+    """Triton-based FP8 tensorwise quantization for contiguous 2D/3D tensors.
+
+    The kernel only depends on the flattened element count, so grouped GEMM
+    weights in ``(G, N, K)`` layout are handled by preserving ``orig_shape``
+    across the flatten/restore path.
+    """
+    fp8_max = FP8_MAX_MAP[out_dtype]
+    orig_shape = x.shape
+    if not x.is_contiguous():
+        x = x.contiguous()
+    n = x.numel()
+    x_flat = x.reshape(-1)
+    out_flat = out.reshape(-1) if out is not None else torch.empty(n, dtype=out_dtype, device=x.device)
+    path, bs, nw, ns, waves = _select_strategy(n)
+
+    if scale is not None:
+        num_tiles = (n + bs - 1) // bs
+        if not isinstance(scale, torch.Tensor):
+            scale = torch.tensor([float(scale)], dtype=torch.float32, device=x.device)
+        scale = scale.to(device=x.device, dtype=torch.float32).reshape(1)
+        _quant_with_known_scale_kernel[(num_tiles,)](
+            x_flat,
+            out_flat,
+            scale,
+            n,
+            FP8_MAX=fp8_max,
+            BLOCK_SIZE=bs,
+            num_warps=nw,
+            num_stages=ns,
+            waves_per_eu=waves,
+        )
+        scale_inv = (1.0 / scale).clone()
+        return out_flat.reshape(orig_shape), scale_inv
+
+    if buf_cache is None:
+        buf_cache = _cache
+
+    num_tiles = (n + bs - 1) // bs
+    partials, scale_buf = buf_cache.get(x.device, num_tiles)
+
+    _amax_partial_kernel[(num_tiles,)](
+        x_flat,
+        partials,
+        n,
+        BLOCK_SIZE=bs,
+        num_warps=nw,
+        num_stages=ns,
+        waves_per_eu=waves,
+    )
+
+    if path == "2k":
+        scale_inv_ptr = scale_buf[1:2]
+        red_bs = min(4096, triton.next_power_of_2(num_tiles))
+        _reduce_and_quant_kernel[(num_tiles,)](
+            x_flat,
+            out_flat,
+            partials,
+            scale_inv_ptr,
+            n,
+            num_tiles,
+            FP8_MAX=fp8_max,
+            BLOCK_SIZE=bs,
+            RED_BS=red_bs,
+            num_warps=nw,
+            num_stages=ns,
+            waves_per_eu=waves,
+        )
+        return out_flat.reshape(orig_shape), scale_inv_ptr.clone()
+
+    scale_ptr = scale_buf[0:1]
+    scale_inv_ptr = scale_buf[1:2]
+    red_bs = min(4096, triton.next_power_of_2(num_tiles))
+    red_nw = min(16, max(1, red_bs // 64))
+
+    _reduce_scale_kernel[(1,)](
+        partials,
+        scale_ptr,
+        scale_inv_ptr,
+        num_tiles,
+        FP8_MAX=fp8_max,
+        BLOCK_SIZE=red_bs,
+        num_warps=red_nw,
+        waves_per_eu=waves,
+    )
+
+    _quant_scaled_kernel[(num_tiles,)](
+        x_flat,
+        out_flat,
+        scale_ptr,
+        n,
+        FP8_MAX=fp8_max,
+        BLOCK_SIZE=bs,
+        num_warps=nw,
+        num_stages=ns,
+        waves_per_eu=waves,
+    )
+
+    return out_flat.reshape(orig_shape), scale_inv_ptr.clone()

--- a/primus_turbo/triton/quantization/quant_fp8_tensorwise.py
+++ b/primus_turbo/triton/quantization/quant_fp8_tensorwise.py
@@ -26,6 +26,8 @@ FP8_MAX_MAP = {
 }
 
 FUSE_THRESHOLD = 70_000_000
+TRITON_USE_MIN_NUMEL = 8_000_000
+TRITON_USE_MAX_NUMEL = 600_000_000
 
 @triton.jit
 def _amax_partial_kernel(
@@ -157,6 +159,12 @@ class _BufferCache:
 _cache = _BufferCache()
 
 
+def _should_use_triton_fp8_tensorwise(x: torch.Tensor) -> bool:
+    """Conservative MI355 gate from direct C++ vs Triton quant sweeps."""
+    n = x.numel()
+    return TRITON_USE_MIN_NUMEL <= n <= TRITON_USE_MAX_NUMEL
+
+
 def _select_strategy(n: int):
     """Select path + launch config from MI355X sweep data."""
     if n <= 3_000_000:
@@ -205,12 +213,13 @@ def quantize_fp8_tensorwise(
     if scale is not None:
         num_tiles = (n + bs - 1) // bs
         if not isinstance(scale, torch.Tensor):
-            scale = torch.tensor([float(scale)], dtype=torch.float32, device=x.device)
-        scale = scale.to(device=x.device, dtype=torch.float32).reshape(1)
+            scale = torch.tensor(float(scale), dtype=torch.float32, device=x.device)
+        scale = scale.to(device=x.device, dtype=torch.float32).reshape(())
+        scale_view = scale.view(1)
         _quant_with_known_scale_kernel[(num_tiles,)](
             x_flat,
             out_flat,
-            scale,
+            scale_view,
             n,
             FP8_MAX=fp8_max,
             BLOCK_SIZE=bs,
@@ -218,14 +227,15 @@ def quantize_fp8_tensorwise(
             num_stages=ns,
             waves_per_eu=waves,
         )
-        scale_inv = (1.0 / scale).clone()
-        return out_flat.reshape(orig_shape), scale_inv
+        return out_flat.reshape(orig_shape), scale.reciprocal()
 
     if buf_cache is None:
         buf_cache = _cache
 
     num_tiles = (n + bs - 1) // bs
     partials, scale_buf = buf_cache.get(x.device, num_tiles)
+    scale_inv_out = torch.empty((), dtype=torch.float32, device=x.device)
+    scale_inv_ptr = scale_inv_out.view(1)
 
     _amax_partial_kernel[(num_tiles,)](
         x_flat,
@@ -238,7 +248,6 @@ def quantize_fp8_tensorwise(
     )
 
     if path == "2k":
-        scale_inv_ptr = scale_buf[1:2]
         red_bs = min(4096, triton.next_power_of_2(num_tiles))
         _reduce_and_quant_kernel[(num_tiles,)](
             x_flat,
@@ -254,10 +263,9 @@ def quantize_fp8_tensorwise(
             num_stages=ns,
             waves_per_eu=waves,
         )
-        return out_flat.reshape(orig_shape), scale_inv_ptr.clone()
+        return out_flat.reshape(orig_shape), scale_inv_out
 
     scale_ptr = scale_buf[0:1]
-    scale_inv_ptr = scale_buf[1:2]
     red_bs = min(4096, triton.next_power_of_2(num_tiles))
     red_nw = min(16, max(1, red_bs // 64))
 
@@ -284,4 +292,4 @@ def quantize_fp8_tensorwise(
         waves_per_eu=waves,
     )
 
-    return out_flat.reshape(orig_shape), scale_inv_ptr.clone()
+    return out_flat.reshape(orig_shape), scale_inv_out

--- a/primus_turbo/triton/utils/hardware_helper.py
+++ b/primus_turbo/triton/utils/hardware_helper.py
@@ -7,6 +7,22 @@ import torch
 import triton
 
 
+def _is_torch_compiling() -> bool:
+    compiler = getattr(torch, "compiler", None)
+    if compiler is not None:
+        is_compiling = getattr(compiler, "is_compiling", None)
+        if is_compiling is not None and is_compiling():
+            return True
+
+    dynamo = getattr(torch, "_dynamo", None)
+    if dynamo is not None:
+        is_compiling = getattr(dynamo, "is_compiling", None)
+        if is_compiling is not None and is_compiling():
+            return True
+
+    return False
+
+
 @functools.lru_cache(maxsize=1)
 def _get_current_target():
     try:
@@ -30,18 +46,28 @@ def _get_device_name_upper(device_index: int) -> str | None:
         return None
 
 
-def _is_mi355_quant_device(device: torch.device | None = None) -> bool:
-    """Return whether the runtime target is specifically MI355 on gfx950."""
+@functools.lru_cache(maxsize=8)
+def _is_mi355_quant_device_index(device_index: int) -> bool:
     if not torch.cuda.is_available() or not _is_gfx950():
         return False
 
+    device_name = _get_device_name_upper(device_index)
+    return device_name is not None and "MI355" in device_name
+
+
+def _is_mi355_quant_device(device: torch.device | None = None) -> bool:
+    """Return whether the runtime target is specifically MI355 on gfx950."""
+    if _is_torch_compiling():
+        return False
+
     if device is None:
+        if not torch.cuda.is_available():
+            return False
         device_index = torch.cuda.current_device()
     else:
         device_index = device.index if device.index is not None else torch.cuda.current_device()
 
-    device_name = _get_device_name_upper(device_index)
-    return device_name is not None and "MI355" in device_name
+    return _is_mi355_quant_device_index(device_index)
 
 
 _KNOBS_SET = False

--- a/primus_turbo/triton/utils/hardware_helper.py
+++ b/primus_turbo/triton/utils/hardware_helper.py
@@ -1,79 +1,62 @@
 from __future__ import annotations
 
-import functools
 import os
 
 import torch
 import triton
 
 
-def _is_torch_compiling() -> bool:
-    compiler = getattr(torch, "compiler", None)
-    if compiler is not None:
-        is_compiling = getattr(compiler, "is_compiling", None)
-        if is_compiling is not None and is_compiling():
-            return True
-
-    dynamo = getattr(torch, "_dynamo", None)
-    if dynamo is not None:
-        is_compiling = getattr(dynamo, "is_compiling", None)
-        if is_compiling is not None and is_compiling():
-            return True
-
-    return False
-
-
-@functools.lru_cache(maxsize=1)
-def _get_current_target():
-    try:
-        return triton.runtime.driver.active.get_current_target()
-    except (AttributeError, TypeError):
+def _resolve_device_index(device: torch.device | int | None = None) -> int | None:
+    if not torch.cuda.is_available():
         return None
 
+    if device is None:
+        return torch.cuda.current_device()
+    if isinstance(device, int):
+        return device
+    return device.index if device.index is not None else torch.cuda.current_device()
 
-@functools.lru_cache(maxsize=1)
-def _is_gfx950() -> bool:
-    """Check if the active Triton target is gfx950 (CDNA4 / MI350X / MI355X)."""
-    target = _get_current_target()
-    return target is not None and target.backend == "hip" and target.arch == "gfx950"
+
+def _get_device_arch_name(device_index: int) -> str:
+    try:
+        props = torch.cuda.get_device_properties(device_index)
+    except (AssertionError, RuntimeError, TypeError):
+        return ""
+    return getattr(props, "gcnArchName", "").split(":")[0]
 
 
-@functools.lru_cache(maxsize=8)
+def is_gfx950(device: torch.device | int | None = None) -> bool:
+    """Check if the active device is gfx950 (CDNA4 / MI350X / MI355X)."""
+    device_index = _resolve_device_index(device)
+    return device_index is not None and _get_device_arch_name(device_index) == "gfx950"
+
+
 def _get_device_name_upper(device_index: int) -> str | None:
     try:
-        return torch.cuda.get_device_name(device_index).upper()
+        props = torch.cuda.get_device_properties(device_index)
     except (AssertionError, RuntimeError, TypeError):
         return None
+    return getattr(props, "name", "").upper() or None
 
 
-@functools.lru_cache(maxsize=8)
 def _is_mi355_quant_device_index(device_index: int) -> bool:
-    if not torch.cuda.is_available() or not _is_gfx950():
+    if not is_gfx950(device_index):
         return False
 
     device_name = _get_device_name_upper(device_index)
     return device_name is not None and "MI355" in device_name
 
 
-def _is_mi355_quant_device(device: torch.device | None = None) -> bool:
+def is_mi355_quant_device(device: torch.device | None = None) -> bool:
     """Return whether the runtime target is specifically MI355 on gfx950."""
-    if _is_torch_compiling():
-        return False
-
-    if device is None:
-        if not torch.cuda.is_available():
-            return False
-        device_index = torch.cuda.current_device()
-    else:
-        device_index = device.index if device.index is not None else torch.cuda.current_device()
-
-    return _is_mi355_quant_device_index(device_index)
+    device_index = _resolve_device_index(device)
+    return device_index is not None and _is_mi355_quant_device_index(device_index)
 
 
 _KNOBS_SET = False
 
 
-def _set_knobs_gfx950():
+def set_knobs_gfx950():
     """Enable AMD compiler knobs for gfx950 (async_copy, block_pingpong, scalarize)."""
     global _KNOBS_SET
     if _KNOBS_SET:

--- a/primus_turbo/triton/utils/hardware_helper.py
+++ b/primus_turbo/triton/utils/hardware_helper.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import functools
+import os
+
+import torch
+import triton
+
+
+@functools.lru_cache(maxsize=1)
+def _get_current_target():
+    try:
+        return triton.runtime.driver.active.get_current_target()
+    except (AttributeError, TypeError):
+        return None
+
+
+@functools.lru_cache(maxsize=1)
+def _is_gfx950() -> bool:
+    """Check if the active Triton target is gfx950 (CDNA4 / MI350X / MI355X)."""
+    target = _get_current_target()
+    return target is not None and target.backend == "hip" and target.arch == "gfx950"
+
+
+@functools.lru_cache(maxsize=8)
+def _get_device_name_upper(device_index: int) -> str | None:
+    try:
+        return torch.cuda.get_device_name(device_index).upper()
+    except (AssertionError, RuntimeError, TypeError):
+        return None
+
+
+def _is_mi355_quant_device(device: torch.device | None = None) -> bool:
+    """Return whether the runtime target is specifically MI355 on gfx950."""
+    if not torch.cuda.is_available() or not _is_gfx950():
+        return False
+
+    if device is None:
+        device_index = torch.cuda.current_device()
+    else:
+        device_index = device.index if device.index is not None else torch.cuda.current_device()
+
+    device_name = _get_device_name_upper(device_index)
+    return device_name is not None and "MI355" in device_name
+
+
+_KNOBS_SET = False
+
+
+def _set_knobs_gfx950():
+    """Enable AMD compiler knobs for gfx950 (async_copy, block_pingpong, scalarize)."""
+    global _KNOBS_SET
+    if _KNOBS_SET:
+        return
+    _KNOBS_SET = True
+    if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
+        triton.knobs.amd.use_async_copy = True
+        triton.knobs.amd.scalarize_packed_fops = True
+        triton.knobs.amd.use_block_pingpong = True
+    else:
+        os.environ.setdefault("TRITON_HIP_USE_ASYNC_COPY", "1")
+        os.environ.setdefault("AMDGCN_SCALARIZE_PACKED_FOPS", "1")
+        os.environ.setdefault("TRITON_HIP_USE_BLOCK_PINGPONG", "1")


### PR DESCRIPTION
## Key Results
- DeepSeek-V2 shows the strongest gains at `M=1024/2048`, with `1.0258x` / `1.0245x` E2E speedup.
- DeepSeek-V3 is also positive at `M=1024/2048`, with `1.0104x` / `1.0171x` E2E speedup.
- Larger V3 shapes are close to parity: `M=8192` is neutral and `M=16384` is slightly below parity.
### DeepSeek-V2
| M | Before Fwd TFLOPS | After Fwd TFLOPS | Before Bwd TFLOPS | After Bwd TFLOPS | FWD+BWD Average Speedup |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 512 | 525.20 | 542.03 | 612.73 | 612.73 | 1.0116 |
| 1024 | 816.98 | 849.82 | 871.72 | 883.10 | 1.0223 |
| 2048 | 997.72 | 1031.18 | 1252.70 | 1269.15 | 1.0209 |
| 4096 | 1394.76 | 1439.27 | 1416.66 | 1428.63 | 1.0162 |
| 8192 | 1558.66 | 1589.79 | 1690.09 | 1713.63 | 1.0160 |
| 16384 | 1631.00 | 1649.90 | 1737.29 | 1739.52 | 1.0048 |
### DeepSeek-V3
| M | Before Fwd TFLOPS | After Fwd TFLOPS | Before Bwd TFLOPS | After Bwd TFLOPS | FWD+BWD Average Speedup |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 512 | 691.90 | 715.42 | 695.71 | 703.47 | 1.0187 |
| 1024 | 963.91 | 982.66 | 974.13 | 981.71 | 1.0117 |
| 2048 | 1343.32 | 1378.14 | 1458.74 | 1480.11 | 1.0186 |
| 4096 | 1593.34 | 1609.84 | 1717.99 | 1720.91 | 1.0047 |
| 8192 | 1723.85 | 1738.69 | 1849.72 | 1847.18 | 1.0021 |
| 16384 | 1801.07 | 1803.08 | 1873.30 | 1868.10 | 0.9986 |