### PR TITLE
opt(gemm): add hipBLASLt algorithm cache and thread-local workspace

### DIFF
--- a/benchmark/ops/bench_algo_cache.py
+++ b/benchmark/ops/bench_algo_cache.py
@@ -1,0 +1,178 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Benchmark hipBLASLt algorithm cache impact on FP8 GEMM dispatch latency.
+
+Measures cold-cache (first call, includes heuristic lookup) vs warm-cache
+(subsequent calls, heuristic skipped) latency for model-realistic GEMM shapes.
+
+Usage:
+    cd benchmark/ops
+    python bench_algo_cache.py [--warmup 5] [--repeat 50] [--output results.csv]
+"""
+
+import argparse
+from datetime import datetime
+
+import pandas as pd
+import torch
+from config import (
+    BATCH_SIZE_LIST,
+    DenseModelConfigs,
+    gen_gemm_test_cases,
+    get_platform_info,
+)
+from tabulate import tabulate
+
+from primus_turbo.pytorch.core.backend import BackendType, GlobalBackendManager
+from primus_turbo.pytorch.core.low_precision import (
+    Float8QuantConfig,
+    Format,
+    ScalingGranularity,
+)
+from primus_turbo.pytorch.ops import gemm_fp8
+
+DEVICE = "cuda:0"
+DTYPE = torch.bfloat16
+
+
+def bench_gemm_cache(m, n, k, config, warmup_iters, repeat):
+    """Return (cold_ms, warm_median_ms, warm_min_ms) for a single GEMM shape."""
+    a = torch.randn(m, k, dtype=DTYPE, device=DEVICE)
+    b = torch.randn(n, k, dtype=DTYPE, device=DEVICE)
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    gemm_fp8(a, b, False, True, DTYPE, config)
+    end.record()
+    torch.cuda.synchronize()
+    cold_ms = start.elapsed_time(end)
+
+    for _ in range(warmup_iters):
+        gemm_fp8(a, b, False, True, DTYPE, config)
+    torch.cuda.synchronize()
+
+    timings = []
+    for _ in range(repeat):
+        s = torch.cuda.Event(enable_timing=True)
+        e = torch.cuda.Event(enable_timing=True)
+        s.record()
+        gemm_fp8(a, b, False, True, DTYPE, config)
+        e.record()
+        torch.cuda.synchronize()
+        timings.append(s.elapsed_time(e))
+
+    timings.sort()
+    warm_median = timings[len(timings) // 2]
+    warm_min = timings[0]
+
+    flops = 2 * m * n * k
+    warm_tflops = flops / (warm_median * 1e-3) / 1e12
+    cold_tflops = flops / (cold_ms * 1e-3) / 1e12
+
+    return cold_ms, warm_median, warm_min, cold_tflops, warm_tflops
+
+
+def benchmark_algo_cache(warmup_iters, repeat, output_csv):
+    platform, gpu_name = get_platform_info()
+
+    GlobalBackendManager.set_gemm_backend(BackendType.HIPBLASLT)
+    GlobalBackendManager.set_auto_tune(False)
+
+    config = Float8QuantConfig(granularity=ScalingGranularity.TENSORWISE, format=Format.E4M3)
+
+    print(f"\nhipBLASLt Algo Cache Benchmark")
+    print(f"Platform: {platform}, GPU: {gpu_name}")
+    print(f"warmup={warmup_iters}, repeat={repeat}\n")
+
+    _a = torch.randn(64, 64, dtype=DTYPE, device=DEVICE)
+    _b = torch.randn(64, 64, dtype=DTYPE, device=DEVICE)
+    gemm_fp8(_a, _b, False, True, DTYPE, config)
+    torch.cuda.synchronize()
+    del _a, _b
+
+    rows = []
+    test_id = 0
+
+    for model_name, model_config in DenseModelConfigs.items():
+        test_cases = gen_gemm_test_cases(model_config)
+        for mbs in BATCH_SIZE_LIST:
+            for shape in test_cases:
+                test_id += 1
+                m = shape[0] * mbs
+                n = shape[1]
+                k = shape[2]
+
+                try:
+                    cold, warm_med, warm_min, cold_tflops, warm_tflops = bench_gemm_cache(
+                        m, n, k, config, warmup_iters, repeat
+                    )
+                    speedup = cold / warm_med if warm_med > 0 else float("inf")
+                    overhead_saved_us = (cold - warm_med) * 1000
+
+                    rows.append(
+                        {
+                            "TestID": test_id,
+                            "Case": model_name,
+                            "MBS": mbs,
+                            "M": m,
+                            "N": n,
+                            "K": k,
+                            "Cold (ms)": f"{cold:.3f}",
+                            "Warm med (ms)": f"{warm_med:.3f}",
+                            "Warm min (ms)": f"{warm_min:.3f}",
+                            "Cold TFLOPS": f"{cold_tflops:.2f}",
+                            "Warm TFLOPS": f"{warm_tflops:.2f}",
+                            "Overhead saved (us)": f"{overhead_saved_us:.0f}",
+                            "Speedup": f"{speedup:.1f}x",
+                        }
+                    )
+                except Exception as e:
+                    print(f"  FAILED ({model_name} MBS={mbs} {m}x{n}x{k}): {e}")
+                    rows.append(
+                        {
+                            "TestID": test_id,
+                            "Case": model_name,
+                            "MBS": mbs,
+                            "M": m,
+                            "N": n,
+                            "K": k,
+                            "Cold (ms)": "ERROR",
+                            "Warm med (ms)": "ERROR",
+                            "Warm min (ms)": "ERROR",
+                            "Cold TFLOPS": "0.00",
+                            "Warm TFLOPS": "0.00",
+                            "Overhead saved (us)": "0",
+                            "Speedup": "N/A",
+                        }
+                    )
+
+    results = pd.DataFrame(rows)
+    print("\nResults:")
+    print(tabulate(results, headers="keys", tablefmt="grid", showindex=False))
+
+    overhead_vals = results["Overhead saved (us)"].apply(lambda x: float(x) if x != "0" else 0)
+    print(f"\nMean overhead saved per GEMM call: {overhead_vals.mean():.0f} us")
+
+    if output_csv:
+        filename = output_csv
+    else:
+        timestamp = datetime.now().strftime("%Y%m%d")
+        filename = f"algo_cache_{timestamp}_{gpu_name}.csv"
+    results.to_csv(filename, index=False)
+    print(f"Results saved to {filename}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Benchmark hipBLASLt algo cache")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeat", type=int, default=50)
+    parser.add_argument("--output", "-o", type=str, default=None, help="Output CSV filename")
+    args = parser.parse_args()
+
+    benchmark_algo_cache(args.warmup, args.repeat, args.output)

--- a/csrc/kernels/gemm/hipblaslt/hipblaslt_algo_cache.h
+++ b/csrc/kernels/gemm/hipblaslt/hipblaslt_algo_cache.h
@@ -80,7 +80,17 @@ public:
 
     void store(const Key &key, const CachedAlgo &algo) {
         std::lock_guard<std::mutex> lock(mtx_);
+        // Prevent unbounded growth under dynamic-shape workloads
+        // (e.g. MoE without capacity factor produces near-unique M per expert per step)
+        if (cache_.size() >= kMaxEntries) {
+            cache_.clear();
+        }
         cache_[key] = algo;
+    }
+
+    void clear() {
+        std::lock_guard<std::mutex> lock(mtx_);
+        cache_.clear();
     }
 
     static int device_cap() {
@@ -97,6 +107,8 @@ public:
         }();
         return cap;
     }
+
+    static constexpr size_t kMaxEntries = 256;
 
 private:
     HipblasltAlgoCache() = default;

--- a/csrc/kernels/gemm/hipblaslt_algo_cache.h
+++ b/csrc/kernels/gemm/hipblaslt_algo_cache.h
@@ -1,0 +1,108 @@
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+//
+// See LICENSE for license information.
+
+#pragma once
+
+#include "primus_turbo/arch.h"
+
+#include <cstdint>
+#include <hipblaslt/hipblaslt.h>
+#include <mutex>
+#include <unordered_map>
+
+namespace primus_turbo {
+
+class HipblasltAlgoCache {
+public:
+    struct Key {
+        int                          device_cap;
+        hipDataType                  a_type, b_type, d_type;
+        int64_t                      m, n, k;
+        int64_t                      lda, ldb, ldd;
+        hipblasOperation_t           trans_a, trans_b;
+        hipblasLtMatmulMatrixScale_t scale_mode;
+
+        bool operator==(const Key &o) const {
+            return device_cap == o.device_cap && a_type == o.a_type && b_type == o.b_type &&
+                   d_type == o.d_type && m == o.m && n == o.n && k == o.k && lda == o.lda &&
+                   ldb == o.ldb && ldd == o.ldd && trans_a == o.trans_a && trans_b == o.trans_b &&
+                   scale_mode == o.scale_mode;
+        }
+
+        struct Hash {
+            size_t operator()(const Key &k) const {
+                // FNV-1a over all fields
+                size_t h   = 14695981039346656037ULL;
+                auto   mix = [&](auto val) {
+                    const auto *p = reinterpret_cast<const unsigned char *>(&val);
+                    for (size_t i = 0; i < sizeof(val); ++i) {
+                        h ^= static_cast<size_t>(p[i]);
+                        h *= 1099511628211ULL;
+                    }
+                };
+                mix(k.device_cap);
+                mix(k.a_type);
+                mix(k.b_type);
+                mix(k.d_type);
+                mix(k.m);
+                mix(k.n);
+                mix(k.k);
+                mix(k.lda);
+                mix(k.ldb);
+                mix(k.ldd);
+                mix(k.trans_a);
+                mix(k.trans_b);
+                mix(k.scale_mode);
+                return h;
+            }
+        };
+    };
+
+    struct CachedAlgo {
+        hipblasLtMatmulAlgo_t algo;
+    };
+
+    static HipblasltAlgoCache &instance() {
+        static HipblasltAlgoCache inst;
+        return inst;
+    }
+
+    bool find(const Key &key, CachedAlgo &out) {
+        std::lock_guard<std::mutex> lock(mtx_);
+        auto                        it = cache_.find(key);
+        if (it != cache_.end()) {
+            out = it->second;
+            return true;
+        }
+        return false;
+    }
+
+    void store(const Key &key, const CachedAlgo &algo) {
+        std::lock_guard<std::mutex> lock(mtx_);
+        cache_[key] = algo;
+    }
+
+    static int device_cap() {
+        static const int cap = [] {
+            switch (get_current_arch()) {
+            case GPUArch::GFX942:
+                return 942;
+            case GPUArch::GFX950:
+                return 950;
+            case GPUArch::UNKNOWN:
+            default:
+                return 0;
+            }
+        }();
+        return cap;
+    }
+
+private:
+    HipblasltAlgoCache() = default;
+
+    std::mutex                                     mtx_;
+    std::unordered_map<Key, CachedAlgo, Key::Hash> cache_;
+};
+
+} // namespace primus_turbo

--- a/csrc/kernels/gemm/hipblaslt_gemm.cu
+++ b/csrc/kernels/gemm/hipblaslt_gemm.cu
@@ -2,6 +2,7 @@
 //
 // See LICENSE for license information.
 
+#include "hipblaslt_algo_cache.h"
 #include "primus_turbo/common.h"
 #include "primus_turbo/gemm.h"
 
@@ -36,11 +37,10 @@ void hipblaslt_gemm_impl(const void *A, const hipDataType A_type, const int64_t 
                          const int64_t ldd, void *workspace, const int64_t workspace_size,
                          const bool use_low_precision, hipblasLtMatmulMatrixScale_t scale_mode,
                          hipblasLtHandle_t handle, hipStream_t stream) {
-    hipblasLtMatmulDesc_t       operation_desc = nullptr;
-    hipblasLtMatrixLayout_t     A_desc = nullptr, B_desc = nullptr, D_desc = nullptr;
-    hipblasLtMatmulPreference_t preference        = nullptr;
-    hipblasLtEpilogue_t         epilogue          = HIPBLASLT_EPILOGUE_DEFAULT;
-    hipblasComputeType_t        gemm_compute_type = HIPBLAS_COMPUTE_32F;
+    hipblasLtMatmulDesc_t   operation_desc = nullptr;
+    hipblasLtMatrixLayout_t A_desc = nullptr, B_desc = nullptr, D_desc = nullptr;
+    hipblasLtEpilogue_t     epilogue          = HIPBLASLT_EPILOGUE_DEFAULT;
+    hipblasComputeType_t    gemm_compute_type = HIPBLAS_COMPUTE_32F;
 
     PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatrixLayoutCreate(&A_desc, A_type, rows_a, cols_a, lda));
     PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatrixLayoutCreate(&B_desc, B_type, rows_b, cols_b, ldb));
@@ -78,20 +78,45 @@ void hipblaslt_gemm_impl(const void *A, const hipDataType A_type, const int64_t 
             operation_desc, scaleB_inv_ptr_desc, &scaleB_inv, sizeof(scaleB_inv)));
     }
 
-    const int                                     request_solutions = 1;
-    std::vector<hipblasLtMatmulHeuristicResult_t> algos(request_solutions);
-    int                                           returnedAlgoCount = 0;
+    // Algorithm cache: skip heuristic on repeat calls for the same GEMM config
+    auto                          &cache = HipblasltAlgoCache::instance();
+    HipblasltAlgoCache::Key        key{HipblasltAlgoCache::device_cap(),
+                                A_type,
+                                B_type,
+                                D_type,
+                                rows_a,
+                                cols_a,
+                                rows_b,
+                                lda,
+                                ldb,
+                                ldd,
+                                transA,
+                                transB,
+                                scale_mode};
+    HipblasltAlgoCache::CachedAlgo cached;
 
-    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulPreferenceCreate(&preference));
-    PRIMUS_TURBO_CHECK_HIPBLAS(
-        hipblasLtMatmulPreferenceSetAttribute(preference, HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
-                                              &workspace_size, sizeof(workspace_size)));
+    if (!cache.find(key, cached)) {
+        hipblasLtMatmulPreference_t preference = nullptr;
+        PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulPreferenceCreate(&preference));
+        PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulPreferenceSetAttribute(
+            preference, HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &workspace_size,
+            sizeof(workspace_size)));
 
-    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulAlgoGetHeuristic(
-        handle, operation_desc, A_desc, B_desc, D_desc, D_desc, preference, request_solutions,
-        algos.data(), &returnedAlgoCount));
-    PRIMUS_TURBO_CHECK(returnedAlgoCount > 0,
-                       "hipBLASLt: no valid algorithm found for current matmul config");
+        const int                                     request_solutions = 1;
+        std::vector<hipblasLtMatmulHeuristicResult_t> algos(request_solutions);
+        int                                           returnedAlgoCount = 0;
+
+        PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulAlgoGetHeuristic(
+            handle, operation_desc, A_desc, B_desc, D_desc, D_desc, preference, request_solutions,
+            algos.data(), &returnedAlgoCount));
+        PRIMUS_TURBO_CHECK(returnedAlgoCount > 0,
+                           "hipBLASLt: no valid algorithm found for current matmul config");
+
+        cached = {algos[0].algo};
+        cache.store(key, cached);
+
+        PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulPreferenceDestroy(preference));
+    }
 
     const float alpha = 1.0;
     const float beta  = 0.0;
@@ -105,7 +130,7 @@ void hipblaslt_gemm_impl(const void *A, const hipDataType A_type, const int64_t 
         &beta,
         D, D_desc,
         D, D_desc,
-        &algos[0].algo,
+        &cached.algo,
         workspace, workspace_size,
         stream));
     // clang-format on
@@ -114,7 +139,6 @@ void hipblaslt_gemm_impl(const void *A, const hipDataType A_type, const int64_t 
     PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatrixLayoutDestroy(B_desc));
     PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatrixLayoutDestroy(A_desc));
     PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulDescDestroy(operation_desc));
-    PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmulPreferenceDestroy(preference));
 }
 
 } // namespace primus_turbo

--- a/csrc/kernels/gemm/hipblaslt_gemm.cu
+++ b/csrc/kernels/gemm/hipblaslt_gemm.cu
@@ -2,7 +2,7 @@
 //
 // See LICENSE for license information.
 
-#include "hipblaslt_algo_cache.h"
+#include "hipblaslt/hipblaslt_algo_cache.h"
 #include "primus_turbo/common.h"
 #include "primus_turbo/gemm.h"
 

--- a/csrc/pytorch/bindings_pytorch.cpp
+++ b/csrc/pytorch/bindings_pytorch.cpp
@@ -96,6 +96,9 @@ TORCH_LIBRARY(primus_turbo_cpp_extension, m) {
           "Tensor group_lens, Tensor group_offs, bool transA, bool transB, "
           "ScalarType out_dtype, str granularity, bool pre_sync) -> Tensor");
     m.def("grouped_gemm_compute_offs(Tensor group_lens) -> Tensor");
+
+    // ********* Testing Utilities *********
+    m.def("hipblaslt_algo_cache_clear", hipblaslt_algo_cache_clear);
 }
 
 TORCH_LIBRARY_IMPL(primus_turbo_cpp_extension, CUDA, m) {

--- a/csrc/pytorch/extensions.h
+++ b/csrc/pytorch/extensions.h
@@ -270,6 +270,12 @@ void unpermute_meta(at::Tensor permuted_tokens, at::Tensor output_tokens,
                     int64_t hidden_size, bool with_probs, int64_t probs_stride);
 
 //==================================================================
+//  Testing Utilities
+//==================================================================
+
+void hipblaslt_algo_cache_clear();
+
+//==================================================================
 //  Runtime
 //==================================================================
 

--- a/csrc/pytorch/gemm/hipblaslt_gemm.cpp
+++ b/csrc/pytorch/gemm/hipblaslt_gemm.cpp
@@ -9,6 +9,17 @@
 
 namespace primus_turbo::pytorch {
 
+namespace {
+static thread_local at::Tensor tl_workspace;
+
+at::Tensor &get_workspace_tensor(int64_t size, const at::Device &device) {
+    if (!tl_workspace.defined() || tl_workspace.numel() < size || tl_workspace.device() != device) {
+        tl_workspace = at::empty({size}, at::TensorOptions().dtype(at::kByte).device(device));
+    }
+    return tl_workspace;
+}
+} // namespace
+
 at::Tensor hipblaslt_gemm(at::Tensor A, at::Tensor B, const at::ScalarType out_dtype, bool transA,
                           bool transB, bool transC) {
     PRIMUS_TURBO_CHECK(is_floating_point_dtype(A.scalar_type()));
@@ -73,7 +84,7 @@ at::Tensor hipblaslt_gemm(at::Tensor A, at::Tensor B, const at::ScalarType out_d
     const hipDataType  C_type            = get_hipblaslt_dtype(C.scalar_type());
 
     const int64_t workspace_size = get_hipblaslt_workspace_size_in_byte();
-    at::Tensor workspace = at::empty({workspace_size}, torch::dtype(at::kByte).device(at::kCUDA));
+    auto         &workspace      = get_workspace_tensor(workspace_size, A.device());
 
     // clang-format off
     // NOTE: hipblaslt expects tensor in col-major but torch Tensor is in row-major.
@@ -199,7 +210,7 @@ at::Tensor hipblaslt_gemm_fp8(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
     const hipDataType  C_type            = get_hipblaslt_dtype(C.scalar_type());
 
     const int64_t workspace_size = get_hipblaslt_workspace_size_in_byte();
-    at::Tensor workspace = at::empty({workspace_size}, torch::dtype(at::kByte).device(at::kCUDA));
+    auto         &workspace      = get_workspace_tensor(workspace_size, A.device());
 
     // clang-format off
     // NOTE: hipblaslt expects tensor in col-major but torch Tensor is in row-major.
@@ -322,7 +333,7 @@ at::Tensor hipblaslt_gemm_fp4(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
     const hipDataType  C_type            = get_hipblaslt_dtype(C.scalar_type());
 
     const int64_t workspace_size = get_hipblaslt_workspace_size_in_byte();
-    at::Tensor workspace = at::empty({workspace_size}, torch::dtype(at::kByte).device(at::kCUDA));
+    auto         &workspace      = get_workspace_tensor(workspace_size, A.device());
 
     // clang-format off
     // NOTE: hipblaslt expects tensor in col-major but torch Tensor is in row-major.

--- a/csrc/pytorch/gemm/hipblaslt_gemm.cpp
+++ b/csrc/pytorch/gemm/hipblaslt_gemm.cpp
@@ -6,12 +6,15 @@
 
 #include "../extensions.h"
 #include "../type_traits.h"
+#include "kernels/gemm/hipblaslt/hipblaslt_algo_cache.h"
 
 namespace primus_turbo::pytorch {
 
 namespace {
 static thread_local at::Tensor tl_workspace;
 
+// Assumes single HIP stream per CPU thread. If a thread dispatches GEMMs on
+// multiple streams concurrently, the workspace could be concurrently overwritten.
 at::Tensor &get_workspace_tensor(int64_t size, const at::Device &device) {
     if (!tl_workspace.defined() || tl_workspace.numel() < size || tl_workspace.device() != device) {
         tl_workspace = at::empty({size}, at::TensorOptions().dtype(at::kByte).device(device));
@@ -356,6 +359,10 @@ at::Tensor hipblaslt_gemm_fp4(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
     // clang-format on
 
     return C;
+}
+
+void hipblaslt_algo_cache_clear() {
+    primus_turbo::HipblasltAlgoCache::instance().clear();
 }
 
 } // namespace primus_turbo::pytorch

--- a/tests/pytorch/ops/test_algo_cache.py
+++ b/tests/pytorch/ops/test_algo_cache.py
@@ -32,6 +32,7 @@ def _set_hipblaslt_backend():
     """Force hipBLASLt for all tests and reset afterwards."""
     GlobalBackendManager.set_gemm_backend(BackendType.HIPBLASLT)
     GlobalBackendManager.set_auto_tune(False)
+    torch.ops.primus_turbo_cpp_extension.hipblaslt_algo_cache_clear()
     yield
     GlobalBackendManager.reset()
 
@@ -146,3 +147,21 @@ class TestAlgoCacheLayouts:
         c_ref = a_mat @ b_mat
         snr = compute_snr(c_ref, c)
         assert snr > 25, f"SNR {snr:.1f} dB too low for layout {layout}"
+
+
+class TestAlgoCacheOverflow:
+    """Cache overflow (clear) must not break correctness."""
+
+    def test_correctness_after_overflow(self):
+        """Insert >256 unique shapes to trigger cache clear, verify correctness holds."""
+        config = Float8QuantConfig(granularity=ScalingGranularity.TENSORWISE, format=Format.E4M3)
+        n, k = 512, 1024
+        for m in range(64, 64 + 300):
+            torch.manual_seed(m)
+            a = torch.randn(m, k, dtype=DTYPE, device=DEVICE)
+            b = torch.randn(n, k, dtype=DTYPE, device=DEVICE)
+            c = gemm_fp8(a, b, False, True, DTYPE, config)
+            torch.cuda.synchronize()
+            c_ref = a.float() @ b.float().T
+            snr = compute_snr(c_ref, c)
+            assert snr > 20, f"SNR {snr:.1f} dB at m={m} (post-overflow)"

--- a/tests/pytorch/ops/test_algo_cache.py
+++ b/tests/pytorch/ops/test_algo_cache.py
@@ -1,0 +1,148 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Tests for the hipBLASLt algorithm cache.
+
+Verifies that caching the hipblasLtMatmulAlgo_t across repeat GEMM calls
+produces bit-identical results and that different GEMM shapes do not
+collide in the cache.
+"""
+
+import pytest
+import torch
+
+from primus_turbo.pytorch.core.backend import BackendType, GlobalBackendManager
+from primus_turbo.pytorch.core.low_precision import (
+    Float8QuantConfig,
+    Format,
+    ScalingGranularity,
+)
+from primus_turbo.pytorch.ops import gemm, gemm_fp8
+from tests.pytorch.test_utils import compute_snr
+
+DEVICE = "cuda:0"
+DTYPE = torch.bfloat16
+
+
+@pytest.fixture(autouse=True)
+def _set_hipblaslt_backend():
+    """Force hipBLASLt for all tests and reset afterwards."""
+    GlobalBackendManager.set_gemm_backend(BackendType.HIPBLASLT)
+    GlobalBackendManager.set_auto_tune(False)
+    yield
+    GlobalBackendManager.reset()
+
+
+class TestAlgoCacheBitExact:
+    """Cache hit must produce the same result as cache miss."""
+
+    @pytest.mark.parametrize("m,n,k", [(256, 512, 1024)])
+    def test_repeated_call_same_result(self, m, n, k):
+        torch.manual_seed(0)
+        a_shape = (m, k)
+        b_shape = (n, k)
+
+        a = torch.randn(a_shape, dtype=DTYPE, device=DEVICE)
+        b = torch.randn(b_shape, dtype=DTYPE, device=DEVICE)
+
+        config = Float8QuantConfig(granularity=ScalingGranularity.TENSORWISE, format=Format.E4M3)
+
+        c1 = gemm_fp8(a, b, False, True, DTYPE, config)
+        torch.cuda.synchronize()
+        c2 = gemm_fp8(a, b, False, True, DTYPE, config)
+        torch.cuda.synchronize()
+
+        assert torch.equal(c1, c2), "Repeat calls with same inputs must be bit-identical"
+
+
+class TestAlgoCacheMultipleShapes:
+    """Different shapes must produce correct results (no key collisions)."""
+
+    SHAPES = [
+        (128, 256, 512),
+        (256, 512, 1024),
+        (512, 1024, 2048),
+        (1024, 3072, 768),
+    ]
+
+    @pytest.mark.parametrize("m,n,k", SHAPES)
+    def test_shape_correctness(self, m, n, k):
+        torch.manual_seed(42)
+        a = torch.randn(m, k, dtype=DTYPE, device=DEVICE)
+        b = torch.randn(n, k, dtype=DTYPE, device=DEVICE)
+
+        config = Float8QuantConfig(granularity=ScalingGranularity.TENSORWISE, format=Format.E4M3)
+        c = gemm_fp8(a, b, False, True, DTYPE, config)
+        torch.cuda.synchronize()
+
+        c_ref = a @ b.T
+        snr = compute_snr(c_ref, c)
+        assert snr > 25, f"SNR {snr:.1f} dB too low for shape ({m},{n},{k})"
+
+
+class TestAlgoCacheBF16:
+    """Cache must work correctly for BF16 (non-FP8) GEMM path."""
+
+    @pytest.mark.parametrize("m,n,k", [(256, 512, 1024)])
+    def test_bf16_repeated_call_same_result(self, m, n, k):
+        torch.manual_seed(0)
+        a = torch.randn(m, k, dtype=DTYPE, device=DEVICE)
+        b = torch.randn(n, k, dtype=DTYPE, device=DEVICE)
+
+        c1 = gemm(a, b, trans_b=True)
+        torch.cuda.synchronize()
+        c2 = gemm(a, b, trans_b=True)
+        torch.cuda.synchronize()
+
+        assert torch.equal(c1, c2), "BF16 repeat calls must be bit-identical"
+
+    SHAPES = [
+        (128, 256, 512),
+        (256, 512, 1024),
+        (1024, 3072, 768),
+    ]
+
+    @pytest.mark.parametrize("m,n,k", SHAPES)
+    def test_bf16_shape_correctness(self, m, n, k):
+        torch.manual_seed(42)
+        a = torch.randn(m, k, dtype=DTYPE, device=DEVICE)
+        b = torch.randn(n, k, dtype=DTYPE, device=DEVICE)
+
+        c = gemm(a, b, trans_b=True)
+        torch.cuda.synchronize()
+
+        c_ref = a @ b.T
+        assert torch.allclose(
+            c, c_ref, rtol=1e-2, atol=1e-2
+        ), f"BF16 GEMM result mismatch for shape ({m},{n},{k})"
+
+
+class TestAlgoCacheLayouts:
+    """Cache must handle different transpose layouts correctly."""
+
+    @pytest.mark.parametrize("layout", ["NT", "NN"])
+    def test_layout(self, layout):
+        m, n, k = 256, 512, 1024
+        torch.manual_seed(42)
+
+        trans_a = layout[0] == "T"
+        trans_b = layout[1] == "T"
+
+        a_shape = (k, m) if trans_a else (m, k)
+        b_shape = (n, k) if trans_b else (k, n)
+
+        a = torch.randn(a_shape, dtype=DTYPE, device=DEVICE)
+        b = torch.randn(b_shape, dtype=DTYPE, device=DEVICE)
+
+        config = Float8QuantConfig(granularity=ScalingGranularity.TENSORWISE, format=Format.E4M3)
+        c = gemm_fp8(a, b, trans_a, trans_b, DTYPE, config)
+        torch.cuda.synchronize()
+
+        a_mat = a.T if trans_a else a
+        b_mat = b.T if trans_b else b
+        c_ref = a_mat @ b_mat
+        snr = compute_snr(c_ref, c)
+        assert snr > 25, f"SNR {snr:.1f} dB too low for layout {layout}"


