### PR TITLE
feat: clean unused env var and unify env var

### DIFF
--- a/primus_turbo/common/constants.py
+++ b/primus_turbo/common/constants.py
@@ -1,0 +1,37 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+# ---------------------------------------------------------------------------
+# Centralized environment-variable keys used throughout Primus-Turbo.
+#
+# Keeping every key in one place avoids typo-induced mismatches and makes it
+# easy to discover which knobs the library exposes.
+# ---------------------------------------------------------------------------
+
+# Log level for the primus_turbo logger (DEBUG / INFO / WARNING / ERROR / CRITICAL).
+# Default: WARNING
+ENV_LOG_LEVEL = "PRIMUS_TURBO_LOG_LEVEL"
+
+# GEMM backend selection (e.g. HIPBLASLT, AITER).
+# Supports per-precision format: "FP4:HIPBLASLT,FP8:AITER" or a single value.
+# Default: None (auto-select)
+ENV_GEMM_BACKEND = "PRIMUS_TURBO_GEMM_BACKEND"
+
+# Grouped GEMM backend selection. Same format as ENV_GEMM_BACKEND.
+# Default: None (auto-select)
+ENV_GROUPED_GEMM_BACKEND = "PRIMUS_TURBO_GROUPED_GEMM_BACKEND"
+
+# MoE dispatch/combine EP backend (TURBO, DEEP_EP, or custom names like UCCL_EP).
+# Default: TURBO
+ENV_MOE_DISPATCH_COMBINE_BACKEND = "PRIMUS_TURBO_MOE_DISPATCH_COMBINE_BACKEND"
+
+# Enable auto-tuning across registered kernel backends ("1" to enable).
+# Default: "0" (disabled)
+ENV_AUTO_TUNE = "PRIMUS_TURBO_AUTO_TUNE"
+
+# Whether Attention V3 uses FP32 atomic accumulation ("1" to enable, "0" to disable).
+# Default: "1" (enabled)
+ENV_ATTN_V3_ATOMIC_FP32 = "PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32"

--- a/primus_turbo/common/logger.py
+++ b/primus_turbo/common/logger.py
@@ -9,7 +9,8 @@ import os
 import sys
 from enum import Enum
 
-_LOG_LEVEL_ENV = "PRIMUS_TURBO_LOG_LEVEL"
+from primus_turbo.common.constants import ENV_LOG_LEVEL
+
 _DEFAULT_FORMAT = "[%(asctime)s] [%(levelname)s] [%(name)s] %(message)s"
 _DEFAULT_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 
@@ -57,7 +58,7 @@ class PrimusTurboLogger:
 
     @staticmethod
     def _resolve_log_level() -> int:
-        level_str = os.environ.get(_LOG_LEVEL_ENV, LogLevelEnum.WARNING.value).upper()
+        level_str = os.environ.get(ENV_LOG_LEVEL, LogLevelEnum.WARNING.value).upper()
         numeric = getattr(logging, level_str, None)
         if not isinstance(numeric, int):
             numeric = logging.WARNING

--- a/primus_turbo/pytorch/core/backend.py
+++ b/primus_turbo/pytorch/core/backend.py
@@ -14,6 +14,12 @@ from typing import Any, Dict, Hashable, List, Optional, Type
 
 import torch
 
+from primus_turbo.common.constants import (
+    ENV_AUTO_TUNE,
+    ENV_GEMM_BACKEND,
+    ENV_GROUPED_GEMM_BACKEND,
+    ENV_MOE_DISPATCH_COMBINE_BACKEND,
+)
 from primus_turbo.common.logger import logger
 from primus_turbo.triton.gemm.gemm_kernel import clear_origami_caches
 
@@ -32,11 +38,6 @@ __all__ = [
     "TuneCache",
     "AutoKernelDispatcher",
 ]
-
-_ENV_GEMM_BACKEND_KEY = "PRIMUS_TURBO_GEMM_BACKEND"
-_ENV_GROUPED_GEMM_BACKEND_KEY = "PRIMUS_TURBO_GROUPED_GEMM_BACKEND"
-_ENV_MOE_DISPATCH_COMBINE_BACKEND_KEY = "PRIMUS_TURBO_MOE_DISPATCH_COMBINE_BACKEND"
-_ENV_AUTO_TUNE_KEY = "PRIMUS_TURBO_AUTO_TUNE"
 
 
 class PrecisionType(Enum):
@@ -171,12 +172,12 @@ class GlobalBackendManager:
         """Get the GEMM backend configuration. Returns None if not set."""
         if cls._gemm_backend is not None:
             return cls._gemm_backend[precision]
