### PR TITLE
fix: hipblaslt_gemm correct workspace size for MI300X

### DIFF
--- a/csrc/kernels/gemm/hipblaslt_gemm.cu
+++ b/csrc/kernels/gemm/hipblaslt_gemm.cu
@@ -14,7 +14,16 @@ int64_t get_hipblaslt_workspace_size_in_byte() {
         return 67108864; // 64 MiB
     case GPUArch::GFX942:
     case GPUArch::UNKNOWN:
-        return 33554432; // 32 MiB
+        // 128 MiB. Some FP8 mixed-precision shapes on MI300X (gfx942) -- e.g.
+        // the (M=3072, N=3072, K=8192) E4M3 x E5M2 -> BF16 grad_weight GEMM
+        // emitted by the FLUX-12B backward graph -- cause hipBLASLt's
+        // heuristic to return an algorithm whose required workspace exceeds
+        // the previous 32 MiB cap (~72 MiB observed). hipblasLtMatmul then
+        // returns HIPBLAS_STATUS_INVALID_VALUE at execution time (logged by
+        // hipBLASLt as "Input workspace size ... is less than the required
+        // workspace size ..."). Bumping to 128 MiB covers that case with
+        // comfortable headroom for similar-sized algos.
+        return 134217728; // 128 MiB
     }
 }
 

--- a/tests/pytorch/ops/test_gemm_fp8.py
+++ b/tests/pytorch/ops/test_gemm_fp8.py
@@ -200,6 +200,49 @@ def _run_gemm_fp8_deterministic_test(
         GlobalBackendManager.reset()
 
 
+# Regression test for the hipBLASLt FP8 workspace shortage on MI300X (gfx942).
+#
+# Background:
+#   The HIPBLASLT FP8 backend uses a fixed-size workspace returned by
+#   ``get_hipblaslt_workspace_size_in_byte()`` in
+#   ``csrc/kernels/gemm/hipblaslt_gemm.cu``. Before commit
+#   ``fix/gemm-fp8-workspace-invalid-value-mi300x`` that value was 32 MiB
+#   on gfx942. For the specific FLUX-12B backward grad_weight GEMM
+#   ``(M=3072, N=3072, K=8192)`` with mixed E4M3 x E5M2 -> BF16
+#   tensorwise scaling, hipBLASLt's heuristic returns an algorithm whose
+#   actual workspace requirement is ~72 MiB. ``hipblasLtMatmul`` then
+#   returns ``HIPBLAS_STATUS_INVALID_VALUE`` at execution time (visible
+#   in hipBLASLt logs as ``runContractionProblem: Input workspace size
+#   33554432 is less than the required workspace size 75497472``).
+#
+#   This test reproduces the exact failing problem shape, dtype mix,
+#   layout, granularity and backend. It must succeed (no
+#   ``HIPBLAS_STATUS_INVALID_VALUE``, finite gradients) once the workspace
+#   is bumped to >= 75 497 472 bytes; it fails with a ``RuntimeError``
+#   from ``hipblaslt_gemm_impl`` if the regression is reintroduced.
+@pytest.mark.parametrize(
+    "m,n,k,layout,format,dtype,backend",
+    [
+        # FLUX-12B backward grad_weight GEMM that triggered the original crash.
+        (3072, 3072, 8192, "NT", Format.HYBRID, torch.bfloat16, BackendType.HIPBLASLT),
+    ],
+)
+def test_gemm_fp8_hipblaslt_workspace_regression(m, n, k, layout, format, dtype, backend):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    _run_gemm_fp8_test(
+        m=m,
+        n=n,
+        k=k,
+        layout=layout,
+        format=format,
+        dtype=dtype,
+        granularity=ScalingGranularity.TENSORWISE,
+        backend=backend,
+        auto_tune=False,
+    )
+
+
 @pytest.mark.parametrize("m", [255, 507, 1032, 2056])
 @pytest.mark.parametrize("n", [512, 1024, 2048, 4096])
 @pytest.mark.parametrize("k", [256, 512, 576, 1024, 2048])


### PR DESCRIPTION
# Description

Issue arised during running Primux Flux1 FP8 local spec DDP training.

The HIPBLASLT FP8 GEMM backend on MI300X (gfx942) intermittently aborted training with HIPBLAS_STATUS_INVALID_VALUE from hipblasLtMatmul because Primus-Turbo passed a fixed 32 MiB scratch buffer to hipBLASLt, while hipBLASLt's own heuristic returned algorithms whose actual workspace requirement was up to ≈72 MiB for some FP8 mixed-precision shapes. The first reproducible victim was the (M=3072, N=3072, K=8192) E4M3 × E5M2 → BF16 grad-weight GEMM emitted by the FLUX-12B backward graph, which crashed within the first backward step of every run.

This PR resolves the crash by raising the gfx942 hipBLASLt workspace from 32 MiB → 128 MiB in get_hipblaslt_workspace_size_in_byte() and adds a targeted regression test that reproduces the exact failing problem shape, dtype mix, layout, granularity and backend so the issue cannot silently regress. gfx950 is left at 64 MiB and is unaffected.

# Fixes  (issue)

Fixes HIPBLAS_STATUS_INVALID_VALUE (code=3) from hipblaslt_gemm_impl (csrc/kernels/gemm/hipblaslt_gemm.hip:127) on MI300X / gfx942 when running FP8 mixed-precision GEMMs whose hipBLASLt-selected algorithm requires more than 32 MiB of workspace — observed on the FLUX-12B backward grad-weight GEMM (M=3072, N=3072, K=8192) E4M3 × E5M2 → BF16 (≈72 MiB required, hipBLASLt log: runContractionProblem: Input workspace size 33554432 is less than the required workspace size 75497472).

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- csrc/kernels/gemm/hipblaslt_gemm.cu — bump the gfx942 / UNKNOWN return value of get_hipblaslt_workspace_size_in_byte() from 33554432 (32 MiB) to 134217728 (128 MiB), with an in-source comment explaining the FLUX-12B crash that motivates it. gfx950 stays at 64 MiB.

- tests/pytorch/ops/test_gemm_fp8.py — add test_gemm_fp8_hipblaslt_workspace_regression, a parameterized pytest that reuses _run_gemm_fp8_test to drive the exact failing production configuration (M=3072, N=3072, K=8192, layout NT, Format.HYBRID, torch.bfloat16, BackendType.HIPBLASLT, ScalingGranularity.TENSORWISE, auto_tune=False). The test fails with a RuntimeError from hipblaslt_gemm_impl if the 32 MiB cap is reintroduced and passes once the workspace is ≥ 75 497 472 bytes; it also validates SNR vs. the BF16 reference.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
