### PR TITLE
feat(benchmark): add --backend flag to GEMM and grouped GEMM benchmarks

### DIFF
--- a/benchmark/ops/bench_gemm_turbo.py
+++ b/benchmark/ops/bench_gemm_turbo.py
@@ -24,6 +24,11 @@ from config import (
 from tabulate import tabulate
 
 import primus_turbo.pytorch as turbo
+from primus_turbo.pytorch.core.backend import (
+    BackendType,
+    GlobalBackendManager,
+    PrecisionType,
+)
 from primus_turbo.pytorch.core.low_precision import (
     Float4QuantConfig,
     Float8QuantConfig,
@@ -222,8 +227,27 @@ def profile_gemm_fp4(M, N, K, dtype, config, trans_b):
     return fwd_mean_time_ms, fwd_tflops, bwd_mean_time_ms, bwd_tflops, correct
 
 
-def benchmark_gemm_turbo(dtype_name="bf16", granularity_name="tensorwise", output_csv=None):
+def _set_backend(backend_name, dtype_name):
+    """Set GEMM backend via GlobalBackendManager."""
+    if backend_name == "default":
+        return
+    backend = BackendType[backend_name.upper()]
+    if dtype_name == "fp8":
+        GlobalBackendManager.set_gemm_backend(backend, PrecisionType.FP8)
+    elif dtype_name == "fp4":
+        GlobalBackendManager.set_gemm_backend(backend, PrecisionType.FP4)
+    else:
+        GlobalBackendManager.set_gemm_backend(backend, PrecisionType.BF16_FP16_FP32)
+
+
+def benchmark_gemm_turbo(
+    dtype_name="bf16", granularity_name="tensorwise", output_csv=None, backend_name="default"
+):
     platform, gpu_name = get_platform_info()
+
+    _set_backend(backend_name, dtype_name)
+    if backend_name != "default":
+        print(f"Backend: {backend_name.upper()}")
 
     is_fp8 = dtype_name == "fp8"
     is_fp4 = dtype_name == "fp4"
@@ -376,6 +400,13 @@ if __name__ == "__main__":
         help="FP8 scaling granularity (only used when dtype=fp8 or fp4, default: tensorwise)",
     )
     parser.add_argument(
+        "--backend",
+        type=str,
+        choices=["default", "ck", "triton", "hipblaslt"],
+        default="default",
+        help="Force a specific backend: ck, triton, hipblaslt, or default (auto-dispatch)",
+    )
+    parser.add_argument(
         "--output",
         "-o",
         type=str,
@@ -383,4 +414,9 @@ if __name__ == "__main__":
         help="Output CSV filename",
     )
     args = parser.parse_args()
-    benchmark_gemm_turbo(dtype_name=args.dtype, granularity_name=args.granularity, output_csv=args.output)
+    benchmark_gemm_turbo(
+        dtype_name=args.dtype,
+        granularity_name=args.granularity,
+        output_csv=args.output,
+        backend_name=args.backend,
+    )

--- a/benchmark/ops/bench_grouped_gemm_turbo.py
+++ b/benchmark/ops/bench_grouped_gemm_turbo.py
@@ -23,6 +23,11 @@ from config import (
 from tabulate import tabulate
 
 import primus_turbo.pytorch as turbo
+from primus_turbo.pytorch.core.backend import (
+    BackendType,
+    GlobalBackendManager,
+    PrecisionType,
+)
 from primus_turbo.pytorch.core.low_precision import (
     Float8QuantConfig,
     Format,
@@ -168,8 +173,25 @@ def profile_grouped_gemm_fp8(B, M, N, K, dtype, config):
     return fwd_mean_time_ms, fwd_tflops, bwd_mean_time_ms, bwd_tflops, correct
 
 
-def benchmark_grouped_gemm_turbo(dtype_name="bf16", granularity_name="tensorwise", output_csv=None):
+def _set_backend(backend_name, dtype_name):
+    """Set grouped GEMM backend via GlobalBackendManager."""
+    if backend_name == "default":
+        return
+    backend = BackendType[backend_name.upper()]
+    if dtype_name == "fp8":
+        GlobalBackendManager.set_grouped_gemm_backend(backend, PrecisionType.FP8)
+    else:
+        GlobalBackendManager.set_grouped_gemm_backend(backend, PrecisionType.BF16_FP16_FP32)
+
+
+def benchmark_grouped_gemm_turbo(
+    dtype_name="bf16", granularity_name="tensorwise", output_csv=None, backend_name="default"
+):
     platform, gpu_name = get_platform_info()
+
+    _set_backend(backend_name, dtype_name)
+    if backend_name != "default":
+        print(f"Backend: {backend_name.upper()}")
 
     is_fp8 = dtype_name == "fp8"
     config = GRANULARITY_CONFIG_MAP[granularity_name] if is_fp8 else None
@@ -291,6 +313,13 @@ if __name__ == "__main__":
         help="FP8 scaling granularity (only used when dtype=fp8, default: tensorwise)",
     )
     parser.add_argument(
+        "--backend",
+        type=str,
+        choices=["default", "ck", "triton", "hipblaslt"],
+        default="default",
+        help="Force a specific backend: ck, triton, hipblaslt, or default (auto-dispatch)",
+    )
+    parser.add_argument(
         "--output",
         "-o",
         type=str,
@@ -299,5 +328,8 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     benchmark_grouped_gemm_turbo(
-        dtype_name=args.dtype, granularity_name=args.granularity, output_csv=args.output
+        dtype_name=args.dtype,
+        granularity_name=args.granularity,
+        output_csv=args.output,
+        backend_name=args.backend,
     )


### PR DESCRIPTION
## Summary

- Add `--backend {default,ck,triton,hipblaslt}` argument to both `bench_gemm_turbo.py` and `bench_grouped_gemm_turbo.py`
- Uses `GlobalBackendManager` to lock the backend before benchmark execution, enabling isolated per-backend performance comparison without separate scripts

## Motivation

Operator optimization PRs previously shipped one-off benchmark scripts (e.g. `bench_ck_m_aware.py`, `bench_gemm_backends.py`, `bench_gg_ck_vs_triton.py`) to isolate a specific backend for A/B testing. These scripts hardcoded shapes, duplicated the existing benchmark framework, and added maintenance burden. With a `--backend` flag on the existing benchmarks, all backend-isolation use cases are covered by a single entry point.

## Changes

| File | Change |
|------|--------|
| `benchmark/ops/bench_gemm_turbo.py` | Import `BackendType`, `GlobalBackendManager`, `PrecisionType`; add `_set_backend()` helper that maps `--backend` + `--dtype` to the correct `set_gemm_backend()` call; add `--backend` argparse argument |
| `benchmark/ops/bench_grouped_gemm_turbo.py` | Same pattern: `_set_backend()` helper calling `set_grouped_gemm_backend()`; add `--backend` argparse argument |

## Usage

```bash
# Compare CK vs Triton for BF16 GEMM
python bench_gemm_turbo.py --dtype bf16 --backend ck
python bench_gemm_turbo.py --dtype bf16 --backend triton

# Isolate CK backend for FP8 grouped GEMM (M-aware tile validation)
python bench_grouped_gemm_turbo.py --dtype fp8 --granularity rowwise --backend ck

# Default behavior unchanged (auto-dispatch)
python bench_gemm_turbo.py --dtype bf16
```

## Design Notes

- `--backend default` (the default) does not call `GlobalBackendManager` at all, preserving existing auto-dispatch behavior
- Backend is set once at the start of the benchmark run; all shapes within the run use the same backend
- The `--backend` flag interacts correctly with `--dtype`: FP8 sets `PrecisionType.FP8`, FP4 sets `PrecisionType.FP4`, BF16 sets `PrecisionType.BF16_FP16_FP32`
- Attention benchmark is not modified — no `GlobalBackendManager` API exists for attention backend selection

## Test Plan

- [ ] `python bench_gemm_turbo.py --backend ck --dtype bf16 -o /dev/null` (verify CK backend is used)
- [ ] `python bench_gemm_turbo.py --backend triton --dtype fp8 --granularity blockwise -o /dev/null`
- [ ] `python bench_grouped_gemm_turbo.py --backend ck --dtype fp8 --granularity rowwise -o /dev/null`
- [ ] `python bench_gemm_turbo.py --dtype bf16 -o /dev/null` (verify default behavior unchanged)
