### PR TITLE
fix: compile warning

### DIFF
--- a/csrc/include/primus_turbo/device/reduce.cuh
+++ b/csrc/include/primus_turbo/device/reduce.cuh
@@ -171,7 +171,7 @@ template <template <class> class Func, typename T> PRIMUS_TURBO_DEVICE T BlockRe
  * Reference: AMD CDNA4 ISA, ds_swizzle_b32 (page 480)
  */
 
-PRIMUS_TURBO_DEVICE __forceinline__ float ds_swizzle_xor1(float val) {
+PRIMUS_TURBO_DEVICE float ds_swizzle_xor1(float val) {
     float result;
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x041F\n\t"
                  "s_waitcnt lgkmcnt(0)"
@@ -180,7 +180,7 @@ PRIMUS_TURBO_DEVICE __forceinline__ float ds_swizzle_xor1(float val) {
     return result;
 }
 
-PRIMUS_TURBO_DEVICE __forceinline__ float ds_swizzle_xor2(float val) {
+PRIMUS_TURBO_DEVICE float ds_swizzle_xor2(float val) {
     float result;
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x081F\n\t"
                  "s_waitcnt lgkmcnt(0)"
@@ -189,7 +189,7 @@ PRIMUS_TURBO_DEVICE __forceinline__ float ds_swizzle_xor2(float val) {
     return result;
 }
 
-PRIMUS_TURBO_DEVICE __forceinline__ float ds_swizzle_xor8(float val) {
+PRIMUS_TURBO_DEVICE float ds_swizzle_xor8(float val) {
     float result;
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x201F\n\t"
                  "s_waitcnt lgkmcnt(0)"
@@ -198,7 +198,7 @@ PRIMUS_TURBO_DEVICE __forceinline__ float ds_swizzle_xor8(float val) {
     return result;
 }
 
-PRIMUS_TURBO_DEVICE __forceinline__ float ds_swizzle_xor16(float val) {
+PRIMUS_TURBO_DEVICE float ds_swizzle_xor16(float val) {
     float result;
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x401F\n\t"
                  "s_waitcnt lgkmcnt(0)"
@@ -222,7 +222,7 @@ PRIMUS_TURBO_DEVICE __forceinline__ float ds_swizzle_xor16(float val) {
  *   Step 2: XOR 2 - reduce 4 values to 2 (threads 0-1, 2-3)
  *   Step 3: XOR 1 - reduce 2 values to 1 (thread 0)
  */
-PRIMUS_TURBO_DEVICE __forceinline__ float warp_reduce_max_8_dpp(float val) {
+PRIMUS_TURBO_DEVICE float warp_reduce_max_8_dpp(float val) {
     uint32_t v = float_as_uint(val);
     uint32_t tmp;
 
@@ -246,7 +246,7 @@ PRIMUS_TURBO_DEVICE __forceinline__ float warp_reduce_max_8_dpp(float val) {
     return val;
 }
 
-PRIMUS_TURBO_DEVICE __forceinline__ float warp_reduce_max_64_dpp(float val) {
+PRIMUS_TURBO_DEVICE float warp_reduce_max_64_dpp(float val) {
     val = warp_reduce_max_8_dpp(val);
     val = fmaxf(val, ds_swizzle_xor8(val));
     val = fmaxf(val, ds_swizzle_xor16(val));

--- a/csrc/include/primus_turbo/device/shuffle.cuh
+++ b/csrc/include/primus_turbo/device/shuffle.cuh
@@ -31,8 +31,7 @@ using namespace primus_turbo::detail;
  *   i5 = col % 4
  *   index = i0*(scale_n_pad//8)*256 + i3*256 + i5*64 + i2*4 + i4*2 + i1
  */
-PRIMUS_TURBO_DEVICE __forceinline__ int compute_shuffle_scale_index(int row, int col,
-                                                                    int scale_n_pad) {
+PRIMUS_TURBO_DEVICE int compute_shuffle_scale_index(int row, int col, int scale_n_pad) {
     int i0 = row >> 5;       // row // 32
     int i1 = (row >> 4) & 1; // (row % 32) // 16
     int i2 = row & 15;       // row % 16
@@ -55,7 +54,7 @@ PRIMUS_TURBO_DEVICE __forceinline__ int compute_shuffle_scale_index(int row, int
  *   - Data is stored in (BN=16, BK=32) tiles
  */
 template <typename DType>
-PRIMUS_TURBO_DEVICE __forceinline__ int compute_shuffled_index(int row, int col, int K_packed) {
+PRIMUS_TURBO_DEVICE int compute_shuffled_index(int row, int col, int K_packed) {
     static_assert(std::is_same_v<DType, dtype::float4x2_e2m1> ||
                       std::is_same_v<DType, dtype::float8_e4m3> ||
                       std::is_same_v<DType, dtype::float8_e5m2>,

--- a/csrc/include/primus_turbo/device/utils.cuh
+++ b/csrc/include/primus_turbo/device/utils.cuh
@@ -49,11 +49,11 @@ template <typename T, const int N> PRIMUS_TURBO_DEVICE void store_data(T *dst, c
     }
 }
 
-PRIMUS_TURBO_DEVICE __forceinline__ uint32_t float_as_uint(float f) {
+PRIMUS_TURBO_DEVICE uint32_t float_as_uint(float f) {
     return __float_as_uint(f);
 }
 
-PRIMUS_TURBO_DEVICE __forceinline__ float uint_as_float(uint32_t u) {
+PRIMUS_TURBO_DEVICE float uint_as_float(uint32_t u) {
     return __uint_as_float(u);
 }
 
@@ -63,8 +63,8 @@ PRIMUS_TURBO_DEVICE __forceinline__ float uint_as_float(uint32_t u) {
  * bfloat16 is FP32 with the lower 16 bits truncated, so we reconstruct
  * by shifting the 16-bit value left by 16 bits.
  */
-PRIMUS_TURBO_DEVICE __forceinline__ void bfloat16x4_to_floatx4(uint64_t packed, float &v0,
-                                                               float &v1, float &v2, float &v3) {
+PRIMUS_TURBO_DEVICE void bfloat16x4_to_floatx4(uint64_t packed, float &v0, float &v1, float &v2,
+                                               float &v3) {
     v0 = uint_as_float(((uint32_t) (packed & 0xFFFF)) << 16);
     v1 = uint_as_float(((uint32_t) ((packed >> 16) & 0xFFFF)) << 16);
     v2 = uint_as_float(((uint32_t) ((packed >> 32) & 0xFFFF)) << 16);
@@ -77,8 +77,8 @@ PRIMUS_TURBO_DEVICE __forceinline__ void bfloat16x4_to_floatx4(uint64_t packed, 
  * Convert 4 packed half values (in a uint64_t) to 4 floats using
  * the HIP __half intrinsic.
  */
-PRIMUS_TURBO_DEVICE __forceinline__ void halfx4_to_floatx4(uint64_t packed, float &v0, float &v1,
-                                                           float &v2, float &v3) {
+PRIMUS_TURBO_DEVICE void halfx4_to_floatx4(uint64_t packed, float &v0, float &v1, float &v2,
+                                           float &v3) {
     uint16_t h0 = (uint16_t) (packed & 0xFFFF);
     uint16_t h1 = (uint16_t) ((packed >> 16) & 0xFFFF);
     uint16_t h2 = (uint16_t) ((packed >> 32) & 0xFFFF);
@@ -93,8 +93,8 @@ PRIMUS_TURBO_DEVICE __forceinline__ void halfx4_to_floatx4(uint64_t packed, floa
  * Templated conversion helpers dispatching bfloat16 vs half at compile time.
  */
 template <bool IS_half>
-PRIMUS_TURBO_DEVICE __forceinline__ void
-packed_uint16x4_to_floatx4(uint64_t packed, float &v0, float &v1, float &v2, float &v3) {
+PRIMUS_TURBO_DEVICE void packed_uint16x4_to_floatx4(uint64_t packed, float &v0, float &v1,
+                                                    float &v2, float &v3) {
     if constexpr (IS_half) {
         halfx4_to_floatx4(packed, v0, v1, v2, v3);
     } else {
@@ -102,7 +102,7 @@ packed_uint16x4_to_floatx4(uint64_t packed, float &v0, float &v1, float &v2, flo
     }
 }
 
-template <bool IS_half> PRIMUS_TURBO_DEVICE __forceinline__ float uint16_to_float(uint16_t val) {
+template <bool IS_half> PRIMUS_TURBO_DEVICE float uint16_to_float(uint16_t val) {
     if constexpr (IS_half) {
         return __half2float(*reinterpret_cast<const half *>(&val));
     } else {

--- a/setup.py
+++ b/setup.py
@@ -217,6 +217,7 @@ def get_common_flags():
         "-fvisibility=hidden",
         "-std=c++20",
         "-fgpu-rdc",
+        "-Wno-unknown-warning-option",
     ]
 
     nvcc_flags = [
@@ -239,6 +240,7 @@ def get_common_flags():
         # "-amdgpu-function-calls=false",
         "-std=c++20",
         "-fgpu-rdc",
+        "-Wno-unknown-warning-option",
     ]
 
     # Check and add optional compiler flags (for ROCm version compatibility)


### PR DESCRIPTION
# Description

Fix all compiler warnings in the Primus-Turbo project build. The build previously produced **1024 warnings** across 3 categories:

1. **`-Wduplicate-decl-specifier` (152 occurrences):** The `PRIMUS_TURBO_DEVICE` macro (defined as `inline __device__`) was used together with `__forceinline__`, causing duplicate `inline` specifier warnings. Fixed by removing the redundant `__forceinline__` from affected functions, relying on the `inline` already provided by the macro.

2. **`-Wunknown-warning-option` (868 occurrences):** Third-party Composable Kernel headers use `#pragma clang diagnostic ignored "-Wlifetime-safety-intra-tu-suggestions"`, which is unrecognized by the current HIP/Clang compiler. Suppressed by adding `-Wno-unknown-warning-option` to build flags.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Remove redundant `__forceinline__` from 6 device functions in `csrc/include/primus_turbo/device/utils.cuh` (`float_as_uint`, `uint_as_float`, `bfloat16x4_to_floatx4`, `halfx4_to_floatx4`, `packed_uint16x4_to_floatx4`, `uint16_to_float`)
- Remove redundant `__forceinline__` from 6 device functions in `csrc/include/primus_turbo/device/reduce.cuh` (`ds_swizzle_xor1/2/8/16`, `warp_reduce_max_8_dpp`, `warp_reduce_max_64_dpp`)
- Remove redundant `__forceinline__` from 2 device functions in `csrc/include/primus_turbo/device/shuffle.cuh` (`compute_shuffle_scale_index`, `compute_shuffled_index`)
- Add `-Wno-unknown-warning-option` to both `cxx_flags` and `nvcc_flags` in `setup.py` to suppress warnings from third-party Composable Kernel headers

# Checklist:

- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
