### PR TITLE
feat: attn add bhsd layout support

### DIFF
--- a/primus_turbo/pytorch/kernels/attention/attention_aiter_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_aiter_impl.py
@@ -42,27 +42,42 @@ def _normalize_sink_window(causal: bool, window_size_left: int, window_size_righ
 # =============================================================================
 
 
-_SUPPORTED_QKV_FORMATS = ["sbhd", "bshd"]
+_SUPPORTED_QKV_FORMATS = ["sbhd", "bshd", "bhsd"]
 
 
 class AttnFwdAiterBackend(KernelBackend):
 
     @staticmethod
-    def can_handle(**kwargs) -> bool:
-        q = kwargs["q"]
-        v = kwargs["v"]
-        head_dim_qk = q.shape[-1]
-        head_dim_v = v.shape[-1]
+    def can_handle(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        dropout_p: float,
+        softmax_scale: float,
+        causal: bool,
+        window_size_left: int,
+        window_size_right: int,
+        bias: Optional[torch.Tensor],
+        alibi_slopes: Optional[torch.Tensor],
+        return_lse: bool,
+        return_softmax: bool,
+        max_seqlen_q: Optional[int] = None,
+        max_seqlen_k: Optional[int] = None,
+        sink: Optional[torch.Tensor] = None,
+        qkv_format: Optional[str] = "bshd",
+    ) -> bool:
 
-        sink = kwargs.get("sink", None)
-        qkv_format = kwargs["qkv_format"]
+        if sink is not None:
+            if qkv_format in ("sbhd", "bhsd"):
+                # sink attention is not supported for sbhd and bhsd format
+                return False
 
-        if sink is not None and qkv_format == "sbhd":
-            # sink attention is not supported for sbhd format
-            return False
+            head_dim_qk = q.size(-1)
+            head_dim_v = v.size(-1)
+            if head_dim_qk != head_dim_v or not _is_power_of_2(head_dim_qk):
+                return False
 
-        supported = kwargs["qkv_format"] in _SUPPORTED_QKV_FORMATS
-        supported &= head_dim_qk == head_dim_v and _is_power_of_2(head_dim_qk)
+        supported = qkv_format in _SUPPORTED_QKV_FORMATS
 
         return supported
 
@@ -83,7 +98,6 @@ class AttnFwdAiterBackend(KernelBackend):
         max_seqlen_q: Optional[int] = None,
         max_seqlen_k: Optional[int] = None,
         sink: Optional[torch.Tensor] = None,
-        out: Optional[torch.Tensor] = None,
         qkv_format: Optional[str] = "sbhd",
     ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], Any]:
         batch_size, seq_len, num_heads_qk, head_dim_qk = q.size()
@@ -95,9 +109,11 @@ class AttnFwdAiterBackend(KernelBackend):
                 out = torch.empty(
                     (seq_len, batch_size, num_heads_qk, head_dim_v), dtype=q.dtype, device=q.device
                 ).permute(1, 0, 2, 3)
+            elif qkv_format == "bhsd":
+                out = torch.empty(
+                    (batch_size, num_heads_qk, seq_len, head_dim_v), dtype=q.dtype, device=q.device
+                ).permute(0, 2, 1, 3)
             else:
-                # BSHD
-                assert qkv_format == "bshd"
                 out = torch.empty(
                     (batch_size, seq_len, num_heads_qk, head_dim_v), dtype=q.dtype, device=q.device
                 )
@@ -122,13 +138,6 @@ class AttnFwdAiterBackend(KernelBackend):
                 out=out,
             )
         else:
-            assert qkv_format == "bshd", "Sink attention is not supported for sbhd format"
-
-            if head_dim_qk != head_dim_v or not _is_power_of_2(head_dim_qk):
-                raise ValueError(
-                    "Triton sink attention requires head_dim_qk == head_dim_v and head_dim power-of-2"
-                )
-
             if max_seqlen_q is None:
                 max_seqlen_q = q.size(1)
             if max_seqlen_k is None:
@@ -166,27 +175,47 @@ class AttnFwdAiterBackend(KernelBackend):
 class AttnBwdAiterBackend(KernelBackend):
 
     @staticmethod
