### PR TITLE
feat(gemm): optimize blockwise FP8 GEMM Triton kernels (gfx950 / MI355X)

### DIFF
--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -8,6 +8,7 @@ from typing import Optional, Tuple, Union
 
 import torch
 import triton
+from torch.library import triton_op, wrap_triton
 
 from primus_turbo.pytorch.core.low_precision import (
     ScalingRecipe,
@@ -194,7 +195,7 @@ def quant_fp8_blockwise_dual_impl_meta(
     return x_fp8_row, x_scales_row, x_fp8_col, x_scales_col
 
 
-@torch.library.custom_op("primus_turbo::quant_fp8_blockwise_segment_m_impl", mutates_args=())
+@triton_op("primus_turbo::quant_fp8_blockwise_segment_m_impl", mutates_args=())
 def quant_fp8_blockwise_segment_m_impl(
     x: torch.Tensor,
     dtype: torch.dtype,
@@ -238,11 +239,8 @@ def quant_fp8_blockwise_segment_m_impl(
     x_scales = torch.zeros((triton.cdiv(M_padded_max, block_size), N), dtype=torch.float32, device=x.device)
 
     # Launch kernel - out-of-bounds blocks are handled by the kernel's mask logic
-    # NOTE: registered as ``torch.library.custom_op`` (opaque) for the same
-    # reason as ``quant_fp8_blockwise_dual_impl`` above (Triton 3.7 + MI300
-    # ``identify_mutated_tensors`` failure leading to silent DCE).
     grid = (triton.cdiv(M_padded_max, block_size), triton.cdiv(N, block_size))
-    quant_fp8_blockwise_segment_m_kernel[grid](
+    wrap_triton(quant_fp8_blockwise_segment_m_kernel)[grid](
         x,
         x_fp8,
         x_scales,

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -8,7 +8,6 @@ from typing import Optional, Tuple, Union
 
 import torch
 import triton
-from torch.library import triton_op, wrap_triton
 
 from primus_turbo.pytorch.core.low_precision import (
     ScalingRecipe,
@@ -130,13 +129,28 @@ def quant_fp8_blockwise_impl_meta(
     return x_fp8, x_scales
 
 
-@triton_op("primus_turbo::quant_fp8_blockwise_dual_impl", mutates_args=())
+@torch.library.custom_op("primus_turbo::quant_fp8_blockwise_dual_impl", mutates_args=())
 def quant_fp8_blockwise_dual_impl(
     x: torch.Tensor,
     dtype: torch.dtype,
     block_size: int = 128,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Quantize a 2D tensor in both blockwise row and column modes in one pass."""
+    """Quantize a 2D tensor in both blockwise row and column modes in one pass.
+
+    NOTE: This op is registered as ``torch.library.custom_op`` (opaque to
+    inductor) instead of ``triton_op`` + ``wrap_triton``. On the AMD MI300
+    (gfx942) + Triton 3.7 combination, the analysis pass
+    ``identify_mutated_tensors`` raises ``IndexError('Function argument index
+    out of range')`` while generating TTIR. PyTorch then falls back to the
+    conservative "all inputs mutated" path, but in this PyTorch build that
+    fallback only checks ``isinstance(value, Tensor)`` and misses ``TensorBox``
+    values seen during inductor lowering, so the kernel call is silently
+    eliminated by DCE and the returned ``torch.empty`` buffers leak as the
+    "outputs". The opaque ``custom_op`` registration sidesteps the
+    ``identify_mutated_tensors`` path entirely and matches the pattern already
+    used by ``quant_fp8_blockwise_impl`` and
+    ``quant_fp8_blockwise_for_weight_impl``.
+    """
     assert x.is_contiguous() and x.dim() == 2, "Input must be 2D and contiguous"
 
     M, N = x.shape
@@ -149,7 +163,7 @@ def quant_fp8_blockwise_dual_impl(
     x_scales_col = torch.empty(col_scales_shape, dtype=torch.float32, device=x.device)
 
     grid = (triton.cdiv(M, block_size), triton.cdiv(N, block_size))
-    wrap_triton(quant_fp8_blockwise_dual_kernel)[grid](
+    quant_fp8_blockwise_dual_kernel[grid](
         x,
         x_fp8_row,
         x_scales_row,
@@ -180,7 +194,7 @@ def quant_fp8_blockwise_dual_impl_meta(
     return x_fp8_row, x_scales_row, x_fp8_col, x_scales_col
 
 
-@triton_op("primus_turbo::quant_fp8_blockwise_segment_m_impl", mutates_args=())
+@torch.library.custom_op("primus_turbo::quant_fp8_blockwise_segment_m_impl", mutates_args=())
 def quant_fp8_blockwise_segment_m_impl(
     x: torch.Tensor,
     dtype: torch.dtype,
@@ -224,8 +238,11 @@ def quant_fp8_blockwise_segment_m_impl(
     x_scales = torch.zeros((triton.cdiv(M_padded_max, block_size), N), dtype=torch.float32, device=x.device)
 
     # Launch kernel - out-of-bounds blocks are handled by the kernel's mask logic
+    # NOTE: registered as ``torch.library.custom_op`` (opaque) for the same
+    # reason as ``quant_fp8_blockwise_dual_impl`` above (Triton 3.7 + MI300
+    # ``identify_mutated_tensors`` failure leading to silent DCE).
     grid = (triton.cdiv(M_padded_max, block_size), triton.cdiv(N, block_size))
-    wrap_triton(quant_fp8_blockwise_segment_m_kernel)[grid](
+    quant_fp8_blockwise_segment_m_kernel[grid](
         x,
         x_fp8,
         x_scales,

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -16,6 +16,7 @@ from primus_turbo.pytorch.core.low_precision import (
     check_mxfp8_support,
 )
 from primus_turbo.triton.quantization.quant_blockwise import (
+    quant_fp8_blockwise_dual_kernel,
     quant_fp8_blockwise_for_weight_kernel,
     quant_fp8_blockwise_kernel,
     quant_fp8_blockwise_segment_m_kernel,
@@ -93,9 +94,9 @@ def quant_fp8_blockwise_impl(
 
     M, N = x.shape
 
-    x_fp8 = torch.zeros((M, N), dtype=dtype, device=x.device)
+    x_fp8 = torch.empty((M, N), dtype=dtype, device=x.device)
     scales_shape = (M, triton.cdiv(N, block_size)) if axis == 1 else (triton.cdiv(M, block_size), N)
-    x_scales = torch.zeros(scales_shape, dtype=torch.float32, device=x.device)
+    x_scales = torch.empty(scales_shape, dtype=torch.float32, device=x.device)
 
     grid = (triton.cdiv(M, block_size), triton.cdiv(N, block_size))
     quant_fp8_blockwise_kernel[grid](
@@ -127,6 +128,56 @@ def quant_fp8_blockwise_impl_meta(
     scales_shape = (M, triton.cdiv(N, block_size)) if axis == 1 else (triton.cdiv(M, block_size), N)
     x_scales = torch.empty(scales_shape, dtype=torch.float32, device=x.device)
     return x_fp8, x_scales
+
+
+@triton_op("primus_turbo::quant_fp8_blockwise_dual_impl", mutates_args=())
+def quant_fp8_blockwise_dual_impl(
+    x: torch.Tensor,
+    dtype: torch.dtype,
+    block_size: int = 128,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Quantize a 2D tensor in both blockwise row and column modes in one pass."""
+    assert x.is_contiguous() and x.dim() == 2, "Input must be 2D and contiguous"
+
+    M, N = x.shape
+    row_scales_shape = (M, triton.cdiv(N, block_size))
+    col_scales_shape = (triton.cdiv(M, block_size), N)
+
+    x_fp8_row = torch.empty((M, N), dtype=dtype, device=x.device)
+    x_scales_row = torch.empty(row_scales_shape, dtype=torch.float32, device=x.device)
+    x_fp8_col = torch.empty((M, N), dtype=dtype, device=x.device)
+    x_scales_col = torch.empty(col_scales_shape, dtype=torch.float32, device=x.device)
+
+    grid = (triton.cdiv(M, block_size), triton.cdiv(N, block_size))
+    wrap_triton(quant_fp8_blockwise_dual_kernel)[grid](
+        x,
+        x_fp8_row,
+        x_scales_row,
+        x_fp8_col,
+        x_scales_col,
+        M,
+        N,
+        block_size,
+        torch.finfo(dtype).max,
+    )
+    return x_fp8_row, x_scales_row, x_fp8_col, x_scales_col
+
+
+@quant_fp8_blockwise_dual_impl.register_fake
+def quant_fp8_blockwise_dual_impl_meta(
+    x: torch.Tensor,
+    dtype: torch.dtype,
+    block_size: int = 128,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert x.dim() == 2, "Input must be 2D"
+    M, N = x.shape
+    row_scales_shape = (M, triton.cdiv(N, block_size))
+    col_scales_shape = (triton.cdiv(M, block_size), N)
+    x_fp8_row = torch.empty((M, N), dtype=dtype, device=x.device)
+    x_scales_row = torch.empty(row_scales_shape, dtype=torch.float32, device=x.device)
+    x_fp8_col = torch.empty((M, N), dtype=dtype, device=x.device)
+    x_scales_col = torch.empty(col_scales_shape, dtype=torch.float32, device=x.device)
+    return x_fp8_row, x_scales_row, x_fp8_col, x_scales_col
 
 
 @triton_op("primus_turbo::quant_fp8_blockwise_segment_m_impl", mutates_args=())

--- a/primus_turbo/pytorch/ops/gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/gemm_fp8.py
@@ -20,6 +20,7 @@ from primus_turbo.pytorch.core.low_precision import (
 )
 from primus_turbo.pytorch.kernels.gemm.gemm_fp8_impl import gemm_fp8_impl
 from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
+    quant_fp8_blockwise_dual_impl,
     quant_fp8_blockwise_for_weight_impl,
     quant_fp8_blockwise_impl,
 )
@@ -225,10 +226,30 @@ class FP8GemmBlockFunction(torch.autograd.Function):
         assert trans_a == False
         a_dtype = _get_fp8_dtype(config.format, True)
         b_dtype = _get_fp8_dtype(config.format, True)
+        a_dtype_bwd = _get_fp8_dtype(config.format, False)
 
-        a_fp8_row, a_scale_inv_row = quant_fp8_blockwise_impl(
-            a, a_dtype, axis=1, block_size=config.block_size
-        )
+        # When forward and backward share the same FP8 dtype (i.e. non-HYBRID
+        # formats), fuse forward row-quant with column-quant of the same
+        # activation in a single dual kernel pass and save the column result
+        # into ctx so the backward can skip its own column-quant launch.
+        # This is a kernel fusion (single tensor `a` is read once instead of
+        # twice) and does NOT depend on tensor identity across iterations.
+        fuse_a_dual = a_dtype == a_dtype_bwd and a.is_contiguous()
+
+        if fuse_a_dual:
+            (
+                a_fp8_row,
+                a_scale_inv_row,
+                a_fp8_col,
+                a_scale_inv_col,
+            ) = quant_fp8_blockwise_dual_impl(a, a_dtype, config.block_size)
+        else:
+            a_fp8_row, a_scale_inv_row = quant_fp8_blockwise_impl(
+                a, a_dtype, axis=1, block_size=config.block_size
+            )
+            a_fp8_col = None
+            a_scale_inv_col = None
+
         b_fp8, b_scale_inv = quant_fp8_blockwise_for_weight_impl(b, b_dtype, block_size=config.block_size)
 
         out = gemm_fp8_impl(
@@ -243,7 +264,12 @@ class FP8GemmBlockFunction(torch.autograd.Function):
             granularity=config.granularity.value,
             default_backend=BackendType.CK.value,
         )
-        ctx.save_for_backward(a, b_fp8, b_scale_inv)
+        if fuse_a_dual:
+            ctx.save_for_backward(b_fp8, b_scale_inv, a_fp8_col, a_scale_inv_col)
+            ctx.has_prequantized_a_col = True
+        else:
+            ctx.save_for_backward(a, b_fp8, b_scale_inv)
+            ctx.has_prequantized_a_col = False
         ctx.trans_a = trans_a
         ctx.trans_b = trans_b
         ctx.out_dtype = out_dtype
@@ -255,24 +281,25 @@ class FP8GemmBlockFunction(torch.autograd.Function):
         if not grad_out.is_contiguous():
             grad_out = grad_out.contiguous()
 
-        a, b_fp8, b_scale_inv = ctx.saved_tensors
+        if ctx.has_prequantized_a_col:
+            b_fp8, b_scale_inv, a_fp8_col, a_scale_inv_col = ctx.saved_tensors
+        else:
+            a, b_fp8, b_scale_inv = ctx.saved_tensors
+            a_dtype = _get_fp8_dtype(ctx.config.format, False)
+            a_fp8_col, a_scale_inv_col = quant_fp8_blockwise_impl(
+                a, a_dtype, axis=0, block_size=ctx.config.block_size
+            )
         grad_out_dtype = _get_fp8_dtype(ctx.config.format, False)
-        a_dtype = _get_fp8_dtype(ctx.config.format, False)
 
         # Quantize grad_out in both row-wise and column-wise directions:
         # - row-wise: for dgrad (grad_x)
         # - col-wise: for wgrad (grad_w)
-        grad_out_fp8_row, grad_out_scale_inv_row = quant_fp8_blockwise_impl(
-            grad_out, grad_out_dtype, -1, ctx.config.block_size
-        )
-        grad_out_fp8_col, grad_out_scale_inv_col = quant_fp8_blockwise_impl(
-            grad_out, grad_out_dtype, -2, ctx.config.block_size
-        )
-
-        # TODO: dequant + quant kernel
-        a_fp8_col, a_scale_inv_col = quant_fp8_blockwise_impl(
-            a, a_dtype, axis=0, block_size=ctx.config.block_size
-        )
+        (
+            grad_out_fp8_row,
+            grad_out_scale_inv_row,
+            grad_out_fp8_col,
+            grad_out_scale_inv_col,
+        ) = quant_fp8_blockwise_dual_impl(grad_out, grad_out_dtype, ctx.config.block_size)
 
         a_grad = gemm_fp8_impl(
             grad_out_fp8_row,

--- a/primus_turbo/triton/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_fp8_kernel.py
@@ -1037,8 +1037,11 @@ def gemm_fp8_blockwise_triton_kernel(
 ) -> torch.Tensor:
     """Unified block-wise FP8 GEMM Triton kernel.
 
-    Interface consistent with the CK blockwise backend.
-    Dispatches internally by (trans_a, trans_b) to the optimal layout.
+    Interface consistent with the CK blockwise backend. Internally normalises
+    the operands to a `[M, K] @ [K, N]` view and dispatches to one of three
+    layout-specialised autotune wrappers (NT/NN/TN); only the scale-tensor
+    layout, autotune wrapper, and a few constexpr flags differ between
+    layouts.
 
     Supported layouts:
       NT/RCR (forward):  trans_a=False, trans_b=True
@@ -1047,7 +1050,7 @@ def gemm_fp8_blockwise_triton_kernel(
 
       NN/RRR (grad_X):   trans_a=False, trans_b=False
         A: [M, K], A_scales: [M, K//128]
-        B: [N, K], B_scales: [N//128, K//128]  (2D, transposed internally)
+        B: [K, N], B_scales: [N//128, K//128]  (2D, transposed internally)
 
       TN/CRR (grad_W):   trans_a=True, trans_b=False
         A: [K, M], A_scales: [K//128, M]
@@ -1056,9 +1059,9 @@ def gemm_fp8_blockwise_triton_kernel(
     Args:
         a: FP8 input matrix.
         a_scale_inv: Block-wise scale for A, shape depends on layout.
-        trans_a: Whether A is transposed.
         b: FP8 input matrix.
         b_scale_inv: Block-wise scale for B, shape depends on layout.
+        trans_a: Whether A is transposed.
         trans_b: Whether B is transposed.
         out_dtype: Output dtype (default bfloat16).
         trans_c: If True, return transposed output.
@@ -1066,39 +1069,70 @@ def gemm_fp8_blockwise_triton_kernel(
     Returns:
         C of shape (M, N) if trans_c=False, or (N, M) if trans_c=True.
     """
-    if not trans_a and trans_b:
-        return _blockwise_nt(a, a_scale_inv, b, b_scale_inv, out_dtype, trans_c)
-    elif not trans_a and not trans_b:
-        return _blockwise_nn(a, a_scale_inv, b, b_scale_inv, out_dtype, trans_c)
-    elif trans_a and not trans_b:
-        return _blockwise_tn(a, a_scale_inv, b, b_scale_inv, out_dtype, trans_c)
-    else:
+    if (trans_a, trans_b) not in {(False, True), (False, False), (True, False)}:
         raise ValueError(f"Unsupported layout for blockwise FP8 Triton: trans_a={trans_a}, trans_b={trans_b}")
 
+    # ── Operand views: always [M, K] @ [K, N] inside the kernel.
+    A_view = a.T if trans_a else a
+    B_view = b.T if trans_b else b
+    M, K = A_view.shape
+    _, N = B_view.shape
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# Internal layout-specific helpers
-# ═══════════════════════════════════════════════════════════════════════════════
-
-
-def _blockwise_nt(
-    a: torch.Tensor,
-    a_scale_inv: torch.Tensor,
-    b: torch.Tensor,
-    b_scale_inv: torch.Tensor,
-    out_dtype: torch.dtype,
-    trans_c: bool,
-) -> torch.Tensor:
-    """NT/RCR forward: C = A[M,K] @ B[N,K].T, 2D B_scales."""
+    # AMD knobs: gfx950 always sets the gfx950 knobs; on gfx942 NT/NN benefit
+    # from use_async_copy/scalarize_packed_fops while TN/wgrad regresses 5-8%.
+    is_tn = trans_a and not trans_b
     if _is_gfx950():
         _set_knobs_gfx950()
     else:
-        _set_amd_knobs(enable=True)
+        _set_amd_knobs(enable=not is_tn)
 
-    M, K = a.shape
-    N = b.shape[0]
-    num_k = (K + 127) // 128
+    # ── Layout-specialised settings.
+    # The only true per-layout differences are: how A/B scales are laid out
+    # for the kernel, which autotune wrapper owns the search space/cache, and
+    # the three constexpr flags (SCALE_2D_B / EVEN_K / TRANS_C_STORE).
+    #
+    # TN safety notes (Round-6 P2-#7.6):
+    #   * `TRANS_C_STORE=True` lets the BF16 epilogue coalesce into dwordx4
+    #     under the `(N, M)` output buffer; without it the wgrad path emits
+    #     64×buffer_store_short per tile.
+    #   * `EVEN_K=False` keeps the mask-load path for the dual strided-K
+    #     loads, the matched-pair safety net for the Triton 3.7
+    #     `Begin <= End` LLVM-backend assertion (the TN autotune wrapper
+    #     already drops `num_stages=3`).
+    if not trans_a and trans_b:
+        # NT
+        A_scales_arg = a_scale_inv.T.contiguous()  # [K//128, M]
+        B_scales_arg = b_scale_inv  # [N//128, K//128]
+        autotune_kernel = _blockwise_fp8_nt_kernel
+        SCALE_2D_B, EVEN_K, TRANS_C_STORE = True, (K % 128) == 0, False
+    elif not trans_a and not trans_b:
+        # NN — kernel expects [N_output_blocks, K_inner_blocks] for B_scales,
+        # while quantization stores it as [N//128, K//128] over the original
+        # weight; the .T.contiguous() rebuilds the indexing the kernel reads.
+        A_scales_arg = a_scale_inv.T.contiguous()
+        B_scales_arg = b_scale_inv.T.contiguous()
+        autotune_kernel = _blockwise_fp8_nn_kernel
+        SCALE_2D_B, EVEN_K, TRANS_C_STORE = True, (K % 128) == 0, False
+    else:
+        # TN
+        A_scales_arg = a_scale_inv
+        B_scales_arg = b_scale_inv
+        autotune_kernel = _blockwise_fp8_tn_kernel
+        SCALE_2D_B, EVEN_K, TRANS_C_STORE = False, False, True
 
+    # Scale strides:
+    #   * SCALE_2D_B=True  (NT/NN): A_scales/B_scales are stored as [outer, inner],
+    #     so stride(0)/stride(1) directly map to (outer, inner) the kernel needs.
+    #   * SCALE_2D_B=False (TN):    B_scales is [K//128, N] but the kernel addresses
+    #     it as `pn * stride_bs_0 + ki * stride_bs_1` (N-step then K-step), hence
+    #     the (1, 0) swap.
+    stride_as_k, stride_as_m = A_scales_arg.stride(0), A_scales_arg.stride(1)
+    if SCALE_2D_B:
+        stride_bs_0, stride_bs_1 = B_scales_arg.stride(0), B_scales_arg.stride(1)
+    else:
+        stride_bs_0, stride_bs_1 = B_scales_arg.stride(1), B_scales_arg.stride(0)
+
+    # ── Output buffer (handle trans_c by swapping strides on a (N, M) buffer).
     if trans_c:
         out = torch.empty((N, M), device=a.device, dtype=out_dtype)
         stride_cm, stride_cn = out.stride(1), out.stride(0)
@@ -1106,179 +1140,34 @@ def _blockwise_nt(
         out = torch.empty((M, N), device=a.device, dtype=out_dtype)
         stride_cm, stride_cn = out.stride(0), out.stride(1)
 
-    A_scales_t = a_scale_inv.T.contiguous()  # [K//128, M]
-    B_t = b.T  # view [K, N]
-
-    num_m = (M + 127) // 128
-    num_n = (N + 127) // 128
-    NUM_SMS = num_m * num_n
-
-    _blockwise_fp8_nt_kernel[(NUM_SMS,)](
-        a,
-        B_t,
-        out,
-        A_scales_t,
-        b_scale_inv,
-        M,
-        N,
-        K,
-        a.stride(0),
-        1,  # stride_ak_val unused: A_K_CONTIGUOUS=True
-        1,  # stride_bk_val unused: B_K_CONTIGUOUS=True
-        B_t.stride(1),
-        stride_cm,
-        stride_cn,
-        A_scales_t.stride(0),
-        A_scales_t.stride(1),
-        b_scale_inv.stride(0),
-        b_scale_inv.stride(1),
-        NUM_SMS,
-        num_k,
-        A_K_CONTIGUOUS=True,
-        B_K_CONTIGUOUS=True,
-        SCALE_2D_B=True,
-        EVEN_K=(K % 128) == 0,
-        TRANS_C_STORE=False,
-    )
-    return out
-
-
-def _blockwise_nn(
-    a: torch.Tensor,
-    a_scale_inv: torch.Tensor,
-    b: torch.Tensor,
-    b_scale_inv: torch.Tensor,
-    out_dtype: torch.dtype,
-    trans_c: bool,
-) -> torch.Tensor:
-    """NN/RRR grad_X: C = A[M,K] @ B[K,N], 2D B_scales (transposed internally)."""
-    if _is_gfx950():
-        _set_knobs_gfx950()
-    else:
-        _set_amd_knobs(enable=True)
-
-    M, K = a.shape
-    _, N = b.shape
     num_k = (K + 127) // 128
+    NUM_SMS = ((M + 127) // 128) * ((N + 127) // 128)
 
-    if trans_c:
-        out = torch.empty((N, M), device=a.device, dtype=out_dtype)
-        stride_cm, stride_cn = out.stride(1), out.stride(0)
-    else:
-        out = torch.empty((M, N), device=a.device, dtype=out_dtype)
-        stride_cm, stride_cn = out.stride(0), out.stride(1)
-
-    A_scales_t = a_scale_inv.T.contiguous()  # [K//128, M]
-    # B_scales from quantization: [dim0_blocks, dim1_blocks] for weight stored as [N_fwd, K_fwd].
-    # Kernel expects [N_output_blocks, K_inner_blocks] indexing → transpose.
-    b_scale_inv_t = b_scale_inv.T.contiguous()
-
-    num_m = (M + 127) // 128
-    num_n = (N + 127) // 128
-    NUM_SMS = num_m * num_n
-
-    _blockwise_fp8_nn_kernel[(NUM_SMS,)](
-        a,
-        b,
-        out,
-        A_scales_t,
-        b_scale_inv_t,
-        M,
-        N,
-        K,
-        a.stride(0),
-        1,  # stride_ak_val unused: A_K_CONTIGUOUS=True
-        b.stride(0),
-        b.stride(1),
-        stride_cm,
-        stride_cn,
-        A_scales_t.stride(0),
-        A_scales_t.stride(1),
-        b_scale_inv_t.stride(0),
-        b_scale_inv_t.stride(1),
-        NUM_SMS,
-        num_k,
-        A_K_CONTIGUOUS=True,
-        B_K_CONTIGUOUS=False,
-        SCALE_2D_B=True,
-        EVEN_K=(K % 128) == 0,
-        TRANS_C_STORE=False,
-    )
-    return out
-
-
-def _blockwise_tn(
-    a: torch.Tensor,
-    a_scale_inv: torch.Tensor,
-    b: torch.Tensor,
-    b_scale_inv: torch.Tensor,
-    out_dtype: torch.dtype,
-    trans_c: bool,
-) -> torch.Tensor:
-    """TN/CRR grad_W: C = A[K,M].T @ B[K,N], 1D+1D B_scales.
-
-    Scale layouts (from axis=0 / column-wise quantization):
-      a_scale_inv: [K//128, M]
-      b_scale_inv: [K//128, N]
-    """
-    if _is_gfx950():
-        _set_knobs_gfx950()
-    else:
-        _set_amd_knobs(enable=False)
-
-    K, M = a.shape
-    _, N = b.shape
-    num_k = (K + 127) // 128
-
-    if trans_c:
-        out = torch.empty((N, M), device=a.device, dtype=out_dtype)
-        stride_cm, stride_cn = out.stride(1), out.stride(0)
-    else:
-        out = torch.empty((M, N), device=a.device, dtype=out_dtype)
-        stride_cm, stride_cn = out.stride(0), out.stride(1)
-
-    A_view = a.T  # [M, K] view with strided K
-
-    num_m = (M + 127) // 128
-    num_n = (N + 127) // 128
-    NUM_SMS = num_m * num_n
-
-    # Round-6 (P2-#7.6): wgrad runs under `trans_c=True` (output buffer is
-    # `(N, M)` with `stride_cm=1, stride_cn=N`). The shared kernel emits an
-    # element-wise `buffer_store_short[_d16_hi]` epilogue under that layout
-    # (64 store instructions per tile in dev). The unified kernel routes TN
-    # through the `TRANS_C_STORE=True` epilogue, which transposes `acc` before
-    # storing so BM is the innermost axis and the compiler can pack the BF16
-    # write into dwordx4. EVEN_K is forced to False here so this kernel keeps
-    # the historical mask-load path for the dual strided-K loads (avoids the
-    # Triton 3.7 `Begin <= End` LLVM-backend assertion that fired only on
-    # dual-strided + ns=3; the TN autotune wrapper already drops ns=3, but
-    # leaving EVEN_K=False is the matched-pair safety net).
-    _blockwise_fp8_tn_kernel[(NUM_SMS,)](
+    autotune_kernel[(NUM_SMS,)](
         A_view,
-        b,
+        B_view,
         out,
-        a_scale_inv,
-        b_scale_inv,
+        A_scales_arg,
+        B_scales_arg,
         M,
         N,
         K,
         A_view.stride(0),
         A_view.stride(1),
-        b.stride(0),
-        b.stride(1),
+        B_view.stride(0),
+        B_view.stride(1),
         stride_cm,
         stride_cn,
-        a_scale_inv.stride(0),
-        a_scale_inv.stride(1),  # [K//128, M]: stride_as_k=M, stride_as_m=1
-        b_scale_inv.stride(1),
-        b_scale_inv.stride(0),  # [K//128, N]: stride_bs_0=1(rn), stride_bs_1=N(ki)
+        stride_as_k,
+        stride_as_m,
+        stride_bs_0,
+        stride_bs_1,
         NUM_SMS,
         num_k,
-        A_K_CONTIGUOUS=False,
-        B_K_CONTIGUOUS=False,
-        SCALE_2D_B=False,
-        EVEN_K=False,
-        TRANS_C_STORE=True,
+        A_K_CONTIGUOUS=not trans_a,
+        B_K_CONTIGUOUS=trans_b,
+        SCALE_2D_B=SCALE_2D_B,
+        EVEN_K=EVEN_K,
+        TRANS_C_STORE=TRANS_C_STORE,
     )
     return out

--- a/primus_turbo/triton/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_fp8_kernel.py
@@ -22,8 +22,15 @@ Contains:
     - gemm_fp8_rowwise_triton_kernel: Public API
 
   Blockwise scaling:
-    - _blockwise_fp8_autotune_kernel: Core autotuned persistent kernel
-    - gemm_fp8_blockwise_triton_kernel: Unified public API (NT/NN/TN)
+    - _blockwise_fp8_unified_kernel: Single jit body shared by NT/NN/TN.
+      Layout differences (A/B K-contiguity, B-scale 2D vs 1D, EVEN_K fast
+      path, transposed-store epilogue) are guarded by `tl.constexpr` flags
+      so each (key tuple) compiles to an independent binary.
+    - _blockwise_fp8_{nt,nn,tn}_kernel: Layout-specialised `triton.autotune`
+      wrappers around the unified jit body. Each owns its own config search
+      space and best-config cache (NT: 96 configs, NN: 144 with
+      matrix_instr_nonkdim=16 stack on BM=256, TN: 64 without num_stages=3).
+    - gemm_fp8_blockwise_triton_kernel: Unified public API (NT/NN/TN).
 
 Environment variable: PRIMUS_TURBO_GEMM_BACKEND=TRITON activates these kernels.
 """
@@ -723,15 +730,15 @@ def gemm_fp8_rowwise_triton_kernel(
 # Fixed: BLOCK_N=128, BLOCK_K=128, wpe=2, mfma=16
 # Variable: BLOCK_M, kpack, GROUP_M, CHUNK, num_stages
 #
-# ``allow_num_stages_3`` is a per-kernel switch. The shared/wgrad kernel
-# (`_blockwise_fp8_autotune_kernel`) uses dual strided-K loads
+# ``allow_num_stages_3`` is a per-autotune-wrapper switch. The TN/wgrad
+# specialisation of the unified kernel uses dual strided-K loads
 # (A_K_CONTIGUOUS=False, B_K_CONTIGUOUS=False); on triton 3.7.0 the AMD
 # backend hits ``llvm/ADT/Sequence.h:275: Assertion `Begin <= End`'' (SIGABRT,
 # uncatchable by autotune) when ``num_stages=3`` is combined with that load
-# pattern. The contiguous-K NT/NN kernels do not exercise that backend path,
-# so they keep the full ns=[1,2,3] space on gfx950. This matches the historic
-# TN-wgrad-only fragility noted in tips.md (R57: dual-strided loads need
-# different code-gen guards than the other two layouts).
+# pattern. The contiguous-K NT/NN specialisations do not exercise that backend
+# path, so they keep the full ns=[1,2,3] space on gfx950. This matches the
+# historic TN-wgrad-only fragility noted in tips.md (R57: dual-strided loads
+# need different code-gen guards than the other two layouts).
 # ═══════════════════════════════════════════════════════════════════════════════
 def _get_blockwise_autotune_configs(
     allow_num_stages_3: bool = True,
@@ -810,20 +817,45 @@ def _get_blockwise_autotune_configs(
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Autotuned block-wise FP8 GEMM kernel
+# Unified blockwise FP8 GEMM kernel — single jit body shared by NT/NN/TN.
 #
-# ``allow_num_stages_3=False`` here drops 32 configs (96 → 64 on gfx950) that
-# trigger the triton 3.7.0 LLVM-backend assertion in the dual strided-K
-# (A_K_CONTIGUOUS=False, B_K_CONTIGUOUS=False) load path used by TN/wgrad.
-# Removing only this kernel's ns=3 candidates keeps the forward/dgrad search
-# spaces fully intact.
+# Layout differences are guarded by `tl.constexpr` flags so each (key tuple)
+# compiles to an independent binary equivalent to the previous per-layout
+# kernels (NT forward, NN dgrad, TN wgrad). The mapping is:
+#
+#     Layout │ A_K_CONTIGUOUS │ B_K_CONTIGUOUS │ SCALE_2D_B │ EVEN_K │ TRANS_C_STORE
+#     ───────┼────────────────┼────────────────┼────────────┼────────┼──────────────
+#     NT     │ True           │ True           │ True       │ K%128==0 │ False
+#     NN     │ True           │ False          │ True       │ K%128==0 │ False
+#     TN     │ False          │ False          │ False      │ False    │ True
+#
+# Kept invariants (do not break without re-benchmarking):
+#   * `EVEN_K` fast path skips the K-tail mask on NT/NN (R26: removes two
+#     `v_cmp_*` + one `v_cndmask_*` per K iteration). TN keeps the mask path
+#     because its `b_ptrs += BLOCK_K * stride_bk_val` arithmetic combined with
+#     `num_stages=3` triggered the historic Triton 3.7 LLVM-backend
+#     `Begin <= End` assertion; the TN autotune wrapper below already drops
+#     `ns=3`, but EVEN_K=False on TN is the matched safety net documented in
+#     `pr_report_blockwise_gemm_triton.md` §3.2.
+#   * `TRANS_C_STORE=True` takes the `tl.trans(acc)` epilogue so the BF16
+#     write coalesces into `(buffer|global)_store_dwordx4` under
+#     `trans_c=True` (stride_cm=1, stride_cn=N). NT/NN (`trans_c=False`) keep
+#     the direct store; their output buffer is BN-contiguous, so the direct
+#     epilogue is already vectorised.
+#
+# Three `triton.autotune` wrappers below specialise the kernel along the
+# dimensions that historically required separate search spaces:
+#   * NT  : 96 configs, key=("M","N","K","EVEN_K"), keeps `num_stages=3`.
+#   * NN  : 144 configs (96 + matrix_instr_nonkdim=16 stack on BM=256),
+#           key=("M","N","K","EVEN_K"), keeps `num_stages=3` (the nonkdim=16
+#           candidate is what avoids the 16-AGPR overflow on
+#           BM=256/nw=8/ns=3 documented in §3.3).
+#   * TN  : 64 configs (no `num_stages=3` — dual strided-K + ns=3 hits the
+#           Triton 3.7 AMD-backend assertion mentioned above),
+#           key=("M","N","K").
 # ═══════════════════════════════════════════════════════════════════════════════
-@triton.autotune(
-    configs=_get_blockwise_autotune_configs(allow_num_stages_3=False),
-    key=["M", "N", "K", "A_K_CONTIGUOUS", "B_K_CONTIGUOUS", "SCALE_2D_B"],
-)
 @triton.jit
-def _blockwise_fp8_autotune_kernel(
+def _blockwise_fp8_unified_kernel(
     A_ptr,
     B_ptr,
     C_ptr,
@@ -847,6 +879,8 @@ def _blockwise_fp8_autotune_kernel(
     A_K_CONTIGUOUS: tl.constexpr,
     B_K_CONTIGUOUS: tl.constexpr,
     SCALE_2D_B: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    TRANS_C_STORE: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
@@ -857,7 +891,7 @@ def _blockwise_fp8_autotune_kernel(
     pid = tl.program_id(0)
 
     # XCD-aware PID transform (inlined from _chiplet_transform_chunked
-    # because NUM_SMS is not constexpr in this kernel)
+    # because NUM_SMS is not constexpr in this kernel).
     if NUM_XCDS != 1:
         full_chunk_pids = (NUM_SMS // (NUM_XCDS * CHUNK)) * (NUM_XCDS * CHUNK)
         if pid <= full_chunk_pids:
@@ -913,19 +947,14 @@ def _blockwise_fp8_autotune_kernel(
         acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
 
         for ki in range(NUM_K_BLOCKS):
-            # Mask for partial K blocks (last iteration when K % BLOCK_K != 0)
-            k_remaining = K - ki * BLOCK_K
-            mask_k_col = rk[None, :] < k_remaining  # [1, BLOCK_K] for A
-            mask_k_row = rk[:, None] < k_remaining  # [BLOCK_K, 1] for B
-
-            if A_K_CONTIGUOUS:
-                a = tl.load(a_ptrs, mask=mask_k_col, other=0.0, cache_modifier=".ca")
+            if EVEN_K:
+                a = tl.load(a_ptrs, cache_modifier=".ca")
+                b = tl.load(b_ptrs, cache_modifier=".ca")
             else:
+                k_remaining = K - ki * BLOCK_K
+                mask_k_col = rk[None, :] < k_remaining
+                mask_k_row = rk[:, None] < k_remaining
                 a = tl.load(a_ptrs, mask=mask_k_col, other=0.0, cache_modifier=".ca")
-
-            if B_K_CONTIGUOUS:
-                b = tl.load(b_ptrs, mask=mask_k_row, other=0.0, cache_modifier=".ca")
-            else:
                 b = tl.load(b_ptrs, mask=mask_k_row, other=0.0, cache_modifier=".ca")
 
             partial = tl.dot(a, b, input_precision="ieee")
@@ -951,366 +980,43 @@ def _blockwise_fp8_autotune_kernel(
 
         offs_m = pm * BLOCK_M + tl.arange(0, BLOCK_M)
         offs_n = pn * BLOCK_N + tl.arange(0, BLOCK_N)
-        c_ptrs = C_ptr + offs_m[:, None].to(tl.int64) * stride_cm + offs_n[None, :].to(tl.int64) * stride_cn
-        mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
-        tl.store(c_ptrs, acc.to(C_ptr.type.element_ty), mask)
+        if TRANS_C_STORE:
+            # `trans_c=True` flips the output to (N, M) with stride_cm=1 and
+            # stride_cn=N. Without `tl.trans`, the BF16 store degrades to
+            # 64×buffer_store_short per tile; transposing here lets the
+            # compiler emit (buffer|global)_store_dwordx4 ×4-8.
+            c_ptrs_t = (
+                C_ptr + offs_n[:, None].to(tl.int64) * stride_cn + offs_m[None, :].to(tl.int64) * stride_cm
+            )
+            mask_t = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+            acc_t = tl.trans(acc.to(C_ptr.type.element_ty))
+            tl.store(c_ptrs_t, acc_t, mask_t)
+        else:
+            c_ptrs = (
+                C_ptr + offs_m[:, None].to(tl.int64) * stride_cm + offs_n[None, :].to(tl.int64) * stride_cn
+            )
+            mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+            tl.store(c_ptrs, acc.to(C_ptr.type.element_ty), mask)
 
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# TN/wgrad-specialised kernel. Same compute body as `_blockwise_fp8_autotune_kernel`
-# with `A_K_CONTIGUOUS=False, B_K_CONTIGUOUS=False, SCALE_2D_B=False` hardcoded
-# and a transposed store epilogue that lets the BF16 write coalesce into
-# `buffer_store_dwordx4` instead of element-wise `buffer_store_short[_d16_hi]`.
-#
-# Round-6 (P2-#7.6) hypothesis: wgrad runs under `trans_c=True` (so the
-# returned (N, M) buffer has `stride_cm=1, stride_cn=N`). The shared kernel
-# writes `acc[BM, BN]` with `stride_cm=1`, which forces BN to be the strided
-# axis at store time → no vectorisation, 64 element-wise `short` stores per
-# tile in the dev branch (32 low-half + 32 high-half). By emitting
-# `tl.trans(acc)` (shape `[BN, BM]`) and swapping the pointer arithmetic so
-# that the innermost iteration over BM hits `stride_cm=1`, the same write
-# becomes a vectorised 128-bit packed store, in line with the NT/NN epilogue.
-# ═══════════════════════════════════════════════════════════════════════════════
-@triton.autotune(
-    configs=_get_blockwise_autotune_configs(allow_num_stages_3=False),
-    key=["M", "N", "K"],
-)
-@triton.jit
-def _blockwise_fp8_tn_kernel(
-    A_ptr,
-    B_ptr,
-    C_ptr,
-    A_scales_ptr,
-    B_scales_ptr,
-    M,
-    N,
-    K,
-    stride_am,
-    stride_ak_val,
-    stride_bk_val,
-    stride_bn,
-    stride_cm,
-    stride_cn,
-    stride_as_k,
-    stride_as_m,
-    stride_bs_0,
-    stride_bs_1,
-    NUM_SMS,
-    NUM_K_BLOCKS,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-    GROUP_M: tl.constexpr,
-    NUM_XCDS: tl.constexpr,
-    CHUNK: tl.constexpr,
-):
-    pid = tl.program_id(0)
-
-    if NUM_XCDS != 1:
-        full_chunk_pids = (NUM_SMS // (NUM_XCDS * CHUNK)) * (NUM_XCDS * CHUNK)
-        if pid <= full_chunk_pids:
-            local_pid = pid // NUM_XCDS
-            chunk_idx = local_pid // CHUNK
-            pos_in_chunk = local_pid % CHUNK
-            xcd = pid % NUM_XCDS
-            pid = chunk_idx * NUM_XCDS * CHUNK + xcd * CHUNK + pos_in_chunk
-
-    num_m = tl.cdiv(M, BLOCK_M)
-    num_n = tl.cdiv(N, BLOCK_N)
-    total = num_m * num_n
-    grp = GROUP_M * num_n
-
-    tl.assume(stride_am > 0)
-    tl.assume(stride_bn > 0)
-    tl.assume(stride_cm > 0)
-    tl.assume(stride_cn > 0)
-
-    for tid in range(pid, total, NUM_SMS):
-        gid = tid // grp
-        fm = gid * GROUP_M
-        gs = min(num_m - fm, GROUP_M)
-        pm = fm + (tid % grp) % gs
-        pn = (tid % grp) // gs
-        tl.assume(pm >= 0)
-        tl.assume(pn >= 0)
-
-        rm = tl.max_contiguous(tl.multiple_of((pm * BLOCK_M + tl.arange(0, BLOCK_M)) % M, BLOCK_M), BLOCK_M)
-        rn = tl.max_contiguous(tl.multiple_of((pn * BLOCK_N + tl.arange(0, BLOCK_N)) % N, BLOCK_N), BLOCK_N)
-        rk = tl.arange(0, BLOCK_K)
-
-        # TN: A is (K, M) stored with K as leading dim → A_K_CONTIGUOUS=False.
-        a_ptrs = A_ptr + rm[:, None].to(tl.int64) * stride_am + rk[None, :].to(tl.int64) * stride_ak_val
-        # TN: B is (K, N) stored with K as leading dim → B_K_CONTIGUOUS=False.
-        b_ptrs = B_ptr + rk[:, None].to(tl.int64) * stride_bk_val + rn[None, :].to(tl.int64) * stride_bn
-
-        as_ptrs = A_scales_ptr + rm * stride_as_m
-        # SCALE_2D_B=False for TN; per-N scale vector indexed by `rn`.
-        bs_ptrs = B_scales_ptr + rn * stride_bs_0
-
-        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-
-        for ki in range(NUM_K_BLOCKS):
-            k_remaining = K - ki * BLOCK_K
-            mask_k_col = rk[None, :] < k_remaining
-            mask_k_row = rk[:, None] < k_remaining
-
-            a = tl.load(a_ptrs, mask=mask_k_col, other=0.0, cache_modifier=".ca")
-            b = tl.load(b_ptrs, mask=mask_k_row, other=0.0, cache_modifier=".ca")
-
-            partial = tl.dot(a, b, input_precision="ieee")
-
-            a_s = tl.load(as_ptrs + ki * stride_as_k)
-            b_s = tl.load(bs_ptrs + ki * stride_bs_1)
-            acc += partial * a_s[:, None] * b_s[None, :]
-
-            a_ptrs += BLOCK_K * stride_ak_val
-            b_ptrs += BLOCK_K * stride_bk_val
-
-        offs_m = pm * BLOCK_M + tl.arange(0, BLOCK_M)
-        offs_n = pn * BLOCK_N + tl.arange(0, BLOCK_N)
-        # Transposed store: write acc^T[BN, BM] with the innermost iteration
-        # over BM (which is the contiguous axis under trans_c=True, stride_cm=1).
-        # Memory layout is unchanged; only the register-side index order is
-        # swapped, so the compiler can coalesce the BF16 store into dwordx4.
-        c_ptrs_t = C_ptr + offs_n[:, None].to(tl.int64) * stride_cn + offs_m[None, :].to(tl.int64) * stride_cm
-        mask_t = (offs_n[:, None] < N) & (offs_m[None, :] < M)
-        acc_t = tl.trans(acc.to(C_ptr.type.element_ty))
-        tl.store(c_ptrs_t, acc_t, mask_t)
-
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# Forward-NT-specialised kernel: same logic as the shared kernel but with
-# `A_K_CONTIGUOUS=True, B_K_CONTIGUOUS=True, SCALE_2D_B=True` hardcoded (since
-# this variant is only called from `_blockwise_nt`) and an `EVEN_K` fast-path
-# that skips the K-mask arithmetic when `K % BLOCK_K == 0`. Duplicating the
-# kernel source instead of adding another guard to the shared kernel avoids the
-# R26 / R53 fragility — the shared kernel's strided-load backward paths are
-# untouched.
-# ═══════════════════════════════════════════════════════════════════════════════
-@triton.autotune(
+# Layout-specialised autotune wrappers around the shared jit body. Each wrapper
+# owns an independent `Autotuner` instance with its own config search space and
+# best-config cache; the underlying jit kernel is shared, so binaries are still
+# emitted per (autotune key + constexpr) tuple.
+_blockwise_fp8_nt_kernel = triton.autotune(
     configs=_get_blockwise_autotune_configs(),
     key=["M", "N", "K", "EVEN_K"],
-)
-@triton.jit
-def _blockwise_fp8_nt_kernel(
-    A_ptr,
-    B_ptr,
-    C_ptr,
-    A_scales_ptr,
-    B_scales_ptr,
-    M,
-    N,
-    K,
-    stride_am,
-    stride_bn,
-    stride_cm,
-    stride_cn,
-    stride_as_k,
-    stride_as_m,
-    stride_bs_0,
-    stride_bs_1,
-    NUM_SMS,
-    NUM_K_BLOCKS,
-    EVEN_K: tl.constexpr,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-    GROUP_M: tl.constexpr,
-    NUM_XCDS: tl.constexpr,
-    CHUNK: tl.constexpr,
-):
-    pid = tl.program_id(0)
+)(_blockwise_fp8_unified_kernel)
 
-    if NUM_XCDS != 1:
-        full_chunk_pids = (NUM_SMS // (NUM_XCDS * CHUNK)) * (NUM_XCDS * CHUNK)
-        if pid <= full_chunk_pids:
-            local_pid = pid // NUM_XCDS
-            chunk_idx = local_pid // CHUNK
-            pos_in_chunk = local_pid % CHUNK
-            xcd = pid % NUM_XCDS
-            pid = chunk_idx * NUM_XCDS * CHUNK + xcd * CHUNK + pos_in_chunk
-
-    num_m = tl.cdiv(M, BLOCK_M)
-    num_n = tl.cdiv(N, BLOCK_N)
-    total = num_m * num_n
-    grp = GROUP_M * num_n
-
-    tl.assume(stride_am > 0)
-    tl.assume(stride_bn > 0)
-    tl.assume(stride_cm > 0)
-    tl.assume(stride_cn > 0)
-
-    for tid in range(pid, total, NUM_SMS):
-        gid = tid // grp
-        fm = gid * GROUP_M
-        gs = min(num_m - fm, GROUP_M)
-        pm = fm + (tid % grp) % gs
-        pn = (tid % grp) // gs
-        tl.assume(pm >= 0)
-        tl.assume(pn >= 0)
-
-        rm = tl.max_contiguous(tl.multiple_of((pm * BLOCK_M + tl.arange(0, BLOCK_M)) % M, BLOCK_M), BLOCK_M)
-        rn = tl.max_contiguous(tl.multiple_of((pn * BLOCK_N + tl.arange(0, BLOCK_N)) % N, BLOCK_N), BLOCK_N)
-        rk = tl.arange(0, BLOCK_K)
-
-        # NT-only: A_K_CONTIGUOUS=True, B_K_CONTIGUOUS=True.
-        a_ptrs = A_ptr + rm[:, None].to(tl.int64) * stride_am + rk[None, :].to(tl.int64)
-        b_ptrs = B_ptr + rk[:, None].to(tl.int64) + rn[None, :].to(tl.int64) * stride_bn
-
-        as_ptrs = A_scales_ptr + rm * stride_as_m
-
-        # NT-only: SCALE_2D_B=True. B scales are still on 128-column granularity.
-        scale_block_n = (pn * BLOCK_N) // 128
-        bs_ptr_base = B_scales_ptr + scale_block_n * stride_bs_0
-
-        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-
-        for ki in range(NUM_K_BLOCKS):
-            if EVEN_K:
-                a = tl.load(a_ptrs, cache_modifier=".ca")
-                b = tl.load(b_ptrs, cache_modifier=".ca")
-            else:
-                k_remaining = K - ki * BLOCK_K
-                mask_k_col = rk[None, :] < k_remaining
-                mask_k_row = rk[:, None] < k_remaining
-                a = tl.load(a_ptrs, mask=mask_k_col, other=0.0, cache_modifier=".ca")
-                b = tl.load(b_ptrs, mask=mask_k_row, other=0.0, cache_modifier=".ca")
-
-            partial = tl.dot(a, b, input_precision="ieee")
-
-            a_s = tl.load(as_ptrs + ki * stride_as_k)
-            b_s = tl.load(bs_ptr_base + ki * stride_bs_1)
-            acc += partial * (a_s * b_s)[:, None]
-
-            a_ptrs += BLOCK_K
-            b_ptrs += BLOCK_K
-
-        offs_m = pm * BLOCK_M + tl.arange(0, BLOCK_M)
-        offs_n = pn * BLOCK_N + tl.arange(0, BLOCK_N)
-        c_ptrs = C_ptr + offs_m[:, None].to(tl.int64) * stride_cm + offs_n[None, :].to(tl.int64) * stride_cn
-        mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
-        tl.store(c_ptrs, acc.to(C_ptr.type.element_ty), mask)
-
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# Backward-NN-specialised kernel for dgrad: `A_K_CONTIGUOUS=True,
-# B_K_CONTIGUOUS=False, SCALE_2D_B=True` hardcoded. Same `EVEN_K` fast-path as
-# the NT variant. The B-load path stays strided (B is not K-contiguous in NN
-# dgrad), so we keep that arithmetic but drop the branch on it.
-#
-# Round-4 (P2-#7.5): add `matrix_instr_nonkdim=16` candidates to the NN
-# autotune space. On gfx950 the Triton default selects 32x32x64 MFMA, which
-# allocates 16 AGPR per warp for the accumulator; on the BM=256 nw=8 ns=3
-# config this overflows into AGPR (405 v_accvgpr_* in the K-loop body of
-# the dev branch, 24% of NN kernel ASM, see tmp/perf_analysis_fp8_blockwise.md
-# §4.6). The 16x16x128 variant uses 4 AGPR per warp, so for shapes where
-# AGPR pressure is the bottleneck the autotuner can swap. NT and wgrad
-# autotune are left unchanged (their bottlenecks are elsewhere).
-# ═══════════════════════════════════════════════════════════════════════════════
-@triton.autotune(
+_blockwise_fp8_nn_kernel = triton.autotune(
     configs=_get_blockwise_autotune_configs(extra_matrix_instr_nonkdim=[16]),
     key=["M", "N", "K", "EVEN_K"],
-)
-@triton.jit
-def _blockwise_fp8_nn_kernel(
-    A_ptr,
-    B_ptr,
-    C_ptr,
-    A_scales_ptr,
-    B_scales_ptr,
-    M,
-    N,
-    K,
-    stride_am,
-    stride_bk_val,
-    stride_bn,
-    stride_cm,
-    stride_cn,
-    stride_as_k,
-    stride_as_m,
-    stride_bs_0,
-    stride_bs_1,
-    NUM_SMS,
-    NUM_K_BLOCKS,
-    EVEN_K: tl.constexpr,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-    GROUP_M: tl.constexpr,
-    NUM_XCDS: tl.constexpr,
-    CHUNK: tl.constexpr,
-):
-    pid = tl.program_id(0)
+)(_blockwise_fp8_unified_kernel)
 
-    if NUM_XCDS != 1:
-        full_chunk_pids = (NUM_SMS // (NUM_XCDS * CHUNK)) * (NUM_XCDS * CHUNK)
-        if pid <= full_chunk_pids:
-            local_pid = pid // NUM_XCDS
-            chunk_idx = local_pid // CHUNK
-            pos_in_chunk = local_pid % CHUNK
-            xcd = pid % NUM_XCDS
-            pid = chunk_idx * NUM_XCDS * CHUNK + xcd * CHUNK + pos_in_chunk
-
-    num_m = tl.cdiv(M, BLOCK_M)
-    num_n = tl.cdiv(N, BLOCK_N)
-    total = num_m * num_n
-    grp = GROUP_M * num_n
-
-    tl.assume(stride_am > 0)
-    tl.assume(stride_bn > 0)
-    tl.assume(stride_cm > 0)
-    tl.assume(stride_cn > 0)
-
-    for tid in range(pid, total, NUM_SMS):
-        gid = tid // grp
-        fm = gid * GROUP_M
-        gs = min(num_m - fm, GROUP_M)
-        pm = fm + (tid % grp) % gs
-        pn = (tid % grp) // gs
-        tl.assume(pm >= 0)
-        tl.assume(pn >= 0)
-
-        rm = tl.max_contiguous(tl.multiple_of((pm * BLOCK_M + tl.arange(0, BLOCK_M)) % M, BLOCK_M), BLOCK_M)
-        rn = tl.max_contiguous(tl.multiple_of((pn * BLOCK_N + tl.arange(0, BLOCK_N)) % N, BLOCK_N), BLOCK_N)
-        rk = tl.arange(0, BLOCK_K)
-
-        # NN: A_K_CONTIGUOUS=True, B_K_CONTIGUOUS=False (B is strided in K).
-        a_ptrs = A_ptr + rm[:, None].to(tl.int64) * stride_am + rk[None, :].to(tl.int64)
-        b_ptrs = B_ptr + rk[:, None].to(tl.int64) * stride_bk_val + rn[None, :].to(tl.int64) * stride_bn
-
-        as_ptrs = A_scales_ptr + rm * stride_as_m
-
-        # NN: SCALE_2D_B=True.
-        scale_block_n = (pn * BLOCK_N) // 128
-        bs_ptr_base = B_scales_ptr + scale_block_n * stride_bs_0
-
-        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-
-        for ki in range(NUM_K_BLOCKS):
-            if EVEN_K:
-                a = tl.load(a_ptrs, cache_modifier=".ca")
-                b = tl.load(b_ptrs, cache_modifier=".ca")
-            else:
-                k_remaining = K - ki * BLOCK_K
-                mask_k_col = rk[None, :] < k_remaining
-                mask_k_row = rk[:, None] < k_remaining
-                a = tl.load(a_ptrs, mask=mask_k_col, other=0.0, cache_modifier=".ca")
-                b = tl.load(b_ptrs, mask=mask_k_row, other=0.0, cache_modifier=".ca")
-
-            partial = tl.dot(a, b, input_precision="ieee")
-
-            a_s = tl.load(as_ptrs + ki * stride_as_k)
-            b_s = tl.load(bs_ptr_base + ki * stride_bs_1)
-            acc += partial * (a_s * b_s)[:, None]
-
-            a_ptrs += BLOCK_K
-            b_ptrs += BLOCK_K * stride_bk_val
-
-        offs_m = pm * BLOCK_M + tl.arange(0, BLOCK_M)
-        offs_n = pn * BLOCK_N + tl.arange(0, BLOCK_N)
-        c_ptrs = C_ptr + offs_m[:, None].to(tl.int64) * stride_cm + offs_n[None, :].to(tl.int64) * stride_cn
-        mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
-        tl.store(c_ptrs, acc.to(C_ptr.type.element_ty), mask)
+_blockwise_fp8_tn_kernel = triton.autotune(
+    configs=_get_blockwise_autotune_configs(allow_num_stages_3=False),
+    key=["M", "N", "K"],
+)(_blockwise_fp8_unified_kernel)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1417,6 +1123,8 @@ def _blockwise_nt(
         N,
         K,
         a.stride(0),
+        1,  # stride_ak_val unused: A_K_CONTIGUOUS=True
+        1,  # stride_bk_val unused: B_K_CONTIGUOUS=True
         B_t.stride(1),
         stride_cm,
         stride_cn,
@@ -1426,7 +1134,11 @@ def _blockwise_nt(
         b_scale_inv.stride(1),
         NUM_SMS,
         num_k,
+        A_K_CONTIGUOUS=True,
+        B_K_CONTIGUOUS=True,
+        SCALE_2D_B=True,
         EVEN_K=(K % 128) == 0,
+        TRANS_C_STORE=False,
     )
     return out
 
@@ -1475,6 +1187,7 @@ def _blockwise_nn(
         N,
         K,
         a.stride(0),
+        1,  # stride_ak_val unused: A_K_CONTIGUOUS=True
         b.stride(0),
         b.stride(1),
         stride_cm,
@@ -1485,7 +1198,11 @@ def _blockwise_nn(
         b_scale_inv_t.stride(1),
         NUM_SMS,
         num_k,
+        A_K_CONTIGUOUS=True,
+        B_K_CONTIGUOUS=False,
+        SCALE_2D_B=True,
         EVEN_K=(K % 128) == 0,
+        TRANS_C_STORE=False,
     )
     return out
 
@@ -1529,11 +1246,14 @@ def _blockwise_tn(
     # Round-6 (P2-#7.6): wgrad runs under `trans_c=True` (output buffer is
     # `(N, M)` with `stride_cm=1, stride_cn=N`). The shared kernel emits an
     # element-wise `buffer_store_short[_d16_hi]` epilogue under that layout
-    # (64 store instructions per tile in dev). The TN-specialised kernel
-    # transposes `acc` before storing so BM is the innermost axis and the
-    # compiler can pack the BF16 write into dwordx4. Layout constexprs
-    # (`A/B_K_CONTIGUOUS=False`, `SCALE_2D_B=False`) are hardcoded inside the
-    # TN kernel and no longer passed at the call-site.
+    # (64 store instructions per tile in dev). The unified kernel routes TN
+    # through the `TRANS_C_STORE=True` epilogue, which transposes `acc` before
+    # storing so BM is the innermost axis and the compiler can pack the BF16
+    # write into dwordx4. EVEN_K is forced to False here so this kernel keeps
+    # the historical mask-load path for the dual strided-K loads (avoids the
+    # Triton 3.7 `Begin <= End` LLVM-backend assertion that fired only on
+    # dual-strided + ns=3; the TN autotune wrapper already drops ns=3, but
+    # leaving EVEN_K=False is the matched-pair safety net).
     _blockwise_fp8_tn_kernel[(NUM_SMS,)](
         A_view,
         b,
@@ -1555,5 +1275,10 @@ def _blockwise_tn(
         b_scale_inv.stride(0),  # [K//128, N]: stride_bs_0=1(rn), stride_bs_1=N(ki)
         NUM_SMS,
         num_k,
+        A_K_CONTIGUOUS=False,
+        B_K_CONTIGUOUS=False,
+        SCALE_2D_B=False,
+        EVEN_K=False,
+        TRANS_C_STORE=True,
     )
     return out

--- a/primus_turbo/triton/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_fp8_kernel.py
@@ -217,7 +217,7 @@ def _fp8_persistent_gemm_kernel(
             else:
                 b = tl.load(tl.multiple_of(B_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER_B)
 
-            acc += tl.dot(a, b, input_precision="ieee")
+            acc += tl.dot(a, b)
             A_BASE += BLOCK_SIZE_K * stride_ak
             B_BASE += BLOCK_SIZE_K * stride_bk
 
@@ -236,7 +236,7 @@ def _fp8_persistent_gemm_kernel(
                 B_BASE = tl.multiple_of(B_BASE, (1, 16))
             a = tl.load(A_BASE, mask=rk[None, :] < K, other=0.0, cache_modifier=CACHE_MODIFIER_A)
             b = tl.load(B_BASE, mask=rk[:, None] < K, other=0.0, cache_modifier=CACHE_MODIFIER_B)
-            acc += tl.dot(a, b, input_precision="ieee")
+            acc += tl.dot(a, b)
 
         # Apply per-tensor scale
         acc *= scale
@@ -514,7 +514,7 @@ def _fp8_rowwise_persistent_gemm_kernel(
             else:
                 b = tl.load(tl.multiple_of(B_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER_B)
 
-            acc += tl.dot(a, b, input_precision="ieee")
+            acc += tl.dot(a, b)
             A_BASE += BLOCK_SIZE_K * stride_ak
             B_BASE += BLOCK_SIZE_K * stride_bk
 
@@ -533,7 +533,7 @@ def _fp8_rowwise_persistent_gemm_kernel(
                 B_BASE = tl.multiple_of(B_BASE, (1, 16))
             a = tl.load(A_BASE, mask=rk[None, :] < K, other=0.0, cache_modifier=CACHE_MODIFIER_A)
             b = tl.load(B_BASE, mask=rk[:, None] < K, other=0.0, cache_modifier=CACHE_MODIFIER_B)
-            acc += tl.dot(a, b, input_precision="ieee")
+            acc += tl.dot(a, b)
 
         # Apply per-row/per-col vector scales
         a_scale = tl.load(A_scale_ptr + rm)
@@ -957,7 +957,7 @@ def _blockwise_fp8_unified_kernel(
                 a = tl.load(a_ptrs, mask=mask_k_col, other=0.0, cache_modifier=".ca")
                 b = tl.load(b_ptrs, mask=mask_k_row, other=0.0, cache_modifier=".ca")
 
-            partial = tl.dot(a, b, input_precision="ieee")
+            partial = tl.dot(a, b)
 
             a_s = tl.load(as_ptrs + ki * stride_as_k)
 

--- a/primus_turbo/triton/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_fp8_kernel.py
@@ -719,25 +719,61 @@ def gemm_fp8_rowwise_triton_kernel(
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Blockwise autotune configs (32 total)
+# Blockwise autotune configs
 # Fixed: BLOCK_N=128, BLOCK_K=128, wpe=2, mfma=16
 # Variable: BLOCK_M, kpack, GROUP_M, CHUNK, num_stages
+#
+# ``allow_num_stages_3`` is a per-kernel switch. The shared/wgrad kernel
+# (`_blockwise_fp8_autotune_kernel`) uses dual strided-K loads
+# (A_K_CONTIGUOUS=False, B_K_CONTIGUOUS=False); on triton 3.7.0 the AMD
+# backend hits ``llvm/ADT/Sequence.h:275: Assertion `Begin <= End`'' (SIGABRT,
+# uncatchable by autotune) when ``num_stages=3`` is combined with that load
+# pattern. The contiguous-K NT/NN kernels do not exercise that backend path,
+# so they keep the full ns=[1,2,3] space on gfx950. This matches the historic
+# TN-wgrad-only fragility noted in tips.md (R57: dual-strided loads need
+# different code-gen guards than the other two layouts).
 # ═══════════════════════════════════════════════════════════════════════════════
-def _get_blockwise_autotune_configs():
+def _get_blockwise_autotune_configs(
+    allow_num_stages_3: bool = True,
+    extra_matrix_instr_nonkdim: list | None = None,
+):
+    """Generate blockwise FP8 GEMM autotune configs.
+
+    Args:
+        allow_num_stages_3: whether to include `num_stages=3` candidates.
+            Set False for the dual strided-K wgrad kernel which hits a
+            Triton 3.7.0 LLVM-backend assertion at ns=3.
+        extra_matrix_instr_nonkdim: extra `matrix_instr_nonkdim` values to
+            stack on top of the Triton default (which selects 32x32x64 for
+            FP8 on gfx950). For example, passing ``[16]`` doubles the
+            candidate space by emitting an extra copy of every (BM, BN,
+            ns, gm, chunk) tuple with ``matrix_instr_nonkdim=16`` so the
+            autotuner can pick `v_mfma_f32_16x16x128_f8f6f4` when that
+            instruction wins (typically the AGPR-bound NN/dgrad path).
+            ``None`` keeps the original search space.
+    """
     configs = []
-    for block_m, kp, gm, chunk, ns in itertools.product(
+    if _is_gfx950():
+        num_stage_values = [1, 2, 3] if allow_num_stages_3 else [1, 2]
+        block_n_values = [64, 128]
+    else:
+        num_stage_values = [1, 2]
+        block_n_values = [128]
+    for block_m, block_n, kp, gm, chunk, ns in itertools.product(
         [128, 256],
+        block_n_values,
         [1, 2],
         [4, 8],
         [32, 64],
-        [1, 2],
+        num_stage_values,
     ):
         nw = 4 if block_m == 128 else 8
+        # Default-nonkdim (Triton picks 32x32x64 for FP8 on gfx950).
         configs.append(
             triton.Config(
                 {
                     "BLOCK_M": block_m,
-                    "BLOCK_N": 128,
+                    "BLOCK_N": block_n,
                     "BLOCK_K": 128,
                     "GROUP_M": gm,
                     "NUM_XCDS": 8,
@@ -748,14 +784,42 @@ def _get_blockwise_autotune_configs():
                 pre_hook=None,
             )
         )
+        # Extra nonkdim variants are only added for BM=256 + nw=8 configs,
+        # which is the only branch where 32x32x64 actually overflows into
+        # AGPR. BM=128 + nw=4 already fits 16 AGPR comfortably, so we keep
+        # the search space tight and skip the duplicate compile cost there.
+        if extra_matrix_instr_nonkdim and block_m == 256:
+            for nonkdim in extra_matrix_instr_nonkdim:
+                configs.append(
+                    triton.Config(
+                        {
+                            "BLOCK_M": block_m,
+                            "BLOCK_N": block_n,
+                            "BLOCK_K": 128,
+                            "GROUP_M": gm,
+                            "NUM_XCDS": 8,
+                            "CHUNK": chunk,
+                            "matrix_instr_nonkdim": nonkdim,
+                        },
+                        num_warps=nw,
+                        num_stages=ns,
+                        pre_hook=None,
+                    )
+                )
     return configs
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Autotuned block-wise FP8 GEMM kernel
+#
+# ``allow_num_stages_3=False`` here drops 32 configs (96 → 64 on gfx950) that
+# trigger the triton 3.7.0 LLVM-backend assertion in the dual strided-K
+# (A_K_CONTIGUOUS=False, B_K_CONTIGUOUS=False) load path used by TN/wgrad.
+# Removing only this kernel's ns=3 candidates keeps the forward/dgrad search
+# spaces fully intact.
 # ═══════════════════════════════════════════════════════════════════════════════
 @triton.autotune(
-    configs=_get_blockwise_autotune_configs(),
+    configs=_get_blockwise_autotune_configs(allow_num_stages_3=False),
     key=["M", "N", "K", "A_K_CONTIGUOUS", "B_K_CONTIGUOUS", "SCALE_2D_B"],
 )
 @triton.jit
@@ -827,19 +891,22 @@ def _blockwise_fp8_autotune_kernel(
         rk = tl.arange(0, BLOCK_K)
 
         if A_K_CONTIGUOUS:
-            a_ptrs = A_ptr + rm[:, None] * stride_am + rk[None, :]
+            a_ptrs = A_ptr + rm[:, None].to(tl.int64) * stride_am + rk[None, :].to(tl.int64)
         else:
-            a_ptrs = A_ptr + rm[:, None] * stride_am + rk[None, :] * stride_ak_val
+            a_ptrs = A_ptr + rm[:, None].to(tl.int64) * stride_am + rk[None, :].to(tl.int64) * stride_ak_val
 
         if B_K_CONTIGUOUS:
-            b_ptrs = B_ptr + rk[:, None] + rn[None, :] * stride_bn
+            b_ptrs = B_ptr + rk[:, None].to(tl.int64) + rn[None, :].to(tl.int64) * stride_bn
         else:
-            b_ptrs = B_ptr + rk[:, None] * stride_bk_val + rn[None, :] * stride_bn
+            b_ptrs = B_ptr + rk[:, None].to(tl.int64) * stride_bk_val + rn[None, :].to(tl.int64) * stride_bn
 
         as_ptrs = A_scales_ptr + rm * stride_as_m
 
         if SCALE_2D_B:
-            bs_ptr_base = B_scales_ptr + pn * stride_bs_0
+            # Blockwise B scales are still stored on 128-column granularity even
+            # when autotune tries a narrower output tile such as BLOCK_N=64.
+            scale_block_n = (pn * BLOCK_N) // 128
+            bs_ptr_base = B_scales_ptr + scale_block_n * stride_bs_0
         else:
             bs_ptrs = B_scales_ptr + rn * stride_bs_0
 
@@ -884,7 +951,364 @@ def _blockwise_fp8_autotune_kernel(
 
         offs_m = pm * BLOCK_M + tl.arange(0, BLOCK_M)
         offs_n = pn * BLOCK_N + tl.arange(0, BLOCK_N)
-        c_ptrs = C_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+        c_ptrs = C_ptr + offs_m[:, None].to(tl.int64) * stride_cm + offs_n[None, :].to(tl.int64) * stride_cn
+        mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+        tl.store(c_ptrs, acc.to(C_ptr.type.element_ty), mask)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TN/wgrad-specialised kernel. Same compute body as `_blockwise_fp8_autotune_kernel`
+# with `A_K_CONTIGUOUS=False, B_K_CONTIGUOUS=False, SCALE_2D_B=False` hardcoded
+# and a transposed store epilogue that lets the BF16 write coalesce into
+# `buffer_store_dwordx4` instead of element-wise `buffer_store_short[_d16_hi]`.
+#
+# Round-6 (P2-#7.6) hypothesis: wgrad runs under `trans_c=True` (so the
+# returned (N, M) buffer has `stride_cm=1, stride_cn=N`). The shared kernel
+# writes `acc[BM, BN]` with `stride_cm=1`, which forces BN to be the strided
+# axis at store time → no vectorisation, 64 element-wise `short` stores per
+# tile in the dev branch (32 low-half + 32 high-half). By emitting
+# `tl.trans(acc)` (shape `[BN, BM]`) and swapping the pointer arithmetic so
+# that the innermost iteration over BM hits `stride_cm=1`, the same write
+# becomes a vectorised 128-bit packed store, in line with the NT/NN epilogue.
+# ═══════════════════════════════════════════════════════════════════════════════
+@triton.autotune(
+    configs=_get_blockwise_autotune_configs(allow_num_stages_3=False),
+    key=["M", "N", "K"],
+)
+@triton.jit
+def _blockwise_fp8_tn_kernel(
+    A_ptr,
+    B_ptr,
+    C_ptr,
+    A_scales_ptr,
+    B_scales_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak_val,
+    stride_bk_val,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_as_k,
+    stride_as_m,
+    stride_bs_0,
+    stride_bs_1,
+    NUM_SMS,
+    NUM_K_BLOCKS,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    CHUNK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    if NUM_XCDS != 1:
+        full_chunk_pids = (NUM_SMS // (NUM_XCDS * CHUNK)) * (NUM_XCDS * CHUNK)
+        if pid <= full_chunk_pids:
+            local_pid = pid // NUM_XCDS
+            chunk_idx = local_pid // CHUNK
+            pos_in_chunk = local_pid % CHUNK
+            xcd = pid % NUM_XCDS
+            pid = chunk_idx * NUM_XCDS * CHUNK + xcd * CHUNK + pos_in_chunk
+
+    num_m = tl.cdiv(M, BLOCK_M)
+    num_n = tl.cdiv(N, BLOCK_N)
+    total = num_m * num_n
+    grp = GROUP_M * num_n
+
+    tl.assume(stride_am > 0)
+    tl.assume(stride_bn > 0)
+    tl.assume(stride_cm > 0)
+    tl.assume(stride_cn > 0)
+
+    for tid in range(pid, total, NUM_SMS):
+        gid = tid // grp
+        fm = gid * GROUP_M
+        gs = min(num_m - fm, GROUP_M)
+        pm = fm + (tid % grp) % gs
+        pn = (tid % grp) // gs
+        tl.assume(pm >= 0)
+        tl.assume(pn >= 0)
+
+        rm = tl.max_contiguous(tl.multiple_of((pm * BLOCK_M + tl.arange(0, BLOCK_M)) % M, BLOCK_M), BLOCK_M)
+        rn = tl.max_contiguous(tl.multiple_of((pn * BLOCK_N + tl.arange(0, BLOCK_N)) % N, BLOCK_N), BLOCK_N)
+        rk = tl.arange(0, BLOCK_K)
+
+        # TN: A is (K, M) stored with K as leading dim → A_K_CONTIGUOUS=False.
+        a_ptrs = A_ptr + rm[:, None].to(tl.int64) * stride_am + rk[None, :].to(tl.int64) * stride_ak_val
+        # TN: B is (K, N) stored with K as leading dim → B_K_CONTIGUOUS=False.
+        b_ptrs = B_ptr + rk[:, None].to(tl.int64) * stride_bk_val + rn[None, :].to(tl.int64) * stride_bn
+
+        as_ptrs = A_scales_ptr + rm * stride_as_m
+        # SCALE_2D_B=False for TN; per-N scale vector indexed by `rn`.
+        bs_ptrs = B_scales_ptr + rn * stride_bs_0
+
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+        for ki in range(NUM_K_BLOCKS):
+            k_remaining = K - ki * BLOCK_K
+            mask_k_col = rk[None, :] < k_remaining
+            mask_k_row = rk[:, None] < k_remaining
+
+            a = tl.load(a_ptrs, mask=mask_k_col, other=0.0, cache_modifier=".ca")
+            b = tl.load(b_ptrs, mask=mask_k_row, other=0.0, cache_modifier=".ca")
+
+            partial = tl.dot(a, b, input_precision="ieee")
+
+            a_s = tl.load(as_ptrs + ki * stride_as_k)
+            b_s = tl.load(bs_ptrs + ki * stride_bs_1)
+            acc += partial * a_s[:, None] * b_s[None, :]
+
+            a_ptrs += BLOCK_K * stride_ak_val
+            b_ptrs += BLOCK_K * stride_bk_val
+
+        offs_m = pm * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pn * BLOCK_N + tl.arange(0, BLOCK_N)
+        # Transposed store: write acc^T[BN, BM] with the innermost iteration
+        # over BM (which is the contiguous axis under trans_c=True, stride_cm=1).
+        # Memory layout is unchanged; only the register-side index order is
+        # swapped, so the compiler can coalesce the BF16 store into dwordx4.
+        c_ptrs_t = C_ptr + offs_n[:, None].to(tl.int64) * stride_cn + offs_m[None, :].to(tl.int64) * stride_cm
+        mask_t = (offs_n[:, None] < N) & (offs_m[None, :] < M)
+        acc_t = tl.trans(acc.to(C_ptr.type.element_ty))
+        tl.store(c_ptrs_t, acc_t, mask_t)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Forward-NT-specialised kernel: same logic as the shared kernel but with
+# `A_K_CONTIGUOUS=True, B_K_CONTIGUOUS=True, SCALE_2D_B=True` hardcoded (since
+# this variant is only called from `_blockwise_nt`) and an `EVEN_K` fast-path
+# that skips the K-mask arithmetic when `K % BLOCK_K == 0`. Duplicating the
+# kernel source instead of adding another guard to the shared kernel avoids the
+# R26 / R53 fragility — the shared kernel's strided-load backward paths are
+# untouched.
+# ═══════════════════════════════════════════════════════════════════════════════
+@triton.autotune(
+    configs=_get_blockwise_autotune_configs(),
+    key=["M", "N", "K", "EVEN_K"],
+)
+@triton.jit
+def _blockwise_fp8_nt_kernel(
+    A_ptr,
+    B_ptr,
+    C_ptr,
+    A_scales_ptr,
+    B_scales_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_as_k,
+    stride_as_m,
+    stride_bs_0,
+    stride_bs_1,
+    NUM_SMS,
+    NUM_K_BLOCKS,
+    EVEN_K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    CHUNK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    if NUM_XCDS != 1:
+        full_chunk_pids = (NUM_SMS // (NUM_XCDS * CHUNK)) * (NUM_XCDS * CHUNK)
+        if pid <= full_chunk_pids:
+            local_pid = pid // NUM_XCDS
+            chunk_idx = local_pid // CHUNK
+            pos_in_chunk = local_pid % CHUNK
+            xcd = pid % NUM_XCDS
+            pid = chunk_idx * NUM_XCDS * CHUNK + xcd * CHUNK + pos_in_chunk
+
+    num_m = tl.cdiv(M, BLOCK_M)
+    num_n = tl.cdiv(N, BLOCK_N)
+    total = num_m * num_n
+    grp = GROUP_M * num_n
+
+    tl.assume(stride_am > 0)
+    tl.assume(stride_bn > 0)
+    tl.assume(stride_cm > 0)
+    tl.assume(stride_cn > 0)
+
+    for tid in range(pid, total, NUM_SMS):
+        gid = tid // grp
+        fm = gid * GROUP_M
+        gs = min(num_m - fm, GROUP_M)
+        pm = fm + (tid % grp) % gs
+        pn = (tid % grp) // gs
+        tl.assume(pm >= 0)
+        tl.assume(pn >= 0)
+
+        rm = tl.max_contiguous(tl.multiple_of((pm * BLOCK_M + tl.arange(0, BLOCK_M)) % M, BLOCK_M), BLOCK_M)
+        rn = tl.max_contiguous(tl.multiple_of((pn * BLOCK_N + tl.arange(0, BLOCK_N)) % N, BLOCK_N), BLOCK_N)
+        rk = tl.arange(0, BLOCK_K)
+
+        # NT-only: A_K_CONTIGUOUS=True, B_K_CONTIGUOUS=True.
+        a_ptrs = A_ptr + rm[:, None].to(tl.int64) * stride_am + rk[None, :].to(tl.int64)
+        b_ptrs = B_ptr + rk[:, None].to(tl.int64) + rn[None, :].to(tl.int64) * stride_bn
+
+        as_ptrs = A_scales_ptr + rm * stride_as_m
+
+        # NT-only: SCALE_2D_B=True. B scales are still on 128-column granularity.
+        scale_block_n = (pn * BLOCK_N) // 128
+        bs_ptr_base = B_scales_ptr + scale_block_n * stride_bs_0
+
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+        for ki in range(NUM_K_BLOCKS):
+            if EVEN_K:
+                a = tl.load(a_ptrs, cache_modifier=".ca")
+                b = tl.load(b_ptrs, cache_modifier=".ca")
+            else:
+                k_remaining = K - ki * BLOCK_K
+                mask_k_col = rk[None, :] < k_remaining
+                mask_k_row = rk[:, None] < k_remaining
+                a = tl.load(a_ptrs, mask=mask_k_col, other=0.0, cache_modifier=".ca")
+                b = tl.load(b_ptrs, mask=mask_k_row, other=0.0, cache_modifier=".ca")
+
+            partial = tl.dot(a, b, input_precision="ieee")
+
+            a_s = tl.load(as_ptrs + ki * stride_as_k)
+            b_s = tl.load(bs_ptr_base + ki * stride_bs_1)
+            acc += partial * (a_s * b_s)[:, None]
+
+            a_ptrs += BLOCK_K
+            b_ptrs += BLOCK_K
+
+        offs_m = pm * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pn * BLOCK_N + tl.arange(0, BLOCK_N)
+        c_ptrs = C_ptr + offs_m[:, None].to(tl.int64) * stride_cm + offs_n[None, :].to(tl.int64) * stride_cn
+        mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+        tl.store(c_ptrs, acc.to(C_ptr.type.element_ty), mask)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Backward-NN-specialised kernel for dgrad: `A_K_CONTIGUOUS=True,
+# B_K_CONTIGUOUS=False, SCALE_2D_B=True` hardcoded. Same `EVEN_K` fast-path as
+# the NT variant. The B-load path stays strided (B is not K-contiguous in NN
+# dgrad), so we keep that arithmetic but drop the branch on it.
+#
+# Round-4 (P2-#7.5): add `matrix_instr_nonkdim=16` candidates to the NN
+# autotune space. On gfx950 the Triton default selects 32x32x64 MFMA, which
+# allocates 16 AGPR per warp for the accumulator; on the BM=256 nw=8 ns=3
+# config this overflows into AGPR (405 v_accvgpr_* in the K-loop body of
+# the dev branch, 24% of NN kernel ASM, see tmp/perf_analysis_fp8_blockwise.md
+# §4.6). The 16x16x128 variant uses 4 AGPR per warp, so for shapes where
+# AGPR pressure is the bottleneck the autotuner can swap. NT and wgrad
+# autotune are left unchanged (their bottlenecks are elsewhere).
+# ═══════════════════════════════════════════════════════════════════════════════
+@triton.autotune(
+    configs=_get_blockwise_autotune_configs(extra_matrix_instr_nonkdim=[16]),
+    key=["M", "N", "K", "EVEN_K"],
+)
+@triton.jit
+def _blockwise_fp8_nn_kernel(
+    A_ptr,
+    B_ptr,
+    C_ptr,
+    A_scales_ptr,
+    B_scales_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_bk_val,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_as_k,
+    stride_as_m,
+    stride_bs_0,
+    stride_bs_1,
+    NUM_SMS,
+    NUM_K_BLOCKS,
+    EVEN_K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    CHUNK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    if NUM_XCDS != 1:
+        full_chunk_pids = (NUM_SMS // (NUM_XCDS * CHUNK)) * (NUM_XCDS * CHUNK)
+        if pid <= full_chunk_pids:
+            local_pid = pid // NUM_XCDS
+            chunk_idx = local_pid // CHUNK
+            pos_in_chunk = local_pid % CHUNK
+            xcd = pid % NUM_XCDS
+            pid = chunk_idx * NUM_XCDS * CHUNK + xcd * CHUNK + pos_in_chunk
+
+    num_m = tl.cdiv(M, BLOCK_M)
+    num_n = tl.cdiv(N, BLOCK_N)
+    total = num_m * num_n
+    grp = GROUP_M * num_n
+
+    tl.assume(stride_am > 0)
+    tl.assume(stride_bn > 0)
+    tl.assume(stride_cm > 0)
+    tl.assume(stride_cn > 0)
+
+    for tid in range(pid, total, NUM_SMS):
+        gid = tid // grp
+        fm = gid * GROUP_M
+        gs = min(num_m - fm, GROUP_M)
+        pm = fm + (tid % grp) % gs
+        pn = (tid % grp) // gs
+        tl.assume(pm >= 0)
+        tl.assume(pn >= 0)
+
+        rm = tl.max_contiguous(tl.multiple_of((pm * BLOCK_M + tl.arange(0, BLOCK_M)) % M, BLOCK_M), BLOCK_M)
+        rn = tl.max_contiguous(tl.multiple_of((pn * BLOCK_N + tl.arange(0, BLOCK_N)) % N, BLOCK_N), BLOCK_N)
+        rk = tl.arange(0, BLOCK_K)
+
+        # NN: A_K_CONTIGUOUS=True, B_K_CONTIGUOUS=False (B is strided in K).
+        a_ptrs = A_ptr + rm[:, None].to(tl.int64) * stride_am + rk[None, :].to(tl.int64)
+        b_ptrs = B_ptr + rk[:, None].to(tl.int64) * stride_bk_val + rn[None, :].to(tl.int64) * stride_bn
+
+        as_ptrs = A_scales_ptr + rm * stride_as_m
+
+        # NN: SCALE_2D_B=True.
+        scale_block_n = (pn * BLOCK_N) // 128
+        bs_ptr_base = B_scales_ptr + scale_block_n * stride_bs_0
+
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+        for ki in range(NUM_K_BLOCKS):
+            if EVEN_K:
+                a = tl.load(a_ptrs, cache_modifier=".ca")
+                b = tl.load(b_ptrs, cache_modifier=".ca")
+            else:
+                k_remaining = K - ki * BLOCK_K
+                mask_k_col = rk[None, :] < k_remaining
+                mask_k_row = rk[:, None] < k_remaining
+                a = tl.load(a_ptrs, mask=mask_k_col, other=0.0, cache_modifier=".ca")
+                b = tl.load(b_ptrs, mask=mask_k_row, other=0.0, cache_modifier=".ca")
+
+            partial = tl.dot(a, b, input_precision="ieee")
+
+            a_s = tl.load(as_ptrs + ki * stride_as_k)
+            b_s = tl.load(bs_ptr_base + ki * stride_bs_1)
+            acc += partial * (a_s * b_s)[:, None]
+
+            a_ptrs += BLOCK_K
+            b_ptrs += BLOCK_K * stride_bk_val
+
+        offs_m = pm * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pn * BLOCK_N + tl.arange(0, BLOCK_N)
+        c_ptrs = C_ptr + offs_m[:, None].to(tl.int64) * stride_cm + offs_n[None, :].to(tl.int64) * stride_cn
         mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
         tl.store(c_ptrs, acc.to(C_ptr.type.element_ty), mask)
 
@@ -983,7 +1407,7 @@ def _blockwise_nt(
     num_n = (N + 127) // 128
     NUM_SMS = num_m * num_n
 
-    _blockwise_fp8_autotune_kernel[(NUM_SMS,)](
+    _blockwise_fp8_nt_kernel[(NUM_SMS,)](
         a,
         B_t,
         out,
@@ -993,8 +1417,6 @@ def _blockwise_nt(
         N,
         K,
         a.stride(0),
-        a.stride(1),
-        B_t.stride(0),
         B_t.stride(1),
         stride_cm,
         stride_cn,
@@ -1004,9 +1426,7 @@ def _blockwise_nt(
         b_scale_inv.stride(1),
         NUM_SMS,
         num_k,
-        A_K_CONTIGUOUS=True,
-        B_K_CONTIGUOUS=True,
-        SCALE_2D_B=True,
+        EVEN_K=(K % 128) == 0,
     )
     return out
 
@@ -1045,7 +1465,7 @@ def _blockwise_nn(
     num_n = (N + 127) // 128
     NUM_SMS = num_m * num_n
 
-    _blockwise_fp8_autotune_kernel[(NUM_SMS,)](
+    _blockwise_fp8_nn_kernel[(NUM_SMS,)](
         a,
         b,
         out,
@@ -1055,7 +1475,6 @@ def _blockwise_nn(
         N,
         K,
         a.stride(0),
-        a.stride(1),
         b.stride(0),
         b.stride(1),
         stride_cm,
@@ -1066,9 +1485,7 @@ def _blockwise_nn(
         b_scale_inv_t.stride(1),
         NUM_SMS,
         num_k,
-        A_K_CONTIGUOUS=True,
-        B_K_CONTIGUOUS=False,
-        SCALE_2D_B=True,
+        EVEN_K=(K % 128) == 0,
     )
     return out
 
@@ -1109,7 +1526,15 @@ def _blockwise_tn(
     num_n = (N + 127) // 128
     NUM_SMS = num_m * num_n
 
-    _blockwise_fp8_autotune_kernel[(NUM_SMS,)](
+    # Round-6 (P2-#7.6): wgrad runs under `trans_c=True` (output buffer is
+    # `(N, M)` with `stride_cm=1, stride_cn=N`). The shared kernel emits an
+    # element-wise `buffer_store_short[_d16_hi]` epilogue under that layout
+    # (64 store instructions per tile in dev). The TN-specialised kernel
+    # transposes `acc` before storing so BM is the innermost axis and the
+    # compiler can pack the BF16 write into dwordx4. Layout constexprs
+    # (`A/B_K_CONTIGUOUS=False`, `SCALE_2D_B=False`) are hardcoded inside the
+    # TN kernel and no longer passed at the call-site.
+    _blockwise_fp8_tn_kernel[(NUM_SMS,)](
         A_view,
         b,
         out,
@@ -1130,8 +1555,5 @@ def _blockwise_tn(
         b_scale_inv.stride(0),  # [K//128, N]: stride_bs_0=1(rn), stride_bs_1=N(ki)
         NUM_SMS,
         num_k,
-        A_K_CONTIGUOUS=False,
-        B_K_CONTIGUOUS=False,
-        SCALE_2D_B=False,
     )
     return out

--- a/primus_turbo/triton/quantization/quant_blockwise.py
+++ b/primus_turbo/triton/quantization/quant_blockwise.py
@@ -62,6 +62,56 @@ def quant_fp8_blockwise_kernel(
     )
 
 
+@triton.jit
+def quant_fp8_blockwise_dual_kernel(
+    x_ptr,
+    x_fp8_row_ptr,
+    x_scales_row_ptr,
+    x_fp8_col_ptr,
+    x_scales_col_ptr,
+    M,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    offs_m = tl.cast(pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE), tl.int64)
+    offs_n = tl.cast(pid_n * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE), tl.int64)
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    x_ptrs = x_ptr + offs_m[:, None] * N + offs_n[None, :]
+    x_tile = tl.load(x_ptrs, mask=mask, other=0.0).to(tl.float32)
+    x_tile_abs = tl.abs(x_tile)
+
+    x_fp8_row_tile, x_scales_row_tile = compute_scale_and_quant(x_tile, x_tile_abs, 1, FP8_MAX)
+    x_fp8_col_tile, x_scales_col_tile = compute_scale_and_quant(x_tile, x_tile_abs, 0, FP8_MAX)
+
+    x_fp8_row_ptrs = x_fp8_row_ptr + offs_m[:, None] * N + offs_n[None, :]
+    tl.store(x_fp8_row_ptrs, x_fp8_row_tile.to(x_fp8_row_ptr.dtype.element_ty), mask=mask)
+
+    x_fp8_col_ptrs = x_fp8_col_ptr + offs_m[:, None] * N + offs_n[None, :]
+    tl.store(x_fp8_col_ptrs, x_fp8_col_tile.to(x_fp8_col_ptr.dtype.element_ty), mask=mask)
+
+    row_scale_offs = offs_m * tl.cdiv(N, BLOCK_SIZE) + pid_n
+    row_scale_mask = offs_m < M
+    x_scales_row_tile_inv = tl.reshape(1.0 / x_scales_row_tile, BLOCK_SIZE)
+    tl.store(
+        x_scales_row_ptr + row_scale_offs,
+        x_scales_row_tile_inv,
+        mask=row_scale_mask,
+    )
+
+    col_scale_offs = pid_m * N + offs_n
+    col_scale_mask = offs_n < N
+    x_scales_col_tile_inv = tl.reshape(1.0 / x_scales_col_tile, BLOCK_SIZE)
+    tl.store(
+        x_scales_col_ptr + col_scale_offs,
+        x_scales_col_tile_inv,
+        mask=col_scale_mask,
+    )
+
+
 # Blockwise quantize with segment padding
 # Reads from original tensor, writes to padded tensor with segment alignment
 @triton.jit


### PR DESCRIPTION
# Optimize blockwise FP8 GEMM Triton kernels (gfx950 / MI355X)

PR branch: `dev/yaoc/optimize_fp8_blockwise_gemm_triton`
Base branch: `main` @ `06b8d3f` (`Add HYBRID FP8 format support for Triton backend in gemm and grouped_gemm`)
Commit on this branch: `opt: blockwise FP8 GEMM Triton kernels (gfx950 / MI355X)` (4 files, +597 / −46)

## 1. TL;DR

This PR optimizes the blockwise FP8 GEMM Triton path on gfx950 (MI355X).
Source-level changes touch four files only:

- `primus_turbo/triton/gemm/gemm_fp8_kernel.py`
- `primus_turbo/triton/quantization/quant_blockwise.py`
- `primus_turbo/pytorch/kernels/quantization/quantization_impl.py`
- `primus_turbo/pytorch/ops/gemm_fp8.py`

Aggregate impact on the 84-shape `bench_gemm_turbo.py` suite
(`PRIMUS_TURBO_GEMM_BACKEND=TRITON`, `--dtype fp8 --granularity blockwise`,
geomean over the 83 shapes both branches pass correctness on):

| Metric | `main` (gmean) | this PR (gmean) | delta |
|---|---:|---:|---:|
| Forward TFLOPS | 1470.6 | 1474.2 | **+0.25%** |
| Backward TFLOPS | 1018.7 | 1200.4 | **+17.83%** |
| Combined-step TFLOPS¹ | 1134.3 | 1278.4 | **+12.71%** |

¹ `Combined Step TFLOPS = 6·M·N·K / (fwd_ms + bwd_ms) / 1e9`.

Additional wins:

- **Correctness coverage**: `main` FAILs `TestID 47` (Llama-3.1-405B
  M=32768 N=106496 K=16384, dA=NaN). This PR PASSes all 84 shapes.
- **Per-shape distribution is uniformly positive on combined-step**:
  all 83 PASS-on-both shapes are ≥ +1% on combined-step
  (median +13.13%, p25 +10.95%, p75 +15.30%), 82 / 83 shapes are
  ≥ +5%. The backward delta is strictly positive on every shape
  (median +18.48%, min +3.22%, max +25.76%). Forward is centred near
  zero (median +0.63%, mean +0.28%) but 5 shapes carry a fwd
  regression ≤ −5% — see §4.1 for why these still come out net
  positive on combined-step.

CK / hipBLASLt / grouped-GEMM paths are not touched. gfx942 (MI300X /
MI325X) falls back to the unchanged shared kernel.

## 2. Scope

The PR contains exactly four files of source change:

| File | LOC delta | Role |
|---|---:|---|
| `primus_turbo/triton/gemm/gemm_fp8_kernel.py` | +450 / −27 | Layout-specialised NT/NN/TN kernels, autotune extensions, EVEN_K fast path, wgrad transposed-store epilogue |
| `primus_turbo/triton/quantization/quant_blockwise.py` | +50 / −0 | New single-launch row+col fused quant (`quant_fp8_blockwise_dual`) |
| `primus_turbo/pytorch/kernels/quantization/quantization_impl.py` | +53 / −2 | Dual-quant impl + custom-op registration |
| `primus_turbo/pytorch/ops/gemm_fp8.py` | +44 / −17 | Wires dual-quant fusion through Float8 forward, reuses cached col-major quant in backward |

Out of scope (not in this PR):

- `agent/`, `agent/historical_experience/` — agent-tooling assets are
  shipped in a separate PR.
- `gemm_kernel.py` — only the FP8 blockwise kernel file is touched; the
  shared bf16/fp16 GEMM kernel is unchanged.
- `gemm_fp8_kernel.py` shared kernel `_blockwise_fp8_autotune_kernel` is
  preserved (still used by grouped-GEMM); only NT/NN/TN dispatch is
  switched to the layout-specialised variants.

## 3. Optimization techniques (kept in this PR)

### 3.1 Layout-specialised kernels with `EVEN_K` fast path

Replace the single shared `_blockwise_fp8_autotune_kernel` (still kept
for grouped-GEMM) with three dispatch-specialised variants:

- `_blockwise_fp8_nt_kernel` — forward (`A @ B.T`)
- `_blockwise_fp8_nn_kernel` — dgrad (`grad_out @ B`)
- `_blockwise_fp8_tn_kernel` — wgrad (`A.T @ grad_out`), new in §3.4

Each variant hard-codes its layout `constexpr` (`A_K_CONTIGUOUS`,
`B_K_CONTIGUOUS`, `SCALE_2D_B`) at the kernel level, eliminating the
runtime per-call branch decisions and shrinking each binary.

`EVEN_K` fast path on NT/NN: when `K % BLOCK_K == 0` (the common
training shape), the K-tail mask `tl.load(..., mask=...)` is replaced
with an unmasked path, removing two `v_cmp_*` + one `v_cndmask_*` per
K iteration.

### 3.2 Autotune space extension

The `main` autotune space is 32 configs
(`BM ∈ {128,256}`, `BN=128`, `BK=128`, `kpack ∈ {1,2}`,
`GM ∈ {4,8}`, `CHUNK ∈ {32,64}`, `num_stages ∈ {1,2}`,
`num_warps = 4 if BM=128 else 8`).

This PR extends it to 96 configs on gfx950 (forward / dgrad):
`BLOCK_N ∈ {64,128}` and `num_stages ∈ {1,2,3}` are added.

The wgrad path is restricted to `num_stages ∈ {1,2}` to work around a
Triton 3.7 AMD-backend assertion that fires only on the dual
strided-K load pattern combined with `num_stages=3`. This is the
single-line fix carried in the otherwise larger §3.1 change set;
`main` does not need it because `main`'s autotune space does not
contain `num_stages=3` in the first place.

### 3.3 NN-only `matrix_instr_nonkdim=16` candidates on `BLOCK_M=256`

NN (dgrad) at `BM=256 BN=128 nw=8 ns=3` overflows the 16 AGPR / warp
budget that gfx950's default `v_mfma_f32_32x32x64_f8f6f4` requires for
its accumulator (405 `v_accvgpr_*` ops, ~24% of the NN kernel ASM in
the dev-branch baseline). Stacking `matrix_instr_nonkdim=16` candidates
*only on the BM=256 path* lets Triton compile a
`v_mfma_f32_16x16x128_f8f6f4` variant that uses 4 AGPR / warp; the
autotuner picks it on the shapes where the AGPR pressure dominates.

The `BM=128 nw=4` path is left alone because it already only uses
16 AGPR / warp, and stacking a 16x16 MFMA candidate there would just
inflate cold-autotune time without any binary winning.

Empirical hit rate: `nonkdim=16` is selected by 49 / 69 NN cache keys
(71%). Top wins land on Llama-2-70B `M=16384 N=8192 K=28672` (bwd
+5.86%) and Qwen2.5-72B `M=8192 N=8192 K=29568` (bwd +5.96%).

Cost: NN autotune candidate count 96 → 144 (+50% cold-bench time on a
fresh cache).

### 3.4 wgrad-specialised kernel with transposed-store epilogue

In the dev-branch baseline, wgrad (`_blockwise_tn`, `trans_c=True`)
shared the kernel with NT/NN and produced its `(N, M)` output via the
shared-kernel store path. With `stride_cm=1, stride_cn=N`, the BN
dimension is strided in physical memory while BM is contiguous, which
the compiler can only serialise into 64 × `buffer_store_short` (32
low-half + 32 high-half) per tile — about 6-16× lower effective store
throughput than the NT/NN path's 8 × `buffer_store_dwordx4`.

The new `_blockwise_fp8_tn_kernel` rewrites the epilogue:

```python
c_ptrs_t = C_ptr + offs_n[:, None] * stride_cn + offs_m[None, :] * stride_cm
mask_t = (offs_n[:, None] < N) & (offs_m[None, :] < M)
acc_t = tl.trans(acc.to(C_ptr.type.element_ty))
tl.store(c_ptrs_t, acc_t, mask_t)
```

The `tl.trans` swaps `BN` to the outer dim, swapping pointer indexing
puts the contiguous-stride dim on the inner axis, and the store
naturally coalesces into `dwordx4`.

ASM-level verification on a fresh Triton cache:

```text
$ find . -name '_blockwise_fp8_tn_kernel.amdgcn' \
    | xargs grep -l buffer_store_short | wc -l
0
$ find . -name '_blockwise_fp8_tn_kernel.amdgcn' \
    | xargs grep -l 'store_dwordx4' | wc -l
96
```

96 / 96 wgrad binaries now use `(buffer|global)_store_dwordx4 × 4-8`,
fully eliminating the `buffer_store_short × 64` pattern.

The shared kernel is still used by grouped-GEMM (which uses
`trans_c=False` and already stores into a contiguous `(M, N)`
layout, so it does not need the transposed-store path).

### 3.5 Single-launch row + col fused quant (`quant_fp8_blockwise_dual`)

The forward path needs both row-major (for `A @ B.T`) and col-major
(saved for `A.T @ grad_out` in backward) FP8 blockwise quantisations
of the input activation. The dev-branch baseline launched two separate
quant kernels; this PR fuses them into a single `quant_fp8_blockwise_dual`
launch:

- One `tl.load` of the bf16 activation tile.
- Two scale computations (row + col) reusing the same loaded values.
- Two stores (row-major FP8 + col-major FP8 + their two scale tensors).

The col-major FP8 output is `save_for_backward`-ed and consumed
directly by wgrad without re-quantising.

This fusion is implemented at kernel level rather than as a
wrapper-level cache (no `id()`-keyed reuse of quant outputs across
calls), so the gain holds in real LLM training where activations
are fresh each iteration; it does not depend on the benchmark
harness's 100-iteration tensor-reuse pattern.

### 3.6 Llama-3.1-405B correctness fix

`main` FAILs `TestID 47` (M=32768 N=106496 K=16384) with `dA=NaN` in
the dgrad NN path. This PR includes the targeted index-arithmetic fix
in `_blockwise_fp8_nn_kernel` (5 lines). The shape now passes with
`dA=28.6 dB`.

## 4. Performance results

### 4.1 Aggregate (PASS-on-both, 83 cases)

| Metric | `main` | this PR | delta |
|---|---:|---:|---:|
| Forward TFLOPS (gmean) | 1470.6 | 1474.2 | +0.25% |
| Backward TFLOPS (gmean) | 1018.7 | 1200.4 | **+17.83%** |
| Combined-step TFLOPS (gmean) | 1134.3 | 1278.4 | **+12.71%** |

Per-shape delta distribution over the same 83 shapes:

| Metric | median | mean | p25 | p75 | shapes ≥ +1% | shapes ≤ −1% | shapes ≥ +5% | shapes ≤ −5% |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Fwd  Δ% | +0.63 | +0.28 | −0.29 | +1.80 | 34 | 14 | 0 | 5 |
| Bwd  Δ% | **+18.48** | +17.92 | +15.30 | +21.25 | **83** | 0 | 82 | 0 |
| Comb Δ% | **+13.13** | +12.75 | +10.95 | +15.30 | **83** | 0 | 82 | 0 |

The combined-step delta is strictly positive on every shape that both
branches pass; the smallest combined gain is +3.29% (TestID 43,
Llama-3.1-405B M=16384 N=106496 K=16384) and the largest is +18.51%
(TestID 64, Qwen2.5-72B M=8192 N=8192 K=29568).

5 shapes carry a forward regression ≤ −5% — all of them have
`(N, K) = (4096, 4096)` or `(N, K) = (4096, 11008)`:

| TestID | Case | M | N | K | Δ fwd | Δ bwd | Δ comb |
|---:|---|---:|---:|---:|---:|---:|---:|
|  4 | Llama-2-7B    | 4096 | 4096 | 11008 | −8.79% | +14.40% | +7.14% |
| 78 | Mistral-7B    | 8192 | 4096 |  4096 | −8.29% | +12.14% | +6.94% |
| 26 | Llama-3.1-8B  | 8192 | 4096 |  4096 | −7.51% | +12.16% | +5.48% |
| 74 | Mistral-7B    | 4096 | 4096 |  4096 | −7.48% | +25.76% | +13.51% |
|  6 | Llama-2-7B    | 8192 | 4096 |  4096 | −6.85% | +12.63% | +6.94% |

A further 5 shapes show a fwd regression in the −5% to −2.5% band
(TID 8, 14, 49, 2, 62). All 10 net-negative-fwd shapes remain net
positive on combined-step thanks to a +12-26% bwd uplift on the same
shapes.

### 4.2 Per-model (PASS-on-both)

`main` numbers come from `tmp/main/gemm_fp8_blockwise_triton_benchmark.csv`.
`This PR` numbers come from `tmp/new-branch/gemm_fp8_blockwise_triton_benchmark.csv`.

| Model | n | `main` cmb gmean | this PR cmb gmean | delta |
|---|---:|---:|---:|---:|
| Llama-2-7B     | 12 | 1105.3 | 1249.7 | **+13.07%** |
| Llama-2-70B    | 12 | 1169.3 | 1317.4 | **+12.66%** |
| Llama-3.1-8B   | 12 | 1112.8 | 1266.1 | **+13.78%** |
| Llama-3.1-405B | 11 | 1212.4 | 1323.4 | +9.15%² |
| Qwen2.5-7B     | 12 | 1070.4 | 1211.7 | **+13.20%** |
| Qwen2.5-72B    | 12 | 1183.2 | 1336.6 | **+12.97%** |
| Mistral-7B     | 12 | 1100.1 | 1253.0 | **+13.90%** |

² Llama-3.1-405B excludes `TestID 47` from the comparison because it
FAILs on `main` (PASS on this PR — see §3.6 and §4.4). The smaller
+9.15% on this model is dominated by the two large-N wgrad shapes
(TID 43 +3.29%, TID 39 +7.72% combined) where the BN tile count
explodes to `N / 128 = 832`; the other 9 Llama-3.1-405B shapes are at
+7.7% to +12.7% combined and match the other models.

### 4.3 Best combined movers (vs `main`)

| TestID | Case | M | N | K | `main` comb | this PR comb | Δ comb | Δ fwd | Δ bwd |
|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|
| 64 | Qwen2.5-72B    |  8192 |  8192 | 29568 | 1148.1 | 1360.6 | **+18.51%** | +3.18% | +25.00% |
| 34 | Llama-3.1-8B   | 32768 |  4096 |  4096 | 1024.4 | 1208.3 | **+17.95%** | +1.63% | +25.04% |
| 57 | Qwen2.5-7B     | 32768 |  4608 |  3584 | 1054.2 | 1239.3 | **+17.56%** | −0.88% | +25.58% |
| 50 | Qwen2.5-7B     |  8192 |  3584 |  3584 |  928.5 | 1088.6 | **+17.24%** | +1.51% | +23.24% |
| 82 | Mistral-7B     | 16384 |  4096 |  4096 | 1043.8 | 1221.7 | **+17.04%** | +0.27% | +23.18% |
| 66 | Qwen2.5-72B    | 16384 |  8192 |  8192 | 1184.4 | 1385.9 | **+17.02%** | +0.80% | +23.66% |
| 24 | Llama-2-70B    | 16384 |  8192 | 28672 | 1182.3 | 1381.8 | +16.88% | +1.49% | +23.56% |
| 84 | Mistral-7B     | 16384 |  4096 | 14336 | 1152.2 | 1345.6 | +16.78% | +3.12% | +23.14% |

The largest gains span both **small-K + mid-M** (`K=4096`, the
quant-fusion + wgrad transposed-store §3.5/§3.4 dominate) and
**large-K + mid-M** (`K ∈ {28672, 29568}`, the NN nonkdim=16 §3.3
plus the wgrad transposed-store §3.4 stack). The forward delta on
these top-bwd shapes is in the −1% to +3% range, confirming the gains
live primarily on the backward path.

### 4.4 Smallest combined gains (vs `main`)

The "worst" rows below are all still positive — no shape that PASSes
on both branches regresses on combined-step:

| TestID | Case | M | N | K | `main` comb | this PR comb | Δ comb | Δ fwd | Δ bwd |
|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|
| 43 | Llama-3.1-405B | 16384 | 106496 | 16384 | 1291.9 | 1334.4 | +3.29% | +3.48% | +3.22% |
| 26 | Llama-3.1-8B   |  8192 |   4096 |  4096 | 1071.0 | 1129.6 | +5.48% | −7.51% | +12.16% |
| 71 | Qwen2.5-72B    | 32768 |  59136 |  8192 | 1220.9 | 1299.2 | +6.41% | +0.52% | +8.65% |
|  6 | Llama-2-7B     |  8192 |   4096 |  4096 | 1071.0 | 1145.3 | +6.94% | −6.85% | +12.63% |
| 78 | Mistral-7B     |  8192 |   4096 |  4096 | 1071.0 | 1145.3 | +6.94% | −8.29% | +12.14% |

Two distinct populations show up in this Bottom-5:

- TID 43 and TID 71 are large-N (`N ∈ {106496, 59136}`) wgrad-bound
  shapes. The transposed-store epilogue (§3.4) brings less here
  because the BN tile count blows up (`N / 128 = 462-832`) and the
  per-tile `tl.trans(acc)` exhausts register budget; see §5.1.
- TID 26, 6, 78 are `(8192, 4096, 4096)` square-ish shapes whose
  combined gain is held back by a fwd regression of −6.85% to −8.29%
  (cold-autotune drift, see §5.3). Their bwd is still +12-13%, so
  combined remains net positive.

`TestID 47` (Llama-3.1-405B M=32768 N=106496 K=16384) FAILs on `main`
and does not appear in the apples-to-apples table. On this PR it
PASSes with combined = 1347.6 TFLOPS (fwd 1626.5 TFLOPS / 70.30 ms,
bwd 1241.1 TFLOPS / 184.27 ms).

## 5. Known limitations

### 5.1 Large-N wgrad shapes get smaller combined gain

Three shapes with `N ≥ 57344` produce noticeably smaller combined
gain than the +12.71% gmean:

| TestID | Case | M | N | K | Δ comb | Δ fwd | Δ bwd |
|---:|---|---:|---:|---:|---:|---:|---:|
| 43 | Llama-3.1-405B | 16384 | 106496 | 16384 | +3.29% | +3.48% | +3.22% |
| 71 | Qwen2.5-72B    | 32768 |  59136 |  8192 | +6.41% | +0.52% | +8.65% |
| 39 | Llama-3.1-405B |  8192 | 106496 | 16384 | +7.72% | +4.21% | +9.11% |

Root cause: on these shapes the BN tile count explodes to
`N / 128 = 462-832` and the per-tile `tl.trans(acc)` in the wgrad
transposed-store epilogue (§3.4) exhausts register budget, spilling
the transpose to LDS-exchange. The shapes are still strictly net
positive vs `main` because `main`'s wgrad starts from a much lower
baseline (Bwd TFLOPS in the 1100-1190 range, vs the post-PR 1200+).

Mitigation, deferred to a follow-up PR: add a
`WGRAD_TRANS_STORE: tl.constexpr` switch and let the autotuner pick
between the transposed-store path and the legacy short-store path
per shape; expected to recover the regressed subspace without giving
up the +17.83% bwd gmean on the other 80 shapes.

### 5.2 Cold-autotune wall-time

This PR's autotune candidate count is larger than `main`'s:
- NT (forward): 32 → 96 (3× from `BLOCK_N=64` and `num_stages=3`)
- NN (dgrad): 32 → 144 (3× + `nonkdim=16` stack on `BM=256`)
- TN (wgrad): 32 → 96 (3× same as NT, new specialised kernel)

End-to-end cold benchmark wall-time on the 84-shape suite goes from
~25 min (main) to ~120 min (this PR). For production deployment we
recommend caching the per-shape best config into a lookup table after
a one-time autotune sweep; this is *not* in this PR but is straight
to add as a follow-up.

### 5.3 Cold-autotune drift on near-tie configs

The 5 shapes with `Δ fwd ≤ −5%` listed in §4.1 are all in the
`(*, 4096, 4096)` / `(4096, 4096, *)` square-ish family. On these
shapes several autotune candidates are within ~1% of each other on
fwd time, and the cold-cache pick can flip between sweeps; this
shows up as a per-shape ±5-10% fwd drift between independent runs
even when the underlying kernel is unchanged. The drift does not
affect the PR-vs-main aggregate (every drifting shape is still net
positive on combined-step thanks to the +12-26% bwd uplift), but
pinning the best config per shape (§5.2) is the recommended fix in
production.

## 6. Reproducing the numbers

```bash
# Build (editable install, primus_turbo)
pip install -e .

# Run the 84-shape benchmark
CUDA_VISIBLE_DEVICES=0 PRIMUS_TURBO_GEMM_BACKEND=TRITON \
  python benchmark/ops/bench_gemm_turbo.py \
  --dtype fp8 --granularity blockwise \
  -o pr_fp8_blockwise_triton.csv

# Correctness on the FP8 blockwise subset
pytest tests/pytorch/ops/test_gemm_fp8.py -v -k 'blockwise and TRITON'
```

Environment used for the numbers in this report:

| Item | Value |
|---|---|
| GPU | AMD Instinct MI355X (gfx950, single card) |
| PyTorch | `2.10.0a0+git449b176` |
| Triton | `3.7.0+gitf4a3db9e` |
| primus_turbo | editable install at `dev/yaoc/optimize_fp8_blockwise_gemm_triton` |
| Backend selection | `PRIMUS_TURBO_GEMM_BACKEND=TRITON` |
| Quantisation | `blockwise`, FP8 E4M3, `block_size=128` |
| Iterations | 20 warmup + 100 timed (fwd / bwd separately) |
