### PR TITLE
fix: mxfp8 gemm WAR race between ds_read and buffer_load_lds

### DIFF
--- a/csrc/kernels/gemm/turbo/turbo_gemm_mxfp8_kernel.h
+++ b/csrc/kernels/gemm/turbo/turbo_gemm_mxfp8_kernel.h
@@ -446,6 +446,10 @@ public:
         mfma_scale_pinned<PIN_A + 8, PIN_B + 8, ACC + 20, PIN_SA + 1, PIN_SB + 1>();
         ds_read_pinned<4, PIN_NEXT_S + 2, 512>(sbase);
         ds_read_pinned<4, PIN_NEXT_S + 3, 768>(sbase);
+
+        // WAR barrier
+        __builtin_amdgcn_s_barrier();
+
         // MFMA #6-#15: GMEM->SMEM prefetch spread across MFMA gaps
         mfma_scale_pinned<PIN_A + 8, PIN_B + 16, ACC + 24, PIN_SA + 1, PIN_SB + 2>();
         load_gmem_to_smem_srd<16>(data_srd, ldg_offsets[0], data_m0_0, data_soff_0);


### PR DESCRIPTION
# Description

fix mxfp8 WAR race between ds_read and buffer_load_lds.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- turbo mxfp8 gemm