-    def can_handle(**kwargs) -> bool:
-        q = kwargs["q"]
-        v = kwargs["v"]
-        head_dim_qk = q.size(-1)
-        head_dim_v = v.size(-1)
+    def can_handle(
+        dout: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        out: torch.Tensor,
+        softmax_lse: torch.Tensor,
+        dq: torch.Tensor,
+        dk: torch.Tensor,
+        dv: torch.Tensor,
+        dbias: Optional[torch.Tensor],
+        dropout_p: float,
+        softmax_scale: float,
+        causal: bool,
+        window_size_left: int,
+        window_size_right: int,
+        bias: Optional[torch.Tensor],
+        alibi_slopes: Optional[torch.Tensor],
+        deterministic: bool,
+        rng_state: Optional[torch.Tensor],
+        is_v3_atomic_fp32: bool,
+        how_v3_bf16_cvt: int,
+        sink: Optional[torch.Tensor] = None,
+        dsink: Optional[torch.Tensor] = None,
+        qkv_format: Optional[str] = "bshd",
+    ) -> bool:
+        if sink is not None:
+            if qkv_format in ("sbhd", "bhsd"):
+                # sink attention is not supported for sbhd and bhsd format
+                return False
 
-        sink = kwargs.get("sink", None)
-        qkv_format = kwargs["qkv_format"]
-
-        if sink is not None and qkv_format == "sbhd":
-            # sink attention is not supported for sbhd format
-            return False
+            head_dim_qk = q.size(-1)
+            head_dim_v = v.size(-1)
+            if head_dim_qk != head_dim_v or not _is_power_of_2(head_dim_qk):
+                return False
 
         supported = qkv_format in _SUPPORTED_QKV_FORMATS
-        supported &= head_dim_qk == head_dim_v and _is_power_of_2(head_dim_qk)
-
-        is_v3_atomic_fp32 = kwargs["is_v3_atomic_fp32"]
 
         # NOTE: gfx942 has numerical issue in fp16 atomic when layout is sbhd.
         if get_device_compute_capability() == (9, 4):
-            supported &= not (qkv_format == "sbhd" and is_v3_atomic_fp32)
+            supported &= not (qkv_format == "sbhd" and not is_v3_atomic_fp32)
 
         return supported
 
@@ -242,8 +271,6 @@ class AttnBwdAiterBackend(KernelBackend):
                 how_v3_bf16_cvt,
             )
         else:
