### PR TITLE
fix(typo): rename MXScalingRecipe, grouped gemm fp8 function name and remove scale args from quantize api

### DIFF
--- a/csrc/include/primus_turbo/quantization.h
+++ b/csrc/include/primus_turbo/quantization.h
@@ -38,7 +38,7 @@ enum class QuantizeMode { ROWWISE, COLWISE };
 constexpr int MXFP4_BLOCK_SIZE = 32;
 constexpr int MXFP8_BLOCK_SIZE = 32;
 
-struct MXScalingRecipe {
+struct ScalingRecipe {
     bool use_2d_block = false;
     bool use_sr       = false;
     bool use_rht      = false;
@@ -82,14 +82,14 @@ void quantize_mxfp4_dual_impl(const DType *input, dtype::float4x2_e2m1 *rowwise_
                               int rowwise_scale_stride, int colwise_scale_stride,
                               int rowwise_scale_N, int rowwise_scale_M_pad, int rowwise_scale_N_pad,
                               int colwise_scale_M, int colwise_scale_N, int colwise_scale_M_pad,
-                              int colwise_scale_N_pad, detail::MXScalingRecipe rowwise_recipe,
-                              detail::MXScalingRecipe colwise_recipe, hipStream_t stream);
+                              int colwise_scale_N_pad, detail::ScalingRecipe rowwise_recipe,
+                              detail::ScalingRecipe colwise_recipe, hipStream_t stream);
 
 template <typename DType>
 void quantize_mxfp4_impl(const DType *input, dtype::float4x2_e2m1 *output, uint8_t *scale,
                          detail::QuantizeMode mode, int M, int N, int M_pad, int N_pad,
                          int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
-                         detail::MXScalingRecipe recipe, hipStream_t stream);
+                         detail::ScalingRecipe recipe, hipStream_t stream);
 
 template <typename IType, typename OType>
 void quantize_mxfp8_dual_impl(const IType *input, OType *rowwise_output, uint8_t *rowwise_scale,
@@ -98,14 +98,14 @@ void quantize_mxfp8_dual_impl(const IType *input, OType *rowwise_output, uint8_t
                               int colwise_scale_stride, int rowwise_scale_N,
                               int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M,
                               int colwise_scale_N, int colwise_scale_M_pad, int colwise_scale_N_pad,
-                              detail::MXScalingRecipe rowwise_recipe,
-                              detail::MXScalingRecipe colwise_recipe, hipStream_t stream);
+                              detail::ScalingRecipe rowwise_recipe,
+                              detail::ScalingRecipe colwise_recipe, hipStream_t stream);
 
 template <typename IType, typename OType>
 void quantize_mxfp8_impl(const IType *input, OType *output, uint8_t *scale,
                          detail::QuantizeMode mode, int M, int N, int M_pad, int N_pad,
                          int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
-                         detail::MXScalingRecipe recipe, hipStream_t stream);
+                         detail::ScalingRecipe recipe, hipStream_t stream);
 
 // *************** DeQuantize ***************
 template <typename FType, typename QType, typename ComputeType = float>

--- a/csrc/kernels/quantization/quantization_mxfp4.cu
+++ b/csrc/kernels/quantization/quantization_mxfp4.cu
@@ -1044,8 +1044,8 @@ void quantize_mxfp4_dual_impl(const DType *input, dtype::float4x2_e2m1 *rowwise_
                               int rowwise_scale_stride, int colwise_scale_stride,
                               int rowwise_scale_N, int rowwise_scale_M_pad, int rowwise_scale_N_pad,
                               int colwise_scale_M, int colwise_scale_N, int colwise_scale_M_pad,
-                              int colwise_scale_N_pad, MXScalingRecipe rowwise_recipe,
-                              MXScalingRecipe colwise_recipe, hipStream_t stream) {
+                              int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
+                              ScalingRecipe colwise_recipe, hipStream_t stream) {
     dim3 grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
     dim3 block(THREADS_PER_BLOCK);
 
@@ -1128,20 +1128,20 @@ template void quantize_mxfp4_dual_impl<dtype::float16>(
     dtype::float4x2_e2m1 *colwise_output, uint8_t *colwise_scale, int M, int N, int M_pad,
     int N_pad, int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
-    int colwise_scale_M_pad, int colwise_scale_N_pad, MXScalingRecipe rowwise_recipe,
-    MXScalingRecipe colwise_recipe, hipStream_t stream);
+    int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
+    ScalingRecipe colwise_recipe, hipStream_t stream);
 template void quantize_mxfp4_dual_impl<dtype::bfloat16>(
     const dtype::bfloat16 *x, dtype::float4x2_e2m1 *rowwise_output, uint8_t *rowwise_scale,
     dtype::float4x2_e2m1 *colwise_output, uint8_t *colwise_scale, int M, int N, int M_pad,
     int N_pad, int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
-    int colwise_scale_M_pad, int colwise_scale_N_pad, MXScalingRecipe rowwise_recipe,
-    MXScalingRecipe colwise_recipe, hipStream_t stream);
+    int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
+    ScalingRecipe colwise_recipe, hipStream_t stream);
 
 template <typename DType>
 void quantize_mxfp4_impl(const DType *input, dtype::float4x2_e2m1 *output, uint8_t *scale,
                          QuantizeMode mode, int M, int N, int M_pad, int N_pad, int scale_stride,
-                         int scale_N, int scale_M_pad, int scale_N_pad, MXScalingRecipe recipe,
+                         int scale_N, int scale_M_pad, int scale_N_pad, ScalingRecipe recipe,
                          hipStream_t stream) {
     dim3 grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
     dim3 block(THREADS_PER_BLOCK);
@@ -1195,12 +1195,12 @@ template void quantize_mxfp4_impl<dtype::float16>(const dtype::float16 *x,
                                                   QuantizeMode mode, int M, int N, int M_pad,
                                                   int N_pad, int scale_stride, int scale_N,
                                                   int scale_M_pad, int scale_N_pad,
-                                                  MXScalingRecipe recipe, hipStream_t stream);
+                                                  ScalingRecipe recipe, hipStream_t stream);
 template void quantize_mxfp4_impl<dtype::bfloat16>(const dtype::bfloat16 *x,
                                                    dtype::float4x2_e2m1 *output, uint8_t *scale,
                                                    QuantizeMode mode, int M, int N, int M_pad,
                                                    int N_pad, int scale_stride, int scale_N,
                                                    int scale_M_pad, int scale_N_pad,
-                                                   MXScalingRecipe recipe, hipStream_t stream);
+                                                   ScalingRecipe recipe, hipStream_t stream);
 
 } // namespace primus_turbo

