### PR TITLE
feat: enable hybrid FP8 dtypes on Triton grouped GEMM backends

### DIFF
--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -322,7 +322,7 @@ class GroupedGEMMFP8TritonBackend(KernelBackend):
         ScalingGranularity.BLOCKWISE,
     }
 
-    SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES)
+    SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES + _HYBRID_SUPPORTED_DTYPES)
 
     @staticmethod
     def can_handle(
@@ -439,7 +439,7 @@ class GroupedGEMMFP8VariableKTritonBackend(KernelBackend):
         ScalingGranularity.BLOCKWISE,
     }
 
-    SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES)
+    SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES + _HYBRID_SUPPORTED_DTYPES)
 
     @staticmethod
     def can_handle(


### PR DESCRIPTION
## Summary

- Enable hybrid (mixed e4m3/e5m2) FP8 dtype support on the two Triton grouped GEMM backends (`GroupedGEMMFP8TritonBackend` and `GroupedGEMMFP8VariableKTritonBackend`)

```python
# GroupedGEMMFP8TritonBackend (line ~325)
# GroupedGEMMFP8VariableKTritonBackend (line ~442)
# Before:
SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES)
# After:
SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES + _HYBRID_SUPPORTED_DTYPES)
```

Made with [Cursor](https://cursor.com)