### PR TITLE
feat(moe): add back deepep_use_comm_stream to force use single-stream

### DIFF
--- a/csrc/include/primus_turbo/deep_ep/configs.h
+++ b/csrc/include/primus_turbo/deep_ep/configs.h
@@ -89,11 +89,9 @@ inline static bool is_enable_cheap_fence() {
     return std::stoi(v) == 0;
 }
 
-// When enabled, all EP dispatch/combine kernels are launched on the
-// caller's current CUDA stream instead of the Buffer's internal comm stream.
-// This removes cross-stream dependencies and makes EP safe to capture inside
-// `torch.cuda.graph`.  Set `PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM=0`(default) to restore
-// the async communication stream path for compute/comm overlap.
+// When set to 1, EP dispatch/combine kernels run on the caller's current
+// CUDA stream instead of the Buffer's internal comm stream.
+// Default: 0.
 inline static bool is_ep_force_current_stream() {
     static uint32_t val = []() {
         const char *v = std::getenv("PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM");

--- a/csrc/pytorch/deep_ep/deep_ep.hpp
+++ b/csrc/pytorch/deep_ep/deep_ep.hpp
@@ -74,11 +74,9 @@ private:
     volatile int *moe_recv_rdma_counter        = nullptr;
     int          *moe_recv_rdma_counter_mapped = nullptr;
 
-    // When true (default, controlled by ``PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM``),
-    // all dispatch/combine kernels are launched on the caller's current CUDA
-    // stream instead of ``comm_stream``, so EP can be captured inside
-    // ``torch.cuda.graph``.  When false, the original async path is used and
-    // ``comm_stream`` fork/joins with the compute stream for overlap.
+    // Controlled by ``PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM`` (default ``0``).
+    // When true, all dispatch/combine kernels run on the caller's current CUDA
+    // stream instead of ``comm_stream``.
     bool force_current_stream = true;
 
     // Pick the launch stream for this dispatch/combine call.  Returns the

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -355,10 +355,8 @@ def get_buffer(group: dist.ProcessGroup,
         num_rdma_bytes = max(config.get_rdma_buffer_size_hint(hidden_bytes, group.size()), num_rdma_bytes)
 
     # Allocate a buffer if not existed or not enough buffer size.
-    # By default dispatch/combine kernels run on the caller's current CUDA stream so
-    # the buffer is safe to use inside ``torch.cuda.graph``.  To enable compute/comm
-    # overlap on a dedicated communication stream, set
-    # ``PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM=0`` in the environment.
+    # Set ``PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM=1`` to force dispatch/combine kernels
+    # onto the caller's current CUDA stream (default ``0``).
     if _buffer is None or _buffer.group != group or _buffer.num_nvl_bytes < num_nvl_bytes or _buffer.num_rdma_bytes < num_rdma_bytes:
         _buffer = Buffer(group, num_nvl_bytes, num_rdma_bytes)
     return _buffer

--- a/primus_turbo/common/constants.py
+++ b/primus_turbo/common/constants.py
@@ -35,3 +35,7 @@ ENV_AUTO_TUNE = "PRIMUS_TURBO_AUTO_TUNE"
 # Whether Attention V3 uses FP32 atomic accumulation ("1" to enable, "0" to disable).
 # Default: "1" (enabled)
 ENV_ATTN_V3_ATOMIC_FP32 = "PRIMUS_TURBO_ATTN_V3_ATOMIC_FP32"
+
+# When set to "1", EP dispatch/combine kernels run on the caller's current CUDA stream.
+# Default: "0"
+ENV_EP_FORCE_CURRENT_STREAM = "PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM"

--- a/primus_turbo/pytorch/deep_ep/buffer.py
+++ b/primus_turbo/pytorch/deep_ep/buffer.py
@@ -73,10 +73,9 @@ class Buffer:
                 Note: Releasing resources in the destructor may cause Python's exception handling process to hang.
 
         Note:
-            Whether dispatch/combine kernels run on the caller's current CUDA
-            stream or on a dedicated async communication stream is controlled
-            by the environment variable ``PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM``
-            (default ``1``: current-stream, CUDA-graph friendly).
+            Controlled by ``PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM`` (default ``0``).
+            When set to ``1``, dispatch/combine kernels run on the caller's
+            current CUDA stream.
         """
         check_nvlink_connections(group)
 

--- a/primus_turbo/pytorch/kernels/moe/moe_dispatch_combine_impl.py
+++ b/primus_turbo/pytorch/kernels/moe/moe_dispatch_combine_impl.py
@@ -405,6 +405,12 @@ _BACKEND_REGISTRY: Dict[str, Type[EPBackend]] = {
 _backend_instances: Dict[str, EPBackend] = {}
 
 
+def clear_backend_instances():
+    global _backend_instances
+
+    _backend_instances.clear()
+
+
 def register_ep_backend(name: str, cls: Type[EPBackend]) -> None:
     """Register a new EP backend class (e.g. ``UCCL_EP``)."""
     _BACKEND_REGISTRY[name] = cls

--- a/primus_turbo/pytorch/modules/moe/token_dispatcher.py
+++ b/primus_turbo/pytorch/modules/moe/token_dispatcher.py
@@ -116,7 +116,7 @@ class DeepEPTokenDispatcher(TokenDispatcher):
         `expert_capacity_factor`: The capacity factor for each expert, None means no token will be dropped
         `permute_fusion`: use permuate fusion kernel when permute_fusion is True
         `permute_max_token_num`: use max_token_num can elimite host sync in permute when set deepep_use_cuda_num_tokens_per_expert=True
-        `deepep_use_comm_stream`: When True, force all EP dispatch/combine kernels onto a single stream by setting PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM=1.
+        `deepep_use_comm_stream`: When False, force all EP dispatch/combine kernels onto the current stream by setting PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM=1.
         `deepep_num_use_cu`: number of cu deepep used
         `deepep_num_worst_tokens`: number of worst tokens for deepep, see DeepEP for more detail.
         `deepep_use_cuda_num_tokens_per_expert`: DeepEPTokenDispatcher will return num_tokens_per_expert by cuda tensor instead of cpu tensor, this may elimate groumlp cpu sync when use turbo's groupgemm.

--- a/primus_turbo/pytorch/modules/moe/token_dispatcher.py
+++ b/primus_turbo/pytorch/modules/moe/token_dispatcher.py
@@ -16,6 +16,7 @@ import torch.distributed as dist
 import primus_turbo.pytorch as turbo
 from primus_turbo.pytorch.deep_ep import Config
 from primus_turbo.pytorch.kernels.moe.moe_dispatch_combine_impl import (
+    clear_backend_instances,
     set_buffer_global_config,
 )
 
@@ -150,6 +151,7 @@ class DeepEPTokenDispatcher(TokenDispatcher):
             )
 
         if not deepep_use_comm_stream:
+            clear_backend_instances()
             os.environ["PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM"] = "1"
 
         self.capacity_factor = expert_capacity_factor

--- a/primus_turbo/pytorch/modules/moe/token_dispatcher.py
+++ b/primus_turbo/pytorch/modules/moe/token_dispatcher.py
@@ -5,6 +5,7 @@
 ###############################################################################
 
 
+import os
 import warnings
 from abc import abstractmethod
 from typing import Optional, Tuple
@@ -115,6 +116,7 @@ class DeepEPTokenDispatcher(TokenDispatcher):
         `expert_capacity_factor`: The capacity factor for each expert, None means no token will be dropped
         `permute_fusion`: use permuate fusion kernel when permute_fusion is True
         `permute_max_token_num`: use max_token_num can elimite host sync in permute when set deepep_use_cuda_num_tokens_per_expert=True
+        `deepep_use_comm_stream`: When True, force all EP dispatch/combine kernels onto a single stream by setting PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM=1.
         `deepep_num_use_cu`: number of cu deepep used
         `deepep_num_worst_tokens`: number of worst tokens for deepep, see DeepEP for more detail.
         `deepep_use_cuda_num_tokens_per_expert`: DeepEPTokenDispatcher will return num_tokens_per_expert by cuda tensor instead of cpu tensor, this may elimate groumlp cpu sync when use turbo's groupgemm.
@@ -134,6 +136,7 @@ class DeepEPTokenDispatcher(TokenDispatcher):
         permute_max_token_num: int = 0,
         deepep_async_finish: bool = True,
         deepep_allocate_on_comm_stream: bool = True,
+        deepep_use_comm_stream: bool = False,
         deepep_num_use_cu: int = 32,
         deepep_num_worst_tokens: int = 0,
         deepep_use_cuda_num_tokens_per_expert: Optional[bool] = False,
@@ -145,6 +148,9 @@ class DeepEPTokenDispatcher(TokenDispatcher):
             raise ValueError(
                 "Please set deepep_use_cuda_num_tokens_per_expert=True when use deepep_num_worst_tokens"
             )
+
+        if not deepep_use_comm_stream:
+            os.environ["PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM"] = "1"
 
         self.capacity_factor = expert_capacity_factor
 

--- a/primus_turbo/pytorch/modules/moe/token_dispatcher.py
+++ b/primus_turbo/pytorch/modules/moe/token_dispatcher.py
@@ -14,6 +14,7 @@ import torch
 import torch.distributed as dist
 
 import primus_turbo.pytorch as turbo
+from primus_turbo.common.constants import ENV_EP_FORCE_CURRENT_STREAM
 from primus_turbo.pytorch.deep_ep import Config
 from primus_turbo.pytorch.kernels.moe.moe_dispatch_combine_impl import (
     clear_backend_instances,
@@ -150,9 +151,9 @@ class DeepEPTokenDispatcher(TokenDispatcher):
                 "Please set deepep_use_cuda_num_tokens_per_expert=True when use deepep_num_worst_tokens"
             )
 
-        if not deepep_use_comm_stream:
+        if not deepep_use_comm_stream and os.environ.get(ENV_EP_FORCE_CURRENT_STREAM) != "1":
             clear_backend_instances()
-            os.environ["PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM"] = "1"
+            os.environ[ENV_EP_FORCE_CURRENT_STREAM] = "1"
 
         self.capacity_factor = expert_capacity_factor
 

--- a/tests/pytorch/modules/test_token_dispatcher.py
+++ b/tests/pytorch/modules/test_token_dispatcher.py
@@ -52,6 +52,7 @@ def _run_dispatch_combine(
     deepep_num_worst_tokens=0,
     permute_max_token_num=0,
     expert_capacity_factor=None,
+    deepep_use_comm_stream=False,
 ):
     """Core dispatch-combine logic shared by all test variants."""
     dispatcher = turbo.modules.DeepEPTokenDispatcher(
@@ -63,6 +64,7 @@ def _run_dispatch_combine(
         deepep_num_worst_tokens=deepep_num_worst_tokens,
         permute_max_token_num=permute_max_token_num,
         expert_capacity_factor=expert_capacity_factor,
+        deepep_use_comm_stream=deepep_use_comm_stream,
     )
 
     hidden_states = torch.randn((num_tokens, hidden_size), dtype=dtype, device="cuda")


### PR DESCRIPTION
# Description

When deepep_use_comm_stream=False, set PRIMUS_TURBO_EP_FORCE_CURRENT_STREAM=1 to force all EP dispatch/combine kernels onto the caller's current stream.

Fixes # (issue): Fix Primus DeepEPTokenDispatcher API incompatibility

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
