### PR TITLE
fix: workaround for jax's deepep combine hang

### DIFF
--- a/csrc/jax/bindings_jax.cpp
+++ b/csrc/jax/bindings_jax.cpp
@@ -5,6 +5,7 @@
 #include "extensions.h"
 #include "ffi.h"
 #include "primus_turbo/arch.h"
+#include "primus_turbo/deep_ep/config.hpp"
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -50,6 +51,35 @@ pybind11::dict Registrations() {
 
 PYBIND11_MODULE(_C, m) {
     m.def("registrations", &Registrations);
+
+    // DeepEP Config
+    pybind11::class_<primus_turbo::deep_ep::Config>(m, "Config")
+        .def(pybind11::init<int, int, int, int, int>(),
+             pybind11::arg("num_sms") = DEFAULT_NUM_CU,
+             pybind11::arg("num_max_nvl_chunked_send_tokens") =
+                 DEFAULT_NUM_MAX_XGMI_CHUNKED_SEND_TOKENS,
+             pybind11::arg("num_max_nvl_chunked_recv_tokens") =
+                 DEFAULT_NUM_MAX_XGMI_CHUNKED_RECV_TOKENS,
+             pybind11::arg("num_max_rdma_chunked_send_tokens") =
+                 DEFAULT_NUM_MAX_RDMA_CHUNKED_SEND_TOKENS,
+             pybind11::arg("num_max_rdma_chunked_recv_tokens") =
+                 DEFAULT_NUM_MAX_RDMA_CHUNKED_RECV_TOKENS)
+        .def_readonly("num_sms", &primus_turbo::deep_ep::Config::num_sms)
+        .def_readonly("num_max_nvl_chunked_send_tokens",
+                      &primus_turbo::deep_ep::Config::num_max_nvl_chunked_send_tokens)
+        .def_readonly("num_max_nvl_chunked_recv_tokens",
+                      &primus_turbo::deep_ep::Config::num_max_nvl_chunked_recv_tokens)
+        .def_readonly("num_max_rdma_chunked_send_tokens",
+                      &primus_turbo::deep_ep::Config::num_max_rdma_chunked_send_tokens)
+        .def_readonly("num_max_rdma_chunked_recv_tokens",
+                      &primus_turbo::deep_ep::Config::num_max_rdma_chunked_recv_tokens)
+        .def("get_nvl_buffer_size_hint",
+             &primus_turbo::deep_ep::Config::get_nvl_buffer_size_hint)
+        .def("get_rdma_buffer_size_hint",
+             &primus_turbo::deep_ep::Config::get_rdma_buffer_size_hint);
+
+    m.def("get_low_latency_rdma_size_hint",
+          &primus_turbo::deep_ep::get_low_latency_rdma_size_hint);
 
     // DType enum
     pybind11::enum_<DType>(m, "DType", pybind11::module_local())

--- a/csrc/jax/bindings_jax.cpp
+++ b/csrc/jax/bindings_jax.cpp
@@ -54,8 +54,7 @@ PYBIND11_MODULE(_C, m) {
 
     // DeepEP Config
     pybind11::class_<primus_turbo::deep_ep::Config>(m, "Config")
-        .def(pybind11::init<int, int, int, int, int>(),
-             pybind11::arg("num_sms") = DEFAULT_NUM_CU,
+        .def(pybind11::init<int, int, int, int, int>(), pybind11::arg("num_sms") = DEFAULT_NUM_CU,
              pybind11::arg("num_max_nvl_chunked_send_tokens") =
                  DEFAULT_NUM_MAX_XGMI_CHUNKED_SEND_TOKENS,
              pybind11::arg("num_max_nvl_chunked_recv_tokens") =
@@ -73,13 +72,11 @@ PYBIND11_MODULE(_C, m) {
                       &primus_turbo::deep_ep::Config::num_max_rdma_chunked_send_tokens)
         .def_readonly("num_max_rdma_chunked_recv_tokens",
                       &primus_turbo::deep_ep::Config::num_max_rdma_chunked_recv_tokens)
-        .def("get_nvl_buffer_size_hint",
-             &primus_turbo::deep_ep::Config::get_nvl_buffer_size_hint)
+        .def("get_nvl_buffer_size_hint", &primus_turbo::deep_ep::Config::get_nvl_buffer_size_hint)
         .def("get_rdma_buffer_size_hint",
              &primus_turbo::deep_ep::Config::get_rdma_buffer_size_hint);
 
-    m.def("get_low_latency_rdma_size_hint",
-          &primus_turbo::deep_ep::get_low_latency_rdma_size_hint);
+    m.def("get_low_latency_rdma_size_hint", &primus_turbo::deep_ep::get_low_latency_rdma_size_hint);
 
     // DType enum
     pybind11::enum_<DType>(m, "DType", pybind11::module_local())

--- a/csrc/jax/deep_ep/deep_ep.cpp
+++ b/csrc/jax/deep_ep/deep_ep.cpp
@@ -221,7 +221,7 @@ void Buffer::IntranodeDispatch(
 
     // Shape and contiguous checks
     PRIMUS_TURBO_CHECK(x.dimensions().size() == 2);
-    PRIMUS_TURBO_CHECK((x.dimensions()[1] * x.element_count()) % sizeof(int4) == 0);
+    PRIMUS_TURBO_CHECK((x.dimensions()[1] * ffi::ByteWidth(x.element_type())) % sizeof(int4) == 0);
     PRIMUS_TURBO_CHECK(is_token_in_rank.dimensions().size() == 2);
     PRIMUS_TURBO_CHECK(is_token_in_rank.dimensions()[0] == x.dimensions()[0] and
                        is_token_in_rank.dimensions()[1] == num_ranks_);

--- a/csrc/jax/deep_ep/handler.cpp
+++ b/csrc/jax/deep_ep/handler.cpp
@@ -102,7 +102,8 @@ ffi::Error MoECombineFFI(
     ffi::Buffer<ffi::S32> channel_prefix_matrix, ffi::Buffer<ffi::S32> send_head, int64_t num_sms,
     int64_t num_max_nvl_chunked_send_tokens, int64_t num_max_nvl_chunked_recv_tokens,
     int64_t num_max_rdma_chunked_send_tokens, int64_t num_max_rdma_chunked_recv_tokens,
-    ffi::Result<ffi::AnyBuffer> recv_x, ffi::Result<ffi::Buffer<ffi::F32>> recv_topk_weights) {
+    ffi::Result<ffi::AnyBuffer> recv_x, ffi::Result<ffi::Buffer<ffi::F32>> recv_topk_weights,
+    ffi::Result<ffi::Buffer<ffi::S32>> send_head_work) {
     int num_ranks = -1;
     int rank      = -1;
     PRIMUS_TURBO_CHECK_HIP(hipGetDevice(&rank));
@@ -119,12 +120,19 @@ ffi::Error MoECombineFFI(
     bool has_bias0   = bias_0.element_count() > 0;
     bool has_bias1   = bias_1.element_count() > 0;
 
-    buffer->IntranodeCombine(stream, x,
-                             has_weights ? std::make_optional(topk_weights) : std::nullopt,
-                             has_bias0 ? std::make_optional(bias_0) : std::nullopt,
-                             has_bias1 ? std::make_optional(bias_1) : std::nullopt, src_idx,
-                             rank_prefix_matrix, channel_prefix_matrix, send_head, cfg, recv_x,
-                             has_weights ? std::make_optional(recv_topk_weights) : std::nullopt);
+    PRIMUS_TURBO_CHECK(send_head_work->dimensions().size() == send_head.dimensions().size());
+    for (int i = 0; i < send_head.dimensions().size(); ++i)
+        PRIMUS_TURBO_CHECK(send_head_work->dimensions()[i] == send_head.dimensions()[i]);
+    PRIMUS_TURBO_CHECK_HIP(hipMemcpyAsync(send_head_work->typed_data(), send_head.typed_data(),
+                                          send_head.element_count() * sizeof(int32_t),
+                                          hipMemcpyDeviceToDevice, stream));
+
+    buffer->IntranodeCombine(
+        stream, x, has_weights ? std::make_optional(topk_weights) : std::nullopt,
+        has_bias0 ? std::make_optional(bias_0) : std::nullopt,
+        has_bias1 ? std::make_optional(bias_1) : std::nullopt, src_idx, rank_prefix_matrix,
+        channel_prefix_matrix, *send_head_work, cfg, recv_x,
+        has_weights ? std::make_optional(recv_topk_weights) : std::nullopt);
 
     return ffi::Error::Success();
 }
@@ -202,6 +210,7 @@ XLA_FFI_DEFINE_HANDLER_SYMBOL(
         .Attr<int64_t>("num_max_rdma_chunked_recv_tokens") // num_max_rdma_chunked_recv_tokens
         .Ret<ffi::AnyBuffer>()                             // recv_x
         .Ret<ffi::Buffer<ffi::F32>>()                      // recv_topk_weights
+        .Ret<ffi::Buffer<ffi::S32>>()                      // send_head_work
 );
 
 } // namespace primus_turbo::jax::deep_ep

--- a/csrc/kernels/deep_ep/intranode.cu
+++ b/csrc/kernels/deep_ep/intranode.cu
@@ -573,10 +573,11 @@ __global__ void cached_notify_combine(void **buffer_ptrs, int *send_head, int nu
         // Barrier after cleaning
         barrier_block<kNumRanks>(barrier_signal_ptrs, rank);
     } else {
-        const auto channel_id = sm_id - 1;
-        const auto thread_id  = static_cast<int>(threadIdx.x);
-        const auto rank_id    = thread_id / kWarpSize;
-        const auto lane_id    = thread_id % kWarpSize;
+        constexpr int kNotifyWarpSize = kEmulatedWarpSize;
+        const auto    channel_id      = sm_id - 1;
+        const auto    thread_id       = static_cast<int>(threadIdx.x);
+        const auto    rank_id         = thread_id / kNotifyWarpSize;
+        const auto    lane_id         = thread_id % kNotifyWarpSize;
         if (rank_id >= kNumRanks)
             return;
 
@@ -587,13 +588,13 @@ __global__ void cached_notify_combine(void **buffer_ptrs, int *send_head, int nu
         // NOTES: `1 << 25` is a heuristic large number
         int last_head = 1 << 25;
         for (int token_idx_tail = token_end_idx - 1; token_idx_tail >= token_start_idx;
-             token_idx_tail -= kWarpSize) {
+             token_idx_tail -= kNotifyWarpSize) {
             int  token_idx = token_idx_tail - lane_id, expected_head = 0;
             auto current_head = (token_idx >= token_start_idx)
                                     ? __ldg(send_head + token_idx * kNumRanks + rank_id)
                                     : -1;
-            for (int i = 0; i < min(kWarpSize, token_idx_tail - token_start_idx + 1); ++i) {
-                const int head = __shfl_sync(kFullWarpMask, current_head, i);
+            for (int i = 0; i < min(kNotifyWarpSize, token_idx_tail - token_start_idx + 1); ++i) {
+                const int head = shfl_sync(current_head, i, kNotifyWarpSize);
                 if (head < 0) {
                     if (lane_id == i)
                         expected_head = -last_head - 1;
@@ -616,7 +617,7 @@ void cached_notify_combine(void **buffer_ptrs, int *send_head, int num_channels,
                                   barrier_signal_ptrs, rank);                                      \
     break
 
-    const int num_threads = std::max(128, kWarpSize * num_ranks);
+    const int num_threads = std::max(128, kEmulatedWarpSize * num_ranks);
     PRIMUS_TURBO_CHECK(num_ranks <= num_threads);
     PRIMUS_TURBO_CHECK(num_threads <= 1024);
     PRIMUS_TURBO_CHECK(1 + num_channels <= num_channels * 2);

--- a/primus_turbo/jax/lax/moe/__init__.py
+++ b/primus_turbo/jax/lax/moe/__init__.py
@@ -8,7 +8,7 @@ from .moe_dispatch_combine import (
     Config,
     get_combine_config,
     get_dispatch_config,
-    set_default_num_sms,
     moe_combine,
     moe_dispatch,
+    set_default_num_sms,
 )

--- a/primus_turbo/jax/lax/moe/__init__.py
+++ b/primus_turbo/jax/lax/moe/__init__.py
@@ -5,8 +5,10 @@
 ###############################################################################
 
 from .moe_dispatch_combine import (
+    Config,
     get_combine_config,
     get_dispatch_config,
+    set_default_num_sms,
     moe_combine,
     moe_dispatch,
 )

--- a/primus_turbo/jax/lax/moe/moe_dispatch_combine.py
+++ b/primus_turbo/jax/lax/moe/moe_dispatch_combine.py
@@ -16,14 +16,19 @@ from primus_turbo.jax.primitive.moe.moe_dispatch import (
     moe_dispatch_p,
 )
 
-from .moe_utils import Config
+from primus_turbo.jax._C import Config
 
-__all__ = ["get_dispatch_config", "moe_dispatch", "get_combine_config", "moe_combine"]
+__all__ = [
+    "Config",
+    "get_dispatch_config",
+    "get_combine_config",
+    "set_default_num_sms",
+    "moe_dispatch",
+    "moe_combine",
+]
 
 
 _default_num_sms = 64
-
-P = jax.sharding.PartitionSpec
 
 
 def set_default_num_sms(num_sms: int):
@@ -47,16 +52,16 @@ def get_dispatch_config() -> Config:
     num_ranks = jax.local_device_count()
     assert num_ranks <= 8, "not support internode"
     config_map = {
-        2: Config(_default_num_sms, 24, 256, 6, 128),
-        4: Config(_default_num_sms, 6, 256, 6, 128),
-        8: Config(_default_num_sms, 6, 256, 6, 128),
-        16: Config(_default_num_sms, 36, 288, 20, 128),
-        24: Config(_default_num_sms, 8, 288, 32, 128),
-        32: Config(_default_num_sms, 32, 288, 32, 128),
-        64: Config(_default_num_sms, 20, 288, 28, 128),
-        128: Config(_default_num_sms, 20, 560, 32, 128),
-        144: Config(_default_num_sms, 32, 720, 12, 128),
-        160: Config(_default_num_sms, 28, 720, 12, 128),
+        2: Config(_default_num_sms, 24, 512, 6, 512),
+        4: Config(_default_num_sms, 6, 512, 6, 512),
+        8: Config(_default_num_sms, 6, 512, 6, 512),
+        16: Config(_default_num_sms, 36, 512, 20, 512),
+        24: Config(_default_num_sms, 8, 512, 32, 512),
+        32: Config(_default_num_sms, 32, 512, 32, 512),
+        64: Config(_default_num_sms, 20, 512, 28, 512),
+        128: Config(_default_num_sms, 20, 560, 32, 512),
+        144: Config(_default_num_sms, 32, 720, 12, 512),
+        160: Config(_default_num_sms, 28, 720, 12, 512),
     }
     assert num_ranks in config_map, f"Unsupported number of EP ranks: {num_ranks}"
     return config_map[num_ranks]
@@ -64,7 +69,7 @@ def get_dispatch_config() -> Config:
 
 def get_combine_config() -> Config:
     """
-    Get a recommended dispatch config.
+    Get a recommended combine config.
     Returns:
         config: the recommended config.
     """
@@ -72,16 +77,16 @@ def get_combine_config() -> Config:
     num_ranks = jax.local_device_count()
     assert num_ranks <= 8, "not support internode"
     config_map = {
-        2: Config(_default_num_sms, 10, 256, 6, 128),
-        4: Config(_default_num_sms, 9, 256, 6, 128),
-        8: Config(_default_num_sms, 4, 256, 6, 128),
-        16: Config(_default_num_sms, 4, 288, 12, 128),
-        24: Config(_default_num_sms, 1, 288, 8, 128),
-        32: Config(_default_num_sms, 1, 288, 8, 128),
-        64: Config(_default_num_sms, 1, 288, 20, 128),
-        128: Config(_default_num_sms, 1, 560, 12, 128),
-        144: Config(_default_num_sms, 2, 720, 8, 128),
-        160: Config(_default_num_sms, 2, 720, 8, 128),
+        2: Config(_default_num_sms, 10, 512, 6, 512),
+        4: Config(_default_num_sms, 9, 512, 6, 512),
+        8: Config(_default_num_sms, 4, 512, 6, 512),
+        16: Config(_default_num_sms, 4, 512, 12, 512),
+        24: Config(_default_num_sms, 1, 512, 8, 512),
+        32: Config(_default_num_sms, 1, 512, 8, 512),
+        64: Config(_default_num_sms, 1, 512, 20, 512),
+        128: Config(_default_num_sms, 1, 560, 12, 512),
+        144: Config(_default_num_sms, 2, 720, 8, 512),
+        160: Config(_default_num_sms, 2, 720, 8, 512),
     }
     assert num_ranks in config_map, f"Unsupported number of EP ranks: {num_ranks}"
     return config_map[num_ranks]

--- a/primus_turbo/jax/lax/moe/moe_dispatch_combine.py
+++ b/primus_turbo/jax/lax/moe/moe_dispatch_combine.py
@@ -10,13 +10,12 @@ from typing import Optional, Tuple, Union
 import jax
 import jax.numpy as jnp
 
+from primus_turbo.jax._C import Config
 from primus_turbo.jax.primitive.moe.moe_combine import moe_combine_p
 from primus_turbo.jax.primitive.moe.moe_dispatch import (
     moe_cached_dispatch_p,
     moe_dispatch_p,
 )
-
-from primus_turbo.jax._C import Config
 
 __all__ = [
     "Config",

--- a/primus_turbo/jax/lax/moe/moe_dispatch_combine.py
+++ b/primus_turbo/jax/lax/moe/moe_dispatch_combine.py
@@ -51,16 +51,16 @@ def get_dispatch_config() -> Config:
     num_ranks = jax.local_device_count()
     assert num_ranks <= 8, "not support internode"
     config_map = {
-        2: Config(_default_num_sms, 24, 512, 6, 512),
-        4: Config(_default_num_sms, 6, 512, 6, 512),
-        8: Config(_default_num_sms, 6, 512, 6, 512),
-        16: Config(_default_num_sms, 36, 512, 20, 512),
-        24: Config(_default_num_sms, 8, 512, 32, 512),
-        32: Config(_default_num_sms, 32, 512, 32, 512),
-        64: Config(_default_num_sms, 20, 512, 28, 512),
-        128: Config(_default_num_sms, 20, 560, 32, 512),
-        144: Config(_default_num_sms, 32, 720, 12, 512),
-        160: Config(_default_num_sms, 28, 720, 12, 512),
+        2: Config(_default_num_sms, 24, 256, 6, 128),
+        4: Config(_default_num_sms, 6, 256, 6, 128),
+        8: Config(_default_num_sms, 6, 256, 6, 128),
+        16: Config(_default_num_sms, 36, 288, 20, 128),
+        24: Config(_default_num_sms, 8, 288, 32, 128),
+        32: Config(_default_num_sms, 32, 288, 32, 128),
+        64: Config(_default_num_sms, 20, 288, 28, 128),
+        128: Config(_default_num_sms, 20, 560, 32, 128),
+        144: Config(_default_num_sms, 32, 720, 12, 128),
+        160: Config(_default_num_sms, 28, 720, 12, 128),
     }
     assert num_ranks in config_map, f"Unsupported number of EP ranks: {num_ranks}"
     return config_map[num_ranks]
@@ -76,16 +76,16 @@ def get_combine_config() -> Config:
     num_ranks = jax.local_device_count()
     assert num_ranks <= 8, "not support internode"
     config_map = {
-        2: Config(_default_num_sms, 10, 512, 6, 512),
-        4: Config(_default_num_sms, 9, 512, 6, 512),
-        8: Config(_default_num_sms, 4, 512, 6, 512),
-        16: Config(_default_num_sms, 4, 512, 12, 512),
-        24: Config(_default_num_sms, 1, 512, 8, 512),
-        32: Config(_default_num_sms, 1, 512, 8, 512),
-        64: Config(_default_num_sms, 1, 512, 20, 512),
-        128: Config(_default_num_sms, 1, 560, 12, 512),
-        144: Config(_default_num_sms, 2, 720, 8, 512),
-        160: Config(_default_num_sms, 2, 720, 8, 512),
+        2: Config(_default_num_sms, 10, 256, 6, 128),
+        4: Config(_default_num_sms, 9, 256, 6, 128),
+        8: Config(_default_num_sms, 4, 256, 6, 128),
+        16: Config(_default_num_sms, 4, 288, 12, 128),
+        24: Config(_default_num_sms, 1, 288, 8, 128),
+        32: Config(_default_num_sms, 1, 288, 8, 128),
+        64: Config(_default_num_sms, 1, 288, 20, 128),
+        128: Config(_default_num_sms, 1, 560, 12, 128),
+        144: Config(_default_num_sms, 2, 720, 8, 128),
+        160: Config(_default_num_sms, 2, 720, 8, 128),
     }
     assert num_ranks in config_map, f"Unsupported number of EP ranks: {num_ranks}"
     return config_map[num_ranks]

--- a/primus_turbo/jax/lax/moe/moe_dispatch_combine.py
+++ b/primus_turbo/jax/lax/moe/moe_dispatch_combine.py
@@ -375,7 +375,7 @@ def _moe_combine_impl(
 
     rank_prefix_matrix, _, channel_prefix_matrix, src_idx, is_recv_token_in_rank, send_head = handle
 
-    combined_x, combined_topk_weights = moe_combine_p.bind(
+    combined_x, combined_topk_weights, _ = moe_combine_p.bind(
         x,
         topk_weights,
         bias_0,

--- a/primus_turbo/jax/lax/moe/moe_utils.py
+++ b/primus_turbo/jax/lax/moe/moe_utils.py
@@ -4,13 +4,6 @@
 # See LICENSE for license information.
 ###############################################################################
 
+from primus_turbo.jax._C import Config
 
-from typing import NamedTuple
-
-
-class Config(NamedTuple):
-    num_sms: int
-    num_max_nvl_chunked_send_tokens: int
-    num_max_nvl_chunked_recv_tokens: int
-    num_max_rdma_chunked_send_tokens: int
-    num_max_rdma_chunked_recv_tokens: int
+__all__ = ["Config"]

--- a/primus_turbo/jax/primitive/moe/moe_combine.py
+++ b/primus_turbo/jax/primitive/moe/moe_combine.py
@@ -62,7 +62,7 @@ ABSTRACT_EVAL_TABLE[moe_combine_p] = _moe_combine_abstract_eval
 # ----------------------------------------
 # Step-4: JIT Lowering
 # ----------------------------------------
-LOWERING_TABLE[moe_combine_p] = jax.ffi.ffi_lowering("moe_combine")
+LOWERING_TABLE[moe_combine_p] = jax.ffi.ffi_lowering("moe_combine", has_side_effect=True)
 # ----------------------------------------
 # Step-5: batching
 # ----------------------------------------

--- a/primus_turbo/jax/primitive/moe/moe_combine.py
+++ b/primus_turbo/jax/primitive/moe/moe_combine.py
@@ -54,7 +54,8 @@ def _moe_combine_abstract_eval(
     recv_x = ShapedArray((num_recv_tokens, hidden_size), x.dtype)
     shape = (num_recv_tokens, topk_weights.shape[1]) if topk_weights.size > 0 else topk_weights.shape
     recv_topk_weights = ShapedArray(shape, topk_weights.dtype)
-    return recv_x, recv_topk_weights
+    send_head_work = ShapedArray(send_head.shape, send_head.dtype)
+    return recv_x, recv_topk_weights, send_head_work
 
 
 ABSTRACT_EVAL_TABLE[moe_combine_p] = _moe_combine_abstract_eval

--- a/primus_turbo/jax/primitive/moe/moe_dispatch.py
+++ b/primus_turbo/jax/primitive/moe/moe_dispatch.py
@@ -132,8 +132,8 @@ ABSTRACT_EVAL_TABLE[moe_cached_dispatch_p] = _moe_cached_dispatch_abstract_eval
 # ----------------------------------------
 # Step-4: JIT Lowering
 # ----------------------------------------
-LOWERING_TABLE[moe_dispatch_p] = jax.ffi.ffi_lowering("moe_dispatch")
-LOWERING_TABLE[moe_cached_dispatch_p] = jax.ffi.ffi_lowering("moe_cached_dispatch")
+LOWERING_TABLE[moe_dispatch_p] = jax.ffi.ffi_lowering("moe_dispatch", has_side_effect=True)
+LOWERING_TABLE[moe_cached_dispatch_p] = jax.ffi.ffi_lowering("moe_cached_dispatch", has_side_effect=True)
 # ----------------------------------------
 # Step-5: batching
 # ----------------------------------------


### PR DESCRIPTION
# Description

Fix DeepEP MoE combine hang by increasing chunked recv token buffer sizes, migrating the `Config` class from a Python NamedTuple to C++ pybind11 binding (exposing buffer size hint methods).

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Expose `Config` class and `get_low_latency_rdma_size_hint` from C++ via pybind11, replacing the Python NamedTuple
- Increase `num_max_nvl_chunked_recv_tokens` and `num_max_rdma_chunked_recv_tokens` to 512 in both dispatch and combine config maps to avoid combine hang
- Export `Config` and `set_default_num_sms` from `primus_turbo.jax.lax.moe`

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
