### PR TITLE
fix(grouped_gemm): bind per-stream hipBLASLt handles to fix bf16 multi-stream stall on gfx942

### DIFF
--- a/benchmark/ops/bench_grouped_gemm_gmm.py
+++ b/benchmark/ops/bench_grouped_gemm_gmm.py
@@ -1,0 +1,205 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""GMM (grouped_gemm) BF16 Grouped GEMM Baseline Benchmark.
+
+Reference: https://github.com/tgale96/grouped_gemm
+"""
+
+import argparse
+from datetime import datetime
+
+import grouped_gemm.ops as gmm_ops
+import pandas as pd
+import torch
+import torch.utils.benchmark as benchmark
+from config import (
+    check_allclose,
+    gen_grouped_gemm_group_lens,
+    gen_grouped_gemm_test_cases,
+    get_platform_info,
+    grouped_gemm_ref,
+)
+from tabulate import tabulate
+
+
+def check_grouped_gemm_gmm_correctness(a, b, batch_sizes, grad_out, dtype):
+    """Check correctness of gmm forward and backward against reference."""
+    out = gmm_ops.gmm(a, b, batch_sizes, trans_b=True)
+
+    group_lens = batch_sizes.to(device=a.device, dtype=torch.int64)
+    out_ref = grouped_gemm_ref(a.detach(), b.detach(), group_lens, trans_b=True)
+    fwd_correct = check_allclose(out.detach(), out_ref, dtype)
+
+    a_ref = a.detach().clone().requires_grad_()
+    b_ref = b.detach().clone().requires_grad_()
+    out_ref = grouped_gemm_ref(a_ref, b_ref, group_lens, trans_b=True)
+    out_ref.backward(grad_out)
+    out.backward(grad_out, retain_graph=True)
+    bwd_correct = check_allclose(a.grad, a_ref.grad, dtype)
+
+    a.grad = None
+
+    correct = fwd_correct and bwd_correct
+    status = "PASS" if correct else "FAIL"
+    print(f"Correctness Check: {status} (fwd={fwd_correct}, bwd={bwd_correct})")
+
+    return correct
+
+
+def profile_grouped_gemm_gmm(B, M, N, K, dtype, balance=True, num_topk=None):
+    """Profile BF16 Grouped GEMM using grouped_gemm (gmm) library."""
+    device = "cuda"
+    # batch_sizes must be on CPU for gmm
+    batch_sizes = gen_grouped_gemm_group_lens(B, M, balance=balance, num_topk=num_topk)
+    total_m = batch_sizes.sum().item()
+
+    a = torch.randn((total_m, K), dtype=dtype, device=device, requires_grad=True)
+    b = torch.randn((B, N, K), dtype=dtype, device=device, requires_grad=True)
+
+    out = gmm_ops.gmm(a, b, batch_sizes, trans_b=True)
+    grad_out = torch.randn_like(out)
+
+    correct = check_grouped_gemm_gmm_correctness(a, b, batch_sizes, grad_out, dtype)
+
+    def fwd_func():
+        return gmm_ops.gmm(a, b, batch_sizes, trans_b=True)
+
+    def fwd_bwd_func():
+        out = gmm_ops.gmm(a, b, batch_sizes, trans_b=True)
+        out.backward(grad_out)
+        a.grad = None
+        b.grad = None
+
+    fwd_total_flops = 2 * B * M * N * K
+    bwd_total_flops = 2 * fwd_total_flops
+
+    for _ in range(100):
+        fwd_bwd_func()
+    torch.cuda.synchronize()
+
+    fwd_timer = benchmark.Timer(stmt="fn()", globals={"fn": fwd_func})
+    fwd_measurement = fwd_timer.timeit(200)
+
+    fwd_bwd_timer = benchmark.Timer(stmt="fn()", globals={"fn": fwd_bwd_func})
+    fwd_bwd_measurement = fwd_bwd_timer.timeit(200)
+
+    fwd_mean_time_ms = fwd_measurement.mean * 1e3
+    fwd_bwd_mean_time_ms = fwd_bwd_measurement.mean * 1e3
+    bwd_mean_time_ms = fwd_bwd_mean_time_ms - fwd_mean_time_ms
+
+    fwd_tflops = fwd_total_flops / (fwd_mean_time_ms * 1e-3) / 1e12
+    bwd_tflops = bwd_total_flops / (bwd_mean_time_ms * 1e-3) / 1e12
+    print(f"Forward  Mean time: {fwd_mean_time_ms:.3f} ms | TFLOPS: {fwd_tflops:.2f}")
+    print(f"Backward Mean time: {bwd_mean_time_ms:.3f} ms | TFLOPS: {bwd_tflops:.2f}")
+
+    return fwd_mean_time_ms, fwd_tflops, bwd_mean_time_ms, bwd_tflops, correct
+
+
+def benchmark_grouped_gemm_gmm(output_csv=None):
+    platform, gpu_name = get_platform_info()
+
+    test_cases = gen_grouped_gemm_test_cases()
+
+    rows = []
+    test_id = 0
+    dtype = torch.bfloat16
+
+    for case in test_cases:
+        test_id += 1
+        B, M, N, K = case["B"], case["M"], case["N"], case["K"]
+
+        balance = case.get("balance", True)
+        balance_str = "balanced" if balance else "unbalanced"
+        print(f"\n{'='*60}")
+        print(
+            f"TestID: {test_id}, Case: {case['Case']}, B: {B}, M: {M}, N: {N}, K: {K}, dtype: bf16, {balance_str}"
+        )
+        print(f"{'='*60}")
+
+        try:
+            fwd_time_ms, fwd_tflops, bwd_time_ms, bwd_tflops, correct = profile_grouped_gemm_gmm(
+                B=B,
+                M=M,
+                N=N,
+                K=K,
+                dtype=dtype,
+                balance=balance,
+                num_topk=case.get("num_topk"),
+            )
+
+            row = {
+                "TestID": test_id,
+                "Platform": platform,
+                "GPU": gpu_name,
+                "Case": case["Case"],
+                "B": B,
+                "M": M,
+                "N": N,
+                "K": K,
+                "Dtype": "bf16",
+                "Balance": "Y" if balance else "N",
+                "Check": "PASS" if correct else "FAIL",
+                "Forward Time (ms)": f"{fwd_time_ms:.2f}",
+                "Forward TFLOPS": f"{fwd_tflops:.2f}",
+                "Backward Time (ms)": f"{bwd_time_ms:.2f}",
+                "Backward TFLOPS": f"{bwd_tflops:.2f}",
+            }
+            rows.append(row)
+
+        except Exception as e:
+            import traceback
+
+            print(f"Failed: {str(e)}")
+            traceback.print_exc()
+            row = {
+                "TestID": test_id,
+                "Platform": platform,
+                "GPU": gpu_name,
+                "Case": case["Case"],
+                "B": B,
+                "M": M,
+                "N": N,
+                "K": K,
+                "Dtype": "bf16",
+                "Balance": "Y" if balance else "N",
+                "Check": "ERROR",
+                "Forward Time (ms)": "ERROR",
+                "Forward TFLOPS": "0.00",
+                "Backward Time (ms)": "ERROR",
+                "Backward TFLOPS": "0.00",
+            }
+            rows.append(row)
+
+    results = pd.DataFrame(rows)
+    print("\nFinal Results:")
+    print(tabulate(results, headers="keys", tablefmt="grid", showindex=False))
+
+    avg_fwd_tflops = results["Forward TFLOPS"].astype(float).mean()
+    avg_bwd_tflops = results["Backward TFLOPS"].astype(float).mean()
+    print(f"\nAverage Forward TFLOPS: {avg_fwd_tflops:.2f}")
+    print(f"Average Backward TFLOPS: {avg_bwd_tflops:.2f}")
+
+    if output_csv:
+        filename = output_csv
+    else:
+        timestamp = datetime.now().strftime("%Y%m%d")
+        filename = f"grouped_gemm_gmm_bf16_{timestamp}_{gpu_name}.csv"
+    results.to_csv(filename, index=False)
+    print(f"Results saved to {filename}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Benchmark grouped_gemm (gmm) BF16 Grouped GEMM")
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        default=None,
+        help="Output CSV filename",
+    )
+    args = parser.parse_args()
+    benchmark_grouped_gemm_gmm(output_csv=args.output)

--- a/csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu
+++ b/csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <hip/hip_runtime.h>
+#include <hipblas/hipblas.h>
 #include <hipblaslt/hipblaslt.h>
 
 #include "primus_turbo/gemm.h"
@@ -28,6 +29,14 @@ public:
             PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtCreate(&handles_[i]));
             PRIMUS_TURBO_CHECK_HIP(
                 hipStreamCreateWithPriority(&compute_streams_[i], hipStreamNonBlocking, -1));
+            // Bind each handle to its dedicated compute stream. hipBLASLt's
+            // internal state (heuristic cache, workspace accounting) is
+            // per-handle and assumes a one-to-one handle<->stream association.
+            // Reusing a single handle concurrently across multiple streams can
+            // trigger intermittent serialisation/stalls. See ROCm TE and
+            // grouped-gemm-ck reference for the same pattern.
+            PRIMUS_TURBO_CHECK_HIPBLAS(hipblasSetStream(
+                reinterpret_cast<hipblasHandle_t>(handles_[i]), compute_streams_[i]));
             PRIMUS_TURBO_CHECK_HIP(
                 hipEventCreateWithFlags(&hipblaslt_events_[i], hipEventDisableTiming));
         }
@@ -85,17 +94,26 @@ public:
         const size_t num_stream_used{std::min<size_t>(kMaxNumStreams, num_gemms)};
 
         if (num_gemms > 0) {
-            // wait for current stream to finish
-            PRIMUS_TURBO_CHECK_HIP(hipEventRecord(sync_event_, params.stream));
-
-            for (size_t s = 0; s < num_stream_used; ++s) {
-                PRIMUS_TURBO_CHECK_HIP(hipStreamWaitEvent(compute_streams_[s], sync_event_, 0));
+            // Slot 0 runs on params.stream directly; only extra slots need
+            // fan-out from params.stream via sync_event_.
+            if (num_stream_used > 1) {
+                PRIMUS_TURBO_CHECK_HIP(hipEventRecord(sync_event_, params.stream));
+                for (size_t s = 1; s < num_stream_used; ++s) {
+                    PRIMUS_TURBO_CHECK_HIP(
+                        hipStreamWaitEvent(compute_streams_[s], sync_event_, 0));
+                }
             }
 
             for (size_t idx = 0; idx < num_gemms; ++idx) {
                 const auto stream_idx = idx % kMaxNumStreams;
-                auto       stream     = compute_streams_[stream_idx];
-                auto       handle     = handles_[stream_idx];
+                // Slot 0 uses the caller's stream and hipBLASLt handle (the
+                // PyTorch current stream/handle, which is already bound
+                // one-to-one). Extra slots use our internal streams bound via
+                // hipblasSetStream above.
+                auto       stream     = (stream_idx == 0) ? params.stream
+                                                          : compute_streams_[stream_idx];
+                auto       handle     = (stream_idx == 0) ? params.handle
+                                                          : handles_[stream_idx];
                 auto       workspace  = workspaces_[stream_idx];
                 // clang-format off
                 hipblaslt_gemm_impl(
@@ -115,14 +133,17 @@ public:
                 // clang-format on
             }
 
-            // record events on compute streams
-            for (size_t s = 0; s < num_stream_used; ++s) {
-                PRIMUS_TURBO_CHECK_HIP(hipEventRecord(hipblaslt_events_[s], compute_streams_[s]));
-            }
-
-            // wait for all compute streams to finish
-            for (size_t s = 0; s < num_stream_used; ++s) {
-                PRIMUS_TURBO_CHECK_HIP(hipStreamWaitEvent(params.stream, hipblaslt_events_[s], 0));
+            if (num_stream_used > 1) {
+                // Slot 0 already runs on params.stream; fan extra slots back
+                // into params.stream.
+                for (size_t s = 1; s < num_stream_used; ++s) {
+                    PRIMUS_TURBO_CHECK_HIP(
+                        hipEventRecord(hipblaslt_events_[s], compute_streams_[s]));
+                }
+                for (size_t s = 1; s < num_stream_used; ++s) {
+                    PRIMUS_TURBO_CHECK_HIP(
+                        hipStreamWaitEvent(params.stream, hipblaslt_events_[s], 0));
+                }
             }
         }
     }

--- a/csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu
+++ b/csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu
@@ -14,7 +14,15 @@
 
 namespace primus_turbo {
 
+// Number of streams actively used by `run()` (1 caller stream + 3 internal).
 static constexpr size_t kMaxNumStreams = 4;
+// Number of internal handle / stream / event slots actually pre-allocated at
+// construction time. Mirrors upstream `grouped-gemm-ck::HipBlasLt`'s
+// `kDefaultInitKmaxNumStream = 8`. With only `kMaxNumStreams = 4` slots
+// pre-allocated, BF16 multi-stream grouped GEMM stalls intermittently on
+// MI355X after a few dozen fwd+bwd iterations; over-provisioning the slot
+// pool empirically eliminates the stall (see PR description for traces).
+static constexpr size_t kInitNumStreams = 8;
 
 std::int64_t get_hipblaslt_grouped_gemm_workspace_size() {
     return kMaxNumStreams * get_hipblaslt_workspace_size_in_byte();
@@ -25,18 +33,24 @@ public:
     HipblasltGroupedGemm() {
         PRIMUS_TURBO_CHECK_HIP(hipEventCreateWithFlags(&sync_event_, hipEventDisableTiming));
 
-        for (size_t i = 0; i < kMaxNumStreams; ++i) {
-            PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtCreate(&handles_[i]));
-            PRIMUS_TURBO_CHECK_HIP(
-                hipStreamCreateWithPriority(&compute_streams_[i], hipStreamNonBlocking, -1));
-            // Bind each handle to its dedicated compute stream. hipBLASLt's
-            // internal state (heuristic cache, workspace accounting) is
-            // per-handle and assumes a one-to-one handle<->stream association.
-            // Reusing a single handle concurrently across multiple streams can
-            // trigger intermittent serialisation/stalls. See ROCm TE and
-            // grouped-gemm-ck reference for the same pattern.
-            PRIMUS_TURBO_CHECK_HIPBLAS(hipblasSetStream(
-                reinterpret_cast<hipblasHandle_t>(handles_[i]), compute_streams_[i]));
+        // Slot 0 is the PyTorch current stream (fetched per-call inside
+        // `run(...)`); only slots 1..kInitNumStreams-1 own internal compute
+        // streams + dedicated hipBLASLt handles. Creating a "ghost" handle
+        // for slot 0 was empirically observed to push hipBLASLt past an
+        // internal resource limit on MI355X and re-trigger the BF16 stall.
+        handles_[0]         = nullptr;
+        compute_streams_[0] = nullptr;
+        for (size_t i = 0; i < kInitNumStreams; ++i) {
+            if (i > 0) {
+                PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtCreate(&handles_[i]));
+                PRIMUS_TURBO_CHECK_HIP(
+                    hipStreamCreateWithPriority(&compute_streams_[i], hipStreamNonBlocking, -1));
+                // Bind each handle to its dedicated compute stream. hipBLASLt's
+                // internal state (heuristic cache, workspace accounting) is
+                // per-handle and assumes a one-to-one handle<->stream association.
+                PRIMUS_TURBO_CHECK_HIPBLAS(hipblasSetStream(
+                    reinterpret_cast<hipblasHandle_t>(handles_[i]), compute_streams_[i]));
+            }
             PRIMUS_TURBO_CHECK_HIP(
                 hipEventCreateWithFlags(&hipblaslt_events_[i], hipEventDisableTiming));
         }
@@ -48,7 +62,7 @@ public:
             (void) hipEventDestroy(sync_event_);
         }
 
-        for (size_t i = 0; i < kMaxNumStreams; ++i) {
+        for (size_t i = 0; i < kInitNumStreams; ++i) {
             if (compute_streams_[i] != nullptr) {
                 (void) hipStreamDestroy(compute_streams_[i]);
             }
@@ -238,11 +252,13 @@ private:
         return shape.at(idx);
     }
 
-    // Handles, events, streams, heuristic, epilogue
-    hipblasLtHandle_t   handles_[kMaxNumStreams]{};
+    // Handles, events, streams, heuristic, epilogue. Sized to
+    // `kInitNumStreams` even though only `kMaxNumStreams` are actually
+    // used by `run(...)`; see the constant declaration for the rationale.
+    hipblasLtHandle_t   handles_[kInitNumStreams]{};
     hipEvent_t          sync_event_{nullptr};
-    hipStream_t         compute_streams_[kMaxNumStreams]{};
-    hipEvent_t          hipblaslt_events_[kMaxNumStreams]{};
+    hipStream_t         compute_streams_[kInitNumStreams]{};
+    hipEvent_t          hipblaslt_events_[kInitNumStreams]{};
     hipblasLtEpilogue_t epilogue_{HIPBLASLT_EPILOGUE_DEFAULT};
 
     // Gemm Pointers
@@ -266,7 +282,13 @@ private:
 };
 
 void hipblaslt_grouped_gemm(const HipblasltGroupedGemmParams &params, const bool pre_sync) {
-    static thread_local HipblasltGroupedGemm instance;
+    // Process-wide singleton (NOT `thread_local`), mirroring upstream
+    // `grouped-gemm-ck::HipBlasLt`. With `thread_local` the autograd worker
+    // thread allocated its own pool of internal streams, so the process
+    // ended up running on >=7 distinct hipBLASLt streams (3 per thread +
+    // PyTorch's default), which appears to push hipBLASLt past an implicit
+    // resource limit on MI355X and triggers BF16 multi-stream stalls.
+    static HipblasltGroupedGemm instance;
     instance.run(params, pre_sync);
 }
 

--- a/setup.py
+++ b/setup.py
@@ -307,7 +307,7 @@ def build_kernels_extension():
         include_dirs=include_dirs,
         sources=kernels_sources,
         library_dirs=library_dirs,
-        libraries=["hipblaslt"],
+        libraries=["hipblaslt", "hipblas"],
         **extra_flags,
     )
 

--- a/tests/pytorch/ops/test_grouped_gemm.py
+++ b/tests/pytorch/ops/test_grouped_gemm.py
@@ -8,7 +8,6 @@ import pytest
 import torch
 
 from primus_turbo.pytorch.core.backend import BackendType, GlobalBackendManager
-from primus_turbo.pytorch.core.utils import get_device_compute_capability
 from primus_turbo.pytorch.ops import grouped_gemm
 from tests.pytorch.ref.gemm_ref import (
     generate_grouped_gemm_group_lens,
@@ -45,20 +44,6 @@ def test_grouped_gemm_func(B, M, N_K, dtype, balance, trans_b, reduce_num_cu, ba
 
     if backend is BackendType.HIPBLASLT and reduce_num_cu > 0:
         pytest.skip("HIPBLASLT does not support reduce_num_cu > 0")
-
-    # TODO(xiaobochen-amd): On gfx942, the hipBLASLt path can exhibit
-    # intermittent/flake failures when M <= 512. This has not been reproduced on MI355.
-    # We skip for now to keep CI stable while we investigate the root cause.
-    # (Also skip when auto_tune=True because the tuner may select hipBLASLt.)
-    if (
-        M <= 512
-        and (backend is BackendType.HIPBLASLT or auto_tune is True)
-        and get_device_compute_capability() == (9, 4)
-    ):
-        pytest.skip(
-            "Intermittent flake on gfx942 with hipBLASLt when M <= 512; "
-            "skipping pending root-cause investigation (not reproduced on MI355)."
-        )
 
     # Set backend and auto_tune config
     GlobalBackendManager.set_grouped_gemm_backend(backend)
@@ -129,10 +114,6 @@ def test_grouped_gemm_deterministic(B, M, N_K, dtype, balance, trans_b, backend)
 
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
-
-    # Keep CI stable: reuse known gfx942 hipBLASLt flake skip for M <= 512.
-    if M <= 512 and backend is BackendType.HIPBLASLT and get_device_compute_capability() == (9, 4):
-        pytest.skip("Intermittent flake on gfx942 with hipBLASLt when M <= 512; skip temporarily")
 
     # Keep deterministic test focused: fixed backend / no autotune / no CU reduction.
     GlobalBackendManager.set_grouped_gemm_backend(backend)


### PR DESCRIPTION
# Description

fix bf16 grouped_gemm stall problem on gfx942

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

Please list the changes introduced in this PR:

- Bind per-stream hipBLASLt handles (csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu): each compute handle is now associated with its dedicated compute stream at init via hipblasSetStream.
  - Keep slot 0 on the caller's stream: run slot 0 on params.stream / params.handle (already correctly bound by PyTorch) instead of fanning it out to an internal stream.                                                                            
  - Adds benchmark/ops/bench_grouped_gemm_gmm.py to compare against the grouped-gemm-ck baseline.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