-        env_value = os.environ.get(_ENV_GEMM_BACKEND_KEY, None)
+        env_value = os.environ.get(ENV_GEMM_BACKEND, None)
         if env_value is not None:
             backend = cls._extract_backend_from_env(env_value).get(precision, None)
             if backend is None:
                 logger.warning(
-                    f"Precision {precision.name} not found in the environment variable {_ENV_GEMM_BACKEND_KEY}. "
+                    f"Precision {precision.name} not found in the environment variable {ENV_GEMM_BACKEND}. "
                     f"Using default backend.",
                     once=True,
                 )
@@ -189,13 +190,13 @@ class GlobalBackendManager:
         """Get the Grouped GEMM backend configuration. Returns None if not set."""
         if cls._grouped_gemm_backend is not None:
             return cls._grouped_gemm_backend[precision]
-        env_value = os.environ.get(_ENV_GROUPED_GEMM_BACKEND_KEY, None)
+        env_value = os.environ.get(ENV_GROUPED_GEMM_BACKEND, None)
         if env_value is not None:
             backend = cls._extract_backend_from_env(env_value).get(precision, None)
             if backend is None:
                 logger.warning(
                     f"Precision {precision.name} not found in the environment variable "
-                    f"{_ENV_GROUPED_GEMM_BACKEND_KEY}. Using default backend.",
+                    f"{ENV_GROUPED_GEMM_BACKEND}. Using default backend.",
                     once=True,
                 )
             return backend
