### PR TITLE
feat: add rowwise dequant kernel

### DIFF
--- a/csrc/include/primus_turbo/quantization.h
+++ b/csrc/include/primus_turbo/quantization.h
@@ -112,4 +112,18 @@ template <typename FType, typename QType, typename ComputeType = float>
 void dequantize_tensorwise_impl(const QType *x, const float *scale_inv, FType *y, const int64_t n,
                                 hipStream_t stream);
 
+// Rowwise dequantize when the per-row dim is the innermost (last) dim.
+// scale_inv has shape [outer_len] (one scalar per row).
+template <typename FType, typename QType, typename ComputeType = float>
+void dequantize_rowwise_row_major_impl(const QType *x, const float *scale_inv, FType *y,
+                                       const int64_t outer_len, const int64_t inner_len,
+                                       hipStream_t stream);
+
+// Rowwise dequantize when the per-row dim is a middle dim.
+// Input is viewed as [B, M, N], scale_inv has shape [B, N] (broadcast across M).
+template <typename FType, typename QType, typename ComputeType = float>
+void dequantize_rowwise_col_major_impl(const QType *x, const float *scale_inv, FType *y,
+                                       const int64_t batch, const int64_t m, const int64_t n,
+                                       hipStream_t stream);
+
 } // namespace primus_turbo