--- a/csrc/kernels/quantization/quantization_mxfp8.cu
+++ b/csrc/kernels/quantization/quantization_mxfp8.cu
@@ -899,7 +899,7 @@ void quantize_mxfp8_dual_impl(const IType *input, OType *rowwise_output, uint8_t
                               int colwise_scale_stride, int rowwise_scale_N,
                               int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M,
                               int colwise_scale_N, int colwise_scale_M_pad, int colwise_scale_N_pad,
-                              MXScalingRecipe rowwise_recipe, MXScalingRecipe colwise_recipe,
+                              ScalingRecipe rowwise_recipe, ScalingRecipe colwise_recipe,
                               hipStream_t stream) {
     dim3 grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
     dim3 block(THREADS_PER_BLOCK);
@@ -947,34 +947,34 @@ template void quantize_mxfp8_dual_impl<dtype::float16, dtype::float8_e5m2>(
     dtype::float8_e5m2 *colwise_output, uint8_t *colwise_scale, int M, int N, int M_pad, int N_pad,
     int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
-    int colwise_scale_M_pad, int colwise_scale_N_pad, MXScalingRecipe rowwise_recipe,
-    MXScalingRecipe colwise_recipe, hipStream_t stream);
+    int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
+    ScalingRecipe colwise_recipe, hipStream_t stream);
 template void quantize_mxfp8_dual_impl<dtype::bfloat16, dtype::float8_e5m2>(
     const dtype::bfloat16 *x, dtype::float8_e5m2 *rowwise_output, uint8_t *rowwise_scale,
     dtype::float8_e5m2 *colwise_output, uint8_t *colwise_scale, int M, int N, int M_pad, int N_pad,
     int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
-    int colwise_scale_M_pad, int colwise_scale_N_pad, MXScalingRecipe rowwise_recipe,
-    MXScalingRecipe colwise_recipe, hipStream_t stream);
+    int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
+    ScalingRecipe colwise_recipe, hipStream_t stream);
 template void quantize_mxfp8_dual_impl<dtype::float16, dtype::float8_e4m3>(
     const dtype::float16 *x, dtype::float8_e4m3 *rowwise_output, uint8_t *rowwise_scale,
     dtype::float8_e4m3 *colwise_output, uint8_t *colwise_scale, int M, int N, int M_pad, int N_pad,
     int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
-    int colwise_scale_M_pad, int colwise_scale_N_pad, MXScalingRecipe rowwise_recipe,
-    MXScalingRecipe colwise_recipe, hipStream_t stream);
+    int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
+    ScalingRecipe colwise_recipe, hipStream_t stream);
 template void quantize_mxfp8_dual_impl<dtype::bfloat16, dtype::float8_e4m3>(
     const dtype::bfloat16 *x, dtype::float8_e4m3 *rowwise_output, uint8_t *rowwise_scale,
     dtype::float8_e4m3 *colwise_output, uint8_t *colwise_scale, int M, int N, int M_pad, int N_pad,
     int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
-    int colwise_scale_M_pad, int colwise_scale_N_pad, MXScalingRecipe rowwise_recipe,
-    MXScalingRecipe colwise_recipe, hipStream_t stream);
+    int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
+    ScalingRecipe colwise_recipe, hipStream_t stream);
 
 template <typename IType, typename OType>
 void quantize_mxfp8_impl(const IType *input, OType *output, uint8_t *scale, QuantizeMode mode,
                          int M, int N, int M_pad, int N_pad, int scale_stride, int scale_N,
-                         int scale_M_pad, int scale_N_pad, MXScalingRecipe recipe,
+                         int scale_M_pad, int scale_N_pad, ScalingRecipe recipe,
                          hipStream_t stream) {
     dim3 grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
     dim3 block(THREADS_PER_BLOCK);
@@ -1013,18 +1013,18 @@ void quantize_mxfp8_impl(const IType *input, OType *output, uint8_t *scale, Quan
 template void quantize_mxfp8_impl<dtype::float16, dtype::float8_e5m2>(
     const dtype::float16 *x, dtype::float8_e5m2 *output, uint8_t *scale, QuantizeMode mode, int M,
     int N, int M_pad, int N_pad, int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
-    MXScalingRecipe recipe, hipStream_t stream);
+    ScalingRecipe recipe, hipStream_t stream);
 template void quantize_mxfp8_impl<dtype::bfloat16, dtype::float8_e5m2>(
     const dtype::bfloat16 *x, dtype::float8_e5m2 *output, uint8_t *scale, QuantizeMode mode, int M,
     int N, int M_pad, int N_pad, int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
-    MXScalingRecipe recipe, hipStream_t stream);
+    ScalingRecipe recipe, hipStream_t stream);
 template void quantize_mxfp8_impl<dtype::float16, dtype::float8_e4m3>(
     const dtype::float16 *x, dtype::float8_e4m3 *output, uint8_t *scale, QuantizeMode mode, int M,
     int N, int M_pad, int N_pad, int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
-    MXScalingRecipe recipe, hipStream_t stream);
+    ScalingRecipe recipe, hipStream_t stream);
 template void quantize_mxfp8_impl<dtype::bfloat16, dtype::float8_e4m3>(
     const dtype::bfloat16 *x, dtype::float8_e4m3 *output, uint8_t *scale, QuantizeMode mode, int M,
     int N, int M_pad, int N_pad, int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
-    MXScalingRecipe recipe, hipStream_t stream);
+    ScalingRecipe recipe, hipStream_t stream);
 
 } // namespace primus_turbo