### PR DESCRIPTION
Cache `hipblasLtMatmulAlgo_t` across repeat GEMM calls to skip expensive heuristic lookups on recurring shapes. Pre-allocate workspace via a thread-local tensor to avoid per-call CUDA malloc overhead.

Changes:
- Add `hipblaslt_algo_cache.h` with FNV-1a hashed lookup by GEMM config
- Integrate cache into `hipblaslt_gemm_impl` (store on miss, reuse on hit)
- Replace per-call `at::empty` workspace with thread-local pre-allocation
- Add unit tests for bit-exactness, multi-shape, and layout correctness
- Add benchmark script for cold-cache vs warm-cache latency comparison

# Description

Cache `hipblasLtMatmulAlgo_t` results across repeated GEMM calls so that expensive hipBLASLt heuristic lookups are only performed once per unique shape/config. On subsequent calls with the same GEMM configuration, the cached algorithm is reused directly. Additionally, the per-call workspace allocation (`at::empty`) is replaced with a thread-local pre-allocated tensor, eliminating repeated CUDA malloc/free overhead on every GEMM invocation.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `csrc/kernels/gemm/hipblaslt_algo_cache.h` implementing a thread-safe algorithm cache with FNV-1a hashing keyed on GEMM config (M, N, K, dtypes, layouts, compute type)
- Integrate the cache into `csrc/kernels/gemm/hipblaslt_gemm.cu` and `csrc/pytorch/gemm/hipblaslt_gemm.cpp` -- store algorithm on cache miss, reuse on hit
- Replace per-call `at::empty` workspace allocation with a thread-local pre-allocated tensor that grows as needed
- Add `tests/pytorch/ops/test_algo_cache.py` with tests for bit-exact repeatability, multi-shape correctness (no key collisions), BF16 support, and NT/NN layout handling
- Add `benchmark/ops/bench_algo_cache.py` for measuring cold-cache vs warm-cache GEMM latency across model configurations

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes