### PR TITLE
chore: remove ck tensorwise pytest skip

### DIFF
--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -395,10 +395,6 @@ def test_grouped_gemm_fp8_blockwise_triton_deterministic(
 @pytest.mark.parametrize("backend", [None, BackendType.CK, BackendType.HIPBLASLT, BackendType.TRITON])
 @pytest.mark.parametrize("auto_tune", [False, True])
 def test_grouped_gemm_fp8_tensorwise(B, M, NK, ori_dtype, format, trans_b, balance, backend, auto_tune):
-    # FIXME(ruibin): CK backend has numerical issues.
-    if backend == BackendType.CK or backend == None:
-        pytest.skip("CK backend has numerical issues currently")
-
     if backend == BackendType.TRITON and format == Format.HYBRID:
         pytest.skip("TRITON backend not support HYBRID format currently")
 


### PR DESCRIPTION
# Description

Remove the `pytest.skip` guard that was unconditionally skipping CK and default (None) backends in `test_grouped_gemm_fp8_tensorwise`. The skip was originally added as a workaround for CK numerical issues which have since been resolved in newer hipcc as image upgrade to primus/26.2 .

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Remove the `pytest.skip("CK backend has numerical issues currently")` block in `test_grouped_gemm_fp8_tensorwise` that was skipping `BackendType.CK` and `None` (default) backends.
- This re-enables tensorwise FP8 grouped GEMM test coverage for CK and default backend dispatch paths.

# Checklist:

- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