--- a/csrc/pytorch/quantization/quantization.cpp
+++ b/csrc/pytorch/quantization/quantization.cpp
@@ -310,10 +310,10 @@ std::vector<at::Tensor> quantize_mxfp4_dual(
             colwise_scale.data_ptr<uint8_t>(), M, N, M_pad, N_pad, rowwise_scale_stride,
             colwise_scale_stride, rowwise_scale_N, rowwise_scale_M_pad, rowwise_scale_N_pad, N,
             colwise_scale_N, colwise_scale_M_pad, colwise_scale_N_pad,
-            MXScalingRecipe(rowwise_use_2d_block, rowwise_use_sr, rowwise_use_rht,
-                            shuffle_rowwise_scale, shuffle_rowwise),
-            MXScalingRecipe(colwise_use_2d_block, colwise_use_sr, colwise_use_rht,
-                            shuffle_colwise_scale, shuffle_colwise),
+            ScalingRecipe(rowwise_use_2d_block, rowwise_use_sr, rowwise_use_rht,
+                          shuffle_rowwise_scale, shuffle_rowwise),
+            ScalingRecipe(colwise_use_2d_block, colwise_use_sr, colwise_use_rht,
+                          shuffle_colwise_scale, shuffle_colwise),
             stream);
     });
 
@@ -394,7 +394,7 @@ std::vector<at::Tensor> quantize_mxfp4(const at::Tensor input, const at::ScalarT
             reinterpret_cast<dtype::float4x2_e2m1 *>(output.data_ptr()),
             scale_tensor.data_ptr<uint8_t>(), mode, M, N, M_pad, N_pad, scale_stride, scale_N,
             scale_M_pad, scale_N_pad,
-            MXScalingRecipe(use_2d_block, use_sr, use_rht, shuffle_scale, shuffle_out), stream);
+            ScalingRecipe(use_2d_block, use_sr, use_rht, shuffle_scale, shuffle_out), stream);
     });
 
     return {output.view(at::kFloat4_e2m1fn_x2), scale_tensor.view(at::kFloat8_e8m0fnu)};
@@ -488,10 +488,10 @@ quantize_mxfp8_dual(const at::Tensor input, const at::ScalarType dest_dtype,
                 colwise_scale.data_ptr<uint8_t>(), M, N, M_pad, N_pad, rowwise_scale_stride,
                 colwise_scale_stride, rowwise_scale_N, rowwise_scale_M_pad, rowwise_scale_N_pad, N,
                 colwise_scale_N, colwise_scale_M_pad, colwise_scale_N_pad,
-                MXScalingRecipe(rowwise_use_2d_block, false, false, shuffle_rowwise_scale,
-                                shuffle_rowwise),
-                MXScalingRecipe(colwise_use_2d_block, false, false, shuffle_colwise_scale,
-                                shuffle_colwise),
+                ScalingRecipe(rowwise_use_2d_block, false, false, shuffle_rowwise_scale,
+                              shuffle_rowwise),
+                ScalingRecipe(colwise_use_2d_block, false, false, shuffle_colwise_scale,
+                              shuffle_colwise),
                 stream);
         })});
 
@@ -572,7 +572,7 @@ std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarT
                 reinterpret_cast<IType *>(input.data_ptr()),
                 reinterpret_cast<OType *>(output.data_ptr()), scale_tensor.data_ptr<uint8_t>(),
                 mode, M, N, M_pad, N_pad, scale_stride, scale_N, scale_M_pad, scale_N_pad,
-                MXScalingRecipe(use_2d_block, false, false, shuffle_scale, shuffle_out), stream);
+                ScalingRecipe(use_2d_block, false, false, shuffle_scale, shuffle_out), stream);
         })});
 
     return {output.view(dest_dtype), scale_tensor.view(at::kFloat8_e8m0fnu)};

--- a/primus_turbo/pytorch/core/low_precision.py
+++ b/primus_turbo/pytorch/core/low_precision.py
@@ -135,7 +135,7 @@ class ScalingStrategy(Enum):
 
 
 @dataclass
