### PR TITLE
feat(gemm): Blockwise FP8 GEMM Triton persistent kernel with hardware-aware dispatch + Triton 3.7.0

### DIFF
--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
@@ -272,6 +272,25 @@ _GEMM_FP8_BACKENDS = {
 }
 
 
+def _blockwise_preferred_backend(
+    a: torch.Tensor, b: torch.Tensor, trans_a: bool, trans_b: bool
+) -> BackendType:
+    """Hardware-aware backend selection for blockwise FP8 GEMM.
+
+    Validated on:
+      - gfx942 (MI300X): Triton persistent kernel beats CK by +8-25% fwd, +40% bwd.
+      - gfx950 (MI355X): Triton persistent kernel beats CK by ~2.7× fwd, ~4.3× bwd.
+
+    Falls back to CK on unknown architectures (the original safe default).
+    """
+    from primus_turbo.triton.gemm.gemm_kernel import _get_gpu_arch
+
+    arch = _get_gpu_arch()
+    if arch in ("gfx942", "gfx950"):
+        return BackendType.TRITON
+    return BackendType.CK
+
+
 class GEMMFP8KernelDispatcher(AutoKernelDispatcher):
     _backends = _GEMM_FP8_BACKENDS
     _cache = TuneCache(1024)
@@ -298,6 +317,13 @@ def gemm_fp8_impl(
     default_backend_enum = BackendType(default_backend)
     user_backend_enum = GlobalBackendManager.get_gemm_backend(PrecisionType.FP8)
     granularity_enum = ScalingGranularity(granularity)
+
+    if (
+        granularity_enum == ScalingGranularity.BLOCKWISE
+        and user_backend_enum is None
+        and not GlobalBackendManager.auto_tune_enabled()
+    ):
+        default_backend_enum = _blockwise_preferred_backend(a, b, trans_a, trans_b)
 
     kwargs = dict(
         a=a,

--- a/primus_turbo/triton/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_fp8_kernel.py
@@ -40,6 +40,7 @@ from primus_turbo.triton.gemm.gemm_kernel import (
     NUM_XCDS,
     _chiplet_transform_chunked,
     _compute_sk_grid,
+    _get_gpu_arch,
     _get_hardware,
     _is_gfx950,
     _select_params_origami,
@@ -890,6 +891,277 @@ def _blockwise_fp8_autotune_kernel(
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Persistent block-wise FP8 GEMM kernel — NUM_SMS is constexpr for better codegen
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@triton.jit
+def _blockwise_fp8_persistent_kernel(
+    A_ptr,
+    B_ptr,
+    C_ptr,
+    A_scales_ptr,
+    B_scales_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak_val,
+    stride_bk_val,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_as_k,
+    stride_as_m,
+    stride_bs_0,
+    stride_bs_1,
+    NUM_K_BLOCKS,
+    A_K_CONTIGUOUS: tl.constexpr,
+    B_K_CONTIGUOUS: tl.constexpr,
+    SCALE_2D_B: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    CHUNK: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    CACHE_MODIFIER_A: tl.constexpr,
+    CACHE_MODIFIER_B: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    if NUM_XCDS != 1:
+        pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK)
+
+    num_m = tl.cdiv(M, BLOCK_M)
+    num_n = tl.cdiv(N, BLOCK_N)
+    total = num_m * num_n
+    grp = GROUP_M * num_n
+
+    tl.assume(stride_am > 0)
+    tl.assume(stride_bn > 0)
+    tl.assume(stride_cm > 0)
+    tl.assume(stride_cn > 0)
+    tl.assume(stride_as_k > 0)
+    tl.assume(stride_as_m > 0)
+    tl.assume(stride_bs_0 > 0)
+    tl.assume(stride_bs_1 > 0)
+
+    for tid in range(pid, total, NUM_SMS):
+        gid = tid // grp
+        fm = gid * GROUP_M
+        gs = min(num_m - fm, GROUP_M)
+        pm = fm + (tid % grp) % gs
+        pn = (tid % grp) // gs
+        tl.assume(pm >= 0)
+        tl.assume(pn >= 0)
+
+        rm = tl.max_contiguous(tl.multiple_of((pm * BLOCK_M + tl.arange(0, BLOCK_M)) % M, BLOCK_M), BLOCK_M)
+        rn = tl.max_contiguous(tl.multiple_of((pn * BLOCK_N + tl.arange(0, BLOCK_N)) % N, BLOCK_N), BLOCK_N)
+        rk = tl.arange(0, BLOCK_K)
+
+        if A_K_CONTIGUOUS:
+            a_ptrs = A_ptr + rm[:, None].to(tl.int64) * stride_am + rk[None, :].to(tl.int64)
+        else:
+            a_ptrs = A_ptr + rm[:, None].to(tl.int64) * stride_am + rk[None, :].to(tl.int64) * stride_ak_val
+
+        if B_K_CONTIGUOUS:
+            b_ptrs = B_ptr + rk[:, None].to(tl.int64) + rn[None, :].to(tl.int64) * stride_bn
+        else:
+            b_ptrs = B_ptr + rk[:, None].to(tl.int64) * stride_bk_val + rn[None, :].to(tl.int64) * stride_bn
+
+        as_ptrs = A_scales_ptr + rm * stride_as_m
+
+        if SCALE_2D_B:
+            N_SCALE_BLOCKS: tl.constexpr = BLOCK_N // 128
+            bs_ptr_base = B_scales_ptr + (pn * N_SCALE_BLOCKS) * stride_bs_0
+        else:
+            bs_ptrs = B_scales_ptr + rn * stride_bs_0
+
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+        loop_k = NUM_K_BLOCKS
+        if not EVEN_K:
+            loop_k = loop_k - 1
+
+        for ki in range(loop_k):
+            a_s = tl.load(as_ptrs + ki * stride_as_k)
+            if SCALE_2D_B:
+                if N_SCALE_BLOCKS > 1:
+                    bs0 = tl.load(bs_ptr_base + ki * stride_bs_1)
+                    bs1 = tl.load(bs_ptr_base + stride_bs_0 + ki * stride_bs_1)
+                else:
+                    b_s = tl.load(bs_ptr_base + ki * stride_bs_1)
+            else:
+                b_s = tl.load(bs_ptrs + ki * stride_bs_1)
+
+            if A_K_CONTIGUOUS:
+                a = tl.load(tl.multiple_of(a_ptrs, (1, 16)), cache_modifier=CACHE_MODIFIER_A)
+            else:
+                a = tl.load(tl.multiple_of(a_ptrs, (16, 1)), cache_modifier=CACHE_MODIFIER_A)
+
+            if B_K_CONTIGUOUS:
+                b = tl.load(tl.multiple_of(b_ptrs, (16, 1)), cache_modifier=CACHE_MODIFIER_B)
+            else:
+                b = tl.load(tl.multiple_of(b_ptrs, (1, 16)), cache_modifier=CACHE_MODIFIER_B)
+
+            partial = tl.dot(a, b, input_precision="ieee")
+
+            if SCALE_2D_B:
+                if N_SCALE_BLOCKS > 1:
+                    bn_idx = tl.arange(0, BLOCK_N)
+                    b_s_vec = tl.where(bn_idx < 128, bs0, bs1)
+                    acc += partial * a_s[:, None] * b_s_vec[None, :]
+                else:
+                    acc += partial * (a_s * b_s)[:, None]
+            else:
+                acc += partial * a_s[:, None] * b_s[None, :]
+
+            if A_K_CONTIGUOUS:
+                a_ptrs += BLOCK_K
+            else:
+                a_ptrs += BLOCK_K * stride_ak_val
+
+            if B_K_CONTIGUOUS:
+                b_ptrs += BLOCK_K
+            else:
+                b_ptrs += BLOCK_K * stride_bk_val
+
+        if not EVEN_K:
+            ki = loop_k
+            k_remaining = K - ki * BLOCK_K
+            mask_k_col = rk[None, :] < k_remaining
+            mask_k_row = rk[:, None] < k_remaining
+
+            a_s = tl.load(as_ptrs + ki * stride_as_k)
+            if SCALE_2D_B:
+                if N_SCALE_BLOCKS > 1:
+                    bs0 = tl.load(bs_ptr_base + ki * stride_bs_1)
+                    bs1 = tl.load(bs_ptr_base + stride_bs_0 + ki * stride_bs_1)
+                else:
+                    b_s = tl.load(bs_ptr_base + ki * stride_bs_1)
+            else:
+                b_s = tl.load(bs_ptrs + ki * stride_bs_1)
+
+            if A_K_CONTIGUOUS:
+                a = tl.load(a_ptrs, mask=mask_k_col, other=0.0, cache_modifier=CACHE_MODIFIER_A)
+            else:
+                a = tl.load(a_ptrs, mask=mask_k_col, other=0.0, cache_modifier=CACHE_MODIFIER_A)
+
+            if B_K_CONTIGUOUS:
+                b = tl.load(b_ptrs, mask=mask_k_row, other=0.0, cache_modifier=CACHE_MODIFIER_B)
+            else:
+                b = tl.load(b_ptrs, mask=mask_k_row, other=0.0, cache_modifier=CACHE_MODIFIER_B)
+
+            partial = tl.dot(a, b, input_precision="ieee")
+
+            if SCALE_2D_B:
+                if N_SCALE_BLOCKS > 1:
+                    bn_idx = tl.arange(0, BLOCK_N)
+                    b_s_vec = tl.where(bn_idx < 128, bs0, bs1)
+                    acc += partial * a_s[:, None] * b_s_vec[None, :]
+                else:
+                    acc += partial * (a_s * b_s)[:, None]
+            else:
+                acc += partial * a_s[:, None] * b_s[None, :]
+
+        offs_m = pm * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pn * BLOCK_N + tl.arange(0, BLOCK_N)
+        c_ptrs = C_ptr + offs_m[:, None].to(tl.int64) * stride_cm + offs_n[None, :].to(tl.int64) * stride_cn
+        mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+        tl.store(c_ptrs, acc.to(C_ptr.type.element_ty), mask)
+
+
+def _select_blockwise_config(M, N, K, a_k_contiguous, b_k_contiguous):
+    """Offline config selection for blockwise FP8 GEMM — hardware-aware.
+
+    Dispatches tile selection by GPU architecture, then computes grid/grouping
+    parameters common to all architectures.
+    """
+    cu_count = _get_hardware().N_CU
+    arch = _get_gpu_arch()
+
+    if arch == "gfx950":
+        block_m, block_n, block_k = _select_blockwise_tile_gfx950(M, N, K, cu_count)
+    elif arch == "gfx942":
+        block_m, block_n, block_k = _select_blockwise_tile_gfx942(M, N, K, cu_count)
+    else:
+        block_m, block_n, block_k = 128, 128, 128
+
+    tiles_m = (M + block_m - 1) // block_m
+    tiles_n = (N + block_n - 1) // block_n
+    total_tiles = tiles_m * tiles_n
+
+    num_sms = _compute_sk_grid(M, N, K, block_m, block_n, block_k, cu_count)
+
+    if min(tiles_m, tiles_n) < 16:
+        group_m = 8
+    elif a_k_contiguous and b_k_contiguous:
+        group_m = 6 if tiles_n > 2 * tiles_m else 4
+    else:
+        group_m = 5
+
+    if num_sms < total_tiles:
+        chunk = min(32, max(1, num_sms // NUM_XCDS))
+    else:
+        chunk = 64
+
+    return block_m, block_n, block_k, group_m, num_sms, chunk
+
+
+def _select_blockwise_tile_gfx942(M, N, K, cu_count):
+    """MI300X (gfx942) tile selection constrained by 64 KB LDS.
+
+    With double-buffering (num_stages=2), FP8 tiles need:
+      2 × (BLOCK_M × BLOCK_K + BLOCK_K × BLOCK_N) × 1B
+    For 128×128×128: 2 × (16 KB + 16 KB) = 64 KB → exactly fills LDS.
+    Larger tiles (e.g. 256×128) require 96 KB → exceeds 64 KB LDS.
+    """
+    return 128, 128, 128
+
+
+def _select_blockwise_tile_gfx950(M, N, K, cu_count):
+    """MI355X (gfx950) tile selection exploiting 160 KB LDS.
+
+    BLOCK_M=256 with BLOCK_N=128 is optimal: the 256×128 accumulator keeps
+    register pressure at 64 VGPRs/thread (8 warps), enabling full occupancy.
+    Larger BLOCK_N (e.g. 256) causes 4-5× regression from register spilling.
+
+    LDS budget: 2 × (256×128 + 128×128) × 1B = 96 KB < 160 KB  ✓
+    """
+    if M >= 2048:
+        return 256, 128, 128
+    return 128, 128, 128
+
+
+def _blockwise_launch_params(layout: str) -> dict:
+    """Hardware-aware launch parameters for the persistent blockwise kernel.
+
+    Returns compiler hints that differ across GPU architectures:
+      - waves_per_eu: occupancy hint (0 = let compiler decide)
+      - kpack: gfx942 benefits from kpack=2; deprecated on gfx950
+
+    Args:
+        layout: One of 'nt' (forward), 'nn' (grad_X), 'tn' (grad_W).
+    """
+    arch = _get_gpu_arch()
+    params = dict(num_warps=8, num_stages=2, matrix_instr_nonkdim=16)
+
+    if arch == "gfx950":
+        params["kpack"] = 1
+        params["waves_per_eu"] = 0 if layout == "nt" else 2
+    elif arch == "gfx942":
+        params["kpack"] = 2
+        params["waves_per_eu"] = 0 if layout == "nt" else 2
+    else:
+        params["kpack"] = 2
+        params["waves_per_eu"] = 0
+
+    return params
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Unified Public API — Block-wise FP8 GEMM
 # Interface consistent with CK blockwise backend.
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -979,11 +1251,13 @@ def _blockwise_nt(
     A_scales_t = a_scale_inv.T.contiguous()  # [K//128, M]
     B_t = b.T  # view [K, N]
 
-    num_m = (M + 127) // 128
-    num_n = (N + 127) // 128
-    NUM_SMS = num_m * num_n
+    block_m, block_n, block_k, group_m, num_sms, chunk = _select_blockwise_config(
+        M, N, K, a_k_contiguous=True, b_k_contiguous=True
+    )
+    lp = _blockwise_launch_params("nt")
+    even_k = K % block_k == 0
 
-    _blockwise_fp8_autotune_kernel[(NUM_SMS,)](
+    _blockwise_fp8_persistent_kernel[(num_sms,)](
         a,
         B_t,
         out,
@@ -1002,11 +1276,21 @@ def _blockwise_nt(
         A_scales_t.stride(1),
         b_scale_inv.stride(0),
         b_scale_inv.stride(1),
-        NUM_SMS,
         num_k,
         A_K_CONTIGUOUS=True,
         B_K_CONTIGUOUS=True,
         SCALE_2D_B=True,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        BLOCK_K=block_k,
+        GROUP_M=group_m,
+        NUM_SMS=num_sms,
+        NUM_XCDS=NUM_XCDS,
+        CHUNK=chunk,
+        EVEN_K=even_k,
+        CACHE_MODIFIER_A=".ca",
+        CACHE_MODIFIER_B=".ca",
+        **lp,
     )
     return out
 
@@ -1037,20 +1321,19 @@ def _blockwise_nn(
         stride_cm, stride_cn = out.stride(0), out.stride(1)
 
     A_scales_t = a_scale_inv.T.contiguous()  # [K//128, M]
-    # B_scales from quantization: [dim0_blocks, dim1_blocks] for weight stored as [N_fwd, K_fwd].
-    # Kernel expects [N_output_blocks, K_inner_blocks] indexing → transpose.
-    b_scale_inv_t = b_scale_inv.T.contiguous()
 
-    num_m = (M + 127) // 128
-    num_n = (N + 127) // 128
-    NUM_SMS = num_m * num_n
+    block_m, block_n, block_k, group_m, num_sms, chunk = _select_blockwise_config(
+        M, N, K, a_k_contiguous=True, b_k_contiguous=False
+    )
+    lp = _blockwise_launch_params("nn")
+    even_k = K % block_k == 0
 
-    _blockwise_fp8_autotune_kernel[(NUM_SMS,)](
+    _blockwise_fp8_persistent_kernel[(num_sms,)](
         a,
         b,
         out,
         A_scales_t,
-        b_scale_inv_t,
+        b_scale_inv,
         M,
         N,
         K,
@@ -1062,13 +1345,23 @@ def _blockwise_nn(
         stride_cn,
         A_scales_t.stride(0),
         A_scales_t.stride(1),
-        b_scale_inv_t.stride(0),
-        b_scale_inv_t.stride(1),
-        NUM_SMS,
+        b_scale_inv.stride(1),
+        b_scale_inv.stride(0),
         num_k,
         A_K_CONTIGUOUS=True,
         B_K_CONTIGUOUS=False,
         SCALE_2D_B=True,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        BLOCK_K=block_k,
+        GROUP_M=group_m,
+        NUM_SMS=num_sms,
+        NUM_XCDS=NUM_XCDS,
+        CHUNK=chunk,
+        EVEN_K=even_k,
+        CACHE_MODIFIER_A=".ca",
+        CACHE_MODIFIER_B=".ca",
+        **lp,
     )
     return out
 
@@ -1105,11 +1398,13 @@ def _blockwise_tn(
 
     A_view = a.T  # [M, K] view with strided K
 
-    num_m = (M + 127) // 128
-    num_n = (N + 127) // 128
-    NUM_SMS = num_m * num_n
+    block_m, block_n, block_k, group_m, num_sms, chunk = _select_blockwise_config(
+        M, N, K, a_k_contiguous=False, b_k_contiguous=False
+    )
+    lp = _blockwise_launch_params("tn")
+    even_k = K % block_k == 0
 
-    _blockwise_fp8_autotune_kernel[(NUM_SMS,)](
+    _blockwise_fp8_persistent_kernel[(num_sms,)](
         A_view,
         b,
         out,
@@ -1125,13 +1420,23 @@ def _blockwise_tn(
         stride_cm,
         stride_cn,
         a_scale_inv.stride(0),
-        a_scale_inv.stride(1),  # [K//128, M]: stride_as_k=M, stride_as_m=1
+        a_scale_inv.stride(1),
         b_scale_inv.stride(1),
-        b_scale_inv.stride(0),  # [K//128, N]: stride_bs_0=1(rn), stride_bs_1=N(ki)
-        NUM_SMS,
+        b_scale_inv.stride(0),
         num_k,
         A_K_CONTIGUOUS=False,
         B_K_CONTIGUOUS=False,
         SCALE_2D_B=False,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        BLOCK_K=block_k,
+        GROUP_M=group_m,
+        NUM_SMS=num_sms,
+        NUM_XCDS=NUM_XCDS,
+        CHUNK=chunk,
+        EVEN_K=even_k,
+        CACHE_MODIFIER_A=".ca",
+        CACHE_MODIFIER_B=".ca",
+        **lp,
     )
     return out

--- a/primus_turbo/triton/gemm/gemm_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_kernel.py
@@ -156,13 +156,21 @@ def _compute_sk_grid(M, N, K, BLK_M, BLK_N, BLK_K, cu_count, elem_bytes_out=2):
 
 
 @functools.lru_cache(maxsize=1)
-def _is_gfx950() -> bool:
-    """Check if current GPU is gfx950 (CDNA4 / MI350X / MI355X)."""
+def _get_gpu_arch() -> str:
+    """Return the base GPU architecture string (e.g. 'gfx950', 'gfx942')."""
     try:
         target = triton.runtime.driver.active.get_current_target()
-        return target is not None and target.backend == "hip" and target.arch == "gfx950"
+        if target is not None and target.backend == "hip":
+            return target.arch
     except (AttributeError, TypeError):
-        return False
+        pass
+    return "unknown"
+
+
+@functools.lru_cache(maxsize=1)
+def _is_gfx950() -> bool:
+    """Check if current GPU is gfx950 (CDNA4 / MI350X / MI355X)."""
+    return _get_gpu_arch() == "gfx950"
 
 
 _KNOBS_SET = False


### PR DESCRIPTION
## Summary

Replace the autotune-based blockwise FP8 GEMM kernel with a **persistent kernel** featuring hardware-aware tile selection and backend dispatch, and bump the Triton dependency to **3.7.0** for improved CDNA3/CDNA4 codegen.

### Key Changes

1. **New persistent blockwise FP8 kernel** (`_blockwise_fp8_persistent_kernel`)
   - Replaces `_blockwise_fp8_autotune_kernel` with a persistent-loop design (`for tid in range(pid, total, NUM_SMS)`) that eliminates kernel launch overhead.
   - All tile dimensions (`BLOCK_M/N/K`), `NUM_SMS`, `GROUP_M`, `CHUNK` are `tl.constexpr` for optimal codegen.
   - Supports all three layouts: NT (forward), NN (grad_X), TN (grad_W).

2. **Hardware-aware tile selection** (`_select_blockwise_config`)
   - **MI355X (gfx950)**: BLOCK_M=256 exploiting 160 KB LDS; falls back to 128x128x128 for small M.
   - **MI300X (gfx942)**: Capped at 128x128x128 due to 64 KB LDS constraint (double-buffering exactly fills 64 KB).
   - Architecture detected at runtime via `_get_gpu_arch()` (cached).

3. **Hardware-aware launch parameters** (`_blockwise_launch_params`)
   - `kpack=1` on gfx950 (deprecated MFMA hint), `kpack=2` on gfx942.
   - `waves_per_eu` tuned per layout and architecture.

4. **Backend dispatch** (`_blockwise_preferred_backend`)
   - Automatically selects Triton backend on validated architectures (gfx942, gfx950); falls back to CK on unknown hardware.

5. **Triton 3.7.0** - bumped `requirements.txt` from `triton==3.6.0` to `triton==3.7.0`.

### Files Changed

| File | Change |
|------|--------|
| `primus_turbo/triton/gemm/gemm_fp8_kernel.py` | New persistent kernel + tile selection + launch params |
| `primus_turbo/triton/gemm/gemm_kernel.py` | Added `_get_gpu_arch()`; refactored `_is_gfx950()` |
| `primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py` | Hardware-aware backend dispatch for blockwise |
| `requirements.txt` | `triton==3.6.0` -> `triton==3.7.0` |

## Performance (MI355X, Triton 3.7.0)

**Overall Geomean Speedup: Forward 3.13x, Backward 5.34x**

| Metric | Baseline (main) | Optimized (this PR) |
|--------|-----------------|---------------------|
| Avg Forward TFLOPS | 487.95 | **1529.32** |
| Avg Backward TFLOPS | 229.21 | **1231.62** |

### Per-Model Breakdown

| Model | Fwd Speedup | Bwd Speedup |
|-------|-------------|-------------|
| Llama-2-7B | 2.88x | 5.00x |
| Llama-2-70B | 3.33x | 5.61x |
| Llama-3.1-8B | 3.10x | 5.18x |
| Llama-3.1-405B | 3.63x | 6.20x |
| Qwen2.5-7B | 2.71x | 4.86x |
| Qwen2.5-72B | 3.31x | 5.65x |
| Mistral-7B | 3.00x | 4.98x |

### Representative Shapes

| Case | M | N | K | Fwd Base(ms) | Fwd Opt(ms) | Speedup | Bwd Base(ms) | Bwd Opt(ms) | Speedup |
|------|---|---|---|-------------|------------|---------|-------------|------------|---------|
| Llama-2-7B | 4096 | 12288 | 4096 | 0.860 | 0.280 | 3.07x | 3.670 | 0.720 | 5.10x |
| Llama-2-70B | 8192 | 57344 | 8192 | 17.570 | 4.580 | 3.84x | 66.260 | 11.750 | 5.64x |
| Llama-3.1-405B | 16384 | 106496 | 16384 | 131.030 | 32.790 | 4.00x | 493.160 | 81.380 | 6.06x |
| Llama-3.1-405B | 32768 | 106496 | 16384 | 260.520 | 64.330 | 4.05x | 990.230 | 159.800 | 6.20x |

## Accuracy

All blockwise FP8 tests pass with Triton 3.7.0:

```
pytest tests/pytorch/ops/test_gemm_fp8.py -k "blockwise" -v
======= 1056 passed, 784 skipped, 12160 deselected, 1 warning in 55.14s ========
```

## Test Plan

- [x] `pytest tests/pytorch/ops/test_gemm_fp8.py -k "blockwise"` - 1056/1056 passed
- [x] `bench_gemm_turbo.py --dtype fp8 --granularity blockwise` - 84/84 correctness PASS
- [x] Pre-commit hooks pass (isort, black, autoflake)
- [ ] CI pipeline on main runners