--- a/csrc/kernels/quantization/quantization.cu
+++ b/csrc/kernels/quantization/quantization.cu
@@ -476,4 +476,201 @@ DECL_QUANT_AND_DEQUANT_ROWWISE_COL_MAJOR_INSTANCE(dtype::float32, dtype::float8_
 
 #undef DECL_QUANT_AND_DEQUANT_ROWWISE_COL_MAJOR_INSTANCE
 
+// ******************************************************************
+// ******************************************************************
+//                       Dequantize Rowwise
+// ******************************************************************
+
+// Row-major dequant: scale_inv has one element per row of the
+// flattened [outer_len, inner_len] view.
+template <int BLOCK_SIZE, int UNROLL, typename FType, typename QType, typename ComputeType = float>
+__launch_bounds__(BLOCK_SIZE) __global__
+    void dequantize_rowwise_row_major_kernel(const QType *__restrict__ input_ptr,
+                                             const float *__restrict__ scale_inv_ptr,
+                                             FType *__restrict__ output_ptr,
+                                             const int64_t inner_len) {
+    const int64_t bid = blockIdx.x;
+    const int32_t tid = threadIdx.x;
+
+    const ComputeType scale_inv = static_cast<ComputeType>(scale_inv_ptr[bid]);
+
+    input_ptr += bid * inner_len;
+    output_ptr += bid * inner_len;
+
+    QType ld_regs[UNROLL];
+    FType st_regs[UNROLL];
+
+    const int64_t start_offset = static_cast<int64_t>(tid) * UNROLL;
+    const int64_t stride       = static_cast<int64_t>(BLOCK_SIZE) * UNROLL;
+
+    for (int64_t offset = start_offset; offset < inner_len; offset += stride) {
+        load_data<QType, UNROLL>(input_ptr + offset, ld_regs);
+#pragma unroll
+        for (int32_t i = 0; i < UNROLL; ++i) {
+            st_regs[i] = static_cast<FType>(static_cast<ComputeType>(ld_regs[i]) * scale_inv);
+        }
+        store_data<FType, UNROLL>(output_ptr + offset, st_regs);
+    }
+}
+
+template <typename FType, typename QType, typename ComputeType>
+void dequantize_rowwise_row_major_impl(const QType *x, const float *scale_inv, FType *y,
+                                       const int64_t outer_len, const int64_t inner_len,
+                                       hipStream_t stream) {
+    const int32_t BLOCK_SIZE = 512;
+    const int32_t GRID_SIZE  = outer_len;
+    int32_t       pack_size  = std::min(get_pack_size<QType>(x), get_pack_size<FType>(y));
+    pack_size                = get_quantize_rowwise_pack_size<FType>(pack_size, inner_len);
+
+    switch (pack_size) {
+    case 8: {
+        const int32_t UNROLL = valid_pack<FType, 8>();
+        dequantize_rowwise_row_major_kernel<BLOCK_SIZE, UNROLL, FType, QType, ComputeType>
+            <<<GRID_SIZE, BLOCK_SIZE, 0, stream>>>(x, scale_inv, y, inner_len);
+        break;
+    }
+    case 4: {
+        const int32_t UNROLL = valid_pack<FType, 4>();
+        dequantize_rowwise_row_major_kernel<BLOCK_SIZE, UNROLL, FType, QType, ComputeType>
+            <<<GRID_SIZE, BLOCK_SIZE, 0, stream>>>(x, scale_inv, y, inner_len);
+        break;
+    }
+    case 2: {
+        const int32_t UNROLL = valid_pack<FType, 2>();
+        dequantize_rowwise_row_major_kernel<BLOCK_SIZE, UNROLL, FType, QType, ComputeType>
+            <<<GRID_SIZE, BLOCK_SIZE, 0, stream>>>(x, scale_inv, y, inner_len);
+        break;
+    }
+    case 1: {
+        const int32_t UNROLL = 1;
+        dequantize_rowwise_row_major_kernel<BLOCK_SIZE, UNROLL, FType, QType, ComputeType>
+            <<<GRID_SIZE, BLOCK_SIZE, 0, stream>>>(x, scale_inv, y, inner_len);
+        break;
+    }
+    default:
+        PRIMUS_TURBO_ERROR("Error Pack Size");
+        break;
+    }
+}
+
+// Col-major dequant: input is viewed as [B, M, N] and scale_inv as [B, N]
+// (broadcast across the M dim).
+template <int BLOCK_SIZE, int UNROLL_M, int UNROLL_N, typename FType, typename QType,
+          typename ComputeType = float>
+__launch_bounds__(BLOCK_SIZE) __global__
+    void dequantize_rowwise_col_major_kernel(const QType *__restrict__ input_ptr,
+                                             const float *__restrict__ scale_inv_ptr,
+                                             FType *__restrict__ output_ptr, const int64_t m,
+                                             const int64_t n) {
+    const int32_t tid   = threadIdx.x;
+    const int32_t bid_x = blockIdx.x;
+    const int32_t bid_y = blockIdx.y;
+    const int32_t bid_z = blockIdx.z;
+
+    const int64_t offset_m         = bid_y * UNROLL_M;
+    const int64_t offset_n         = bid_x * BLOCK_SIZE * UNROLL_N + tid * UNROLL_N;
+    const int64_t offset_input     = bid_z * m * n + offset_m * n + offset_n;
+    const int64_t offset_scale_inv = bid_z * n + offset_n;
+
+    if (offset_n >= n)
+        return;
+
+    input_ptr += offset_input;
+    scale_inv_ptr += offset_scale_inv;
+    output_ptr += offset_input;
+
+    QType ld_regs[UNROLL_N];
+    FType st_regs[UNROLL_N];
+    float scale_inv_regs[UNROLL_N];
+
+    if constexpr (UNROLL_N == 8) {
+        load_data<float, 4>(scale_inv_ptr + 0, scale_inv_regs + 0);
+        load_data<float, 4>(scale_inv_ptr + 4, scale_inv_regs + 4);
+    } else {
+        load_data<float, UNROLL_N>(scale_inv_ptr, scale_inv_regs);
+    }
+
+    const int32_t m_remaining = static_cast<int32_t>(m - offset_m);
+    const int32_t m_valid     = m_remaining > UNROLL_M ? UNROLL_M : m_remaining;
+    for (int mi = 0; mi < m_valid; ++mi) {
+        load_data<QType, UNROLL_N>(input_ptr + mi * n, ld_regs);
+#pragma unroll
+        for (int i = 0; i < UNROLL_N; ++i) {
+            st_regs[i] = static_cast<FType>(static_cast<ComputeType>(ld_regs[i]) *
+                                            static_cast<ComputeType>(scale_inv_regs[i]));
+        }
+        store_data<FType, UNROLL_N>(output_ptr + mi * n, st_regs);
+    }
+}
+
+template <typename FType, typename QType, typename ComputeType>
+void dequantize_rowwise_col_major_impl(const QType *x, const float *scale_inv, FType *y,
+                                       const int64_t batch, const int64_t m, const int64_t n,
+                                       hipStream_t stream) {
+    const int32_t UNROLL_M = 32;
+
+    int32_t pack_size        = std::min(get_pack_size<QType>(x), get_pack_size<FType>(y));
+    pack_size                = get_quantize_rowwise_pack_size<FType>(pack_size, n);
+    const int32_t BLOCK_SIZE = 512;
+
+    switch (pack_size) {
+    case 8: {
+        const int32_t UNROLL_N = valid_pack<FType, 8>();
+        const dim3 GRID_SIZE(DIVUP<int64_t>(n, BLOCK_SIZE * UNROLL_N), DIVUP<int64_t>(m, UNROLL_M),
+                             batch);
+        dequantize_rowwise_col_major_kernel<BLOCK_SIZE, UNROLL_M, UNROLL_N, FType, QType,
+                                            ComputeType>
+            <<<GRID_SIZE, BLOCK_SIZE, 0, stream>>>(x, scale_inv, y, m, n);
+        break;
+    }
+    case 4: {
+        const int32_t UNROLL_N = valid_pack<FType, 4>();
+        const dim3 GRID_SIZE(DIVUP<int64_t>(n, BLOCK_SIZE * UNROLL_N), DIVUP<int64_t>(m, UNROLL_M),
+                             batch);
+        dequantize_rowwise_col_major_kernel<BLOCK_SIZE, UNROLL_M, UNROLL_N, FType, QType,
+                                            ComputeType>
+            <<<GRID_SIZE, BLOCK_SIZE, 0, stream>>>(x, scale_inv, y, m, n);
+        break;
+    }
+    case 2: {
+        const int32_t UNROLL_N = valid_pack<FType, 2>();
+        const dim3 GRID_SIZE(DIVUP<int64_t>(n, BLOCK_SIZE * UNROLL_N), DIVUP<int64_t>(m, UNROLL_M),
+                             batch);
+        dequantize_rowwise_col_major_kernel<BLOCK_SIZE, UNROLL_M, UNROLL_N, FType, QType,
+                                            ComputeType>
+            <<<GRID_SIZE, BLOCK_SIZE, 0, stream>>>(x, scale_inv, y, m, n);
+        break;
+    }
+    case 1: {
+        const int32_t UNROLL_N = 1;
+        const dim3 GRID_SIZE(DIVUP<int64_t>(n, BLOCK_SIZE * UNROLL_N), DIVUP<int64_t>(m, UNROLL_M),
+                             batch);
+        dequantize_rowwise_col_major_kernel<BLOCK_SIZE, UNROLL_M, UNROLL_N, FType, QType,
+                                            ComputeType>
+            <<<GRID_SIZE, BLOCK_SIZE, 0, stream>>>(x, scale_inv, y, m, n);
+        break;
+    }
+    default:
+        PRIMUS_TURBO_ERROR("Error Pack Size");
+        break;
+    }
+}
+
+#define DECL_DEQUANT_ROWWISE_INSTANCE(FType, QType)                                                \
+    template void dequantize_rowwise_row_major_impl<FType, QType, float>(                          \
+        const QType *x, const float *scale_inv, FType *y, const int64_t outer_len,                 \
+        const int64_t inner_len, hipStream_t stream);                                              \
+    template void dequantize_rowwise_col_major_impl<FType, QType, float>(                          \
+        const QType *x, const float *scale_inv, FType *y, const int64_t batch, const int64_t m,    \
+        const int64_t n, hipStream_t stream);
+
+DECL_DEQUANT_ROWWISE_INSTANCE(dtype::float16, dtype::float8_e4m3)
+DECL_DEQUANT_ROWWISE_INSTANCE(dtype::float16, dtype::float8_e5m2)
+DECL_DEQUANT_ROWWISE_INSTANCE(dtype::bfloat16, dtype::float8_e4m3)
+DECL_DEQUANT_ROWWISE_INSTANCE(dtype::bfloat16, dtype::float8_e5m2)
+DECL_DEQUANT_ROWWISE_INSTANCE(dtype::float32, dtype::float8_e4m3)
+DECL_DEQUANT_ROWWISE_INSTANCE(dtype::float32, dtype::float8_e5m2)
+
+#undef DECL_DEQUANT_ROWWISE_INSTANCE
+
 } // namespace primus_turbo