-class MXScalingRecipe:
+class ScalingRecipe:
     """
     Supported MXFP8/MXFP4 scaling recipe.
 

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -11,7 +11,7 @@ import triton
 from torch.library import triton_op, wrap_triton
 
 from primus_turbo.pytorch.core.low_precision import (
-    MXScalingRecipe,
+    ScalingRecipe,
     check_mxfp4_support,
     check_mxfp8_support,
 )
@@ -292,17 +292,17 @@ def quantize_mxfp8_impl(
     axis: Union[int, None],
     block_size: int,
     with_trans: bool = False,
-    scaling_recipe: Optional[MXScalingRecipe] = None,
-    scaling_recipe_for_trans: Optional[MXScalingRecipe] = None,
+    scaling_recipe: Optional[ScalingRecipe] = None,
+    scaling_recipe_for_trans: Optional[ScalingRecipe] = None,
 ) -> Union[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]]:
     # NOTE: quantize fp8 kernel use the ISA which only available on cdna4.
     mxfp8_support, reason = check_mxfp8_support()
     assert mxfp8_support, reason
 
-    scaling_recipe = MXScalingRecipe() if scaling_recipe is None else scaling_recipe
+    scaling_recipe = ScalingRecipe() if scaling_recipe is None else scaling_recipe
     if with_trans:
         scaling_recipe_for_trans = (
-            MXScalingRecipe() if scaling_recipe_for_trans is None else scaling_recipe_for_trans
+            ScalingRecipe() if scaling_recipe_for_trans is None else scaling_recipe_for_trans
         )
     else:
         scaling_recipe_for_trans = scaling_recipe
@@ -397,17 +397,17 @@ def quantize_mxfp4_impl(
     axis: Union[int, None],
     block_size: int,
     with_trans: bool = False,
-    scaling_recipe: Optional[MXScalingRecipe] = None,
-    scaling_recipe_for_trans: Optional[MXScalingRecipe] = None,
+    scaling_recipe: Optional[ScalingRecipe] = None,
+    scaling_recipe_for_trans: Optional[ScalingRecipe] = None,
 ) -> Union[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]]:
     # NOTE: quantize fp4 kernel use the ISA which only available on cdna4.
     mxfp4_support, reason = check_mxfp4_support()
     assert mxfp4_support, reason
 
-    scaling_recipe = MXScalingRecipe() if scaling_recipe is None else scaling_recipe
+    scaling_recipe = ScalingRecipe() if scaling_recipe is None else scaling_recipe
     if with_trans:
         scaling_recipe_for_trans = (
-            MXScalingRecipe() if scaling_recipe_for_trans is None else scaling_recipe_for_trans
+            ScalingRecipe() if scaling_recipe_for_trans is None else scaling_recipe_for_trans
         )
     else:
         scaling_recipe_for_trans = scaling_recipe

--- a/primus_turbo/pytorch/ops/gemm_fp4.py
+++ b/primus_turbo/pytorch/ops/gemm_fp4.py
@@ -12,8 +12,8 @@ from primus_turbo.pytorch.core.backend import BackendType
 from primus_turbo.pytorch.core.low_precision import (
     Float4QuantConfig,
     Format,
-    MXScalingRecipe,
     ScalingGranularity,
+    ScalingRecipe,
     check_mxfp4_support,
 )
 from primus_turbo.pytorch.kernels.gemm.gemm_fp4_impl import (
@@ -62,13 +62,13 @@ class FP4GemmMXFunction(torch.autograd.Function):
             a_dtype,
             config.granularity,
             block_size=config.block_size,
-            scaling_recipe=MXScalingRecipe(
+            scaling_recipe=ScalingRecipe(
                 use_2d_block=False,
                 use_sr=False,
                 use_rht=False,
                 shuffle_scale=enable_preshuffle(),
             ),
-            scaling_recipe_for_trans=MXScalingRecipe(
+            scaling_recipe_for_trans=ScalingRecipe(
                 use_2d_block=False,
                 use_sr=False,
                 use_rht=True,
@@ -82,14 +82,14 @@ class FP4GemmMXFunction(torch.autograd.Function):
             b_dtype,
             config.granularity,
             block_size=config.block_size,
-            scaling_recipe=MXScalingRecipe(
+            scaling_recipe=ScalingRecipe(
                 use_2d_block=True,
                 use_sr=False,
                 use_rht=False,
                 shuffle_scale=enable_preshuffle(),
                 shuffle_out=enable_preshuffle(),
             ),
-            scaling_recipe_for_trans=MXScalingRecipe(
+            scaling_recipe_for_trans=ScalingRecipe(
                 use_2d_block=True,
                 use_sr=False,
                 use_rht=False,
@@ -137,13 +137,13 @@ class FP4GemmMXFunction(torch.autograd.Function):
             grad_out_dtype,
             ctx.config.granularity,
             block_size=ctx.config.block_size,
-            scaling_recipe=MXScalingRecipe(
+            scaling_recipe=ScalingRecipe(
                 use_2d_block=False,
                 use_sr=False,
                 use_rht=False,
                 shuffle_scale=enable_preshuffle(),
             ),
-            scaling_recipe_for_trans=MXScalingRecipe(
+            scaling_recipe_for_trans=ScalingRecipe(
                 use_2d_block=False,
                 use_sr=False,
                 use_rht=True,

--- a/primus_turbo/pytorch/ops/gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/gemm_fp8.py
@@ -12,8 +12,8 @@ from primus_turbo.pytorch.core.backend import BackendType
 from primus_turbo.pytorch.core.low_precision import (
     Float8QuantConfig,
     Format,
-    MXScalingRecipe,
     ScalingGranularity,
+    ScalingRecipe,
     check_mxfp8_support,
     float8_e4m3,
     float8_e5m2,
@@ -332,10 +332,10 @@ class FP8GemmMXFunction(torch.autograd.Function):
             b_dtype,
             config.granularity,
             block_size=config.block_size,
-            scaling_recipe=MXScalingRecipe(
+            scaling_recipe=ScalingRecipe(
                 use_2d_block=True,
             ),
-            scaling_recipe_for_trans=MXScalingRecipe(
+            scaling_recipe_for_trans=ScalingRecipe(
                 use_2d_block=True,
             ),
         )

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -49,7 +49,7 @@ def _ensure_contiguous_grad_out(grad_out: torch.Tensor) -> torch.Tensor:
     return grad_out if grad_out.is_contiguous() else grad_out.contiguous()
 
 
-class GroupedGemmFP8BlockFunc(torch.autograd.Function):
+class FP8GroupedGemmBlockFunc(torch.autograd.Function):
 
     @staticmethod
     def forward(
@@ -180,7 +180,7 @@ class GroupedGemmFP8BlockFunc(torch.autograd.Function):
         return grad_a, grad_b, None, None, None, None, None
 
 
-class GroupedGemmFP8RowFunc(torch.autograd.Function):
+class FP8GroupedGemmRowFunc(torch.autograd.Function):
 
     @staticmethod
     def forward(
@@ -284,7 +284,7 @@ class GroupedGemmFP8RowFunc(torch.autograd.Function):
         return grad_a, grad_b, None, None, None, None, None
 
 
-class GroupedGemmFP8TensorFunc(torch.autograd.Function):
+class FP8GroupedGemmTensorFunc(torch.autograd.Function):
 
     @staticmethod
     def forward(
@@ -395,10 +395,10 @@ def grouped_gemm_fp8(
     args = (a, b, group_lens, group_offs, trans_b, config, num_cu)
 
     if config.granularity == ScalingGranularity.TENSORWISE:
-        return GroupedGemmFP8TensorFunc.apply(*args)
+        return FP8GroupedGemmTensorFunc.apply(*args)
     elif config.granularity == ScalingGranularity.ROWWISE:
-        return GroupedGemmFP8RowFunc.apply(*args)
+        return FP8GroupedGemmRowFunc.apply(*args)
     elif config.granularity == ScalingGranularity.BLOCKWISE:
-        return GroupedGemmFP8BlockFunc.apply(*args)
+        return FP8GroupedGemmBlockFunc.apply(*args)
     else:
         raise ValueError(f"Unsupported FP8 ScalingGranularity: {config.granularity}")

--- a/primus_turbo/pytorch/ops/quantization.py
+++ b/primus_turbo/pytorch/ops/quantization.py
@@ -47,7 +47,6 @@ def quantize_fp8(
             1. The x must be 2D tensor.
             2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction. If not specified, the `with_trans` must be True.
             3. The block size must be 32.
-            4. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise when `with_trans` is True.
     """
     if granularity == ScalingGranularity.TENSORWISE:
         return quantize_fp8_tensorwise_impl(x, out_dtype)
@@ -96,7 +95,7 @@ def quantize_fp8_with_trans(
             1. The x must be 2D tensor.
             2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction. If not specified, the `with_trans` must be True.
             3. The block size must be 32.
-            4. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise when `with_trans` is True.
+            4. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise.
     """
     if granularity == ScalingGranularity.MX_BLOCKWISE:
         assert block_size == MX_BLOCK_SIZE, f"The block size must be {MX_BLOCK_SIZE} for MXFP8 quantization"
@@ -168,7 +167,6 @@ def quantize_fp4(
             1. The x must be 2D tensor.
             2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction. If not specified, the `with_trans` must be True.
             3. The block size must be 32.
-            4. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise when `with_trans` is True.
     """
     if granularity == ScalingGranularity.MX_BLOCKWISE:
         assert block_size == MX_BLOCK_SIZE, f"The block size must be {MX_BLOCK_SIZE} for MXFP8 quantization"
@@ -192,7 +190,6 @@ def quantize_fp4_with_trans(
     *,
     block_size: Optional[int] = None,
     axis: Optional[int] = None,
-    scale: Optional[torch.Tensor] = None,
     scaling_recipe: Optional[ScalingRecipe] = None,
     scaling_recipe_for_trans: Optional[ScalingRecipe] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -204,10 +201,9 @@ def quantize_fp4_with_trans(
             1. The x must be 2D tensor.
             2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction. If not specified, the `with_trans` must be True.
             3. The block size must be 32.
-            5. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise when `with_trans` is True.
+            4. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise.
     """
     if granularity == ScalingGranularity.MX_BLOCKWISE:
-        assert scale is None, "The scale is not supported for MXFP4 quantization"
         assert block_size == MX_BLOCK_SIZE, f"The block size must be {MX_BLOCK_SIZE} for MXFP4 quantization"
 
         return quantize_mxfp4_impl(

--- a/primus_turbo/pytorch/ops/quantization.py
+++ b/primus_turbo/pytorch/ops/quantization.py
@@ -8,12 +8,14 @@ from typing import Optional, Tuple
 
 import torch
 
-from primus_turbo.pytorch.core.low_precision import MXScalingRecipe, ScalingGranularity
+from primus_turbo.pytorch.core.low_precision import ScalingGranularity, ScalingRecipe
 from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
     dequantize_fp8_rowwise_impl,
     dequantize_fp8_tensorwise_impl,
     dequantize_mxfp4_impl,
     dequantize_mxfp8_impl,
+    quant_fp8_blockwise_for_weight_impl,
+    quant_fp8_blockwise_impl,
     quantize_fp8_rowwise_impl,
     quantize_fp8_tensorwise_impl,
     quantize_mxfp4_impl,
@@ -32,9 +34,7 @@ def quantize_fp8(
     *,
     block_size: Optional[int] = None,
     axis: Optional[int] = None,
-    scale: Optional[torch.Tensor] = None,
-    padding_align_size: Optional[int] = None,
-    scaling_recipe: Optional[MXScalingRecipe] = None,
+    scaling_recipe: Optional[ScalingRecipe] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     FP8 Quantize
@@ -47,18 +47,24 @@ def quantize_fp8(
             1. The x must be 2D tensor.
             2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction. If not specified, the `with_trans` must be True.
             3. The block size must be 32.
-            4. The out tensor will be padded in specified axis if padding_align_size is not `None`.
-            5. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise when `with_trans` is True.
+            4. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise when `with_trans` is True.
     """
     if granularity == ScalingGranularity.TENSORWISE:
-        return quantize_fp8_tensorwise_impl(x, out_dtype, scale)
+        return quantize_fp8_tensorwise_impl(x, out_dtype)
 
     elif granularity == ScalingGranularity.ROWWISE:
 
-        return quantize_fp8_rowwise_impl(x, out_dtype, axis, scale)
+        return quantize_fp8_rowwise_impl(x, out_dtype, axis)
+    elif granularity == ScalingGranularity.BLOCKWISE:
+        assert block_size is not None, "block_size must be specified for BLOCKWISE quantization"
+        if scaling_recipe is not None and scaling_recipe.use_2d_block:
+            # 2D block (for weight): ignores axis; scales along both dims.
+            return quant_fp8_blockwise_for_weight_impl(x, out_dtype, block_size=block_size)
+        assert axis is not None, "axis must be specified for 1D BLOCKWISE quantization"
+
+        return quant_fp8_blockwise_impl(x, out_dtype, axis=axis, block_size=block_size)
     elif granularity == ScalingGranularity.MX_BLOCKWISE:
         assert block_size == MX_BLOCK_SIZE, f"The block size must be {MX_BLOCK_SIZE} for MXFP8 quantization"
-        assert scale is None, "The scale is not supported for MXFP8 quantization"
 
         return quantize_mxfp8_impl(
             x,
@@ -79,9 +85,8 @@ def quantize_fp8_with_trans(
     *,
     block_size: Optional[int] = None,
     axis: Optional[int] = None,
-    scale: Optional[torch.Tensor] = None,
-    scaling_recipe: Optional[MXScalingRecipe] = None,
-    scaling_recipe_for_trans: Optional[MXScalingRecipe] = None,
+    scaling_recipe: Optional[ScalingRecipe] = None,
+    scaling_recipe_for_trans: Optional[ScalingRecipe] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     FP8 Quantize with trans
@@ -95,7 +100,6 @@ def quantize_fp8_with_trans(
     """
     if granularity == ScalingGranularity.MX_BLOCKWISE:
         assert block_size == MX_BLOCK_SIZE, f"The block size must be {MX_BLOCK_SIZE} for MXFP8 quantization"
-        assert scale is None, "The scale is not supported for MXFP8 quantization"
 
         return quantize_mxfp8_impl(
             x,
@@ -118,7 +122,7 @@ def dequantize_fp8(
     block_size: Optional[int] = None,
     axis: Optional[int] = None,
     scale_inv: torch.Tensor,
-    scaling_recipe: Optional[MXScalingRecipe] = None,
+    scaling_recipe: Optional[ScalingRecipe] = None,
 ):
     """
     FP8 DeQuantize
@@ -154,8 +158,7 @@ def quantize_fp4(
     *,
     block_size: Optional[int] = None,
     axis: Optional[int] = None,
-    scale: Optional[torch.Tensor] = None,
-    scaling_recipe: Optional[MXScalingRecipe] = None,
+    scaling_recipe: Optional[ScalingRecipe] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     FP4 Quantize
@@ -165,11 +168,9 @@ def quantize_fp4(
             1. The x must be 2D tensor.
             2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction. If not specified, the `with_trans` must be True.
             3. The block size must be 32.
-            4. The out tensor will be padded in specified axis if padding_align_size is not `None`.
-            5. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise when `with_trans` is True.
+            4. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise when `with_trans` is True.
     """
     if granularity == ScalingGranularity.MX_BLOCKWISE:
-        assert scale is None, "The scale is not supported for MXFP4 quantization"
         assert block_size == MX_BLOCK_SIZE, f"The block size must be {MX_BLOCK_SIZE} for MXFP8 quantization"
 
         return quantize_mxfp4_impl(
@@ -192,8 +193,8 @@ def quantize_fp4_with_trans(
     block_size: Optional[int] = None,
     axis: Optional[int] = None,
     scale: Optional[torch.Tensor] = None,
-    scaling_recipe: Optional[MXScalingRecipe] = None,
-    scaling_recipe_for_trans: Optional[MXScalingRecipe] = None,
+    scaling_recipe: Optional[ScalingRecipe] = None,
+    scaling_recipe_for_trans: Optional[ScalingRecipe] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     FP4 Quantize with trans
@@ -230,7 +231,7 @@ def dequantize_fp4(
     block_size: Optional[int] = None,
     axis: Optional[int] = None,
     scale_inv: torch.Tensor,
-    scaling_recipe: Optional[MXScalingRecipe] = None,
+    scaling_recipe: Optional[ScalingRecipe] = None,
 ) -> torch.Tensor:
     """
     FP4 DeQuantize

--- a/primus_turbo/pytorch/ops/quantization.py
+++ b/primus_turbo/pytorch/ops/quantization.py
@@ -45,7 +45,7 @@ def quantize_fp8(
 
         For MXFP8 quantization:
             1. The x must be 2D tensor.
-            2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction. If not specified, the `with_trans` must be True.
+            2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction.
             3. The block size must be 32.
     """
     if granularity == ScalingGranularity.TENSORWISE:
@@ -93,7 +93,7 @@ def quantize_fp8_with_trans(
     NOTE:
         For MXFP8 quantization:
             1. The x must be 2D tensor.
-            2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction. If not specified, the `with_trans` must be True.
+            2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction.
             3. The block size must be 32.
             4. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise.
     """
@@ -165,7 +165,7 @@ def quantize_fp4(
     NOTE:
         For MXFP4 quantization:
             1. The x must be 2D tensor.
-            2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction. If not specified, the `with_trans` must be True.
+            2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction.
             3. The block size must be 32.
     """
     if granularity == ScalingGranularity.MX_BLOCKWISE:
@@ -199,7 +199,7 @@ def quantize_fp4_with_trans(
     NOTE:
         For MXFP4 quantization:
             1. The x must be 2D tensor.
-            2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction. If not specified, the `with_trans` must be True.
+            2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction.
             3. The block size must be 32.
             4. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise.
     """

--- a/tests/pytorch/ops/test_quantization.py
+++ b/tests/pytorch/ops/test_quantization.py
@@ -12,8 +12,8 @@ import primus_turbo.pytorch as turbo
 from primus_turbo.pytorch.core.low_precision import (
     MXFP4_BLOCK_SIZE,
     MXFP8_BLOCK_SIZE,
-    MXScalingRecipe,
     ScalingGranularity,
+    ScalingRecipe,
     check_mxfp4_support,
     check_mxfp8_support,
 )
@@ -30,31 +30,25 @@ from tests.pytorch.test_utils import get_tolerances
 @pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16, torch.float32])
 @pytest.mark.parametrize("dest_dtype", [turbo.float8_e4m3, turbo.float8_e5m2])
 @pytest.mark.parametrize("numel", [6 * 1 * 7168 * 8192])
-@pytest.mark.parametrize("dynamic_quantize", [True, False])
 @pytest.mark.parametrize("torch_compile", [True, False])
 @pytest.mark.parametrize("granularity", [ScalingGranularity.TENSORWISE])
-def test_quantize_fp8_tensorwise(orig_dtype, dest_dtype, numel, dynamic_quantize, torch_compile, granularity):
+def test_quantize_fp8_tensorwise(orig_dtype, dest_dtype, numel, torch_compile, granularity):
     torch.manual_seed(42)
 
     x = torch.rand(numel, device="cuda", dtype=orig_dtype)
     x_ref = x.detach().clone()
     x_fp8_ref, x_scale_ref, x_scale_inv_ref = quantize_fp8_ref(x_ref, dest_dtype, granularity)
 
-    # Quantize
-    scale = None
-    if dynamic_quantize == False:
-        scale = x_scale_ref.detach().clone()
-
     if torch_compile is True:
         torch._dynamo.reset()
         compiled_func = torch.compile(
-            lambda t: quantize_fp8(t, dest_dtype, granularity=granularity, scale=scale),
+            lambda t: quantize_fp8(t, dest_dtype, granularity=granularity),
             fullgraph=True,
             mode="max-autotune",
         )
         x_fp8, x_scale_inv = compiled_func(x)
     else:
-        x_fp8, x_scale_inv = quantize_fp8(x, dest_dtype, granularity=granularity, scale=scale)
+        x_fp8, x_scale_inv = quantize_fp8(x, dest_dtype, granularity=granularity)
 
     torch.testing.assert_close(x_scale_inv_ref, x_scale_inv, **get_tolerances(torch.float32))
     torch.testing.assert_close(
@@ -75,12 +69,9 @@ def test_quantize_fp8_tensorwise(orig_dtype, dest_dtype, numel, dynamic_quantize
 @pytest.mark.parametrize("B", [1, 4])
 @pytest.mark.parametrize("M", [1, 111, 7168])
 @pytest.mark.parametrize("N", [1, 111, 4096])
-@pytest.mark.parametrize("dynamic_quantize", [True, False])
 @pytest.mark.parametrize("torch_compile", [True, False])
 @pytest.mark.parametrize("granularity", [ScalingGranularity.ROWWISE])
-def test_quantize_fp8_rowwise(
-    orig_dtype, dest_dtype, axis, B, M, N, dynamic_quantize, torch_compile, granularity
-):
+def test_quantize_fp8_rowwise(orig_dtype, dest_dtype, axis, B, M, N, torch_compile, granularity):
     # print("\n", orig_dtype, dest_dtype, axis, B, M, N)
     torch.manual_seed(42)
 
@@ -88,20 +79,16 @@ def test_quantize_fp8_rowwise(
     x_ref = x.detach().clone()
     x_fp8_ref, x_scale_ref, x_scale_inv_ref = quantize_fp8_ref(x_ref, dest_dtype, granularity, axis)
 
-    scale = None
-    if dynamic_quantize == False:
-        scale = x_scale_ref.detach().clone()
-
     if torch_compile is True:
         torch._dynamo.reset()
         compiled_func = torch.compile(
-            lambda t: quantize_fp8(t, dest_dtype, granularity=granularity, axis=axis, scale=scale),
+            lambda t: quantize_fp8(t, dest_dtype, granularity=granularity, axis=axis),
             fullgraph=True,
             mode="max-autotune",
         )
         x_fp8, x_scale_inv = compiled_func(x)
     else:
-        x_fp8, x_scale_inv = quantize_fp8(x, dest_dtype, granularity=granularity, axis=axis, scale=scale)
+        x_fp8, x_scale_inv = quantize_fp8(x, dest_dtype, granularity=granularity, axis=axis)
 
     torch.testing.assert_close(x_scale_inv_ref, x_scale_inv, **get_tolerances(torch.float32))
     torch.testing.assert_close(
@@ -168,7 +155,7 @@ def test_quantize_mxfp8(orig_dtype, dest_dtype, B, M, N, axis, granularity, use_
     else:
         x_2d_ref = x_2d
 
-    scaling_recipe = MXScalingRecipe(
+    scaling_recipe = ScalingRecipe(
         use_2d_block=use_2d_block,
     )
 
@@ -210,7 +197,7 @@ def test_quantize_mxfp8_with_trans(orig_dtype, dest_dtype, B, M, N, granularity,
     if not mxfp8_supported:
         pytest.skip(reason)
 
-    scaling_recipe = MXScalingRecipe(
+    scaling_recipe = ScalingRecipe(
         use_2d_block=use_2d_block,
     )
 
@@ -311,7 +298,7 @@ def test_quantize_mxfp8_shuffle(orig_dtype, dest_dtype, B, M, N, granularity, us
     row_length = x.size(-1)
     x_2d = x.view(-1, row_length)
 
-    scaling_recipe = MXScalingRecipe(
+    scaling_recipe = ScalingRecipe(
         use_2d_block=use_2d_block,
     )
     _, rowwise_scale, _, colwise_scale = quantize_fp8_with_trans(
@@ -326,7 +313,7 @@ def test_quantize_mxfp8_shuffle(orig_dtype, dest_dtype, B, M, N, granularity, us
     rowwise_scale_shuffle = torch.ops.primus_turbo_cpp_extension.shuffle_scale(rowwise_scale, [16, 16])
     colwise_scale_shuffle = torch.ops.primus_turbo_cpp_extension.shuffle_scale(colwise_scale, [16, 16])
 
-    scaling_recipe_with_shuffle = MXScalingRecipe(
+    scaling_recipe_with_shuffle = ScalingRecipe(
         use_2d_block=use_2d_block,
         shuffle_scale=True,
         shuffle_out=False,
@@ -371,7 +358,7 @@ def test_quantize_mxfp4(orig_dtype, dest_dtype, B, M, N, axis, granularity, use_
     if not mxfp4_supported:
         pytest.skip(reason)
 
-    scaling_recipe = MXScalingRecipe(
+    scaling_recipe = ScalingRecipe(
         use_2d_block=use_2d_block,
     )
 
@@ -452,7 +439,7 @@ def test_quantize_mxfp4_with_trans(orig_dtype, dest_dtype, B, M, N, granularity,
     if not mxfp4_supported:
         pytest.skip(reason)
 
-    scaling_recipe = MXScalingRecipe(
+    scaling_recipe = ScalingRecipe(
         use_2d_block=use_2d_block,
     )
 
@@ -552,7 +539,7 @@ def test_quantize_mxfp4_shuffle(orig_dtype, dest_dtype, B, M, N, granularity, us
     row_length = x.size(-1)
     x_2d = x.view(-1, row_length)
 
-    scaling_recipe = MXScalingRecipe(
+    scaling_recipe = ScalingRecipe(
         use_2d_block=use_2d_block,
     )
     rowwise_out, rowwise_scale, colwise_out, colwise_scale = quantize_fp4_with_trans(
@@ -569,7 +556,7 @@ def test_quantize_mxfp4_shuffle(orig_dtype, dest_dtype, B, M, N, granularity, us
     colwise_out_shuffle = torch.ops.primus_turbo_cpp_extension.shuffle_weight(colwise_out, [16, 16])
     colwise_scale_shuffle = torch.ops.primus_turbo_cpp_extension.shuffle_scale(colwise_scale, [16, 16])
 
-    scaling_recipe_with_shuffle = MXScalingRecipe(
+    scaling_recipe_with_shuffle = ScalingRecipe(
         use_2d_block=use_2d_block,
         shuffle_scale=True,
         shuffle_out=True,

--- a/tests/pytorch/ops/test_quantization.py
+++ b/tests/pytorch/ops/test_quantization.py
@@ -165,7 +165,6 @@ def test_quantize_mxfp8(orig_dtype, dest_dtype, B, M, N, axis, granularity, use_
         granularity=granularity,
         axis=axis,
         block_size=MX_BLOCK_SIZE,
-        padding_align_size=padding_align_size,
         scaling_recipe=scaling_recipe,
     )
 


### PR DESCRIPTION
## Summary

This commit performs three related cleanups in the quantization / FP8 / FP4 code paths:

1. **Rename `MXScalingRecipe` → `ScalingRecipe`**
   - Applied consistently across both the Python layer (`primus_turbo/pytorch/core/low_precision.py`, `kernels/quantization/quantization_impl.py`, `ops/gemm_fp4.py`, `ops/gemm_fp8.py`, `ops/quantization.py`) and the C++/HIP layer (`csrc/include/primus_turbo/quantization.h`, `csrc/kernels/quantization/quantization_mxfp4.cu`, `quantization_mxfp8.cu`, `csrc/pytorch/quantization/quantization.cpp`).
   - The struct/class is used for both MXFP8 and MXFP4 recipes, so the `MX` prefix was misleading. The new name reflects that it is a generic scaling recipe.

2. **Rename grouped GEMM FP8 autograd function classes**
   - `GroupedGemmFP8BlockFunc`  → `FP8GroupedGemmBlockFunc`
   - `GroupedGemmFP8RowFunc`    → `FP8GroupedGemmRowFunc`
   - `GroupedGemmFP8TensorFunc` → `FP8GroupedGemmTensorFunc`
   - Brings the naming convention in line with the existing FP8 GEMM functions (e.g. `FP8GemmMXFunction`) so that the dtype prefix comes first.

3. **Remove the `scale` argument from the `quantize_fp8` Python API**
   - Drops `scale: Optional[torch.Tensor] = None` from `quantize_fp8` and `quantize_fp8_with_trans` in `primus_turbo/pytorch/ops/quantization.py`, as well as the now-dead `assert scale is None` checks in the MX_BLOCKWISE branches.
   - Internal calls to `quantize_fp8_tensorwise_impl` / `quantize_fp8_rowwise_impl` no longer forward `scale`; the kernel-level impls keep their signatures unchanged.
   - Updates `tests/pytorch/ops/test_quantization.py` accordingly: removes the `scale=scale` kwarg and the now-redundant `dynamic_quantize` parametrization / precomputed-scale logic from `test_quantize_fp8_tensorwise` and `test_quantize_fp8_rowwise`.

## Impact

- No behavioral change for users who were already calling `quantize_fp8` / `quantize_fp8_with_trans` without an explicit `scale` (the only supported path in practice, since the static-scale path was not exercised outside of tests).
- Callers that import `MXScalingRecipe` must switch to `ScalingRecipe`.
- Callers that import the grouped-GEMM FP8 autograd function classes directly must switch to the new names (the `grouped_gemm_fp8(...)` entry point is unchanged).

## Test plan

- [x] `pytest tests/pytorch/ops/test_quantization.py`
- [x] `pytest tests/pytorch/ops/` (FP8 / FP4 GEMM and grouped GEMM tests)
- [x] Build the C++ extension (`pip install -e .`) to verify the `ScalingRecipe` rename compiles on the HIP/CUDA side.
