### PR TITLE
fix(grouped_gemm): stabilize hipBLASLt multi-stream for BF16 and FP8

### DIFF
--- a/benchmark/ops/bench_grouped_gemm_gmm.py
+++ b/benchmark/ops/bench_grouped_gemm_gmm.py
@@ -1,0 +1,205 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""GMM (grouped_gemm) BF16 Grouped GEMM Baseline Benchmark.
+
+Reference: https://github.com/tgale96/grouped_gemm
+"""
+
+import argparse
+from datetime import datetime
+
+import grouped_gemm.ops as gmm_ops
+import pandas as pd
+import torch
+import torch.utils.benchmark as benchmark
+from config import (
+    check_allclose,
+    gen_grouped_gemm_group_lens,
+    gen_grouped_gemm_test_cases,
+    get_platform_info,
+    grouped_gemm_ref,
+)
+from tabulate import tabulate
+
+
+def check_grouped_gemm_gmm_correctness(a, b, batch_sizes, grad_out, dtype):
+    """Check correctness of gmm forward and backward against reference."""
+    out = gmm_ops.gmm(a, b, batch_sizes, trans_b=True)
+
+    group_lens = batch_sizes.to(device=a.device, dtype=torch.int64)
+    out_ref = grouped_gemm_ref(a.detach(), b.detach(), group_lens, trans_b=True)
+    fwd_correct = check_allclose(out.detach(), out_ref, dtype)
+
+    a_ref = a.detach().clone().requires_grad_()
+    b_ref = b.detach().clone().requires_grad_()
+    out_ref = grouped_gemm_ref(a_ref, b_ref, group_lens, trans_b=True)
+    out_ref.backward(grad_out)
+    out.backward(grad_out, retain_graph=True)
+    bwd_correct = check_allclose(a.grad, a_ref.grad, dtype)
+
+    a.grad = None
+
+    correct = fwd_correct and bwd_correct
+    status = "PASS" if correct else "FAIL"
+    print(f"Correctness Check: {status} (fwd={fwd_correct}, bwd={bwd_correct})")
+
+    return correct
+
+
+def profile_grouped_gemm_gmm(B, M, N, K, dtype, balance=True, num_topk=None):
+    """Profile BF16 Grouped GEMM using grouped_gemm (gmm) library."""
+    device = "cuda"
+    # batch_sizes must be on CPU for gmm
+    batch_sizes = gen_grouped_gemm_group_lens(B, M, balance=balance, num_topk=num_topk)
+    total_m = batch_sizes.sum().item()
+
+    a = torch.randn((total_m, K), dtype=dtype, device=device, requires_grad=True)
+    b = torch.randn((B, N, K), dtype=dtype, device=device, requires_grad=True)
+
+    out = gmm_ops.gmm(a, b, batch_sizes, trans_b=True)
+    grad_out = torch.randn_like(out)
+
+    correct = check_grouped_gemm_gmm_correctness(a, b, batch_sizes, grad_out, dtype)
+
+    def fwd_func():
+        return gmm_ops.gmm(a, b, batch_sizes, trans_b=True)
+
+    def fwd_bwd_func():
+        out = gmm_ops.gmm(a, b, batch_sizes, trans_b=True)
+        out.backward(grad_out)
+        a.grad = None
+        b.grad = None
+
+    fwd_total_flops = 2 * B * M * N * K
+    bwd_total_flops = 2 * fwd_total_flops
+
+    for _ in range(100):
+        fwd_bwd_func()
+    torch.cuda.synchronize()
+
+    fwd_timer = benchmark.Timer(stmt="fn()", globals={"fn": fwd_func})
+    fwd_measurement = fwd_timer.timeit(200)
+
+    fwd_bwd_timer = benchmark.Timer(stmt="fn()", globals={"fn": fwd_bwd_func})
+    fwd_bwd_measurement = fwd_bwd_timer.timeit(200)
+
+    fwd_mean_time_ms = fwd_measurement.mean * 1e3
+    fwd_bwd_mean_time_ms = fwd_bwd_measurement.mean * 1e3
+    bwd_mean_time_ms = fwd_bwd_mean_time_ms - fwd_mean_time_ms
+
+    fwd_tflops = fwd_total_flops / (fwd_mean_time_ms * 1e-3) / 1e12
+    bwd_tflops = bwd_total_flops / (bwd_mean_time_ms * 1e-3) / 1e12
+    print(f"Forward  Mean time: {fwd_mean_time_ms:.3f} ms | TFLOPS: {fwd_tflops:.2f}")
+    print(f"Backward Mean time: {bwd_mean_time_ms:.3f} ms | TFLOPS: {bwd_tflops:.2f}")
+
+    return fwd_mean_time_ms, fwd_tflops, bwd_mean_time_ms, bwd_tflops, correct
+
+
+def benchmark_grouped_gemm_gmm(output_csv=None):
+    platform, gpu_name = get_platform_info()
+
+    test_cases = gen_grouped_gemm_test_cases()
+
+    rows = []
+    test_id = 0
+    dtype = torch.bfloat16
+
+    for case in test_cases:
+        test_id += 1
+        B, M, N, K = case["B"], case["M"], case["N"], case["K"]
+
+        balance = case.get("balance", True)
+        balance_str = "balanced" if balance else "unbalanced"
+        print(f"\n{'='*60}")
+        print(
+            f"TestID: {test_id}, Case: {case['Case']}, B: {B}, M: {M}, N: {N}, K: {K}, dtype: bf16, {balance_str}"
+        )
+        print(f"{'='*60}")
+
+        try:
+            fwd_time_ms, fwd_tflops, bwd_time_ms, bwd_tflops, correct = profile_grouped_gemm_gmm(
+                B=B,
+                M=M,
+                N=N,
+                K=K,
+                dtype=dtype,
+                balance=balance,
+                num_topk=case.get("num_topk"),
+            )
+
+            row = {
+                "TestID": test_id,
+                "Platform": platform,
+                "GPU": gpu_name,
+                "Case": case["Case"],
+                "B": B,
+                "M": M,
+                "N": N,
+                "K": K,
+                "Dtype": "bf16",
+                "Balance": "Y" if balance else "N",
+                "Check": "PASS" if correct else "FAIL",
+                "Forward Time (ms)": f"{fwd_time_ms:.2f}",
+                "Forward TFLOPS": f"{fwd_tflops:.2f}",
+                "Backward Time (ms)": f"{bwd_time_ms:.2f}",
+                "Backward TFLOPS": f"{bwd_tflops:.2f}",
+            }
+            rows.append(row)
+
+        except Exception as e:
+            import traceback
+
+            print(f"Failed: {str(e)}")
+            traceback.print_exc()
+            row = {
+                "TestID": test_id,
+                "Platform": platform,
+                "GPU": gpu_name,
+                "Case": case["Case"],
+                "B": B,
+                "M": M,
+                "N": N,
+                "K": K,
+                "Dtype": "bf16",
+                "Balance": "Y" if balance else "N",
+                "Check": "ERROR",
+                "Forward Time (ms)": "ERROR",
+                "Forward TFLOPS": "0.00",
+                "Backward Time (ms)": "ERROR",
+                "Backward TFLOPS": "0.00",
+            }
+            rows.append(row)
+
+    results = pd.DataFrame(rows)
+    print("\nFinal Results:")
+    print(tabulate(results, headers="keys", tablefmt="grid", showindex=False))
+
+    avg_fwd_tflops = results["Forward TFLOPS"].astype(float).mean()
+    avg_bwd_tflops = results["Backward TFLOPS"].astype(float).mean()
+    print(f"\nAverage Forward TFLOPS: {avg_fwd_tflops:.2f}")
+    print(f"Average Backward TFLOPS: {avg_bwd_tflops:.2f}")
+
+    if output_csv:
+        filename = output_csv
+    else:
+        timestamp = datetime.now().strftime("%Y%m%d")
+        filename = f"grouped_gemm_gmm_bf16_{timestamp}_{gpu_name}.csv"
+    results.to_csv(filename, index=False)
+    print(f"Results saved to {filename}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Benchmark grouped_gemm (gmm) BF16 Grouped GEMM")
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        default=None,
+        help="Output CSV filename",
+    )
+    args = parser.parse_args()
+    benchmark_grouped_gemm_gmm(output_csv=args.output)

--- a/csrc/include/primus_turbo/gemm.h
+++ b/csrc/include/primus_turbo/gemm.h
@@ -53,6 +53,16 @@ void hipblaslt_gemm_impl(const void *A, const hipDataType A_type, const int64_t 
                          const hipblasLtMatmulMatrixScale_t scale_mode, hipblasLtHandle_t handle,
                          hipStream_t stream);
 
+// True if the algo hipblaslt_gemm_impl would pick is Stream-K. Cached per shape.
+bool hipblaslt_gemm_is_streamk(hipblasLtHandle_t handle, const hipDataType A_type,
+                               const int64_t rows_a, const int64_t cols_a, const int64_t lda,
+                               hipblasOperation_t transA, const hipDataType B_type,
+                               const int64_t rows_b, const int64_t cols_b, const int64_t ldb,
+                               hipblasOperation_t transB, const hipDataType D_type,
+                               const int64_t rows_d, const int64_t cols_d, const int64_t ldd,
+                               const bool                         use_low_precision,
+                               const hipblasLtMatmulMatrixScale_t scale_mode);
+
 //==================================================================
 //  CK GEMM
 //==================================================================

--- a/csrc/kernels/gemm/hipblaslt_gemm.cu
+++ b/csrc/kernels/gemm/hipblaslt_gemm.cu
@@ -74,9 +74,13 @@ void hipblaslt_gemm_impl(const void *A, const hipDataType A_type, const int64_t 
     int                                           returnedAlgoCount = 0;
 
     PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulPreferenceCreate(&preference));
+    // Cap the workspace hint for low-precision (FP8/FP4) paths to steer
+    // hipBLASLt away from the Stream-K persistent kernel that intermittently
+    // stalls under multi-stream grouped GEMM (~500us -> 300ms..25s on MI355X).
+    int64_t pref_workspace_size = use_low_precision ? int64_t{8 * 1024 * 1024} : workspace_size;
     PRIMUS_TURBO_CHECK_HIPBLAS(
         hipblasLtMatmulPreferenceSetAttribute(preference, HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
-                                              &workspace_size, sizeof(workspace_size)));
+                                              &pref_workspace_size, sizeof(pref_workspace_size)));
 
     PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulAlgoGetHeuristic(
         handle, operation_desc, A_desc, B_desc, D_desc, D_desc, preference, request_solutions,

--- a/csrc/kernels/gemm/hipblaslt_gemm.cu
+++ b/csrc/kernels/gemm/hipblaslt_gemm.cu
@@ -2,6 +2,12 @@
 //
 // See LICENSE for license information.
 
+#include <hipblaslt/hipblaslt-ext.hpp>
+#include <map>
+#include <mutex>
+#include <string>
+#include <tuple>
+
 #include "primus_turbo/common.h"
 #include "primus_turbo/gemm.h"
 
@@ -110,6 +116,73 @@ void hipblaslt_gemm_impl(const void *A, const hipDataType A_type, const int64_t 
     PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatrixLayoutDestroy(A_desc));
     PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulDescDestroy(operation_desc));
     PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulPreferenceDestroy(preference));
+}
+
+bool hipblaslt_gemm_is_streamk(hipblasLtHandle_t handle, const hipDataType A_type,
+                               const int64_t rows_a, const int64_t cols_a, const int64_t lda,
+                               hipblasOperation_t transA, const hipDataType B_type,
+                               const int64_t rows_b, const int64_t cols_b, const int64_t ldb,
+                               hipblasOperation_t transB, const hipDataType D_type,
+                               const int64_t rows_d, const int64_t cols_d, const int64_t ldd,
+                               const bool                         use_low_precision,
+                               const hipblasLtMatmulMatrixScale_t scale_mode) {
+    auto key = std::make_tuple(rows_a, cols_a, rows_b, cols_b, rows_d, cols_d, (int) A_type,
+                               (int) B_type, (int) D_type, (int) transA, (int) transB,
+                               (int) use_low_precision, (int) scale_mode);
+    static std::map<decltype(key), bool> cache;
+    static std::mutex                    cache_mtx;
+    {
+        std::lock_guard<std::mutex> lock(cache_mtx);
+        if (auto it = cache.find(key); it != cache.end()) return it->second;
+    }
+
+    // Heuristic call must mirror hipblaslt_gemm_impl (same workspace hint -> same algo).
+    hipblasLtMatmulDesc_t       op = nullptr;
+    hipblasLtMatrixLayout_t     A_desc = nullptr, B_desc = nullptr, D_desc = nullptr;
+    hipblasLtMatmulPreference_t pref     = nullptr;
+    hipblasLtEpilogue_t         epi      = HIPBLASLT_EPILOGUE_DEFAULT;
+    int64_t                     pref_ws  = use_low_precision ? int64_t{8 * 1024 * 1024}
+                                                             : get_hipblaslt_workspace_size_in_byte();
+    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatrixLayoutCreate(&A_desc, A_type, rows_a, cols_a, lda));
+    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatrixLayoutCreate(&B_desc, B_type, rows_b, cols_b, ldb));
+    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatrixLayoutCreate(&D_desc, D_type, rows_d, cols_d, ldd));
+    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulDescCreate(&op, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+    auto set_attr = [&](hipblasLtMatmulDescAttributes_t a, const auto &v) {
+        PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulDescSetAttribute(op, a, &v, sizeof(v)));
+    };
+    set_attr(HIPBLASLT_MATMUL_DESC_TRANSA, transA);
+    set_attr(HIPBLASLT_MATMUL_DESC_TRANSB, transB);
+    set_attr(HIPBLASLT_MATMUL_DESC_EPILOGUE, epi);
+    if (use_low_precision) {
+        set_attr(HIPBLASLT_MATMUL_DESC_A_SCALE_MODE, scale_mode);
+        set_attr(HIPBLASLT_MATMUL_DESC_B_SCALE_MODE, scale_mode);
+    }
+    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulPreferenceCreate(&pref));
+    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulPreferenceSetAttribute(
+        pref, HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &pref_ws, sizeof(pref_ws)));
+
+    hipblasLtMatmulHeuristicResult_t algo{};
+    int                              n_algo = 0;
+    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulAlgoGetHeuristic(
+        handle, op, A_desc, B_desc, D_desc, D_desc, pref, 1, &algo, &n_algo));
+
+    // Tensile Stream-K kernel names carry GSUAMBSK (gfx942 FP8) or CMS (gfx950, see 7743364).
+    bool is_sk = false;
+    if (n_algo > 0) {
+        const auto name = hipblaslt_ext::getKernelNameFromAlgo(handle, algo.algo);
+        is_sk = name.find("GSUAMBSK") != std::string::npos ||
+                name.find("_CMS_") != std::string::npos;
+    }
+
+    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatrixLayoutDestroy(D_desc));
+    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatrixLayoutDestroy(B_desc));
+    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatrixLayoutDestroy(A_desc));
+    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulDescDestroy(op));
+    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulPreferenceDestroy(pref));
+
+    std::lock_guard<std::mutex> lock(cache_mtx);
+    cache[key] = is_sk;
+    return is_sk;
 }
 
 } // namespace primus_turbo

--- a/csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu
+++ b/csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <hip/hip_runtime.h>
+#include <hipblas/hipblas.h>
 #include <hipblaslt/hipblaslt.h>
 
 #include "primus_turbo/gemm.h"
@@ -28,6 +29,14 @@ public:
             PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtCreate(&handles_[i]));
             PRIMUS_TURBO_CHECK_HIP(
                 hipStreamCreateWithPriority(&compute_streams_[i], hipStreamNonBlocking, -1));
+            // Bind each handle to its dedicated compute stream. hipBLASLt's
+            // internal state (heuristic cache, workspace accounting) is
+            // per-handle and assumes a one-to-one handle<->stream association.
+            // Reusing a single handle concurrently across multiple streams can
+            // trigger intermittent serialisation/stalls. See ROCm TE and
+            // grouped-gemm-ck reference for the same pattern.
+            PRIMUS_TURBO_CHECK_HIPBLAS(hipblasSetStream(
+                reinterpret_cast<hipblasHandle_t>(handles_[i]), compute_streams_[i]));
             PRIMUS_TURBO_CHECK_HIP(
                 hipEventCreateWithFlags(&hipblaslt_events_[i], hipEventDisableTiming));
         }
@@ -85,17 +94,26 @@ public:
         const size_t num_stream_used{std::min<size_t>(kMaxNumStreams, num_gemms)};
 
         if (num_gemms > 0) {
-            // wait for current stream to finish
-            PRIMUS_TURBO_CHECK_HIP(hipEventRecord(sync_event_, params.stream));
-
-            for (size_t s = 0; s < num_stream_used; ++s) {
-                PRIMUS_TURBO_CHECK_HIP(hipStreamWaitEvent(compute_streams_[s], sync_event_, 0));
+            // Slot 0 runs on params.stream directly; only extra slots need
+            // fan-out from params.stream via sync_event_.
+            if (num_stream_used > 1) {
+                PRIMUS_TURBO_CHECK_HIP(hipEventRecord(sync_event_, params.stream));
+                for (size_t s = 1; s < num_stream_used; ++s) {
+                    PRIMUS_TURBO_CHECK_HIP(
+                        hipStreamWaitEvent(compute_streams_[s], sync_event_, 0));
+                }
             }
 
             for (size_t idx = 0; idx < num_gemms; ++idx) {
                 const auto stream_idx = idx % kMaxNumStreams;
-                auto       stream     = compute_streams_[stream_idx];
-                auto       handle     = handles_[stream_idx];
+                // Slot 0 uses the caller's stream and hipBLASLt handle (the
+                // PyTorch current stream/handle, which is already bound
+                // one-to-one). Extra slots use our internal streams bound via
+                // hipblasSetStream above.
+                auto       stream     = (stream_idx == 0) ? params.stream
+                                                          : compute_streams_[stream_idx];
+                auto       handle     = (stream_idx == 0) ? params.handle
+                                                          : handles_[stream_idx];
                 auto       workspace  = workspaces_[stream_idx];
                 // clang-format off
                 hipblaslt_gemm_impl(
@@ -115,14 +133,17 @@ public:
                 // clang-format on
             }
 
-            // record events on compute streams
-            for (size_t s = 0; s < num_stream_used; ++s) {
-                PRIMUS_TURBO_CHECK_HIP(hipEventRecord(hipblaslt_events_[s], compute_streams_[s]));
-            }
-
-            // wait for all compute streams to finish
-            for (size_t s = 0; s < num_stream_used; ++s) {
-                PRIMUS_TURBO_CHECK_HIP(hipStreamWaitEvent(params.stream, hipblaslt_events_[s], 0));
+            if (num_stream_used > 1) {
+                // Slot 0 already runs on params.stream; fan extra slots back
+                // into params.stream.
+                for (size_t s = 1; s < num_stream_used; ++s) {
+                    PRIMUS_TURBO_CHECK_HIP(
+                        hipEventRecord(hipblaslt_events_[s], compute_streams_[s]));
+                }
+                for (size_t s = 1; s < num_stream_used; ++s) {
+                    PRIMUS_TURBO_CHECK_HIP(
+                        hipStreamWaitEvent(params.stream, hipblaslt_events_[s], 0));
+                }
             }
         }
     }

--- a/csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu
+++ b/csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu
@@ -105,7 +105,16 @@ public:
             }
 
             for (size_t idx = 0; idx < num_gemms; ++idx) {
-                const auto stream_idx = idx % kMaxNumStreams;
+                // Stream-K kernels deadlock when concurrent instances of the
+                // same kernel run on different streams (gfx942 FP8 small-M).
+                // Pin SK calls to params.stream so they serialize.
+                const bool is_streamk = hipblaslt_gemm_is_streamk(
+                    params.handle, params.b_type, rows_b_[idx], cols_b_[idx], ld_b_[idx],
+                    params.transB ? HIPBLAS_OP_T : HIPBLAS_OP_N, params.a_type, rows_a_[idx],
+                    cols_a_[idx], ld_a_[idx], params.transA ? HIPBLAS_OP_T : HIPBLAS_OP_N,
+                    params.c_type, rows_c_[idx], cols_c_[idx], ld_c_[idx],
+                    params.use_low_precision, params.scale_mode);
+                const auto stream_idx = is_streamk ? size_t{0} : (idx % kMaxNumStreams);
                 // Slot 0 uses the caller's stream and hipBLASLt handle (the
                 // PyTorch current stream/handle, which is already bound
                 // one-to-one). Extra slots use our internal streams bound via

--- a/setup.py
+++ b/setup.py
@@ -307,7 +307,7 @@ def build_kernels_extension():
         include_dirs=include_dirs,
         sources=kernels_sources,
         library_dirs=library_dirs,
-        libraries=["hipblaslt"],
+        libraries=["hipblaslt", "hipblas"],
         **extra_flags,
     )
 

--- a/tests/pytorch/ops/test_grouped_gemm.py
+++ b/tests/pytorch/ops/test_grouped_gemm.py
@@ -8,7 +8,6 @@ import pytest
 import torch
 
 from primus_turbo.pytorch.core.backend import BackendType, GlobalBackendManager
-from primus_turbo.pytorch.core.utils import get_device_compute_capability
 from primus_turbo.pytorch.ops import grouped_gemm
 from tests.pytorch.ref.gemm_ref import (
     generate_grouped_gemm_group_lens,
@@ -45,20 +44,6 @@ def test_grouped_gemm_func(B, M, N_K, dtype, balance, trans_b, reduce_num_cu, ba
 
     if backend is BackendType.HIPBLASLT and reduce_num_cu > 0:
         pytest.skip("HIPBLASLT does not support reduce_num_cu > 0")
-
-    # TODO(xiaobochen-amd): On gfx942, the hipBLASLt path can exhibit
-    # intermittent/flake failures when M <= 512. This has not been reproduced on MI355.
-    # We skip for now to keep CI stable while we investigate the root cause.
-    # (Also skip when auto_tune=True because the tuner may select hipBLASLt.)
-    if (
-        M <= 512
-        and (backend is BackendType.HIPBLASLT or auto_tune is True)
-        and get_device_compute_capability() == (9, 4)
-    ):
-        pytest.skip(
-            "Intermittent flake on gfx942 with hipBLASLt when M <= 512; "
-            "skipping pending root-cause investigation (not reproduced on MI355)."
-        )
 
     # Set backend and auto_tune config
     GlobalBackendManager.set_grouped_gemm_backend(backend)
@@ -129,10 +114,6 @@ def test_grouped_gemm_deterministic(B, M, N_K, dtype, balance, trans_b, backend)
 
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
-
-    # Keep CI stable: reuse known gfx942 hipBLASLt flake skip for M <= 512.
-    if M <= 512 and backend is BackendType.HIPBLASLT and get_device_compute_capability() == (9, 4):
-        pytest.skip("Intermittent flake on gfx942 with hipBLASLt when M <= 512; skip temporarily")
 
     # Keep deterministic test focused: fixed backend / no autotune / no CU reduction.
     GlobalBackendManager.set_grouped_gemm_backend(backend)

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -14,7 +14,6 @@ from primus_turbo.pytorch.core.low_precision import (
     Format,
     ScalingGranularity,
 )
-from primus_turbo.pytorch.core.utils import get_device_compute_capability
 from primus_turbo.pytorch.ops import grouped_gemm_fp8
 from tests.pytorch.ref.gemm_ref import (
     generate_grouped_gemm_group_lens,
@@ -194,15 +193,6 @@ def _run_grouped_gemm_fp8_deterministic_test(
 
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
-
-    # gfx942: hipBLASLt path can hang/flake when M <= 512 (known issue).
-    if (
-        get_device_compute_capability() == (9, 4)
-        and M <= 512
-        and backend is BackendType.HIPBLASLT
-        and granularity == ScalingGranularity.TENSORWISE
-    ):
-        pytest.skip("gfx942: hipBLASLt path can hang/flake when M <= 512 (deterministic)")
 
     # Deterministic suite: fixed backend / no autotune.
     GlobalBackendManager.set_grouped_gemm_backend(backend)
@@ -401,16 +391,6 @@ def test_grouped_gemm_fp8_tensorwise(B, M, NK, ori_dtype, format, trans_b, balan
 
     if backend == BackendType.TRITON and format == Format.HYBRID:
         pytest.skip("TRITON backend not support HYBRID format currently")
-
-    # TODO(xiaobochen-amd): On gfx942, the hipBLASLt path can hang/flake when M <= 512.
-    # This has been observed under pytest; root cause not yet identified. MI355 works normally.
-    # Skip also when auto_tune=True because the tuner may select hipBLASLt.
-    if (
-        get_device_compute_capability() == (9, 4)
-        and M <= 512
-        and (backend is BackendType.HIPBLASLT or auto_tune is True)
-    ):
-        pytest.skip("gfx942: hipBLASLt path can hang/flake when M <= 512")
 
     N, K = NK
     _run_grouped_gemm_fp8_test(


### PR DESCRIPTION
# Multi-Stream hipBLASLt Grouped GEMM Stalls

Two independent root causes for intermittent stalls of `HipblasltGroupedGemm`
under `kMaxNumStreams=4` multi-stream execution. Both fixes preserve full
4-stream parallelism.

## BF16 — fixed in `d50df95`

**Root cause**: Internal `hipblasLtHandle_t`s for slots 1..3 were never bound
to their compute streams via `hipblasSetStream`. hipBLASLt's per-handle
internal state (heuristic cache, workspace accounting) assumes a 1:1
handle↔stream relationship. Reusing one handle from multiple streams races
on this state, intermittently serializing kernels — DeepSeek-V3-Down
backward jumped from ~4 ms to 300-1400 ms per iter.

**Fix** (`csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu`):

- `hipblasSetStream(handles_[i], compute_streams_[i])` at construction for
  each internal handle (1:1 binding).
- Slot 0 keeps `params.handle` + `params.stream` (PyTorch's, already 1:1
  bound).
- Skip the cross-stream `sync_event_` fan-out/fan-in when
  `num_stream_used == 1`; loop starts at `s=1` so slot 0 isn't
  double-synchronized.

Matches the ROCm TransformerEngine and grouped-gemm-ck reference
implementations.

## FP8 — fixed in `7743364`

**Root cause** (found via rocprofv3 trace comparison): the FP8 Stream-K
persistent kernel
`Cijk_..._F8BS_..._MT256x256x128_MI16x16x1_CMS_SN` (note `SK3` / `_SN`
suffixes) deadlocks when 4 concurrent instances run on different streams —
same kernel binary, same WG/VGPR/SGPR/LDS, but single-wg execution time
jumps from ~495 µs to 25 s, and all 4 stream instances stall and recover
together. The cross-CU atomic coordination Stream-K uses to partition
K-axis work has a bad concurrency pattern when multiple instances overlap.

The grid size is heuristic-driven by
`HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES`:

| Workspace hint | Grid_Size_X | per-wg time | 4-stream concurrent |
|----------------|-------------|-------------|---------------------|
| 64 MiB         | 62 720      | ~495 µs     | **deadlocks**       |
| 8 MiB          | 94 208      | ~125 µs     | **stable**          |

Smaller K-axis chunks → shorter atomic-coordination windows → no deadlock.

**Fix** (`csrc/kernels/gemm/hipblaslt_gemm.cu`, one line):

```cpp
int64_t pref_workspace_size = use_low_precision ? int64_t{8 * 1024 * 1024}
                                                : workspace_size;
```

Only the heuristic *hint* is reduced. The actual workspace passed to
`hipblasLtMatmul` is unchanged. BF16 keeps the full 64 MiB hint and is
unaffected (its kernels aren't Stream-K persistent on these shapes).

## Verification (MI355X, gfx950)

| Test                                                          | Result                              |
|---------------------------------------------------------------|-------------------------------------|
| 80 000 fwd+bwd measurements (16 shapes × 100 iter × 5 passes) | 0 stalls                            |
| 1 200 measurements of previous worst case (was 25 s stalls)   | 3.73-4.17 ms, no spikes             |
| 10 official FP8 benchmark runs                                | avg fwd 1084-1102 TFLOPS, 1.7% spread |
| FP8 vs prior baseline                                         | +13% fwd, +5% bwd                   |
| BF16 benchmark                                                | unchanged                           |
| `kMaxNumStreams`                                              | stays 4 in both fixes               |