-            assert qkv_format == "bshd", "Sink attention is not supported for sbhd format"
-
             assert (
                 isinstance(rng_state, torch.Tensor)
                 and rng_state.device.type == "cpu"
@@ -308,24 +335,32 @@ def attention_aiter_forward_impl(
     sink: Optional[torch.Tensor] = None,
     qkv_format: Optional[str] = "bshd",
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], Any]:
-    return AttnFwdAiterBackend.execute(
-        q=q,
-        k=k,
-        v=v,
-        dropout_p=dropout_p,
-        softmax_scale=softmax_scale,
-        causal=causal,
-        window_size_left=window_size_left,
-        window_size_right=window_size_right,
-        bias=bias,
-        alibi_slopes=alibi_slopes,
-        return_lse=return_lse,
-        return_softmax=return_softmax,
-        max_seqlen_q=max_seqlen_q,
-        max_seqlen_k=max_seqlen_k,
-        sink=sink,
-        qkv_format=qkv_format,
-    )
+    kwargs = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "dropout_p": dropout_p,
+        "softmax_scale": softmax_scale,
+        "causal": causal,
+        "window_size_left": window_size_left,
+        "window_size_right": window_size_right,
+        "bias": bias,
+        "alibi_slopes": alibi_slopes,
+        "return_lse": return_lse,
+        "return_softmax": return_softmax,
+        "max_seqlen_q": max_seqlen_q,
+        "max_seqlen_k": max_seqlen_k,
+        "sink": sink,
+        "qkv_format": qkv_format,
+    }
+    # TODO(ruibin): Add unified attention kernel dispatcher
+    if not AttnFwdAiterBackend.can_handle(**kwargs):
+        raise ValueError(
+            f"AttnFwdAiterBackend cannot handle the given inputs. "
+            f"Please check input constraints or choose a different backend."
+        )
+
+    return AttnFwdAiterBackend.execute(**kwargs)
 
 
 def attention_aiter_backward_impl(
@@ -354,29 +389,38 @@ def attention_aiter_backward_impl(
     sink: Optional[torch.Tensor] = None,
     qkv_format: Optional[str] = "bshd",
 ):
-    return AttnBwdAiterBackend.execute(
-        dout=dout,
-        q=q,
-        k=k,
-        v=v,
-        out=out,
-        softmax_lse=softmax_lse,
-        dq=dq,
-        dk=dk,
-        dv=dv,
-        dropout_p=dropout_p,
-        softmax_scale=softmax_scale,
-        causal=causal,
-        window_size_left=window_size_left,
-        window_size_right=window_size_right,
-        bias=bias,
-        alibi_slopes=alibi_slopes,
-        deterministic=deterministic,
-        rng_state=rng_state,
-        is_v3_atomic_fp32=is_v3_atomic_fp32,
-        how_v3_bf16_cvt=how_v3_bf16_cvt,
-        dbias=dbias,
-        dsink=dsink,
-        sink=sink,
-        qkv_format=qkv_format,
-    )
+    kwargs = {
+        "dout": dout,
+        "q": q,
+        "k": k,
+        "v": v,
+        "out": out,
+        "softmax_lse": softmax_lse,
+        "dq": dq,
+        "dk": dk,
+        "dv": dv,
+        "dropout_p": dropout_p,
+        "softmax_scale": softmax_scale,
+        "causal": causal,
+        "window_size_left": window_size_left,
+        "window_size_right": window_size_right,
+        "bias": bias,
+        "alibi_slopes": alibi_slopes,
+        "deterministic": deterministic,
+        "rng_state": rng_state,
+        "is_v3_atomic_fp32": is_v3_atomic_fp32,
+        "how_v3_bf16_cvt": how_v3_bf16_cvt,
+        "dbias": dbias,
+        "dsink": dsink,
+        "sink": sink,
+        "qkv_format": qkv_format,
+    }
+
+    # TODO(ruibin): Add unified attention kernel dispatcher
+    if not AttnBwdAiterBackend.can_handle(**kwargs):
+        raise ValueError(
+            f"AttnBwdAiterBackend cannot handle the given inputs. "
+            f"Please check input constraints or choose a different backend."
+        )
+
+    return AttnBwdAiterBackend.execute(**kwargs)

--- a/primus_turbo/pytorch/ops/attention/attention_utils.py
+++ b/primus_turbo/pytorch/ops/attention/attention_utils.py
@@ -60,6 +60,9 @@ def _infer_qkv_format(
         # sbhd: sequence outermost → s1 > s0 > s2
         if s1 >= s0 >= s2:
             return "sbhd"
+        # bhsd: transposed bshd (e.g. bshd.transpose(1,2)) → s0 > s2 > s1
+        if s0 >= s2 >= s1:
+            return "bhsd"
 
         assert False, (
             f"Cannot infer qkv layout from shape {tuple(t.size())} " f"and strides {tuple(t.stride())}"

--- a/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
+++ b/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
@@ -104,9 +104,14 @@ class AiterFlashAttnFunc(torch.autograd.Function):
             qkv_format=qkv_format if not enable_sink else "bshd",
         )
 
-        if enable_sink and qkv_format == "sbhd":
-            # permute back to SBHD
-            out_padded = out_padded.permute(1, 0, 2, 3).contiguous()
+        if enable_sink:
+            if qkv_format == "sbhd":
+                # permute back to SBHD
+                out_padded = out_padded.permute(1, 0, 2, 3).contiguous()
+            elif qkv_format == "bhsd":
+                out_padded = out_padded.permute(0, 2, 1, 3).contiguous()
+            else:
+                assert qkv_format == "bshd"
 
         if is_grad:
             ctx.save_for_backward(q, k, v, out_padded, softmax_lse, rng_state)
@@ -144,7 +149,7 @@ class AiterFlashAttnFunc(torch.autograd.Function):
         enable_sink = ctx.sink is not None
         qkv_format = ctx.qkv_format
 
-        if enable_sink and qkv_format == "sbhd":
+        if enable_sink and qkv_format in ("sbhd", "bhsd"):
             dout = dout.contiguous()
 
         dout_padded = dout
@@ -166,6 +171,16 @@ class AiterFlashAttnFunc(torch.autograd.Function):
             dv_padded = torch.empty(
                 (seq_len, batch_size, num_heads_v, head_dim_v), dtype=v.dtype, device=v.device
             ).permute(1, 0, 2, 3)
+        elif bwd_qkv_format == "bhsd":
+            dq = torch.ones(
+                (batch_size, num_heads_q, seq_len, head_dim_qk), dtype=q.dtype, device=q.device
+            ).permute(0, 2, 1, 3)
+            dk = torch.empty(
+                (batch_size, num_heads_k, seq_len, head_dim_k), dtype=k.dtype, device=k.device
+            ).permute(0, 2, 1, 3)
+            dv_padded = torch.empty(
+                (batch_size, num_heads_v, seq_len, head_dim_v), dtype=v.dtype, device=v.device
+            ).permute(0, 2, 1, 3)
         else:
             dq = torch.ones((batch_size, seq_len, num_heads_q, head_dim_qk), dtype=q.dtype, device=q.device)
             dk = torch.empty((batch_size, seq_len, num_heads_k, head_dim_k), dtype=k.dtype, device=k.device)
@@ -202,10 +217,17 @@ class AiterFlashAttnFunc(torch.autograd.Function):
             qkv_format=bwd_qkv_format,
         )
 
-        if enable_sink and qkv_format == "sbhd":
-            dq = dq.permute(1, 0, 2, 3).contiguous()
-            dk = dk.permute(1, 0, 2, 3).contiguous()
-            dv_padded = dv_padded.permute(1, 0, 2, 3).contiguous()
+        if enable_sink:
+            if qkv_format == "sbhd":
+                dq = dq.permute(1, 0, 2, 3).contiguous()
+                dk = dk.permute(1, 0, 2, 3).contiguous()
+                dv_padded = dv_padded.permute(1, 0, 2, 3).contiguous()
+            elif qkv_format == "bhsd":
+                dq = dq.permute(0, 2, 1, 3).contiguous()
+                dk = dk.permute(0, 2, 1, 3).contiguous()
+                dv_padded = dv_padded.permute(0, 2, 1, 3).contiguous()
+            else:
+                assert qkv_format == "bshd"
 
         dq = dq[..., :head_size_q_og]
         dk = dk[..., :head_size_q_og]
@@ -351,7 +373,7 @@ def flash_attn_func(
 ):
     qkv_format = _infer_qkv_format(q, k, v)
 
-    return AiterFlashAttnFunc.apply(
+    result = AiterFlashAttnFunc.apply(
         q,
         k,
         v,
@@ -369,6 +391,8 @@ def flash_attn_func(
         sink,
         qkv_format,
     )
+
+    return result
 
 
 def flash_attn_fp8_func(
@@ -388,7 +412,11 @@ def flash_attn_fp8_func(
 ):
     qkv_format = _infer_qkv_format(q, k, v)
 
-    if qkv_format == "sbhd":
+    if qkv_format == "bhsd":
+        q = q.permute(0, 2, 1, 3).contiguous()
+        k = k.permute(0, 2, 1, 3).contiguous()
+        v = v.permute(0, 2, 1, 3).contiguous()
+    elif qkv_format == "sbhd":
         q = q.permute(1, 0, 2, 3).contiguous()
         k = k.permute(1, 0, 2, 3).contiguous()
         v = v.permute(1, 0, 2, 3).contiguous()
@@ -428,5 +456,7 @@ def flash_attn_fp8_func(
 
     if qkv_format == "sbhd":
         o = o.permute(1, 0, 2, 3).contiguous()
+    elif qkv_format == "bhsd":
+        o = o.permute(0, 2, 1, 3).contiguous()
 
     return o

--- a/primus_turbo/pytorch/ops/attention/flash_attn_usp_interface.py
+++ b/primus_turbo/pytorch/ops/attention/flash_attn_usp_interface.py
@@ -517,7 +517,11 @@ def flash_attn_fp8_usp_func(
 ):
     qkv_format = _infer_qkv_format(q, k, v)
 
-    if qkv_format == "sbhd":
+    if qkv_format == "bhsd":
+        q = q.permute(0, 2, 1, 3).contiguous()
+        k = k.permute(0, 2, 1, 3).contiguous()
+        v = v.permute(0, 2, 1, 3).contiguous()
+    elif qkv_format == "sbhd":
         q = q.permute(1, 0, 2, 3).contiguous()
         k = k.permute(1, 0, 2, 3).contiguous()
         v = v.permute(1, 0, 2, 3).contiguous()
@@ -559,5 +563,7 @@ def flash_attn_fp8_usp_func(
 
     if qkv_format == "sbhd":
         o = o.permute(1, 0, 2, 3).contiguous()
+    elif qkv_format == "bhsd":
+        o = o.permute(0, 2, 1, 3).contiguous()
 
     return o

--- a/primus_turbo/pytorch/ops/attention/usp/attention_ring.py
+++ b/primus_turbo/pytorch/ops/attention/usp/attention_ring.py
@@ -64,7 +64,6 @@ def _update_out_and_lse(
     lse: torch.Tensor,
     block_out: torch.Tensor,
     block_lse: torch.Tensor,
-    is_sbhd: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
 
     block_out = block_out.to(torch.float32)
@@ -85,7 +84,6 @@ def update_out_and_lse(
     block_out: torch.Tensor,
     block_lse: torch.Tensor,
     slice_=None,
-    is_sbhd: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     if out is None:
         if slice_ is not None:
@@ -95,12 +93,10 @@ def update_out_and_lse(
         lse = block_lse.transpose(-2, -1).unsqueeze(dim=-1)
     elif slice_ is not None:
         slice_out, slice_lse = out[slice_], lse[slice_]
-        slice_out, slice_lse = _update_out_and_lse(
-            slice_out, slice_lse, block_out, block_lse, is_sbhd=is_sbhd
-        )
+        slice_out, slice_lse = _update_out_and_lse(slice_out, slice_lse, block_out, block_lse)
         out[slice_], lse[slice_] = slice_out, slice_lse
     else:
-        out, lse = _update_out_and_lse(out, lse, block_out, block_lse, is_sbhd=is_sbhd)
+        out, lse = _update_out_and_lse(out, lse, block_out, block_lse)
     return out, lse
 
 
@@ -117,9 +113,8 @@ def ring_attn_fwd(
 
     arg_causal = kwargs.pop("causal", False)
     qkv_format = kwargs.get("qkv_format", "bshd")
-    if qkv_format not in ("bshd", "sbhd"):
+    if qkv_format not in ("bshd", "sbhd", "bhsd"):
         raise ValueError(f"Unsupported qkv format: {qkv_format}")
-    is_sbhd = qkv_format == "sbhd"
     comm = RingComm(process_group)
 
     out = None
@@ -142,7 +137,7 @@ def ring_attn_fwd(
                 **kwargs,
             )
             output_dtype = block_out.dtype
-            out, lse = update_out_and_lse(out, lse, block_out, block_lse, is_sbhd=is_sbhd)
+            out, lse = update_out_and_lse(out, lse, block_out, block_lse)
 
         if step + 1 != comm.world_size:
             comm.wait()
@@ -166,7 +161,7 @@ def ring_attn_bwd(
     **kwargs,
 ):
     qkv_format = kwargs.get("qkv_format", "bshd")
-    if qkv_format not in ("bshd", "sbhd"):
+    if qkv_format not in ("bshd", "sbhd", "bhsd"):
         raise ValueError(f"Unsupported qkv format: {qkv_format}")
 
     block_dq_buffer = torch.empty(q.shape, dtype=q.dtype, device=q.device)

--- a/tests/pytorch/ops/test_attention.py
+++ b/tests/pytorch/ops/test_attention.py
@@ -50,7 +50,7 @@ test_cases = [
 @pytest.mark.parametrize("causal", [True, False])
 @pytest.mark.parametrize("enable_sink", [False, True])
 @pytest.mark.parametrize("window_size_left", [-1, 32, 64, 128])
-@pytest.mark.parametrize("qkv_format", ["bshd", "sbhd"])
+@pytest.mark.parametrize("qkv_format", ["bshd", "sbhd", "bhsd"])
 @pytest.mark.parametrize("is_v3_atomic_fp32", [False, True])
 def test_attention_16bit(
     batch, dtype, config, causal, enable_sink, window_size_left, qkv_format, is_v3_atomic_fp32
@@ -76,8 +76,8 @@ def test_attention_16bit(
     if not enable_sink and window_size_left != -1:
         pytest.skip("window_size_left only applies when sink is enabled")
 
-    if enable_sink and qkv_format == "sbhd":
-        pytest.skip("Sink attention is not supported for sbhd format")
+    if enable_sink and qkv_format in ("sbhd", "bhsd"):
+        pytest.skip("Sink attention is not supported for sbhd/bhsd format")
 
     # Sink attention constraints / runtime control (skip early to avoid big allocations).
     if enable_sink:
@@ -101,6 +101,11 @@ def test_attention_16bit(
         k_layout = (seqlen_kv, batch, num_head_kv, head_dim_qk)
         v_layout = (seqlen_kv, batch, num_head_kv, head_dim_v)
         o_layout = (seqlen_q, batch, num_head_q, head_dim_v)
+    elif qkv_format == "bhsd":
+        q_layout = (batch, num_head_q, seqlen_q, head_dim_qk)
+        k_layout = (batch, num_head_kv, seqlen_kv, head_dim_qk)
+        v_layout = (batch, num_head_kv, seqlen_kv, head_dim_v)
+        o_layout = (batch, num_head_q, seqlen_q, head_dim_v)
     elif qkv_format == "bshd":
         q_layout = (batch, seqlen_q, num_head_q, head_dim_qk)
         k_layout = (batch, seqlen_kv, num_head_kv, head_dim_qk)
@@ -125,6 +130,11 @@ def test_attention_16bit(
         key = key.permute(1, 0, 2, 3)
         value = value.permute(1, 0, 2, 3)
         grad_out = grad_out.permute(1, 0, 2, 3)
+    elif qkv_format == "bhsd":
+        query = query.transpose(1, 2)
+        key = key.transpose(1, 2)
+        value = value.transpose(1, 2)
+        grad_out = grad_out.transpose(1, 2)
 
     sm_scale = head_dim_qk ** (-0.5)
 
@@ -169,6 +179,8 @@ def test_attention_16bit(
 
     if qkv_format == "sbhd":
         o_ref_cmp = o_ref.permute(1, 0, 2, 3).contiguous()
+    elif qkv_format == "bhsd":
+        o_ref_cmp = o_ref.transpose(1, 2).contiguous()
     else:
         o_ref_cmp = o_ref
     out_snr = compute_snr(o_ref_cmp, o)

--- a/tests/pytorch/ops/test_attention_with_cp.py
+++ b/tests/pytorch/ops/test_attention_with_cp.py
@@ -5,7 +5,11 @@
 ###############################################################################
 
 import itertools
+import os
 from typing import List
+
+# Must be set before importing common_distributed, which reads it at import time.
+os.environ.setdefault("DISTRIBUTED_TESTS_DEFAULT_TIMEOUT", "600")
 
 import torch
 import torch.distributed as dist
@@ -80,7 +84,7 @@ class AttentionWithCPTestCase(MultiProcessTestCase):
             "config": test_cases,
             "causal": [True, False],
             "fp8": [True, False],
-            "qkv_format": ["bshd", "sbhd"],
+            "qkv_format": ["bshd", "sbhd", "bhsd"],
             "ulysses_degree": [1, 2, 4, 8],
         }
 
@@ -127,17 +131,21 @@ class AttentionWithCPTestCase(MultiProcessTestCase):
             config.head_dim_qk,
             config.head_dim_v,
         )
-        if qkv_format == "bshd":
-            q_layout = (batch, seqlen_q, num_head_q, head_dim_qk)
-            k_layout = (batch, seqlen_kv, num_head_kv, head_dim_qk)
-            v_layout = (batch, seqlen_kv, num_head_kv, head_dim_v)
-            seq_dim = 1
-        else:
-            assert qkv_format == "sbhd"
+        if qkv_format == "sbhd":
             q_layout = (seqlen_q, batch, num_head_q, head_dim_qk)
             k_layout = (seqlen_kv, batch, num_head_kv, head_dim_qk)
             v_layout = (seqlen_kv, batch, num_head_kv, head_dim_v)
             seq_dim = 0
+        elif qkv_format == "bhsd":
+            q_layout = (batch, num_head_q, seqlen_q, head_dim_qk)
+            k_layout = (batch, num_head_kv, seqlen_kv, head_dim_qk)
+            v_layout = (batch, num_head_kv, seqlen_kv, head_dim_v)
+            seq_dim = 2
+        else:
+            q_layout = (batch, seqlen_q, num_head_q, head_dim_qk)
+            k_layout = (batch, seqlen_kv, num_head_kv, head_dim_qk)
+            v_layout = (batch, seqlen_kv, num_head_kv, head_dim_v)
+            seq_dim = 1
 
         query = torch.randn(q_layout, device=device, dtype=dtype, requires_grad=True)
         key = torch.randn(k_layout, device=device, dtype=dtype, requires_grad=True)
@@ -162,12 +170,15 @@ class AttentionWithCPTestCase(MultiProcessTestCase):
         )
 
         # flash_attn_usp_func expects shape [b, s, h, d] with format encoded
-        # in strides.  The ref tensors are actual [s, b, h, d]; transpose the
-        # sharded inputs so shape becomes [b, s_local, h, d] with sbhd strides.
+        # in strides.  Transpose sharded inputs to the expected view layout.
         if qkv_format == "sbhd":
             query_local_token = query_local_token.transpose(0, 1)
             key_local_token = key_local_token.transpose(0, 1)
             value_local_token = value_local_token.transpose(0, 1)
+        elif qkv_format == "bhsd":
+            query_local_token = query_local_token.transpose(1, 2)
+            key_local_token = key_local_token.transpose(1, 2)
+            value_local_token = value_local_token.transpose(1, 2)
 
         kwargs = {}
         if func is pt.ops.flash_attn_usp_func:
@@ -193,10 +204,14 @@ class AttentionWithCPTestCase(MultiProcessTestCase):
         grad = shard_cp_input([grad_ref], cp_group, seq_dim)[0]
         if qkv_format == "sbhd":
             grad = grad.transpose(0, 1)
+        elif qkv_format == "bhsd":
+            grad = grad.transpose(1, 2)
         o.backward(grad)
 
         if qkv_format == "sbhd":
             o = o.transpose(0, 1)
+        elif qkv_format == "bhsd":
+            o = o.transpose(1, 2)
         dq, dk, dv = shard_cp_input([query.grad, key.grad, value.grad], cp_group, seq_dim)
         out_snr = compute_snr(o_ref, o)
         query_grad_snr = compute_snr(dq_ref, dq)

--- a/tests/pytorch/ops/test_attention_with_cp.py
+++ b/tests/pytorch/ops/test_attention_with_cp.py
@@ -5,15 +5,12 @@
 ###############################################################################
 
 import itertools
-import os
 from typing import List
-
-# Must be set before importing common_distributed, which reads it at import time.
-os.environ.setdefault("DISTRIBUTED_TESTS_DEFAULT_TIMEOUT", "600")
 
 import torch
 import torch.distributed as dist
 from torch.distributed.device_mesh import init_device_mesh
+from torch.testing._internal import common_distributed
 from torch.testing._internal.common_distributed import (
     MultiProcessTestCase,
     skip_if_lt_x_gpu,
@@ -26,6 +23,9 @@ from tests.pytorch.ref.attention_ref import (
     attention_vanilla_forward_pytorch_ref_impl,
 )
 from tests.pytorch.test_utils import compute_snr
+
+# loosen timeout for this test to avoid timeout failures
+common_distributed.TIMEOUT_DEFAULT = 600
 
 test_cases = [
     AttnConfig(seqlen_q=1024, seqlen_kv=1024, num_head_q=64, num_head_kv=8, head_dim_qk=128, head_dim_v=128),


### PR DESCRIPTION
# Description

Add `bhsd` (batch, head, sequence, dimension) tensor layout support to the attention operators alongside the existing `bshd` and `sbhd` formats. This enables models that natively use the `bhsd` memory layout to run attention forward/backward passes without requiring manual layout conversion at the caller side.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `bhsd` to `_SUPPORTED_QKV_FORMATS` and extend `_infer_qkv_format` to detect `bhsd` layout via stride analysis (`s0 >= s2 >= s1`)
- Refine sink attention guard logic: skip sink for both `sbhd` and `bhsd` formats; move `head_dim` validation into `can_handle()` instead of `execute()`
- Support `bhsd` in `AiterFlashAttnFunc` forward/backward: allocate output and gradient buffers with correct `bhsd` strides, and permute back after sink attention
- Add `bhsd` transpose handling in `flash_attn_fp8_func` and `flash_attn_fp8_usp_func` (permute to `bshd` before compute, permute back after)
- Extend ring attention (`ring_attn_fwd` / `ring_attn_bwd`) to accept `bhsd` format; remove unused `is_sbhd` parameter from `update_out_and_lse`
- Update unit tests (`test_attention.py`, `test_attention_with_cp.py`) to parametrize over `bhsd` layout, including layout construction, transpose logic, and sink attention skip rules
- Set `DISTRIBUTED_TESTS_DEFAULT_TIMEOUT` to 600s before importing `common_distributed` to avoid CP test timeouts on 8-GPU configurations

# Checklist:

- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
