### PR TITLE
[Attention] AITER varlen attention support

### DIFF
--- a/primus_turbo/pytorch/kernels/attention/attention_aiter_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_aiter_impl.py
@@ -15,7 +15,12 @@ Dispatch policy:
 from typing import Any, Optional, Tuple
 
 import torch
-from aiter.ops.mha import _flash_attn_backward, _flash_attn_forward
+from aiter.ops.mha import (
+    _flash_attn_backward,
+    _flash_attn_forward,
+    _flash_attn_varlen_backward,
+    _flash_attn_varlen_forward,
+)
 from aiter.ops.triton.attention.mha import (
     _flash_attn_forward as _triton_flash_attn_forward,
 )
@@ -488,5 +493,350 @@ def _attention_aiter_backward_impl_fake(
     dsink: Optional[torch.Tensor] = None,
     sink: Optional[torch.Tensor] = None,
     qkv_format: Optional[str] = "bshd",
+) -> None:
+    return None
+
+
+# =============================================================================
+# Varlen Forward Backend
+# =============================================================================
+
+
+class AttnFwdAiterVarlenBackend(KernelBackend):
+
+    @staticmethod
+    def can_handle(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        dropout_p: float,
+        softmax_scale: float,
+        causal: bool,
+        window_size_left: int,
+        window_size_right: int,
+        bias: Optional[torch.Tensor],
+        alibi_slopes: Optional[torch.Tensor],
+        return_lse: bool,
+        return_softmax: bool,
+    ) -> bool:
+        if q.dtype not in (torch.bfloat16, torch.float16):
+            return False
+        if q.dim() != 3 or k.dim() != 3 or v.dim() != 3:
+            return False
+        if cu_seqlens_q.dtype != torch.int32 or cu_seqlens_k.dtype != torch.int32:
+            return False
+        return True
+
+    @staticmethod
+    def execute(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        dropout_p: float,
+        softmax_scale: float,
+        causal: bool,
+        window_size_left: int,
+        window_size_right: int,
+        bias: Optional[torch.Tensor],
+        alibi_slopes: Optional[torch.Tensor],
+        return_lse: bool,
+        return_softmax: bool,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        out, softmax_lse, S_dmask, rng_state = _flash_attn_varlen_forward(
+            q,
+            k,
+            v,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            None,  # cu_seqlens_q_padded
+            None,  # cu_seqlens_k_padded
+            max_seqlen_q,
+            max_seqlen_k,
+            0,  # min_seqlen_q
+            dropout_p,
+            softmax_scale,
+            causal=causal,
+            logits_soft_cap=0.0,
+            window_size_left=window_size_left,
+            window_size_right=window_size_right,
+            sink_size=0,
+            bias=bias,
+            alibi_slopes=alibi_slopes,
+            q_descale=None,
+            k_descale=None,
+            v_descale=None,
+            return_lse=return_lse,
+            return_softmax=return_softmax,
+            how_v3_bf16_cvt=1,
+            block_table=None,
+            out=None,
+        )
+        return out, softmax_lse, S_dmask, rng_state
+
+
+# =============================================================================
+# Varlen Backward Backend
+# =============================================================================
+
+
+class AttnBwdAiterVarlenBackend(KernelBackend):
+
+    @staticmethod
+    def can_handle(
+        dout: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        out: torch.Tensor,
+        softmax_lse: torch.Tensor,
+        dq: torch.Tensor,
+        dk: torch.Tensor,
+        dv: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        dropout_p: float,
+        softmax_scale: float,
+        causal: bool,
+        window_size_left: int,
+        window_size_right: int,
+        alibi_slopes: Optional[torch.Tensor],
+        deterministic: bool,
+        rng_state: Optional[torch.Tensor],
+        is_v3_atomic_fp32: bool,
+        how_v3_bf16_cvt: int,
+    ) -> bool:
+        if q.dtype not in (torch.bfloat16, torch.float16):
+            return False
+        if cu_seqlens_q.dtype != torch.int32 or cu_seqlens_k.dtype != torch.int32:
+            return False
+        return True
+
+    @staticmethod
+    def execute(
+        dout: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        out: torch.Tensor,
+        softmax_lse: torch.Tensor,
+        dq: torch.Tensor,
+        dk: torch.Tensor,
+        dv: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        cu_seqlens_k: torch.Tensor,
+        max_seqlen_q: int,
+        max_seqlen_k: int,
+        dropout_p: float,
+        softmax_scale: float,
+        causal: bool,
+        window_size_left: int,
+        window_size_right: int,
+        alibi_slopes: Optional[torch.Tensor],
+        deterministic: bool,
+        rng_state: Optional[torch.Tensor],
+        is_v3_atomic_fp32: bool,
+        how_v3_bf16_cvt: int,
+    ):
+        _flash_attn_varlen_backward(
+            dout,
+            q,
+            k,
+            v,
+            out,
+            softmax_lse,
+            dq,
+            dk,
+            dv,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            dropout_p,
+            softmax_scale,
+            causal,
+            window_size_left,
+            window_size_right,
+            alibi_slopes,
+            deterministic,
+            rng_state=rng_state,
+            is_v3_atomic_fp32=is_v3_atomic_fp32,
+            how_v3_bf16_cvt=how_v3_bf16_cvt,
+            cu_seqlens_q_padded=None,
+            cu_seqlens_k_padded=None,
+        )
+
+
+@_torch_custom_op_wrapper(
+    "primus_turbo::attention_aiter_varlen_forward_impl", mutates_args=(), device_types="cuda"
+)
+def attention_aiter_varlen_forward_impl(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    dropout_p: float,
+    softmax_scale: float,
+    causal: bool,
+    window_size_left: int,
+    window_size_right: int,
+    bias: Optional[torch.Tensor],
+    alibi_slopes: Optional[torch.Tensor],
+    return_lse: bool,
+    return_softmax: bool,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    kwargs = {
+        "q": q,
+        "k": k,
+        "v": v,
+        "cu_seqlens_q": cu_seqlens_q,
+        "cu_seqlens_k": cu_seqlens_k,
+        "max_seqlen_q": max_seqlen_q,
+        "max_seqlen_k": max_seqlen_k,
+        "dropout_p": dropout_p,
+        "softmax_scale": softmax_scale,
+        "causal": causal,
+        "window_size_left": window_size_left,
+        "window_size_right": window_size_right,
+        "bias": bias,
+        "alibi_slopes": alibi_slopes,
+        "return_lse": return_lse,
+        "return_softmax": return_softmax,
+    }
+    if not AttnFwdAiterVarlenBackend.can_handle(**kwargs):
+        raise ValueError(
+            f"AttnFwdAiterVarlenBackend cannot handle the given inputs: {_format_kwargs(kwargs)}. "
+            f"Varlen requires bf16/fp16, 3-D q/k/v in thd layout, and int32 cu_seqlens."
+        )
+    return AttnFwdAiterVarlenBackend.execute(**kwargs)
+
+
+@attention_aiter_varlen_forward_impl.register_fake
+def _attention_aiter_varlen_forward_impl_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    dropout_p: float,
+    softmax_scale: float,
+    causal: bool,
+    window_size_left: int,
+    window_size_right: int,
+    bias: Optional[torch.Tensor],
+    alibi_slopes: Optional[torch.Tensor],
+    return_lse: bool,
+    return_softmax: bool,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    total_q, nheads_q, _ = q.shape
+    head_dim_v = v.shape[-1]
+    out = torch.empty((total_q, nheads_q, head_dim_v), dtype=q.dtype, device=q.device)
+    softmax_lse = torch.empty((nheads_q, total_q), dtype=torch.float32, device=q.device)
+    S_dmask = torch.empty((0,), dtype=q.dtype, device=q.device)
+    rng_state = torch.empty((2,), dtype=torch.int64, device=q.device)
+    return out, softmax_lse, S_dmask, rng_state
+
+
+@_torch_custom_op_wrapper(
+    "primus_turbo::attention_aiter_varlen_backward_impl",
+    mutates_args=("dq", "dk", "dv"),
+    device_types="cuda",
+)
+def attention_aiter_varlen_backward_impl(
+    dout: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    out: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    dv: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    dropout_p: float,
+    softmax_scale: float,
+    causal: bool,
+    window_size_left: int,
+    window_size_right: int,
+    alibi_slopes: Optional[torch.Tensor],
+    deterministic: bool,
+    rng_state: Optional[torch.Tensor],
+    is_v3_atomic_fp32: bool,
+    how_v3_bf16_cvt: int,
+) -> None:
+    kwargs = {
+        "dout": dout,
+        "q": q,
+        "k": k,
+        "v": v,
+        "out": out,
+        "softmax_lse": softmax_lse,
+        "dq": dq,
+        "dk": dk,
+        "dv": dv,
+        "cu_seqlens_q": cu_seqlens_q,
+        "cu_seqlens_k": cu_seqlens_k,
+        "max_seqlen_q": max_seqlen_q,
+        "max_seqlen_k": max_seqlen_k,
+        "dropout_p": dropout_p,
+        "softmax_scale": softmax_scale,
+        "causal": causal,
+        "window_size_left": window_size_left,
+        "window_size_right": window_size_right,
+        "alibi_slopes": alibi_slopes,
+        "deterministic": deterministic,
+        "rng_state": rng_state,
+        "is_v3_atomic_fp32": is_v3_atomic_fp32,
+        "how_v3_bf16_cvt": how_v3_bf16_cvt,
+    }
+    if not AttnBwdAiterVarlenBackend.can_handle(**kwargs):
+        raise ValueError(
+            f"AttnBwdAiterVarlenBackend cannot handle the given inputs: {_format_kwargs(kwargs)}."
+        )
+    AttnBwdAiterVarlenBackend.execute(**kwargs)
+
+
+@attention_aiter_varlen_backward_impl.register_fake
+def _attention_aiter_varlen_backward_impl_fake(
+    dout: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    out: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    dv: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    dropout_p: float,
+    softmax_scale: float,
+    causal: bool,
+    window_size_left: int,
+    window_size_right: int,
+    alibi_slopes: Optional[torch.Tensor],
+    deterministic: bool,
+    rng_state: Optional[torch.Tensor],
+    is_v3_atomic_fp32: bool,
+    how_v3_bf16_cvt: int,
 ) -> None:
     return None

--- a/primus_turbo/pytorch/ops/attention/__init__.py
+++ b/primus_turbo/pytorch/ops/attention/__init__.py
@@ -1,2 +1,6 @@
-from .flash_attn_interface import flash_attn_fp8_func, flash_attn_func
+from .flash_attn_interface import (
+    flash_attn_fp8_func,
+    flash_attn_func,
+    flash_attn_varlen_func,
+)
 from .flash_attn_usp_interface import flash_attn_fp8_usp_func, flash_attn_usp_func

--- a/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
+++ b/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
@@ -16,6 +16,8 @@ from primus_turbo.pytorch.core.utils import get_device_compute_capability
 from primus_turbo.pytorch.kernels.attention.attention_aiter_impl import (
     attention_aiter_backward_impl,
     attention_aiter_forward_impl,
+    attention_aiter_varlen_backward_impl,
+    attention_aiter_varlen_forward_impl,
 )
 from primus_turbo.pytorch.kernels.attention.attention_triton_impl import (
     attention_triton_backward_impl,
@@ -28,7 +30,7 @@ from primus_turbo.pytorch.ops.attention.attention_utils import (
     get_p_scale,
 )
 
-__all__ = ["flash_attn_func", "flash_attn_fp8_func"]
+__all__ = ["flash_attn_func", "flash_attn_fp8_func", "flash_attn_varlen_func"]
 
 
 class AiterFlashAttnFunc(torch.autograd.Function):
@@ -460,3 +462,219 @@ def flash_attn_fp8_func(
         o = o.permute(0, 2, 1, 3).contiguous()
 
     return o
+
+
+# =============================================================================
+# Varlen Attention (thd layout)
+# =============================================================================
+
+
+class AiterFlashAttnVarlenFunc(torch.autograd.Function):
+
+    @staticmethod
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        dropout_p,
+        softmax_scale,
+        causal,
+        window_size,
+        bias,
+        alibi_slopes,
+        deterministic,
+        return_lse,
+        return_softmax,
+        is_grad_enabled,
+    ):
+        is_v3_atomic_fp32 = _resolve_is_v3_atomic_fp32_from_env()
+        # Avoid aiter print warning when how_v3_bf16_cvt!=0 in gfx950.
+        how_v3_bf16_cvt = 0 if get_device_compute_capability() >= (9, 5) else 1
+
+        is_grad = is_grad_enabled and any(x.requires_grad for x in [q, k, v])
+
+        if softmax_scale is None:
+            softmax_scale = q.shape[-1] ** (-0.5)
+
+        head_size_q_og = q.size(-1)
+        head_size_v_og = v.size(-1)
+        if head_size_q_og % 8 != 0:
+            q = torch.nn.functional.pad(q, [0, 8 - head_size_q_og % 8])
+            k = torch.nn.functional.pad(k, [0, 8 - head_size_q_og % 8])
+        if head_size_v_og % 8 != 0:
+            v = torch.nn.functional.pad(v, [0, 8 - head_size_v_og % 8])
+
+        out_padded, softmax_lse, S_dmask, rng_state = attention_aiter_varlen_forward_impl(
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            dropout_p=dropout_p,
+            softmax_scale=softmax_scale,
+            causal=causal,
+            window_size_left=int(window_size[0]),
+            window_size_right=int(window_size[1]),
+            bias=bias,
+            alibi_slopes=alibi_slopes,
+            return_lse=True,
+            return_softmax=return_softmax and dropout_p > 0,
+        )
+
+        if is_grad:
+            ctx.save_for_backward(q, k, v, out_padded, softmax_lse, cu_seqlens_q, cu_seqlens_k, rng_state)
+            ctx.max_seqlen_q = max_seqlen_q
+            ctx.max_seqlen_k = max_seqlen_k
+            ctx.dropout_p = dropout_p
+            ctx.softmax_scale = softmax_scale
+            ctx.causal = causal
+            ctx.window_size = window_size
+            ctx.bias = bias
+            ctx.alibi_slopes = alibi_slopes
+            ctx.deterministic = deterministic
+            ctx.head_size_q_og = head_size_q_og
+            ctx.head_size_v_og = head_size_v_og
+            ctx.is_v3_atomic_fp32 = is_v3_atomic_fp32
+            ctx.how_v3_bf16_cvt = how_v3_bf16_cvt
+
+        out = out_padded[..., :head_size_v_og]
+
+        result = [out]
+        if return_lse:
+            result.append(softmax_lse)
+        if return_softmax:
+            result.append(S_dmask)
+        return result[0] if len(result) == 1 else tuple(result)
+
+    @staticmethod
+    def backward(ctx, dout, *args):
+        q, k, v, out_padded, softmax_lse, cu_seqlens_q, cu_seqlens_k, rng_state = ctx.saved_tensors
+        head_size_q_og = ctx.head_size_q_og
+        head_size_v_og = ctx.head_size_v_og
+
+        dout_padded = dout
+        if head_size_v_og % 8 != 0:
+            dout_padded = torch.nn.functional.pad(dout, [0, 8 - head_size_v_og % 8])
+
+        dq = torch.empty_like(q)
+        dk = torch.empty_like(k)
+        dv_padded = torch.empty_like(v)
+
+        attention_aiter_varlen_backward_impl(
+            dout=dout_padded,
+            q=q,
+            k=k,
+            v=v,
+            out=out_padded,
+            softmax_lse=softmax_lse,
+            dq=dq,
+            dk=dk,
+            dv=dv_padded,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=ctx.max_seqlen_q,
+            max_seqlen_k=ctx.max_seqlen_k,
+            dropout_p=ctx.dropout_p,
+            softmax_scale=ctx.softmax_scale,
+            causal=ctx.causal,
+            window_size_left=int(ctx.window_size[0]),
+            window_size_right=int(ctx.window_size[1]),
+            alibi_slopes=ctx.alibi_slopes,
+            deterministic=ctx.deterministic,
+            rng_state=rng_state,
+            is_v3_atomic_fp32=ctx.is_v3_atomic_fp32,
+            how_v3_bf16_cvt=ctx.how_v3_bf16_cvt,
+        )
+
+        dq = dq[..., :head_size_q_og]
+        dk = dk[..., :head_size_q_og]
+        dv = dv_padded[..., :head_size_v_og]
+
+        return (
+            dq,
+            dk,
+            dv,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+def flash_attn_varlen_func(
+    q,
+    k,
+    v,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    max_seqlen_q,
+    max_seqlen_k,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    window_size=(-1, -1),
+    bias=None,
+    alibi_slopes=None,
+    deterministic=False,
+    return_lse=False,
+    return_attn_probs=False,
+):
+    """Variable-length flash attention (THD layout).
+
+    Mirrors flash-attention's `flash_attn_varlen_func` API. Sequences are
+    packed back-to-back along dim 0.
+
+    Arguments:
+        q: (total_q, nheads_q, headdim_q)
+        k: (total_k, nheads_k, headdim_q)
+        v: (total_k, nheads_k, headdim_v)
+        cu_seqlens_q: (batch + 1,) int32 cumulative query lengths
+        cu_seqlens_k: (batch + 1,) int32 cumulative key lengths
+        max_seqlen_q: maximum query sequence length in the batch
+        max_seqlen_k: maximum key sequence length in the batch
+        dropout_p: dropout probability (set 0.0 during eval).
+        softmax_scale: QK^T scale; defaults to 1 / sqrt(headdim_q).
+        causal: bottom-right aligned causal mask.
+        window_size: (left, right) sliding window. (-1, -1) = full attention.
+        bias: optional attention bias.
+        alibi_slopes: (nheads,) or (batch_size, nheads), fp32.
+        deterministic: use the deterministic backward (slower, more memory).
+        return_lse: also return softmax_lse of shape (nheads, total_q).
+        return_attn_probs: testing-only; return the dropout-encoded softmax output.
+    """
+    return AiterFlashAttnVarlenFunc.apply(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        dropout_p,
+        softmax_scale,
+        causal,
+        window_size,
+        bias,
+        alibi_slopes,
+        deterministic,
+        return_lse,
+        return_attn_probs,
+        torch.is_grad_enabled(),
+    )

--- a/tests/pytorch/ops/test_attention_varlen.py
+++ b/tests/pytorch/ops/test_attention_varlen.py
@@ -1,0 +1,120 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+from typing import List, Tuple
+
+import pytest
+import torch
+
+from primus_turbo.pytorch.ops import flash_attn_varlen_func
+from tests.pytorch.ref.attention_ref import attention_varlen_forward_pytorch_ref_impl
+from tests.pytorch.test_utils import compute_snr
+
+
+def _build_cu_seqlens(seqlens: List[int], device: str) -> Tuple[torch.Tensor, int, int]:
+    cu = torch.zeros(len(seqlens) + 1, dtype=torch.int32, device=device)
+    cu[1:] = torch.tensor(seqlens, dtype=torch.int32, device=device).cumsum(0)
+    return cu, max(seqlens), int(cu[-1].item())
+
+
+# (seqlens_q, seqlens_k)
+SEQLEN_PATTERNS = [
+    pytest.param(([512, 512, 512, 512], [512, 512, 512, 512])),
+    pytest.param(([1024], [1024])),
+    pytest.param(([128, 256, 512, 1024], [128, 256, 512, 1024])),
+    pytest.param(([57, 311, 800, 173], [57, 311, 800, 173])),
+    pytest.param(([2048, 64, 64, 64], [2048, 64, 64, 64])),
+]
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("seqlens", SEQLEN_PATTERNS)
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "num_head_q,num_head_kv",
+    [(8, 8), (16, 4)],  # MHA and GQA
+)
+@pytest.mark.parametrize("head_dim", [64, 128])
+def test_flash_attn_varlen(dtype, seqlens, causal, num_head_q, num_head_kv, head_dim):
+    seqlens_q, seqlens_k = seqlens
+
+    # Causal varlen requires per-batch q_len == k_len(bottom-right aligned mask)
+    if causal and seqlens_q != seqlens_k:
+        pytest.skip("Causal varlen requires matching q/k seqlens per batch")
+
+    device = "cuda"
+    torch.manual_seed(42)
+    torch.cuda.manual_seed_all(42)
+
+    cu_seqlens_q, max_seqlen_q, total_q = _build_cu_seqlens(seqlens_q, device)
+    cu_seqlens_k, max_seqlen_k, total_k = _build_cu_seqlens(seqlens_k, device)
+
+    q = torch.randn((total_q, num_head_q, head_dim), device=device, dtype=dtype, requires_grad=True)
+    k = torch.randn((total_k, num_head_kv, head_dim), device=device, dtype=dtype, requires_grad=True)
+    v = torch.randn((total_k, num_head_kv, head_dim), device=device, dtype=dtype, requires_grad=True)
+    grad_out = torch.randn((total_q, num_head_q, head_dim), device=device, dtype=dtype)
+
+    q_ref = q.clone().detach().requires_grad_()
+    k_ref = k.clone().detach().requires_grad_()
+    v_ref = v.clone().detach().requires_grad_()
+
+    sm_scale = head_dim ** (-0.5)
+
+    o_ref = attention_varlen_forward_pytorch_ref_impl(
+        q_ref, k_ref, v_ref, cu_seqlens_q, cu_seqlens_k, sm_scale, causal
+    )
+    o_ref.backward(grad_out)
+
+    o = flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        max_seqlen_q,
+        max_seqlen_k,
+        dropout_p=0.0,
+        softmax_scale=sm_scale,
+        causal=causal,
+    )
+    o.backward(grad_out)
+
+    torch.cuda.synchronize()
+
+    out_snr = compute_snr(o_ref, o)
+    dq_snr = compute_snr(q_ref.grad, q.grad)
+    dk_snr = compute_snr(k_ref.grad, k.grad)
+    dv_snr = compute_snr(v_ref.grad, v.grad)
+
+    print(
+        f"\ndtype={dtype}, causal={causal}, hq={num_head_q}, hkv={num_head_kv}, "
+        f"hd={head_dim}, seqlens_q={seqlens_q}, seqlens_k={seqlens_k}\n"
+        f"  out={out_snr:.2f} dq={dq_snr:.2f} dk={dk_snr:.2f} dv={dv_snr:.2f}"
+    )
+
+    assert out_snr > 40, f"out_snr too low: {out_snr}"
+    assert dq_snr > 40, f"dq_snr too low: {dq_snr}"
+    assert dk_snr > 40, f"dk_snr too low: {dk_snr}"
+    assert dv_snr > 40, f"dv_snr too low: {dv_snr}"
+
+
+def test_flash_attn_varlen_no_grad():
+    """Smoke test: forward-only (inference) path."""
+    device = "cuda"
+    torch.manual_seed(0)
+    seqlens = [256, 128, 384]
+    cu, max_s, total = _build_cu_seqlens(seqlens, device)
+
+    nh, hd = 8, 64
+    q = torch.randn((total, nh, hd), device=device, dtype=torch.bfloat16)
+    k = torch.randn((total, nh, hd), device=device, dtype=torch.bfloat16)
+    v = torch.randn((total, nh, hd), device=device, dtype=torch.bfloat16)
+
+    with torch.no_grad():
+        o = flash_attn_varlen_func(q, k, v, cu, cu, max_s, max_s, causal=True)
+
+    assert o.shape == (total, nh, hd)
+    assert o.dtype == torch.bfloat16

--- a/tests/pytorch/ref/attention_ref.py
+++ b/tests/pytorch/ref/attention_ref.py
@@ -129,6 +129,45 @@ def attention_with_sink_ref_impl(q, k, v, sink, sm_scale, causal, window_size=(-
     return output
 
 
+def attention_varlen_forward_pytorch_ref_impl(
+    q,
+    k,
+    v,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    sm_scale,
+    causal,
+):
+    """Reference varlen attention; Loops per sequence using cu_seqlens."""
+    total_q, nheads_q, _ = q.shape
+    head_dim_v = v.shape[-1]
+    out = torch.empty((total_q, nheads_q, head_dim_v), dtype=q.dtype, device=q.device)
+
+    n_kv_heads = k.shape[1]
+    n_rep = nheads_q // n_kv_heads
+
+    cu_q = cu_seqlens_q.tolist()
+    cu_k = cu_seqlens_k.tolist()
+    batch = len(cu_q) - 1
+
+    for i in range(batch):
+        q_start, q_end = cu_q[i], cu_q[i + 1]
+        k_start, k_end = cu_k[i], cu_k[i + 1]
+        if q_end == q_start:
+            continue
+        # (s, h, d) -> (1, h, s, d) for SDPA, then back.
+        qi = q[q_start:q_end].transpose(0, 1).unsqueeze(0).contiguous()
+        ki = k[k_start:k_end].transpose(0, 1).unsqueeze(0).contiguous()
+        vi = v[k_start:k_end].transpose(0, 1).unsqueeze(0).contiguous()
+        with sdpa_kernel(ATTN_BACKENDS):
+            oi = torch.nn.functional.scaled_dot_product_attention(
+                qi, ki, vi, is_causal=causal, scale=sm_scale, enable_gqa=n_rep > 1
+            )
+        out[q_start:q_end] = oi.squeeze(0).transpose(0, 1).contiguous()
+
+    return out
+
+
 class TurboAttentionRef(torch.nn.Module):
     def __init__(
         self,


### PR DESCRIPTION
# Description

This PR creates the python interfaces for the underlying aiter varlen kernels. This PR leaves the Triton attention path untouched (can merge this in another PR if relevant).

- Mimics aiter's flash-attention varlen API which mimics the canonical `flash_attn_varlen_func`.
- `torch.compile` compatible wrappers

Tests:
- `test_attention_varlen.py` which splits cu_seqlens and runs attention on each chunk
- `attention_ref.py`.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