--- a/csrc/pytorch/bindings_pytorch.cpp
+++ b/csrc/pytorch/bindings_pytorch.cpp
@@ -35,6 +35,8 @@ TORCH_LIBRARY(primus_turbo_cpp_extension, m) {
 
     m.def("dequantize_fp8_tensorwise(Tensor input, Tensor scale_inv, ScalarType dest_dtype) -> "
           "Tensor");
+    m.def("dequantize_fp8_rowwise(Tensor input, Tensor scale_inv, int axis, "
+          "ScalarType dest_dtype) -> Tensor");
 
     // ********* MXFP4 Quantization *********
     m.def("quantize_mxfp4_dual(Tensor input, ScalarType dest_dtype, "
@@ -92,6 +94,7 @@ TORCH_LIBRARY_IMPL(primus_turbo_cpp_extension, CUDA, m) {
     m.impl("quantize_fp8_tensorwise", quantize_fp8_tensorwise);
     m.impl("dequantize_fp8_tensorwise", dequantize_fp8_tensorwise);
     m.impl("quantize_fp8_rowwise", quantize_fp8_rowwise);
+    m.impl("dequantize_fp8_rowwise", dequantize_fp8_rowwise);
 
     // ********* MXFP4 Quantization *********
     m.impl("quantize_mxfp4_dual", quantize_mxfp4_dual);
@@ -130,6 +133,7 @@ TORCH_LIBRARY_IMPL(primus_turbo_cpp_extension, Meta, m) {
     m.impl("quantize_fp8_tensorwise", quantize_fp8_tensorwise_meta);
     m.impl("dequantize_fp8_tensorwise", dequantize_fp8_tensorwise_meta);
     m.impl("quantize_fp8_rowwise", quantize_fp8_rowwise_meta);
+    m.impl("dequantize_fp8_rowwise", dequantize_fp8_rowwise_meta);
 
     // ********* MXFP4 Quantization *********
     m.impl("quantize_mxfp4_dual", quantize_mxfp4_dual_meta);

--- a/csrc/pytorch/extensions.h
+++ b/csrc/pytorch/extensions.h
@@ -49,12 +49,17 @@ at::Tensor dequantize_fp8_tensorwise_meta(const at::Tensor input, const at::Tens
                                           const at::ScalarType dest_dtype);
 
 std::vector<at::Tensor>
-quantize_mxfp4_dual(const at::Tensor input, const at::ScalarType dest_dtype,
-                    const bool rowwise_use_2d_block, const bool rowwise_use_sr,
-                    const bool rowwise_use_rht, const bool colwise_use_2d_block,
-                    const bool colwise_use_sr, const bool colwise_use_rht,
-                    const bool shuffle_rowwise_scale = false, const bool shuffle_rowwise = false,
-                    const bool shuffle_colwise_scale = false, const bool shuffle_colwise = false);
+           quantize_mxfp4_dual(const at::Tensor input, const at::ScalarType dest_dtype,
+                               const bool rowwise_use_2d_block, const bool rowwise_use_sr,
+                               const bool rowwise_use_rht, const bool colwise_use_2d_block,
+                               const bool colwise_use_sr, const bool colwise_use_rht,
+                               const bool shuffle_rowwise_scale = false, const bool shuffle_rowwise = false,
+                               const bool shuffle_colwise_scale = false, const bool shuffle_colwise = false);
+at::Tensor dequantize_fp8_rowwise(const at::Tensor input, const at::Tensor scale_inv,
+                                  const int64_t axis, const at::ScalarType dest_dtype);
+
+at::Tensor dequantize_fp8_rowwise_meta(const at::Tensor input, const at::Tensor scale_inv,
+                                       const int64_t axis, const at::ScalarType dest_dtype);
 
 std::vector<at::Tensor> quantize_mxfp4_dual_meta(
     const at::Tensor input, const at::ScalarType dest_dtype, const bool rowwise_use_2d_block,

--- a/csrc/pytorch/quantization/quantization.cpp
+++ b/csrc/pytorch/quantization/quantization.cpp
@@ -222,6 +222,58 @@ at::Tensor dequantize_fp8_tensorwise(const at::Tensor input, const at::Tensor sc
     return output;
 }
 
+at::Tensor dequantize_fp8_rowwise(const at::Tensor input, const at::Tensor scale_inv,
+                                  const int64_t axis, const at::ScalarType dest_dtype) {
+    PRIMUS_TURBO_CHECK(dest_dtype == at::kBFloat16 || dest_dtype == at::kHalf ||
+                       dest_dtype == at::kFloat);
+    PRIMUS_TURBO_CHECK(is_torch_fp8(input.scalar_type()));
+    PRIMUS_TURBO_CHECK(scale_inv.scalar_type() == at::kFloat,
+                       "rowwise scale_inv must be float32 tensor");
+    PRIMUS_TURBO_CHECK(input.is_contiguous(), "input must be contiguous");
+    PRIMUS_TURBO_CHECK(scale_inv.is_contiguous(), "scale_inv must be contiguous");
+
+    const int64_t valid_axis = (axis >= 0) ? axis : input.dim() + axis;
+    PRIMUS_TURBO_CHECK(valid_axis >= 0 && valid_axis < input.dim(),
+                       "rowwise dequantize axis out of range");
+
+    std::vector<int64_t> expected_scale_shape(input.sizes().begin(), input.sizes().end());
+    expected_scale_shape[valid_axis] = 1;
+    PRIMUS_TURBO_CHECK(scale_inv.sizes() == at::IntArrayRef(expected_scale_shape),
+                       "scale_inv shape must match input shape with size 1 along axis");
+
+    const bool is_row_major = valid_axis == (input.dim() - 1);
+
+    auto       stream = at::cuda::getCurrentCUDAStream();
+    at::Tensor output = torch::empty_like(input, torch::dtype(dest_dtype).device(input.device()));
+
+    if (is_row_major) {
+        const int64_t inner_len = input.sizes()[valid_axis];
+        const int64_t outer_len = input.numel() / inner_len;
+        TORCH_TYPE_SWITCH_FP16_BF16_FP32(output.scalar_type(), FType, {
+            TORCH_TYPE_SWITCH_FP8(input.scalar_type(), QType, {
+                dequantize_rowwise_row_major_impl<FType, QType, float>(
+                    reinterpret_cast<const QType *>(input.data_ptr()),
+                    reinterpret_cast<const float *>(scale_inv.data_ptr()),
+                    reinterpret_cast<FType *>(output.data_ptr()), outer_len, inner_len, stream);
+            });
+        });
+    } else {
+        int64_t              B, M, N;
+        std::vector<int64_t> input_shape(input.sizes().begin(), input.sizes().end());
+        compute_quantize_fp8_rowwise_bmn(input_shape, valid_axis, B, M, N);
+        TORCH_TYPE_SWITCH_FP16_BF16_FP32(output.scalar_type(), FType, {
+            TORCH_TYPE_SWITCH_FP8(input.scalar_type(), QType, {
+                dequantize_rowwise_col_major_impl<FType, QType, float>(
+                    reinterpret_cast<const QType *>(input.data_ptr()),
+                    reinterpret_cast<const float *>(scale_inv.data_ptr()),
+                    reinterpret_cast<FType *>(output.data_ptr()), B, M, N, stream);
+            });
+        });
+    }
+
+    return output;
+}
+
 // Quantize MXFP4 with dual mode
 std::vector<at::Tensor> quantize_mxfp4_dual(
     const at::Tensor input, const at::ScalarType dest_dtype, const bool rowwise_use_2d_block,

--- a/csrc/pytorch/quantization/quantization_meta.cpp
+++ b/csrc/pytorch/quantization/quantization_meta.cpp
@@ -37,6 +37,14 @@ at::Tensor dequantize_fp8_tensorwise_meta(const at::Tensor input, const at::Tens
     return output;
 }
 
+at::Tensor dequantize_fp8_rowwise_meta(const at::Tensor input, const at::Tensor scale_inv,
+                                       const int64_t axis, const at::ScalarType dest_dtype) {
+    const int64_t valid_axis = (axis >= 0) ? axis : input.dim() + axis;
+    PRIMUS_TURBO_CHECK(valid_axis >= 0 && valid_axis < input.dim());
+    at::Tensor output = at::empty_like(input, at::dtype(dest_dtype).device(at::kMeta));
+    return output;
+}
+
 std::vector<at::Tensor> quantize_mxfp4_dual_meta(
     const at::Tensor input, const at::ScalarType dest_dtype, const bool rowwise_use_2d_block,
     const bool rowwise_use_sr, const bool rowwise_use_rht, const bool colwise_use_2d_block,

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -29,24 +29,24 @@ def ceil_div(a, b):
 
 
 def quantize_fp8_tensorwise_impl(
-    x: torch.Tensor, out_dtype: torch.dtype, scale: Optional[torch.Tensor] = None
+    x: torch.Tensor, out_dtype: torch.dtype
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Quantize FP8 Tensor-Wise
     """
-    x_fp8, scale_inv = torch.ops.primus_turbo_cpp_extension.quantize_fp8_tensorwise(x, out_dtype, scale)
+    x_fp8, scale_inv = torch.ops.primus_turbo_cpp_extension.quantize_fp8_tensorwise(x, out_dtype, None)
     return x_fp8, scale_inv
 
 
 def quantize_fp8_rowwise_impl(
-    x: torch.Tensor, out_dtype: torch.dtype, axis: int, scale: Optional[torch.Tensor] = None
+    x: torch.Tensor, out_dtype: torch.dtype, axis: int
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Quantize FP8 Row-Wise
     """
-    if not x.is_contiguous():
-        x = x.contiguous()
-    x_fp8, scale_inv = torch.ops.primus_turbo_cpp_extension.quantize_fp8_rowwise(x, out_dtype, axis, scale)
+    assert x.is_contiguous(), "The x tensor must be contiguous."
+    x_fp8, scale_inv = torch.ops.primus_turbo_cpp_extension.quantize_fp8_rowwise(x, out_dtype, axis, None)
+
     return x_fp8, scale_inv
 
 
@@ -61,7 +61,10 @@ def dequantize_fp8_rowwise_impl(x: torch.Tensor, out_dtype: torch.dtype, axis: i
     """
     DeQuantize FP8 Row-Wise
     """
-    raise NotImplementedError(f"Un-impl")
+    assert x.is_contiguous(), "The x tensor must be contiguous."
+    assert scale_inv.is_contiguous(), "The scale_inv tensor must be contiguous."
+
+    return torch.ops.primus_turbo_cpp_extension.dequantize_fp8_rowwise(x, scale_inv, axis, out_dtype)
 
 
 @triton_op("primus_turbo::quant_fp8_blockwise_impl", mutates_args=())

--- a/tests/pytorch/ops/test_quantization.py
+++ b/tests/pytorch/ops/test_quantization.py
@@ -127,6 +127,10 @@ def test_quantize_fp8_rowwise(orig_dtype, dest_dtype, axis, B, M, N, torch_compi
         **get_tolerances(dest_dtype),
     )
 
+    x_dq = dequantize_fp8(x_fp8, orig_dtype, granularity, axis=axis, scale_inv=x_scale_inv)
+    x_dq_ref = dequantize_fp8_ref(x_fp8_ref, orig_dtype, granularity, axis=axis, scale_inv=x_scale_inv_ref)
+    torch.testing.assert_close(x_dq, x_dq_ref, **get_tolerances(dest_dtype))
+
 
 def padding_size(n: int, padding_align_size: int) -> int:
     return (n + padding_align_size - 1) // padding_align_size * padding_align_size - n


### PR DESCRIPTION
# Description

Implement the FP8 rowwise dequantize op on the C++ side and wire it up through
the PyTorch dispatcher.

Previously `dequantize_fp8` with `ScalingGranularity.ROWWISE` was unimplemented
— `dequantize_fp8_rowwise_impl` only raised `NotImplementedError`, which left
`primus_turbo.pytorch.ops.dequantize_fp8(..., granularity=ROWWISE)` unusable.
This PR adds a real GPU implementation and exposes it via
`torch.ops.primus_turbo_cpp_extension.dequantize_fp8_rowwise`, mirroring the
existing tensorwise op.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Add two new device kernels in `csrc/kernels/quantization/quantization.cu`:
  - `dequantize_rowwise_row_major_kernel` — for the case where the quantization
    axis is the innermost dim; `scale_inv` has shape `[outer_len]` and is read
    once per row, then broadcast across `inner_len` packed elements per block.
  - `dequantize_rowwise_col_major_kernel` — for the case where the axis is a
    middle dim; input is viewed as `[B, M, N]` with `scale_inv` of shape
    `[B, N]` and broadcast across `M`. Reuses the `UNROLL_M`/`UNROLL_N` tiling
    layout of `quantize_rowwise_col_major_kernel`.
  - Pack-size selection follows `get_quantize_rowwise_pack_size<FType>` so the
    chosen unroll always divides `inner_len`/`N`.
  - Explicit template instantiations are added for `(fp16, bf16, fp32) ×
    (float8_e4m3, float8_e5m2)`.
- Declare the two new function templates in
  `csrc/include/primus_turbo/quantization.h`.
- Add the PyTorch op `dequantize_fp8_rowwise(input, scale_inv, axis, dest_dtype)`
  in `csrc/pytorch/quantization/quantization.cpp`. It validates dtypes,
  contiguity and `scale_inv` shape (must equal `input.sizes()` with size `1`
  along `axis`), computes `valid_axis = axis < 0 ? input.dim() + axis : axis`,
  and dispatches to either the row-major or col-major kernel based on whether
  `axis` is the last dim.
- Add the corresponding `dequantize_fp8_rowwise_meta` in
  `csrc/pytorch/quantization/quantization_meta.cpp` so the op is fully usable
  under `torch.compile` / fake-tensor tracing.
- Register the new op (`m.def`, CUDA `m.impl`, Meta `m.impl`) in
  `csrc/pytorch/bindings_pytorch.cpp` and add the declarations to
  `csrc/pytorch/extensions.h`.
- Update
  `primus_turbo/pytorch/kernels/quantization/quantization_impl.py::dequantize_fp8_rowwise_impl`:
  replace the `NotImplementedError` placeholder with a thin wrapper that
  ensures contiguity and calls
  `torch.ops.primus_turbo_cpp_extension.dequantize_fp8_rowwise`. This makes
  `primus_turbo.pytorch.ops.dequantize_fp8(granularity=ROWWISE)` functional.
- Extend `tests/pytorch/ops/test_quantization.py::test_quantize_fp8_rowwise`
  with a dequantize step that calls `dequantize_fp8(...)` and compares against
  `dequantize_fp8_ref(...)` using the existing tolerance helpers, so the
  rowwise dequant path is exercised in CI for every parametrized
  `(orig_dtype × dest_dtype × axis × B × M × N × torch_compile)` combination.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pytest
      tests/pytorch/ops/test_quantization.py -k "tensorwise or rowwise"` —
      1338 passed)

# Performance
```bash
==== Benchmark (warmup=5, iters=50) ====
case                           FType  QType        avg_ms          GiB/s
--------------------------------------------------------------------------------
row[1024x4096]                 fp16   e4m3         0.0037        3149.84
row[4096x4096]                 fp16   e4m3         0.0084        5572.04
row[8192x8192]                 fp16   e4m3         0.0238        7882.53
row[1x16777216]                fp16   e4m3         1.5509          30.22
row[32768x4096]                fp16   e4m3         0.0691        5431.20
col[1x4096x4096]               fp16   e4m3         0.0181        2588.31
col[1x8192x8192]               fp16   e4m3         0.0248        7553.35
col[4x4096x4096]               fp16   e4m3         0.0249        7532.49
col[1x8192x4096]               fp16   e4m3         0.0173        5416.90
row[1024x4096]                 bf16   e4m3         0.0043        2729.20
row[4096x4096]                 bf16   e4m3         0.0099        4715.00
row[8192x8192]                 bf16   e4m3         0.0258        7272.15
row[1x16777216]                bf16   e4m3         2.5847          18.14
row[32768x4096]                bf16   e4m3         0.0844        4445.58
col[1x4096x4096]               bf16   e4m3         0.0265        1767.24
col[1x8192x8192]               bf16   e4m3         0.0308        6084.95
col[4x4096x4096]               bf16   e4m3         0.0309        6063.44
col[1x8192x4096]               bf16   e4m3         0.0243        3861.54
row[1024x4096]                 fp32   e4m3         0.0050        3941.02
row[4096x4096]                 fp32   e4m3         0.0124        6300.75
row[8192x8192]                 fp32   e4m3         0.0662        4718.96
row[1x16777216]                fp32   e4m3         2.7947          27.95
row[32768x4096]                fp32   e4m3         0.1328        4708.75
col[1x4096x4096]               fp32   e4m3         0.0169        4615.99
col[1x8192x8192]               fp32   e4m3         0.0696        4487.24
col[4x4096x4096]               fp32   e4m3         0.0738        4238.09
col[1x8192x4096]               fp32   e4m3         0.0235        6649.96
row[1024x4096]                 fp16   e5m2         0.0037        3188.91
row[4096x4096]                 fp16   e5m2         0.0084        5589.57
row[8192x8192]                 fp16   e5m2         0.0238        7882.26
row[1x16777216]                fp16   e5m2         1.5499          30.24
row[32768x4096]                fp16   e5m2         0.0696        5392.48
col[1x4096x4096]               fp16   e5m2         0.0182        2570.71
col[1x8192x8192]               fp16   e5m2         0.0248        7554.08
col[4x4096x4096]               fp16   e5m2         0.0249        7531.76
col[1x8192x4096]               fp16   e5m2         0.0174        5382.81
```