### PR TITLE
Add HYBRID FP8 format support for Triton backend in gemm and grouped_gemm

### DIFF
--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
@@ -185,7 +185,7 @@ class GEMMFP8TritonBackend(KernelBackend):
     """Triton persistent-kernel backend for FP8 GEMM.
 
     Supports:
-      - TENSORWISE: per-tensor scaling (all layouts)
+      - TENSORWISE: per-tensor scaling (all layouts), including HYBRID format
       - ROWWISE: per-row/per-col vector scaling (all layouts)
       - BLOCKWISE: block-wise scaling with three layouts:
           NT/RCR (forward), NN/RRR (grad_X), TN/CRR (grad_W)
@@ -197,7 +197,7 @@ class GEMMFP8TritonBackend(KernelBackend):
         ScalingGranularity.BLOCKWISE,
     }
 
-    SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES)
+    SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES + _HYBRID_SUPPORTED_DTYPES)
 
     @staticmethod
     def can_handle(

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -311,7 +311,7 @@ class GroupedGEMMFP8TritonBackend(KernelBackend):
     """Triton persistent-kernel backend for FP8 grouped GEMM (CPU-sync-free).
 
     Supports:
-      - TENSORWISE: per-tensor scaling
+      - TENSORWISE: per-tensor scaling, including HYBRID format
       - ROWWISE: per-row/per-col vector scaling
       - BLOCKWISE: block-wise scaling (2D B_scales per group)
     """
@@ -322,7 +322,7 @@ class GroupedGEMMFP8TritonBackend(KernelBackend):
         ScalingGranularity.BLOCKWISE,
     }
 
-    SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES)
+    SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES + _HYBRID_SUPPORTED_DTYPES)
 
     @staticmethod
     def can_handle(
@@ -428,7 +428,7 @@ class GroupedGEMMFP8VariableKTritonBackend(KernelBackend):
     """Triton persistent-kernel backend for FP8 variable-K grouped GEMM (backward).
 
     Supports:
-      - TENSORWISE: per-tensor scaling
+      - TENSORWISE: per-tensor scaling, including HYBRID format
       - ROWWISE: per-row/per-col vector scaling
       - BLOCKWISE: 1D+1D block-wise scaling (TN/CRR layout)
     """
@@ -439,7 +439,7 @@ class GroupedGEMMFP8VariableKTritonBackend(KernelBackend):
         ScalingGranularity.BLOCKWISE,
     }
 
-    SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES)
+    SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES + _HYBRID_SUPPORTED_DTYPES)
 
     @staticmethod
     def can_handle(

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -64,7 +64,7 @@ def dequantize_fp8_rowwise_impl(x: torch.Tensor, out_dtype: torch.dtype, axis: i
     raise NotImplementedError(f"Un-impl")
 
 
-@triton_op("primus_turbo::quant_fp8_blockwise_impl", mutates_args=())
+@torch.library.custom_op("primus_turbo::quant_fp8_blockwise_impl", mutates_args=())
 def quant_fp8_blockwise_impl(
     x: torch.Tensor,
     dtype: torch.dtype,
@@ -98,7 +98,7 @@ def quant_fp8_blockwise_impl(
     x_scales = torch.zeros(scales_shape, dtype=torch.float32, device=x.device)
 
     grid = (triton.cdiv(M, block_size), triton.cdiv(N, block_size))
-    wrap_triton(quant_fp8_blockwise_kernel)[grid](
+    quant_fp8_blockwise_kernel[grid](
         x,
         x_fp8,
         x_scales,
@@ -211,7 +211,7 @@ def quant_fp8_blockwise_segment_m_impl_meta(
     return x_fp8, x_scales, var_k_group_lens, var_k_group_offs
 
 
-@triton_op("primus_turbo::quant_fp8_blockwise_for_weight_impl", mutates_args=())
+@torch.library.custom_op("primus_turbo::quant_fp8_blockwise_for_weight_impl", mutates_args=())
 def quant_fp8_blockwise_for_weight_impl(
     w: torch.Tensor,
     dtype: torch.dtype,
@@ -245,7 +245,7 @@ def quant_fp8_blockwise_for_weight_impl(
         device=w.device,
     )
     grid = (B, triton.cdiv(M, block_size), triton.cdiv(N, block_size))
-    wrap_triton(quant_fp8_blockwise_for_weight_kernel)[grid](
+    quant_fp8_blockwise_for_weight_kernel[grid](
         w,
         w_fp8,
         w_scales,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ clang-format==18.1.6
 hipify_torch @ git+https://github.com/ROCm/hipify_torch.git
 build
 scikit-build-core
-triton==3.6.0
+triton==3.7.0
 expecttest
 pytest
 pytest-xdist

--- a/tests/pytorch/ops/test_gemm_fp8.py
+++ b/tests/pytorch/ops/test_gemm_fp8.py
@@ -209,9 +209,6 @@ def _run_gemm_fp8_deterministic_test(
 @pytest.mark.parametrize("backend", [None, BackendType.TRITON, BackendType.CK, BackendType.HIPBLASLT])
 @pytest.mark.parametrize("auto_tune", [False, True])
 def test_gemm_fp8_tensorwise(m, n, k, layout, format, dtype, backend, auto_tune):
-    if backend == BackendType.TRITON and format == Format.HYBRID:
-        pytest.skip("TRITON backend does not support HYBRID format currently.")
-
     _run_gemm_fp8_test(
         m=m,
         n=n,

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -399,9 +399,6 @@ def test_grouped_gemm_fp8_tensorwise(B, M, NK, ori_dtype, format, trans_b, balan
     if backend == BackendType.CK or backend == None:
         pytest.skip("CK backend has numerical issues currently")
 
-    if backend == BackendType.TRITON and format == Format.HYBRID:
-        pytest.skip("TRITON backend not support HYBRID format currently")
-
     # TODO(xiaobochen-amd): On gfx942, the hipBLASLt path can hang/flake when M <= 512.
     # This has been observed under pytest; root cause not yet identified. MI355 works normally.
     # Skip also when auto_tune=True because the tuner may select hipBLASLt.


### PR DESCRIPTION
must update triton to latest version, otherwise will fail.