@@ -212,7 +213,7 @@ class GlobalBackendManager:
         """
         if cls._moe_dispatch_combine_backend is not None:
             return cls._moe_dispatch_combine_backend[precision]
-        env_value = os.environ.get(_ENV_MOE_DISPATCH_COMBINE_BACKEND_KEY, None)
+        env_value = os.environ.get(ENV_MOE_DISPATCH_COMBINE_BACKEND, None)
         if env_value is not None:
             try:
                 backend = cls._extract_backend_from_env(env_value).get(precision, None)
@@ -222,7 +223,7 @@ class GlobalBackendManager:
             if backend is None:
                 logger.warning(
                     f"Precision {precision.name} not found in the environment variable "
-                    f"{_ENV_MOE_DISPATCH_COMBINE_BACKEND_KEY}. Using default backend.",
+                    f"{ENV_MOE_DISPATCH_COMBINE_BACKEND}. Using default backend.",
                     once=True,
                 )
 
@@ -239,7 +240,7 @@ class GlobalBackendManager:
         """Check if auto-tune is enabled."""
         if cls._auto_tune is not None:
             return cls._auto_tune
-        return os.environ.get(_ENV_AUTO_TUNE_KEY, "0") == "1"
+        return os.environ.get(ENV_AUTO_TUNE, "0") == "1"
 
     @classmethod
     def reset(cls) -> None:

--- a/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
@@ -17,7 +17,6 @@ from torch._library import wrap_triton
 
 from primus_turbo.pytorch.core.low_precision import float8_e4m3, float8_e5m2
 from primus_turbo.triton.attention.attention_kernel import (
-    DEBUG,
     FIXED_BLOCK_M,
     FIXED_BLOCK_N,
     USE_FP8E5M2_BWD,
@@ -85,25 +84,6 @@ def attention_triton_forward_impl(
     max_seqlens_k = k.shape[1]
     return_scores = return_softmax
     use_exp2 = True
-    if DEBUG:
-        print()
-        print("attention_forward_triton_impl")
-        print("q:", q, q.shape)
-        print("k:", k, k.shape)
-        print("v:", v, v.shape)
-        print("softmax_scale:", softmax_scale)
-        print("alibi_slopes:", alibi_slopes)
-        print("causal:", causal)
-        print("bias:", bias)
-        print("dropout_p:", dropout_p)
-        print("layout:", layout)
-        print("cu_seqlens_q:", cu_seqlens_q)
-        print("cu_seqlens_k:", cu_seqlens_k)
-        print("max_seqlens_q:", max_seqlens_q)
-        print("max_seqlens_k:", max_seqlens_k)
-        print("return_scores:", return_scores)
-        print("use_exp2:", use_exp2)
-        print("use_fp8:", use_fp8)
 
     o_shape = list(q.shape)
     o_shape[-1] = v.shape[-1]  # output shape should match v's head dim
@@ -349,29 +329,6 @@ def attention_triton_backward_impl(
     sequence_parallel = True
     do = do.contiguous()
 
-    if DEBUG:
-        print("####################################################")
-        print("attention_backward_triton_new_impl")
-        print("do:", do, do.shape)
-        print("q:", q, q.shape)
-        print("k:", k, k.shape)
-        print("v:", v, v.shape)
-        print("o:", o, o.shape)
-        print("softmax_lse:", softmax_lse_delta, softmax_lse_delta.shape)
-        print("dq:", dq, dq.shape if dq is not None else None)
-        print("dk:", dk, dk.shape if dk is not None else None)
-        print("dv:", dv, dv.shape if dv is not None else None)
-        print("softmax_scale:", softmax_scale)
-        print("alibi_slopes:", alibi_slopes)
-        print("causal:", causal)
-        print("layout:", layout)
-        print("cu_seqlens_q:", cu_seqlens_q)
-        print("cu_seqlens_k:", cu_seqlens_k)
-        print("max_seqlen_q:", max_seqlen_q)
-        print("max_seqlen_k:", max_seqlen_k)
-        print("use_exp2:", use_exp2)
-        print("sequence_parallel:", sequence_parallel)
-
     # get strides and shape
     batch, nheads_q, nheads_k, head_size_qk, head_size_v, max_seqlen_q, max_seqlen_k = get_shape_from_layout(
         q, k, v, layout, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k
@@ -424,9 +381,6 @@ def attention_triton_backward_impl(
             dv_og = dv
             dv = dv.contiguous()
             copy_back["dv"] = True
-
-    if DEBUG:
-        print("copy_back:", copy_back)
 
     # assert contigious
     assert do.is_contiguous()
@@ -508,32 +462,6 @@ def attention_triton_backward_impl(
         F8_BWD_DTYPE=get_tl_f8_bwd_dtype(),
         F8_BWD_MAX=F8_BWD_MAX,
     )
-
-    if DEBUG:
-        print("####################################################")
-        print("_bwd_kernel inputs")
-        print("do:", do, do.shape)
-        print("q:", q, q.shape)
-        print("k:", k, k.shape)
-        print("v:", v, v.shape)
-        print("softmax_scale", softmax_scale)
-        print("o:", o, o.shape)
-        print("dq:", dq, dq.shape)
-        print("dk:", dk, dk.shape)
-        print("dv:", dv, dv.shape)
-        print("L:", softmax_lse_delta, softmax_lse_delta.shape)
-        print("stride_qz, stride_qh, stride_qm, stride_qk:", stride_qz, stride_qh, stride_qm, stride_qk)
-        print("stride_kz, stride_kh, stride_kn, stride_kk:", stride_kz, stride_kh, stride_kn, stride_kk)
-        print("stride_vz, stride_vh, stride_vn, stride_vk:", stride_vz, stride_vh, stride_vn, stride_vk)
-        print("batch_q:", batch)
-        print("heads_q:", nheads_q)
-        print("max_seqlen_q:", max_seqlen_q)
-        print("max_seqlen_k:", max_seqlen_k)
-        print("BLOCK_DMODEL_QK:", padded_d_model_qk)
-        print("BLOCK_DMODEL_V:", padded_d_model_v)
-        print("SEQUENCE_PARALLEL:", sequence_parallel)
-        print("CAUSAL:", causal)
-        print("USE_EXP2:", use_exp2)
 
     log_p_scale = math.log(p_scale)
     num_block_m = triton.cdiv(max_seqlen_q, FIXED_BLOCK_M)
@@ -690,23 +618,6 @@ def attention_triton_backward_impl(
         log_p_scale=log_p_scale,
         F8_FWD_MAX=F8_FWD_MAX,
     )
-
-    if DEBUG:
-        print("####################################################")
-        print("_bwd_kernel outputs")
-        print("dq:", dq, dq.shape)
-        print("dk:", dk, dk.shape)
-        print("dv:", dv, dv.shape)
-        # print("delta:", delta, delta.shape)
-
-    if DEBUG:
-        print("####################################################")
-        print("attention_prefill_backward_triton_new_impl outputs")
-        print("dq:", dq, dq.shape)
-        print("dk:", dk, dk.shape)
-        print("dv:", dv, dv.shape)
-        # print("delta:", delta, delta.shape)
-        print("copy_back:", copy_back)
 
     if copy_back["dq"]:
         dq_og.copy_(dq)

--- a/primus_turbo/pytorch/kernels/moe/moe_dispatch_combine_impl.py
+++ b/primus_turbo/pytorch/kernels/moe/moe_dispatch_combine_impl.py
@@ -23,6 +23,7 @@ from typing import (
 import torch
 import torch.distributed as dist
 
+from primus_turbo.common.constants import ENV_MOE_DISPATCH_COMBINE_BACKEND
 from primus_turbo.pytorch.core.backend import (
     BackendType,
     GlobalBackendManager,
@@ -428,8 +429,6 @@ def _get_backend_instance(name: str) -> EPBackend:
 # Backend selection
 # =========================================================================
 
-_ENV_MOE_DISPATCH_COMBINE_BACKEND_KEY = "PRIMUS_TURBO_MOE_DISPATCH_COMBINE_BACKEND"
-
 _BACKEND_TYPE_TO_NAME: Dict[BackendType, str] = {
     BackendType.TURBO: "TURBO",
     BackendType.DEEP_EP: "DEEP_EP",
@@ -448,7 +447,7 @@ def _resolve_backend_name() -> str:
     if user_backend is not None:
         return _BACKEND_TYPE_TO_NAME.get(user_backend, user_backend.name)
 
-    env_val = os.environ.get(_ENV_MOE_DISPATCH_COMBINE_BACKEND_KEY)
+    env_val = os.environ.get(ENV_MOE_DISPATCH_COMBINE_BACKEND)
     if env_val is not None:
         return env_val.strip().upper()
 

--- a/primus_turbo/pytorch/ops/attention/attention_utils.py
+++ b/primus_turbo/pytorch/ops/attention/attention_utils.py
@@ -8,16 +8,15 @@ import os
 
 import torch
 
+from primus_turbo.common.constants import ENV_ATTN_V3_ATOMIC_FP32
 from primus_turbo.pytorch.kernels.attention.attention_triton_impl import (
     get_f8_fwd_dtype,
 )
 from primus_turbo.triton.attention.attention_kernel import FIXED_BLOCK_M
 
-PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32_ENV_KEY = "PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32"
-
 
 def _resolve_is_v3_atomic_fp32_from_env() -> bool:
-    val = os.getenv(PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32_ENV_KEY, "1")
+    val = os.getenv(ENV_ATTN_V3_ATOMIC_FP32, "1")
     return val == "1" if val in ("0", "1") else True
 
 

--- a/primus_turbo/triton/attention/attention_kernel.py
+++ b/primus_turbo/triton/attention/attention_kernel.py
@@ -36,8 +36,6 @@
 ###############################################################################
 
 
-import os
-
 import triton
 import triton.language as tl
 
@@ -45,9 +43,6 @@ import triton.language as tl
 philox_seed: tl.constexpr = 0x1BF52
 philox_offset: tl.constexpr = 0x1D4B42
 
-AUTOTUNE = os.environ.get("PRIMUS_TURBO_TRITON_AMD_AUTOTUNE", "0").lower() in ("1", "true", "yes")
-DEBUG = os.environ.get("PRIMUS_TURBO_ATTENTION_TRITON_AMD_DEBUG", "0").lower() in ("1", "true", "yes")
-PERF = os.environ.get("PRIMUS_TURBO_ATTENTION_TRITON_AMD_PERF", "0").lower() in ("1", "true", "yes")
 
 FIXED_BLOCK_M = 64
 FIXED_BLOCK_N = 64


### PR DESCRIPTION
# Description

Centralize all Primus-Turbo environment variable keys into a single `primus_turbo/common/constants.py` module, replacing scattered hard-coded string literals across multiple files. This eliminates the risk of typo-induced mismatches and provides a single place to discover every configuration knob the library exposes.

Additionally, three unused environment variable reads (`PRIMUS_TURBO_TRITON_AMD_AUTOTUNE`, `PRIMUS_TURBO_ATTENTION_TRITON_AMD_DEBUG`, `PRIMUS_TURBO_ATTENTION_TRITON_AMD_PERF`) and the now-unnecessary `import os` were removed from `attention_kernel.py`, as they were no longer referenced anywhere in the file.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- **New file `primus_turbo/common/constants.py`**: defines 6 centralized environment-variable key constants (`ENV_LOG_LEVEL`, `ENV_GEMM_BACKEND`, `ENV_GROUPED_GEMM_BACKEND`, `ENV_MOE_DISPATCH_COMBINE_BACKEND`, `ENV_AUTO_TUNE`, `ENV_ATTN_V3_ATOMIC_FP32`) with documentation comments for each.
- **`primus_turbo/common/logger.py`**: replaced local `_LOG_LEVEL_ENV` string literal with imported `ENV_LOG_LEVEL`.
- **`primus_turbo/pytorch/core/backend.py`**: removed 4 local `_ENV_*_KEY` definitions and replaced all usages with the corresponding constants from `constants.py`.
- **`primus_turbo/pytorch/ops/attention/attention_utils.py`**: removed local `PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32_ENV_KEY` and replaced with imported `ENV_ATTN_V3_ATOMIC_FP32`.
- **`primus_turbo/pytorch/kernels/moe/moe_dispatch_combine_impl.py`**: removed local `_ENV_MOE_DISPATCH_COMBINE_BACKEND_KEY` and replaced with imported `ENV_MOE_DISPATCH_COMBINE_BACKEND`.
- **`primus_turbo/triton/attention/attention_kernel.py`**: removed 3 unused environment variable reads (`AUTOTUNE`, `DEBUG`, `PERF`) and the unused `import os`.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
