### PR TITLE
feat(grouped_gemm): add CK work-stealing variant with schedule API

### DIFF
--- a/csrc/include/primus_turbo/grouped_gemm.h
+++ b/csrc/include/primus_turbo/grouped_gemm.h
@@ -39,6 +39,21 @@ template <typename AType, typename BType, typename CType> struct GroupedGemmPara
 
     hipStream_t stream = nullptr;
     uint32_t    num_cu = 0;
+
+    // Work-stealing toggle. When true, ws_counter_ptr must point to an
+    // int32 buffer of size (NUM_XCDS_WS + 2): per-XCD slots [0..NUM_XCDS_WS-1],
+    // global slot [NUM_XCDS_WS], done slot [NUM_XCDS_WS + 1]. On MI355X that
+    // is 10 ints. The buffer is zeroed once at allocation by the Python wrapper;
+    // the kernel self-resets (the last-out CTA writes zeros), so no per-launch
+    // zeroing is required at the C++ binding. Persistent CTAs claim tiles via
+    // atomicAdd; `ws_local_per_xcd` selects the mode:
+    //   = 0                          : global-only (single counter)
+    //   = ceil(total_tiles / 8)      : per-XCD-only (8 counters, no global)
+    //   = anything in between        : hierarchical (per-XCD + global tail)
+    // See vendored grouped_gemm_kernel_ws.hpp for details.
+    bool     work_steal       = false;
+    int32_t *ws_counter_ptr   = nullptr;
+    int32_t  ws_local_per_xcd = 0;
 };
 
 template <typename AType, typename BType, typename CType>

--- a/csrc/kernels/grouped_gemm/ck/ck_grouped_gemm_kernel_template.h
+++ b/csrc/kernels/grouped_gemm/ck/ck_grouped_gemm_kernel_template.h
@@ -15,7 +15,9 @@
 #include <string>
 
 #include "ck_grouped_gemm_kernel_config.h"
+#include "grouped_gemm_kernel_ws.hpp"
 #include "primus_turbo/arch.h"
+#include "primus_turbo/common.h"
 
 namespace primus_turbo {
 // clang-format off
@@ -37,6 +39,35 @@ inline void _launch_ck_grouped_kernel(const ck_tile::stream_config& stream_cfg,
                         ck_tile::cast_pointer_to_constant_address_space(args_ptr), group_num));
 }
 
+// Work-stealing variant: takes an int32 atomic counter buffer (size
+// NUM_XCDS_WS + 2; per-XCD slots first, then global slot, then done slot
+// for last-out CTA detection) and a `local_per_xcd` mode selector. The
+// buffer is zeroed once at allocation by the Python wrapper; the kernel
+// self-resets between launches (the last-out CTA zeros all slots), so no
+// per-launch zeroing is required at the C++ binding.
+//
+// The WS kernel uses `FindGroupId` for O(log G) group lookup, which reads
+// the precomputed `block_start` / `block_end` fields. Those are populated
+// by primus's `compute_grouped_gemm_args` kernel, which is extended to do
+// the per-group prefix sum during the existing args-setup pass. No
+// separate prepass kernel is needed.
+template <typename Kernel>
+inline void _launch_ck_grouped_kernel_ws(const ck_tile::stream_config& stream_cfg,
+                                         ck_tile::index_t group_num,
+                                         void* args_ptr, uint32_t num_cu,
+                                         int32_t* tile_counter_ptr,
+                                         ck_tile::index_t local_per_xcd) {
+    constexpr int kBlockPerCu = 1;
+    const dim3 blocks = Kernel::BlockSize();
+    dim3       grids  = Kernel::MaxOccupancyGridSize(stream_cfg);
+    grids.x           = std::min(grids.x, num_cu);
+    ck_tile::launch_kernel(
+        stream_cfg, ck_tile::make_kernel<kBlockPerCu>(
+                        Kernel{}, grids, blocks, 0,
+                        ck_tile::cast_pointer_to_constant_address_space(args_ptr), group_num,
+                        tile_counter_ptr, local_per_xcd));
+}
+
 class CKGroupedGemmRunnerInterFace {
 public:
     virtual ~CKGroupedGemmRunnerInterFace() = default;
@@ -44,6 +75,26 @@ public:
     virtual void run(const ck_tile::stream_config &stream_cfg,
                      const ck_tile::index_t group_num,
                      void *args_ptr, const uint32_t num_cu) = 0;
+
+    // Optional WS path. Default impl asserts; only the WS-enabled runner
+    // overrides this. Keeps the interface uniform without bifurcating the
+    // factory.
+    virtual void run_ws(const ck_tile::stream_config & /*stream_cfg*/,
+                        const ck_tile::index_t /*group_num*/,
+                        void * /*args_ptr*/, const uint32_t /*num_cu*/,
+                        int32_t * /*tile_counter_ptr*/,
+                        const ck_tile::index_t /*local_per_xcd*/) {
+        // Should be overridden by WS runners. If we land here, the dispatch
+        // table picked the wrong runner.
+        PRIMUS_TURBO_CHECK(false,
+                           "run_ws() called on a non-WS runner -- dispatch table mismatch");
+    }
+
+    // Tile shape exposed to the dispatch site so it can compute block_start /
+    // block_end (the WS kernel's FindGroupId reads them). Defaults to 0;
+    // BF16/FP16 runners override.
+    virtual int32_t m_tile() const { return 0; }
+    virtual int32_t n_tile() const { return 0; }
 };
 
 
@@ -122,7 +173,8 @@ public:
         >
     >;
 
-    using Kernel = ck_tile::GroupedGemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;
+    using Kernel   = ck_tile::GroupedGemmKernel<TilePartitioner, GemmPipeline, GemmEpilogue>;
+    using KernelWS = ck_tile::GroupedGemmKernelWS<TilePartitioner, GemmPipeline, GemmEpilogue>;
 
 
 public:
@@ -131,6 +183,18 @@ public:
              void *args_ptr, const uint32_t num_cu) override {
         _launch_ck_grouped_kernel<Kernel>(stream_cfg, group_num, args_ptr, num_cu);
     }
+
+    void run_ws(const ck_tile::stream_config &stream_cfg,
+                const ck_tile::index_t group_num,
+                void *args_ptr, const uint32_t num_cu,
+                int32_t *tile_counter_ptr,
+                const ck_tile::index_t local_per_xcd) override {
+        _launch_ck_grouped_kernel_ws<KernelWS>(stream_cfg, group_num, args_ptr, num_cu,
+                                               tile_counter_ptr, local_per_xcd);
+    }
+
+    int32_t m_tile() const override { return TileConfig::M_Tile; }
+    int32_t n_tile() const override { return TileConfig::N_Tile; }
 };
 
 template <

--- a/csrc/kernels/grouped_gemm/ck/grouped_gemm_kernel_ws.hpp
+++ b/csrc/kernels/grouped_gemm/ck/grouped_gemm_kernel_ws.hpp
@@ -1,0 +1,222 @@
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+//
+// SPDX-License-Identifier: MIT
+//
+// Vendored work-stealing variant of ck_tile::GroupedGemmKernel. Inherits all
+// host-side machinery (BlockSize, MakeKargs, IsSupportedArgument, ...) and
+// the device-side per-tile compute (Run) from the upstream kernel; replaces
+// the persistent operator() with an atomicAdd-based tile claim.
+//
+// Source: 3rdparty/composable_kernel/include/ck_tile/ops/gemm/kernel/grouped_gemm_kernel.hpp
+// (specifically the persistent `operator()` at lines 540-573).
+//
+// The static-stride persistent loop (block_id += grid_size) gives no
+// straggler tolerance: when one CU is preempted by RCCL, the kernel waits
+// for it to grind through its full quota of tiles. The work-stealing variant
+// has each CU claim the next tile via atomicAdd, so faster CUs absorb work
+// that slow CUs would otherwise have done.
+//
+// Counter layout (caller-allocated int32 buffer of size NUM_XCDS_WS + 2):
+//   [0..NUM_XCDS_WS-1] : per-XCD slots
+//   [NUM_XCDS_WS]      : global slot
+//   [NUM_XCDS_WS + 1]  : done slot (last-out CTA detection for self-reset)
+// `local_per_xcd` selects the mode:
+//   = 0                                : global-only (phase 1 empty)
+//   = ceil(total_tiles / NUM_XCDS_WS)  : per-XCD-only (phase 2 empty)
+//   = anything in-between              : hierarchical (some local + global tail)
+//
+// Self-reset: the kernel guarantees the entire counter buffer is back to 0
+// before it exits. The last CTA out (detected via atomicAdd on the done slot)
+// writes zeros to all slots. Stream ordering then makes those zeros visible
+// to the next kernel launch -- no host-side `counter.zero_()` needed.
+
+#pragma once
+
+#include "ck_tile/ops/gemm/kernel/grouped_gemm_kernel.hpp"
+
+#include <hip/hip_runtime.h>
+
+namespace ck_tile {
+
+// MI355X / MI350 chiplet count. Used to size the counter buffer and to map
+// pid -> xcd_id (round-robin via pid % NUM_XCDS_WS).
+constexpr index_t NUM_XCDS_WS = 8;
+
+// (`block_start`/`block_end` are populated by primus's
+// `compute_grouped_gemm_args` kernel, which the runner extends with a
+// prefix-sum loop using the runner's tile shape. The WS kernel's
+// FindGroupId binary search reads those fields.)
+
+template <typename TilePartitioner_, typename GemmPipeline_, typename EpiloguePipeline_>
+struct GroupedGemmKernelWS
+    : public GroupedGemmKernel<TilePartitioner_, GemmPipeline_, EpiloguePipeline_>
+{
+    using Base = GroupedGemmKernel<TilePartitioner_, GemmPipeline_, EpiloguePipeline_>;
+    using Self = GroupedGemmKernelWS<TilePartitioner_, GemmPipeline_, EpiloguePipeline_>;
+
+    using TilePartitioner         = typename Base::TilePartitioner;
+    using OffsetTile1DPartitioner = typename Base::OffsetTile1DPartitioner;
+    static constexpr index_t NumDTensor_         = Base::NumDTensor_;
+    static constexpr index_t kBlockSize          = Base::kBlockSize;
+    static constexpr bool    UsePersistentKernel = Base::UsePersistentKernel;
+
+    static_assert(UsePersistentKernel,
+                  "GroupedGemmKernelWS requires a persistent GemmPipeline.");
+
+    // Override the host-side occupancy query to match the WS kernel's
+    // 4-arg launch signature.
+    CK_TILE_HOST static auto MaxOccupancyGridSize(const stream_config& s) -> dim3
+    {
+        using ConstantPointer = const void CK_TILE_CONSTANT_ADDRESS_SPACE*;
+        const auto kernel = kentry<1, Self, ConstantPointer, index_t, int32_t*, index_t>;
+        int        occupancy;
+        HIP_CHECK_ERROR(
+            hipOccupancyMaxActiveBlocksPerMultiprocessor(&occupancy, kernel, kBlockSize, 0));
+        const int grid_size = get_available_compute_units(s) * occupancy;
+        return dim3(grid_size, 1, 1);
+    }
+
+    // Hierarchical WS: each CTA first drains its XCD's local counter for up
+    // to `local_per_xcd` claims, then falls back to the global counter for
+    // the ragged tail. Speculative prefetch hides per-claim atomic latency
+    // under Run; FindGroupId is O(log G) and reads precomputed
+    // [block_start, block_end) populated by primus's args-setup kernel.
+    CK_TILE_DEVICE void operator()(
+        const void CK_TILE_CONSTANT_ADDRESS_SPACE* gemm_descs_const,
+        const index_t                              group_count,
+        int32_t*                                   tile_counter_ptr,
+        const index_t                              local_per_xcd) const
+    {
+        const auto gemm_desc_ptr = reinterpret_cast<const GemmTransKernelArg<NumDTensor_>*>(
+            cast_pointer_to_generic_address_space(gemm_descs_const));
+
+        // Total tiles across all groups (O(G) per CTA; group_descs cached in L2).
+        index_t total_tiles = 0;
+        for(index_t g = 0; g < group_count; ++g)
+        {
+            const auto& kargs_g = gemm_desc_ptr[g].group_karg;
+            total_tiles += TilePartitioner::GridSize(kargs_g.M, kargs_g.N) * kargs_g.k_batch;
+        }
+
+        // AMD round-robin pid -> xcd_id mapping.
+        const index_t xcd_id        = blockIdx.x % NUM_XCDS_WS;
+        int32_t* const local_counter  = tile_counter_ptr + xcd_id;
+        int32_t* const global_counter = tile_counter_ptr + NUM_XCDS_WS;
+        const index_t  phase1_total   = local_per_xcd * NUM_XCDS_WS;
+
+        // Single claim slot -- no speculative prefetch. Originally this kernel
+        // double-buffered the next claim while the current Run was in flight,
+        // hoping to hide atomic latency under the GEMM. Under heavy contention
+        // (small shapes / global mode) that doubles the atomic queue depth at
+        // the L2 -- each CTA has *two* atomics in flight at once -- which
+        // measurably increases per-atomic stall (TCC_EA0_ATOMIC_LEVEL_sum was
+        // 2.7x Triton's for the same atomic count). Holding to one atomic per
+        // claim halves the peak queue depth at modest cost to dense shapes
+        // (where speculation would have been useful but contention is already
+        // amortized).
+        __shared__ int32_t s_block_id;
+
+        // -- Phase 1: per-XCD claims ----------------------------------------
+        while(true)
+        {
+            if(threadIdx.x == 0)
+            {
+                s_block_id = atomicAdd(local_counter, 1);
+            }
+            __syncthreads();
+            const index_t local_idx = s_block_id;
+            if(local_idx >= local_per_xcd)
+            {
+                break;
+            }
+            const index_t block_id = xcd_id * local_per_xcd + local_idx;
+            // Bound check: per-XCD-only mode (local_per_xcd = ceil(t/N))
+            // can produce block_ids past total_tiles for the last XCD.
+            if(block_id >= total_tiles)
+            {
+                continue;
+            }
+
+            const index_t group_id =
+                this->FindGroupId(gemm_desc_ptr, block_id, group_count);
+            const auto& kargs        = gemm_desc_ptr[group_id];
+            const auto  grid_size_2d = TilePartitioner::GridSize(
+                kargs.group_karg.M, kargs.group_karg.N);
+            const auto block_idx_2d = OffsetTile1DPartitioner::GetOffsetedTileIndex(
+                0,
+                kargs.group_karg.M,
+                kargs.group_karg.N,
+                (block_id - kargs.block_start) % grid_size_2d);
+            this->Run(kargs.group_karg,
+                      block_idx_2d,
+                      (block_id - kargs.block_start) / grid_size_2d);
+            block_sync_lds();
+        }
+
+        // -- Phase 2: global fallback ----------------------------------------
+        while(true)
+        {
+            if(threadIdx.x == 0)
+            {
+                s_block_id = atomicAdd(global_counter, 1);
+            }
+            __syncthreads();
+            const index_t g_idx    = s_block_id;
+            const index_t block_id = phase1_total + g_idx;
+            if(block_id >= total_tiles)
+            {
+                break;
+            }
+
+            const index_t group_id =
+                this->FindGroupId(gemm_desc_ptr, block_id, group_count);
+            const auto& kargs        = gemm_desc_ptr[group_id];
+            const auto  grid_size_2d = TilePartitioner::GridSize(
+                kargs.group_karg.M, kargs.group_karg.N);
+            const auto block_idx_2d = OffsetTile1DPartitioner::GetOffsetedTileIndex(
+                0,
+                kargs.group_karg.M,
+                kargs.group_karg.N,
+                (block_id - kargs.block_start) % grid_size_2d);
+            this->Run(kargs.group_karg,
+                      block_idx_2d,
+                      (block_id - kargs.block_start) / grid_size_2d);
+            block_sync_lds();
+        }
+
+        // -- Self-reset: last-out CTA zeros the counter buffer --------------
+        // Detect which CTA is last to exit by atomically incrementing a
+        // dedicated "done" slot. The CTA that brings the count to gridDim.x
+        // (i.e. sees gridDim.x - 1 returned) is the last one -- all other CTAs
+        // have already finished claiming and running their tiles, so it is
+        // safe to zero the work counters.
+        //
+        // Memory ordering: the atomicAdd on done_counter below is acquire+release
+        // in HIP's relaxed-equivalent semantics, providing the necessary
+        // happens-before relationship with the prior atomicAdds on the work
+        // counters by all other CTAs. Within this launch, no other CTA will
+        // read or write the work counters after we observe the last-out
+        // condition, so plain stores to the work slots are race-free. Visibility
+        // to the next kernel launch on the same stream is guaranteed by HIP
+        // stream-ordering semantics (kernel launches on the same stream are
+        // serialized; the next launch sees all writes from the prior launch).
+        // No explicit __threadfence() needed.
+        __syncthreads();
+        if(threadIdx.x == 0)
+        {
+            int32_t* const done_counter = tile_counter_ptr + NUM_XCDS_WS + 1;
+            const int32_t prev = atomicAdd(done_counter, 1);
+            if(prev == static_cast<int32_t>(gridDim.x - 1))
+            {
+                // I am the last CTA out. Zero every slot (work + done) so the
+                // next launch starts clean.
+                for(index_t i = 0; i < NUM_XCDS_WS + 2; ++i)
+                {
+                    tile_counter_ptr[i] = 0;
+                }
+            }
+        }
+    }
+};
+
+} // namespace ck_tile

--- a/csrc/kernels/grouped_gemm/ck/grouped_gemm_kernel_ws.hpp
+++ b/csrc/kernels/grouped_gemm/ck/grouped_gemm_kernel_ws.hpp
@@ -87,6 +87,23 @@ struct GroupedGemmKernelWS
         int32_t*                                   tile_counter_ptr,
         const index_t                              local_per_xcd) const
     {
+        // gfx942 has 64 KB LDS per CU and CK's 256x256x64 tile config already
+        // uses the full 64 KB. Our WS kernel adds a 4-byte ``__shared__``
+        // broadcast slot for the atomicAdd result (see s_block_id below),
+        // which pushes total LDS to 65540 bytes and hits the lld error
+        // ``local memory (65540) exceeds limit (65536)``. WS was designed
+        // and tuned for gfx950 (MI355X) where the CK static kernel leaves
+        // enough LDS headroom for the extra slot. On gfx942 we compile an
+        // empty stub; the Python dispatcher's ``can_handle`` refuses to
+        // route ``schedule="work_steal"`` to CK on gfx942, so the stub is
+        // never actually launched -- it exists only to make the gfx942
+        // device object link successfully.
+#if defined(__gfx942__)
+        (void)gemm_descs_const;
+        (void)group_count;
+        (void)tile_counter_ptr;
+        (void)local_per_xcd;
+#else
         const auto gemm_desc_ptr = reinterpret_cast<const GemmTransKernelArg<NumDTensor_>*>(
             cast_pointer_to_generic_address_space(gemm_descs_const));
 
@@ -226,6 +243,7 @@ struct GroupedGemmKernelWS
                 }
             }
         }
+#endif // !defined(__gfx942__)
     }
 };
 

--- a/csrc/kernels/grouped_gemm/ck/grouped_gemm_kernel_ws.hpp
+++ b/csrc/kernels/grouped_gemm/ck/grouped_gemm_kernel_ws.hpp
@@ -98,11 +98,21 @@ struct GroupedGemmKernelWS
             total_tiles += TilePartitioner::GridSize(kargs_g.M, kargs_g.N) * kargs_g.k_batch;
         }
 
-        // AMD round-robin pid -> xcd_id mapping.
-        const index_t xcd_id        = blockIdx.x % NUM_XCDS_WS;
+        // AMD round-robin pid -> xcd_id mapping. When the persistent grid is
+        // capped to fewer CUs than there are XCDs (gridDim.x < NUM_XCDS_WS),
+        // only XCD ids [0, gridDim.x) ever issue phase-1 claims, so both the
+        // per-XCD slot count AND the phase-1 ID span must use
+        // min(gridDim.x, NUM_XCDS_WS). Otherwise phase 2 starts past where
+        // phase 1 actually ended and the tiles in the gap are silently
+        // dropped. The public ``grouped_gemm`` API rejects num_cu != None +
+        // schedule="work_steal", so callers should never hit this branch
+        // from the high-level op, but the kernel-level binding still exposes
+        // num_cu -- belt-and-braces.
+        const index_t active_xcds = min(static_cast<index_t>(gridDim.x), NUM_XCDS_WS);
+        const index_t xcd_id        = blockIdx.x % active_xcds;
         int32_t* const local_counter  = tile_counter_ptr + xcd_id;
         int32_t* const global_counter = tile_counter_ptr + NUM_XCDS_WS;
-        const index_t  phase1_total   = local_per_xcd * NUM_XCDS_WS;
+        const index_t  phase1_total   = local_per_xcd * active_xcds;
 
         // Single claim slot -- no speculative prefetch. Originally this kernel
         // double-buffered the next claim while the current Run was in flight,

--- a/csrc/kernels/grouped_gemm/ck/grouped_gemm_kernel_ws.hpp
+++ b/csrc/kernels/grouped_gemm/ck/grouped_gemm_kernel_ws.hpp
@@ -144,8 +144,23 @@ struct GroupedGemmKernelWS
         __shared__ int32_t s_block_id;
 
         // -- Phase 1: per-XCD claims ----------------------------------------
+        //
+        // ``s_block_id`` is written by thread 0 and read by all threads.
+        // It needs a barrier on both sides of the write: after (so all
+        // threads see the new value -- the mid-loop ``__syncthreads()``)
+        // and before (so a straggler warp still reading the previous
+        // iteration's value isn't clobbered). On the normal path the
+        // trailing ``block_sync_lds()`` after ``Run()`` in iteration N
+        // provides the "before" for iteration N+1, but two exit paths
+        // skip that trailing barrier and let the next write race the
+        // previous read: the ``continue`` on ``block_id >= total_tiles``
+        // and the Phase-1 ``break`` that falls into Phase 2's atomicAdd.
+        // The top-of-loop ``__syncthreads()`` plugs both. Loop-exit
+        // conditions are block-uniform (derived from ``s_block_id``
+        // alone), so this barrier cannot diverge.
         while(true)
         {
+            __syncthreads();
             if(threadIdx.x == 0)
             {
                 s_block_id = atomicAdd(local_counter, 1);
@@ -181,8 +196,10 @@ struct GroupedGemmKernelWS
         }
 
         // -- Phase 2: global fallback ----------------------------------------
+        // Same top-of-loop ``__syncthreads()`` rationale as Phase 1.
         while(true)
         {
+            __syncthreads();
             if(threadIdx.x == 0)
             {
                 s_block_id = atomicAdd(global_counter, 1);

--- a/csrc/kernels/grouped_gemm/ck/grouped_gemm_kernel_ws.hpp
+++ b/csrc/kernels/grouped_gemm/ck/grouped_gemm_kernel_ws.hpp
@@ -107,13 +107,12 @@ struct GroupedGemmKernelWS
         const auto gemm_desc_ptr = reinterpret_cast<const GemmTransKernelArg<NumDTensor_>*>(
             cast_pointer_to_generic_address_space(gemm_descs_const));
 
-        // Total tiles across all groups (O(G) per CTA; group_descs cached in L2).
-        index_t total_tiles = 0;
-        for(index_t g = 0; g < group_count; ++g)
-        {
-            const auto& kargs_g = gemm_desc_ptr[g].group_karg;
-            total_tiles += TilePartitioner::GridSize(kargs_g.M, kargs_g.N) * kargs_g.k_batch;
-        }
+        // Total tiles across all groups. ``block_start``/``block_end`` are
+        // populated as a prefix sum by ``compute_grouped_gemm_args`` in
+        // ck_grouped_gemm.cu, so the last group's ``block_end`` is
+        // exactly the cumulative tile count. One field read instead of
+        // an O(G) recompute per CTA.
+        const index_t total_tiles = gemm_desc_ptr[group_count - 1].block_end;
 
         // AMD round-robin pid -> xcd_id mapping. When the persistent grid is
         // capped to fewer CUs than there are XCDs (gridDim.x < NUM_XCDS_WS),

--- a/csrc/kernels/grouped_gemm/ck_grouped_gemm.cu
+++ b/csrc/kernels/grouped_gemm/ck_grouped_gemm.cu
@@ -25,7 +25,8 @@ compute_grouped_gemm_args(ck_tile::GemmTransKernelArg<> *args_ptr, const ADataTy
                           const int64_t *group_offs_ptr, const ck_tile::index_t group_num,
                           const ck_tile::index_t n, const ck_tile::index_t k,
                           const ck_tile::index_t strideA, const ck_tile::index_t strideB,
-                          const ck_tile::index_t strideC, const ck_tile::index_t k_batch) {
+                          const ck_tile::index_t strideC, const ck_tile::index_t k_batch,
+                          const ck_tile::index_t m_tile, const ck_tile::index_t n_tile) {
     const int64_t group_id = blockIdx.x * blockDim.x + threadIdx.x;
     if (group_id >= group_num)
         return;
@@ -42,6 +43,24 @@ compute_grouped_gemm_args(ck_tile::GemmTransKernelArg<> *args_ptr, const ADataTy
     args_ptr[group_id].group_karg.stride_Bs[0] = strideB;
     args_ptr[group_id].group_karg.stride_E     = strideC;
     args_ptr[group_id].group_karg.k_batch      = k_batch;
+
+    // Prefix sum over prior groups' tile counts -> block_start. Required by the
+    // WS kernel's FindGroupId binary search (and benign for the static path,
+    // which doesn't read these fields). m_tile/n_tile are the runner's tile
+    // shape, supplied by the dispatch site. Each thread does an O(group_id)
+    // scan over `group_lens_ptr` (already populated on device); for G <= ~256
+    // total work is O(G^2) <= ~65k loads -- negligible vs the GEMM.
+    const ck_tile::index_t num_n_tiles = (n + n_tile - 1) / n_tile;
+    ck_tile::index_t       my_block_start = 0;
+    for (int64_t g = 0; g < group_id; ++g) {
+        const ck_tile::index_t M_g       = static_cast<ck_tile::index_t>(group_lens_ptr[g]);
+        const ck_tile::index_t m_tiles_g = (M_g + m_tile - 1) / m_tile;
+        my_block_start += m_tiles_g * num_n_tiles * k_batch;
+    }
+    const ck_tile::index_t my_M       = static_cast<ck_tile::index_t>(group_lens_ptr[group_id]);
+    const ck_tile::index_t my_m_tiles = (my_M + m_tile - 1) / m_tile;
+    args_ptr[group_id].block_start    = my_block_start;
+    args_ptr[group_id].block_end      = my_block_start + my_m_tiles * num_n_tiles * k_batch;
 }
 
 template <typename ADataType, typename BDataType, typename CDataType, typename AccDataType = float,
@@ -127,17 +146,8 @@ void ck_grouped_gemm(const CKGroupedGemmParams<ADataType, BDataType, CDataType> 
     const ck_tile::index_t strideB = params.transB ? params.k : params.n;
     const ck_tile::index_t strideC = params.n;
 
-    // Setting args
-    {
-        const int threads = std::min(MAX_THREADS_PER_BLOCK, params.group_num);
-        const int blocks  = (params.group_num + threads - 1) / threads;
-        compute_grouped_gemm_args<ADataType, BDataType, CDataType>
-            <<<blocks, threads, 0, params.stream>>>(
-                reinterpret_cast<ck_tile::GemmTransKernelArg<> *>(params.args_ptr), params.a_ptr,
-                params.b_ptr, params.c_ptr, params.group_lens_ptr, params.group_offs_ptr,
-                params.group_num, params.n, params.k, strideA, strideB, strideC, k_batch);
-    }
-
+    // Pick the runner first -- we need its tile shape (m_tile, n_tile) to
+    // compute block_start/block_end inside `compute_grouped_gemm_args`.
     const auto stream_cfg = ck_tile::stream_config{params.stream};
     std::unique_ptr<CKGroupedGemmRunnerInterFace> runner;
     using CLayout = RowMajor;
@@ -156,7 +166,27 @@ void ck_grouped_gemm(const CKGroupedGemmParams<ADataType, BDataType, CDataType> 
     } else {
         PRIMUS_TURBO_CHECK(false, "CKGroupedGemm only support NN and NT");
     }
-    runner->run(stream_cfg, params.group_num, params.args_ptr, params.num_cu);
+
+    // Setting args (now also populates block_start/block_end via the runner's
+    // tile shape -- no separate prefix-sum kernel launch needed).
+    {
+        const int threads = std::min(MAX_THREADS_PER_BLOCK, params.group_num);
+        const int blocks  = (params.group_num + threads - 1) / threads;
+        compute_grouped_gemm_args<ADataType, BDataType, CDataType>
+            <<<blocks, threads, 0, params.stream>>>(
+                reinterpret_cast<ck_tile::GemmTransKernelArg<> *>(params.args_ptr), params.a_ptr,
+                params.b_ptr, params.c_ptr, params.group_lens_ptr, params.group_offs_ptr,
+                params.group_num, params.n, params.k, strideA, strideB, strideC, k_batch,
+                runner->m_tile(), runner->n_tile());
+    }
+    if (params.work_steal) {
+        PRIMUS_TURBO_CHECK(params.ws_counter_ptr != nullptr,
+                           "work_steal=true requires a non-null ws_counter_ptr");
+        runner->run_ws(stream_cfg, params.group_num, params.args_ptr, params.num_cu,
+                       params.ws_counter_ptr, params.ws_local_per_xcd);
+    } else {
+        runner->run(stream_cfg, params.group_num, params.args_ptr, params.num_cu);
+    }
 }
 
 template <typename ADataType, typename BDataType, typename CDataType, typename AccDataType,
@@ -230,7 +260,8 @@ __global__ void compute_grouped_gemm_variable_k_args(
     const bool transA, const bool transB, const ck_tile::index_t group_num,
     const ck_tile::index_t m, const ck_tile::index_t n, const ck_tile::index_t strideA,
     const ck_tile::index_t strideB, const ck_tile::index_t strideC,
-    const ck_tile::index_t k_batch) {
+    const ck_tile::index_t k_batch,
+    const ck_tile::index_t m_tile, const ck_tile::index_t n_tile) {
     const int64_t group_id = blockIdx.x * blockDim.x + threadIdx.x;
     if (group_id >= group_num)
         return;
@@ -254,6 +285,22 @@ __global__ void compute_grouped_gemm_variable_k_args(
     args_ptr[group_id].group_karg.stride_Bs[0] = strideB;
     args_ptr[group_id].group_karg.stride_E     = strideC;
     args_ptr[group_id].group_karg.k_batch      = k_batch;
+
+    // Prefix sum for block_start/block_end (variable-K: every group has the
+    // same M and N, only K varies, so the per-group tile count is uniform --
+    // unless `effective_m` is 0 for empty groups, which contributes 0 tiles).
+    // Same pattern as the forward kernel; the WS kernel's FindGroupId reads
+    // these fields.
+    const ck_tile::index_t num_n_tiles = (n + n_tile - 1) / n_tile;
+    ck_tile::index_t       my_block_start = 0;
+    for (int64_t g = 0; g < group_id; ++g) {
+        const ck_tile::index_t M_g = (group_lens_ptr[g] > 0) ? m : 0;
+        const ck_tile::index_t m_tiles_g = (M_g + m_tile - 1) / m_tile;
+        my_block_start += m_tiles_g * num_n_tiles * k_batch;
+    }
+    const ck_tile::index_t my_m_tiles = (effective_m + m_tile - 1) / m_tile;
+    args_ptr[group_id].block_start = my_block_start;
+    args_ptr[group_id].block_end   = my_block_start + my_m_tiles * num_n_tiles * k_batch;
 }
 
 template <typename ADataType, typename BDataType, typename CDataType, typename AccDataType,
@@ -345,17 +392,9 @@ void ck_grouped_gemm_variable_k(
     const ck_tile::index_t strideB = params.transB ? params.k : params.n;
     const ck_tile::index_t strideC = params.n;
 
-    {
-        const int threads = std::min(MAX_THREADS_PER_BLOCK, params.group_num);
-        const int grids   = (params.group_num + threads - 1) / threads;
-        compute_grouped_gemm_variable_k_args<ADataType, BDataType, CDataType>
-            <<<grids, threads, 0, params.stream>>>(
-                reinterpret_cast<ck_tile::GemmTransKernelArg<> *>(params.args_ptr), params.a_ptr,
-                params.b_ptr, params.c_ptr, params.group_lens_ptr, params.group_offs_ptr,
-                params.transA, params.transB, params.group_num, params.m, params.n, strideA,
-                strideB, strideC, k_batch);
-    }
-
+    // Pick the runner first -- we need its tile shape (m_tile, n_tile) for
+    // the args-setup kernel to compute block_start/block_end (mirrors the
+    // forward path).
     const auto stream_cfg = ck_tile::stream_config{params.stream};
     using CLayout         = RowMajor;
     std::unique_ptr<CKGroupedGemmRunnerInterFace> runner;
@@ -368,7 +407,26 @@ void ck_grouped_gemm_variable_k(
     } else {
         PRIMUS_TURBO_CHECK(false, "CKGroupedGemm-VariableK only support TN");
     }
-    runner->run(stream_cfg, params.group_num, params.args_ptr, params.num_cu);
+
+    {
+        const int threads = std::min(MAX_THREADS_PER_BLOCK, params.group_num);
+        const int grids   = (params.group_num + threads - 1) / threads;
+        compute_grouped_gemm_variable_k_args<ADataType, BDataType, CDataType>
+            <<<grids, threads, 0, params.stream>>>(
+                reinterpret_cast<ck_tile::GemmTransKernelArg<> *>(params.args_ptr), params.a_ptr,
+                params.b_ptr, params.c_ptr, params.group_lens_ptr, params.group_offs_ptr,
+                params.transA, params.transB, params.group_num, params.m, params.n, strideA,
+                strideB, strideC, k_batch, runner->m_tile(), runner->n_tile());
+    }
+
+    if (params.work_steal) {
+        PRIMUS_TURBO_CHECK(params.ws_counter_ptr != nullptr,
+                           "work_steal=true requires a non-null ws_counter_ptr");
+        runner->run_ws(stream_cfg, params.group_num, params.args_ptr, params.num_cu,
+                       params.ws_counter_ptr, params.ws_local_per_xcd);
+    } else {
+        runner->run(stream_cfg, params.group_num, params.args_ptr, params.num_cu);
+    }
 
     // Postprocess
     {

--- a/csrc/kernels/grouped_gemm/ck_grouped_gemm.cu
+++ b/csrc/kernels/grouped_gemm/ck_grouped_gemm.cu
@@ -26,7 +26,8 @@ compute_grouped_gemm_args(ck_tile::GemmTransKernelArg<> *args_ptr, const ADataTy
                           const ck_tile::index_t n, const ck_tile::index_t k,
                           const ck_tile::index_t strideA, const ck_tile::index_t strideB,
                           const ck_tile::index_t strideC, const ck_tile::index_t k_batch,
-                          const ck_tile::index_t m_tile, const ck_tile::index_t n_tile) {
+                          const ck_tile::index_t m_tile, const ck_tile::index_t n_tile,
+                          const bool work_steal) {
     const int64_t group_id = blockIdx.x * blockDim.x + threadIdx.x;
     if (group_id >= group_num)
         return;
@@ -44,23 +45,23 @@ compute_grouped_gemm_args(ck_tile::GemmTransKernelArg<> *args_ptr, const ADataTy
     args_ptr[group_id].group_karg.stride_E     = strideC;
     args_ptr[group_id].group_karg.k_batch      = k_batch;
 
-    // Prefix sum over prior groups' tile counts -> block_start. Required by the
-    // WS kernel's FindGroupId binary search (and benign for the static path,
-    // which doesn't read these fields). m_tile/n_tile are the runner's tile
-    // shape, supplied by the dispatch site. Each thread does an O(group_id)
-    // scan over `group_lens_ptr` (already populated on device); for G <= ~256
-    // total work is O(G^2) <= ~65k loads -- negligible vs the GEMM.
-    const ck_tile::index_t num_n_tiles = (n + n_tile - 1) / n_tile;
-    ck_tile::index_t       my_block_start = 0;
-    for (int64_t g = 0; g < group_id; ++g) {
-        const ck_tile::index_t M_g       = static_cast<ck_tile::index_t>(group_lens_ptr[g]);
-        const ck_tile::index_t m_tiles_g = (M_g + m_tile - 1) / m_tile;
-        my_block_start += m_tiles_g * num_n_tiles * k_batch;
+    // Prefix sum over prior groups' tile counts -> block_start. Required by
+    // the WS kernel's FindGroupId binary search. The static path doesn't
+    // read these fields, so skip the O(G^2) scan when work_steal is off --
+    // this keeps args-setup latency at O(G) for the common static case.
+    if (work_steal) {
+        const ck_tile::index_t num_n_tiles = (n + n_tile - 1) / n_tile;
+        ck_tile::index_t       my_block_start = 0;
+        for (int64_t g = 0; g < group_id; ++g) {
+            const ck_tile::index_t M_g       = static_cast<ck_tile::index_t>(group_lens_ptr[g]);
+            const ck_tile::index_t m_tiles_g = (M_g + m_tile - 1) / m_tile;
+            my_block_start += m_tiles_g * num_n_tiles * k_batch;
+        }
+        const ck_tile::index_t my_M       = static_cast<ck_tile::index_t>(group_lens_ptr[group_id]);
+        const ck_tile::index_t my_m_tiles = (my_M + m_tile - 1) / m_tile;
+        args_ptr[group_id].block_start    = my_block_start;
+        args_ptr[group_id].block_end      = my_block_start + my_m_tiles * num_n_tiles * k_batch;
     }
-    const ck_tile::index_t my_M       = static_cast<ck_tile::index_t>(group_lens_ptr[group_id]);
-    const ck_tile::index_t my_m_tiles = (my_M + m_tile - 1) / m_tile;
-    args_ptr[group_id].block_start    = my_block_start;
-    args_ptr[group_id].block_end      = my_block_start + my_m_tiles * num_n_tiles * k_batch;
 }
 
 template <typename ADataType, typename BDataType, typename CDataType, typename AccDataType = float,
@@ -177,7 +178,7 @@ void ck_grouped_gemm(const CKGroupedGemmParams<ADataType, BDataType, CDataType> 
                 reinterpret_cast<ck_tile::GemmTransKernelArg<> *>(params.args_ptr), params.a_ptr,
                 params.b_ptr, params.c_ptr, params.group_lens_ptr, params.group_offs_ptr,
                 params.group_num, params.n, params.k, strideA, strideB, strideC, k_batch,
-                runner->m_tile(), runner->n_tile());
+                runner->m_tile(), runner->n_tile(), params.work_steal);
     }
     if (params.work_steal) {
         PRIMUS_TURBO_CHECK(params.ws_counter_ptr != nullptr,
@@ -261,7 +262,8 @@ __global__ void compute_grouped_gemm_variable_k_args(
     const ck_tile::index_t m, const ck_tile::index_t n, const ck_tile::index_t strideA,
     const ck_tile::index_t strideB, const ck_tile::index_t strideC,
     const ck_tile::index_t k_batch,
-    const ck_tile::index_t m_tile, const ck_tile::index_t n_tile) {
+    const ck_tile::index_t m_tile, const ck_tile::index_t n_tile,
+    const bool work_steal) {
     const int64_t group_id = blockIdx.x * blockDim.x + threadIdx.x;
     if (group_id >= group_num)
         return;
@@ -290,17 +292,19 @@ __global__ void compute_grouped_gemm_variable_k_args(
     // same M and N, only K varies, so the per-group tile count is uniform --
     // unless `effective_m` is 0 for empty groups, which contributes 0 tiles).
     // Same pattern as the forward kernel; the WS kernel's FindGroupId reads
-    // these fields.
-    const ck_tile::index_t num_n_tiles = (n + n_tile - 1) / n_tile;
-    ck_tile::index_t       my_block_start = 0;
-    for (int64_t g = 0; g < group_id; ++g) {
-        const ck_tile::index_t M_g = (group_lens_ptr[g] > 0) ? m : 0;
-        const ck_tile::index_t m_tiles_g = (M_g + m_tile - 1) / m_tile;
-        my_block_start += m_tiles_g * num_n_tiles * k_batch;
+    // these fields. Skip the O(G^2) scan when work_steal is off.
+    if (work_steal) {
+        const ck_tile::index_t num_n_tiles = (n + n_tile - 1) / n_tile;
+        ck_tile::index_t       my_block_start = 0;
+        for (int64_t g = 0; g < group_id; ++g) {
+            const ck_tile::index_t M_g = (group_lens_ptr[g] > 0) ? m : 0;
+            const ck_tile::index_t m_tiles_g = (M_g + m_tile - 1) / m_tile;
+            my_block_start += m_tiles_g * num_n_tiles * k_batch;
+        }
+        const ck_tile::index_t my_m_tiles = (effective_m + m_tile - 1) / m_tile;
+        args_ptr[group_id].block_start = my_block_start;
+        args_ptr[group_id].block_end   = my_block_start + my_m_tiles * num_n_tiles * k_batch;
     }
-    const ck_tile::index_t my_m_tiles = (effective_m + m_tile - 1) / m_tile;
-    args_ptr[group_id].block_start = my_block_start;
-    args_ptr[group_id].block_end   = my_block_start + my_m_tiles * num_n_tiles * k_batch;
 }
 
 template <typename ADataType, typename BDataType, typename CDataType, typename AccDataType,
@@ -416,7 +420,7 @@ void ck_grouped_gemm_variable_k(
                 reinterpret_cast<ck_tile::GemmTransKernelArg<> *>(params.args_ptr), params.a_ptr,
                 params.b_ptr, params.c_ptr, params.group_lens_ptr, params.group_offs_ptr,
                 params.transA, params.transB, params.group_num, params.m, params.n, strideA,
-                strideB, strideC, k_batch, runner->m_tile(), runner->n_tile());
+                strideB, strideC, k_batch, runner->m_tile(), runner->n_tile(), params.work_steal);
     }
 
     if (params.work_steal) {

--- a/csrc/pytorch/bindings_pytorch.cpp
+++ b/csrc/pytorch/bindings_pytorch.cpp
@@ -98,9 +98,11 @@ TORCH_LIBRARY(primus_turbo_cpp_extension, m) {
 
     // ********* Grouped Gemm *********
     m.def("ck_grouped_gemm(Tensor a, Tensor b, Tensor group_lens, Tensor group_offs, bool transA, "
-          "bool transB, int? num_cu=None) -> Tensor");
+          "bool transB, int? num_cu=None, bool work_steal=False, Tensor? ws_counter=None, "
+          "int ws_local_per_xcd=0) -> Tensor");
     m.def("ck_grouped_gemm_variable_k(Tensor a, Tensor b, Tensor group_lens, Tensor group_offs, "
-          "bool transA, bool transB, int? num_cu=None) -> Tensor");
+          "bool transA, bool transB, int? num_cu=None, bool work_steal=False, "
+          "Tensor? ws_counter=None, int ws_local_per_xcd=0) -> Tensor");
     m.def("ck_grouped_gemm_fp8(Tensor a, Tensor b, Tensor a_scales, Tensor b_scales, "
           "Tensor group_lens, Tensor group_offs, bool transA, bool transB, "
           "ScalarType out_dtype, str granularity, int? num_cu) -> Tensor");

--- a/csrc/pytorch/extensions.h
+++ b/csrc/pytorch/extensions.h
@@ -224,19 +224,32 @@ at::Tensor turbo_gemm_fp8_meta(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B
 
 at::Tensor ck_grouped_gemm(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
                            at::Tensor &group_offs, const bool transA, const bool transB,
-                           c10::optional<int64_t> num_cu);
+                           c10::optional<int64_t>    num_cu,
+                           const bool                work_steal,
+                           c10::optional<at::Tensor> ws_counter,
+                           int64_t                   ws_local_per_xcd);
 
 at::Tensor ck_grouped_gemm_meta(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
                                 at::Tensor &group_offs, const bool transA, const bool transB,
-                                c10::optional<int64_t> num_cu);
+                                c10::optional<int64_t>    num_cu,
+                                const bool                work_steal,
+                                c10::optional<at::Tensor> ws_counter,
+                                int64_t                   ws_local_per_xcd);
 
 at::Tensor ck_grouped_gemm_variable_k(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
                                       at::Tensor &group_offs, const bool transA, const bool transB,
-                                      c10::optional<int64_t> num_cu);
+                                      c10::optional<int64_t>    num_cu,
+                                      const bool                work_steal,
+                                      c10::optional<at::Tensor> ws_counter,
+                                      int64_t                   ws_local_per_xcd);
 
 at::Tensor ck_grouped_gemm_variable_k_meta(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
                                            at::Tensor &group_offs, const bool transA,
-                                           const bool transB, c10::optional<int64_t> num_cu);
+                                           const bool                transB,
+                                           c10::optional<int64_t>    num_cu,
+                                           const bool                work_steal,
+                                           c10::optional<at::Tensor> ws_counter,
+                                           int64_t                   ws_local_per_xcd);
 
 at::Tensor ck_grouped_gemm_fp8(at::Tensor &a, at::Tensor &b, at::Tensor &a_scales,
                                at::Tensor &b_scales, at::Tensor &group_lens, at::Tensor &group_offs,

--- a/csrc/pytorch/grouped_gemm/ck_grouped_gemm.cpp
+++ b/csrc/pytorch/grouped_gemm/ck_grouped_gemm.cpp
@@ -120,6 +120,13 @@ at::Tensor ck_grouped_gemm(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
                            "ws_counter must have at least ", kCounterSlots, " int32 slots");
         ws_counter_ptr = static_cast<int32_t *>(counter.data_ptr());
     }
+    // The CK WS kernel takes ws_local_per_xcd as int32. Reject values that
+    // would truncate silently on the cast below (int32 max ~2.1B; the heuristic
+    // returns ceil(total_tiles / 8) at most, and any WS shape that fits in
+    // int32 tile count is well under this limit -- this is a defensive check).
+    PRIMUS_TURBO_CHECK(
+        ws_local_per_xcd >= 0 && ws_local_per_xcd <= INT32_MAX,
+        "ws_local_per_xcd must fit in int32 (got ", ws_local_per_xcd, ")");
 
     // Alloc args workspace
     const int64_t args_sizes = get_ck_grouped_gemm_args_sizes(group_lens.numel());
@@ -264,6 +271,11 @@ at::Tensor ck_grouped_gemm_variable_k(at::Tensor &a, at::Tensor &b, at::Tensor &
                            "ws_counter must have at least ", kCounterSlots, " int32 slots");
         ws_counter_ptr = static_cast<int32_t *>(counter.data_ptr());
     }
+    // See ck_grouped_gemm(): the kernel takes ws_local_per_xcd as int32,
+    // reject values that would truncate silently on the cast below.
+    PRIMUS_TURBO_CHECK(
+        ws_local_per_xcd >= 0 && ws_local_per_xcd <= INT32_MAX,
+        "ws_local_per_xcd must fit in int32 (got ", ws_local_per_xcd, ")");
 
     // Alloc args workspace
     const int64_t args_sizes = get_ck_grouped_gemm_args_sizes(group_lens.numel());

--- a/csrc/pytorch/grouped_gemm/ck_grouped_gemm.cpp
+++ b/csrc/pytorch/grouped_gemm/ck_grouped_gemm.cpp
@@ -115,6 +115,12 @@ at::Tensor ck_grouped_gemm(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
         PRIMUS_TURBO_CHECK(counter.scalar_type() == at::kInt,
                            "ws_counter must be int32");
         PRIMUS_TURBO_CHECK(counter.is_cuda(), "ws_counter must be on CUDA");
+        PRIMUS_TURBO_CHECK(counter.device() == a.device(),
+                           "ws_counter must be on the same CUDA device as `a` "
+                           "(counter cuda:", counter.device().index(),
+                           ", a cuda:", a.device().index(), ")");
+        PRIMUS_TURBO_CHECK(counter.is_contiguous(),
+                           "ws_counter must be contiguous");
         constexpr int64_t kCounterSlots = 8 + 2; // NUM_XCDS_WS + global + done
         PRIMUS_TURBO_CHECK(counter.numel() >= kCounterSlots,
                            "ws_counter must have at least ", kCounterSlots, " int32 slots");
@@ -266,6 +272,12 @@ at::Tensor ck_grouped_gemm_variable_k(at::Tensor &a, at::Tensor &b, at::Tensor &
         at::Tensor &counter = ws_counter.value();
         PRIMUS_TURBO_CHECK(counter.scalar_type() == at::kInt, "ws_counter must be int32");
         PRIMUS_TURBO_CHECK(counter.is_cuda(), "ws_counter must be on CUDA");
+        PRIMUS_TURBO_CHECK(counter.device() == a.device(),
+                           "ws_counter must be on the same CUDA device as `a` "
+                           "(counter cuda:", counter.device().index(),
+                           ", a cuda:", a.device().index(), ")");
+        PRIMUS_TURBO_CHECK(counter.is_contiguous(),
+                           "ws_counter must be contiguous");
         constexpr int64_t kCounterSlots = 8 + 2;
         PRIMUS_TURBO_CHECK(counter.numel() >= kCounterSlots,
                            "ws_counter must have at least ", kCounterSlots, " int32 slots");

--- a/csrc/pytorch/grouped_gemm/ck_grouped_gemm.cpp
+++ b/csrc/pytorch/grouped_gemm/ck_grouped_gemm.cpp
@@ -88,7 +88,10 @@ uint32_t get_grouped_gemm_num_cu(c10::optional<int64_t> num_cu) {
 
 at::Tensor ck_grouped_gemm(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
                            at::Tensor &group_offs, const bool transA, const bool transB,
-                           c10::optional<int64_t> num_cu) {
+                           c10::optional<int64_t>    num_cu,
+                           const bool                work_steal,
+                           c10::optional<at::Tensor> ws_counter,
+                           int64_t                   ws_local_per_xcd) {
     auto out_dtype = a.scalar_type();
 
     // Check
@@ -96,6 +99,27 @@ at::Tensor ck_grouped_gemm(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
     PRIMUS_TURBO_CHECK(is_16bit_floating_point_dtype(b.scalar_type()));
     PRIMUS_TURBO_CHECK(group_lens.scalar_type() == at::kLong);
     PRIMUS_TURBO_CHECK(group_offs.scalar_type() == at::kLong);
+
+    // Validate the WS counter. The buffer is owned and zeroed at allocation
+    // time by the Python wrapper (per-device cache, one-shot torch.zeros);
+    // the kernel self-resets all slots before exit (last-out CTA), so no
+    // per-call zero is needed here.
+    //
+    // Counter buffer layout: [xcd0..xcd7, global, done] -- 10 int32 slots.
+    // ws_local_per_xcd selects the WS mode (see grouped_gemm_kernel_ws.hpp).
+    int32_t *ws_counter_ptr = nullptr;
+    if (work_steal) {
+        PRIMUS_TURBO_CHECK(ws_counter.has_value(),
+                           "ck_grouped_gemm: work_steal=True requires ws_counter");
+        at::Tensor &counter = ws_counter.value();
+        PRIMUS_TURBO_CHECK(counter.scalar_type() == at::kInt,
+                           "ws_counter must be int32");
+        PRIMUS_TURBO_CHECK(counter.is_cuda(), "ws_counter must be on CUDA");
+        constexpr int64_t kCounterSlots = 8 + 2; // NUM_XCDS_WS + global + done
+        PRIMUS_TURBO_CHECK(counter.numel() >= kCounterSlots,
+                           "ws_counter must have at least ", kCounterSlots, " int32 slots");
+        ws_counter_ptr = static_cast<int32_t *>(counter.data_ptr());
+    }
 
     // Alloc args workspace
     const int64_t args_sizes = get_ck_grouped_gemm_args_sizes(group_lens.numel());
@@ -117,6 +141,9 @@ at::Tensor ck_grouped_gemm(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
         auto params = make_ck_groued_gemm_params<AType, BType, CType>(
             args_tensor.data_ptr(), a, b, c, group_lens, group_offs, transA, transB, bs, m, n, k,
             stream, get_grouped_gemm_num_cu(num_cu));
+        params.work_steal       = work_steal;
+        params.ws_counter_ptr   = ws_counter_ptr;
+        params.ws_local_per_xcd = static_cast<int32_t>(ws_local_per_xcd);
         primus_turbo::ck_grouped_gemm<AType, BType, CType>(params);
     } else if (a.dtype() == at::kBFloat16) {
         using AType = typename TorchToCKTileType<at::kBFloat16>::type;
@@ -125,6 +152,9 @@ at::Tensor ck_grouped_gemm(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
         auto params = make_ck_groued_gemm_params<AType, BType, CType>(
             args_tensor.data_ptr(), a, b, c, group_lens, group_offs, transA, transB, bs, m, n, k,
             stream, get_grouped_gemm_num_cu(num_cu));
+        params.work_steal       = work_steal;
+        params.ws_counter_ptr   = ws_counter_ptr;
+        params.ws_local_per_xcd = static_cast<int32_t>(ws_local_per_xcd);
         primus_turbo::ck_grouped_gemm<AType, BType, CType>(params);
     } else {
         PRIMUS_TURBO_CHECK(false, "GroupedGemm only support float16 and bfloat16");
@@ -207,7 +237,10 @@ at::Tensor ck_grouped_gemm_fp8(at::Tensor &a, at::Tensor &b, at::Tensor &a_scale
 
 at::Tensor ck_grouped_gemm_variable_k(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
                                       at::Tensor &group_offs, const bool transA, const bool transB,
-                                      c10::optional<int64_t> num_cu) {
+                                      c10::optional<int64_t>    num_cu,
+                                      const bool                work_steal,
+                                      c10::optional<at::Tensor> ws_counter,
+                                      int64_t                   ws_local_per_xcd) {
     // TODO: output datatype
     auto out_dtype = a.scalar_type();
 
@@ -216,6 +249,21 @@ at::Tensor ck_grouped_gemm_variable_k(at::Tensor &a, at::Tensor &b, at::Tensor &
     PRIMUS_TURBO_CHECK(is_16bit_floating_point_dtype(b.scalar_type()));
     PRIMUS_TURBO_CHECK(group_lens.scalar_type() == at::kLong);
     PRIMUS_TURBO_CHECK(group_offs.scalar_type() == at::kLong);
+
+    // Validate WS counter -- kernel self-resets, no per-call zero needed.
+    // Counter layout: [xcd0..7, global, done] = 10 int32 slots.
+    int32_t *ws_counter_ptr = nullptr;
+    if (work_steal) {
+        PRIMUS_TURBO_CHECK(ws_counter.has_value(),
+                           "ck_grouped_gemm_variable_k: work_steal=True requires ws_counter");
+        at::Tensor &counter = ws_counter.value();
+        PRIMUS_TURBO_CHECK(counter.scalar_type() == at::kInt, "ws_counter must be int32");
+        PRIMUS_TURBO_CHECK(counter.is_cuda(), "ws_counter must be on CUDA");
+        constexpr int64_t kCounterSlots = 8 + 2;
+        PRIMUS_TURBO_CHECK(counter.numel() >= kCounterSlots,
+                           "ws_counter must have at least ", kCounterSlots, " int32 slots");
+        ws_counter_ptr = static_cast<int32_t *>(counter.data_ptr());
+    }
 
     // Alloc args workspace
     const int64_t args_sizes = get_ck_grouped_gemm_args_sizes(group_lens.numel());
@@ -237,6 +285,9 @@ at::Tensor ck_grouped_gemm_variable_k(at::Tensor &a, at::Tensor &b, at::Tensor &
         auto params = make_ck_groued_gemm_params<AType, BType, CType>(
             args_tensor.data_ptr(), a, b, c, group_lens, group_offs, transA, transB, bs, m, n, k,
             stream, get_grouped_gemm_num_cu(num_cu));
+        params.work_steal       = work_steal;
+        params.ws_counter_ptr   = ws_counter_ptr;
+        params.ws_local_per_xcd = static_cast<int32_t>(ws_local_per_xcd);
         primus_turbo::ck_grouped_gemm_variable_k<AType, BType, CType>(params);
     } else if (a.dtype() == at::kBFloat16) {
         using AType = typename TorchToCKTileType<at::kBFloat16>::type;
@@ -245,6 +296,9 @@ at::Tensor ck_grouped_gemm_variable_k(at::Tensor &a, at::Tensor &b, at::Tensor &
         auto params = make_ck_groued_gemm_params<AType, BType, CType>(
             args_tensor.data_ptr(), a, b, c, group_lens, group_offs, transA, transB, bs, m, n, k,
             stream, get_grouped_gemm_num_cu(num_cu));
+        params.work_steal       = work_steal;
+        params.ws_counter_ptr   = ws_counter_ptr;
+        params.ws_local_per_xcd = static_cast<int32_t>(ws_local_per_xcd);
         primus_turbo::ck_grouped_gemm_variable_k<AType, BType, CType>(params);
     } else {
         PRIMUS_TURBO_CHECK(false, "GroupedGemm only support float16 and bfloat16");

--- a/csrc/pytorch/grouped_gemm/grouped_gemm_meta.cpp
+++ b/csrc/pytorch/grouped_gemm/grouped_gemm_meta.cpp
@@ -14,7 +14,10 @@ namespace primus_turbo::pytorch {
 
 at::Tensor ck_grouped_gemm_meta(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
                                 at::Tensor &group_offs, const bool transA, const bool transB,
-                                c10::optional<int64_t> num_cu) {
+                                c10::optional<int64_t>    num_cu,
+                                const bool                /*work_steal*/,
+                                c10::optional<at::Tensor> /*ws_counter*/,
+                                int64_t                   /*ws_local_per_xcd*/) {
     // TODO: out-datatype
     const int64_t m = transA ? a.size(1) : a.size(0);
     const int64_t n = transB ? b.size(1) : b.size(2);
@@ -23,7 +26,11 @@ at::Tensor ck_grouped_gemm_meta(at::Tensor &a, at::Tensor &b, at::Tensor &group_
 
 at::Tensor ck_grouped_gemm_variable_k_meta(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
                                            at::Tensor &group_offs, const bool transA,
-                                           const bool transB, c10::optional<int64_t> num_cu) {
+                                           const bool                transB,
+                                           c10::optional<int64_t>    num_cu,
+                                           const bool                /*work_steal*/,
+                                           c10::optional<at::Tensor> /*ws_counter*/,
+                                           int64_t                   /*ws_local_per_xcd*/) {
     const int64_t bs = group_lens.numel();
     const int64_t m  = transA ? a.size(1) : a.size(0);
     const int64_t n  = transB ? b.size(0) : b.size(1);

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
@@ -14,6 +14,7 @@ from primus_turbo.pytorch.core.backend import (
     PrecisionType,
     TuneCache,
 )
+from primus_turbo.pytorch.core.utils import is_gfx950
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
     BaseGroupedGEMMKernelDispatcher,
     BaseGroupedGEMMVariableKKernelDispatcher,
@@ -87,6 +88,12 @@ class GroupedGEMMCKBackend(KernelBackend):
         supported &= a.dtype in _COMMON_SUPPORTED_DTYPES and b.dtype in _COMMON_SUPPORTED_DTYPES
         supported &= not trans_a
         supported &= schedule in _WS_SUPPORTED_SCHEDULES
+        # The CK WS kernel needs 4 extra bytes of LDS for the atomicAdd
+        # broadcast slot, which fits on gfx950 (MI355X) but overflows
+        # gfx942's 64 KB LDS budget. The device-side WS body is stubbed
+        # out on gfx942, so refuse to dispatch WS to CK on that arch.
+        if schedule == "work_steal" and not is_gfx950():
+            supported = False
         return supported
 
     @staticmethod
@@ -156,6 +163,10 @@ class GroupedGEMMVariableKCKBackend(KernelBackend):
         supported &= a.dtype in _COMMON_SUPPORTED_DTYPES and b.dtype in _COMMON_SUPPORTED_DTYPES
         supported &= trans_a and not trans_b
         supported &= schedule in _WS_SUPPORTED_SCHEDULES
+        # See GroupedGEMMCKBackend.can_handle: the CK WS kernel is
+        # gfx950-only due to LDS budget.
+        if schedule == "work_steal" and not is_gfx950():
+            supported = False
         return supported
 
     @staticmethod

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
@@ -14,7 +14,22 @@ from primus_turbo.pytorch.core.backend import (
     PrecisionType,
     TuneCache,
 )
-from primus_turbo.pytorch.core.utils import is_gfx950
+from primus_turbo.pytorch.core.utils import _get_device_compute_capability
+
+
+def _is_gfx950_device(device: torch.device) -> bool:
+    """Compute capability check bound to a specific tensor's device.
+
+    ``is_gfx950()`` inspects the *current* CUDA device via
+    ``torch.cuda.current_device()``, which is wrong when the tensor lives
+    on a different device than the ambient one (multi-GPU / mixed-arch
+    hosts). Route by the tensor's device instead.
+    """
+    if device.type != "cuda":
+        return False
+    return _get_device_compute_capability(device) == (9, 5)
+
+
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
     BaseGroupedGEMMKernelDispatcher,
     BaseGroupedGEMMVariableKKernelDispatcher,
@@ -92,7 +107,9 @@ class GroupedGEMMCKBackend(KernelBackend):
         # broadcast slot, which fits on gfx950 (MI355X) but overflows
         # gfx942's 64 KB LDS budget. The device-side WS body is stubbed
         # out on gfx942, so refuse to dispatch WS to CK on that arch.
-        if schedule == "work_steal" and not is_gfx950():
+        # Check the *tensor's* device (multi-GPU safe), not the ambient
+        # ``current_device()``.
+        if schedule == "work_steal" and not _is_gfx950_device(a.device):
             supported = False
         return supported
 
@@ -164,8 +181,8 @@ class GroupedGEMMVariableKCKBackend(KernelBackend):
         supported &= trans_a and not trans_b
         supported &= schedule in _WS_SUPPORTED_SCHEDULES
         # See GroupedGEMMCKBackend.can_handle: the CK WS kernel is
-        # gfx950-only due to LDS budget.
-        if schedule == "work_steal" and not is_gfx950():
+        # gfx950-only due to LDS budget. Route by the tensor's device.
+        if schedule == "work_steal" and not _is_gfx950_device(a.device):
             supported = False
         return supported
 

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
@@ -18,6 +18,11 @@ from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
     BaseGroupedGEMMKernelDispatcher,
     BaseGroupedGEMMVariableKKernelDispatcher,
 )
+from primus_turbo.pytorch.kernels.grouped_gemm.ws_ck_heuristic import (
+    approximate_ck_standard_total_tiles,
+    compute_ck_variable_k_total_tiles,
+    resolve_ck_ws_local_per_xcd,
+)
 from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
     grouped_gemm_triton_kernel,
     grouped_gemm_variable_k_triton_kernel,
@@ -30,10 +35,38 @@ _COMMON_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
 #   "work_steal"  -- work-stealing persistent kernel with the kernel-aware
 #                    heuristic that picks the WS sub-mode (per-XCD /
 #                    global / hierarchical) from tensor metadata.
-#                    Triton backend only in this build.
+#                    Triton + CK backends.
 _SUPPORTED_SCHEDULES: tuple[str, ...] = ("static", "work_steal")
-_TRITON_SUPPORTED_SCHEDULES: tuple[str, ...] = ("static", "work_steal")
+_WS_SUPPORTED_SCHEDULES: tuple[str, ...] = ("static", "work_steal")
 _NON_WS_SUPPORTED_SCHEDULES: tuple[str, ...] = ("static",)
+
+# Per-device cache for the CK work-stealing counter buffer.
+#
+# Layout: [xcd0..xcd7, global, done] -- 10 int32 slots. The kernel self-resets
+# every slot to 0 before exit (last-out CTA pattern, see
+# grouped_gemm_kernel_ws.hpp), so the only zero we ever need is the one
+# ``torch.zeros`` does at first allocation. Caching one buffer per device makes
+# that allocation a one-shot cost per process.
+#
+# Caveat: the singleton is not stream-safe. Concurrent WS launches on different
+# streams of the same device would race on the same slots. Safe under the
+# typical single-stream autograd graph. The public ``grouped_gemm()`` op also
+# rejects ``schedule="work_steal"`` paired with ``num_cu != None``, so partial-
+# grid launches never reach the WS path from the high level.
+_CK_WS_COUNTER_NUM_SLOTS = 10
+_ck_ws_counters: dict[torch.device, torch.Tensor] = {}
+
+
+def _get_ck_ws_counter(device: torch.device) -> torch.Tensor:
+    buf = _ck_ws_counters.get(device)
+    if buf is None:
+        buf = torch.zeros(_CK_WS_COUNTER_NUM_SLOTS, dtype=torch.int32, device=device)
+        _ck_ws_counters[device] = buf
+    return buf
+
+
+def _num_cus(device: torch.device) -> int:
+    return torch.cuda.get_device_properties(device).multi_processor_count
 
 
 class GroupedGEMMCKBackend(KernelBackend):
@@ -53,7 +86,7 @@ class GroupedGEMMCKBackend(KernelBackend):
         supported &= a.dim() == 2 and b.dim() == 3
         supported &= a.dtype in _COMMON_SUPPORTED_DTYPES and b.dtype in _COMMON_SUPPORTED_DTYPES
         supported &= not trans_a
-        supported &= schedule in _NON_WS_SUPPORTED_SCHEDULES
+        supported &= schedule in _WS_SUPPORTED_SCHEDULES
         return supported
 
     @staticmethod
@@ -68,8 +101,38 @@ class GroupedGEMMCKBackend(KernelBackend):
         schedule: str = "static",
         **kwargs,
     ) -> torch.Tensor:
+        work_steal = schedule == "work_steal"
+        ws_counter: torch.Tensor | None = None
+        resolved_lpx = 0
+        if work_steal:
+            ws_counter = _get_ck_ws_counter(a.device)
+            # Sync-free: derive total_tiles from tensor metadata
+            # (a.size(0), group_lens.numel()). The approximation is a lower
+            # bound on the exact value; the kernel's bounds check makes any
+            # resulting ws_local_per_xcd correctness-safe.
+            n = b.size(1) if trans_b else b.size(2)
+            total_tiles = approximate_ck_standard_total_tiles(
+                a.size(0),
+                group_lens.numel(),
+                n,
+            )
+            resolved_lpx = resolve_ck_ws_local_per_xcd(
+                "auto",
+                total_tiles,
+                num_cu or _num_cus(a.device),
+                kernel_kind="standard",
+            )
         return torch.ops.primus_turbo_cpp_extension.ck_grouped_gemm(
-            a, b, group_lens, group_offs, trans_a, trans_b, num_cu
+            a,
+            b,
+            group_lens,
+            group_offs,
+            trans_a,
+            trans_b,
+            num_cu,
+            work_steal,
+            ws_counter,
+            resolved_lpx,
         )
 
 
@@ -91,7 +154,7 @@ class GroupedGEMMVariableKCKBackend(KernelBackend):
         supported &= a.dim() == 2 and b.dim() == 2
         supported &= a.dtype in _COMMON_SUPPORTED_DTYPES and b.dtype in _COMMON_SUPPORTED_DTYPES
         supported &= trans_a and not trans_b
-        supported &= schedule in _NON_WS_SUPPORTED_SCHEDULES
+        supported &= schedule in _WS_SUPPORTED_SCHEDULES
         return supported
 
     @staticmethod
@@ -113,8 +176,37 @@ class GroupedGEMMVariableKCKBackend(KernelBackend):
         else:
             lhs, rhs = a, b
             trans_lhs, trans_rhs = trans_a, trans_b
+        work_steal = schedule == "work_steal"
+        ws_counter: torch.Tensor | None = None
+        resolved_lpx = 0
+        if work_steal:
+            ws_counter = _get_ck_ws_counter(lhs.device)
+            # Variable-K total_tiles depends only on tensor shapes
+            # (lhs.size, rhs.size, group_lens.numel) -- exact and sync-free.
+            m_out = lhs.size(1) if trans_lhs else lhs.size(0)
+            n_out = rhs.size(0) if trans_rhs else rhs.size(1)
+            total_tiles = compute_ck_variable_k_total_tiles(
+                group_lens.numel(),
+                m_out,
+                n_out,
+            )
+            resolved_lpx = resolve_ck_ws_local_per_xcd(
+                "auto",
+                total_tiles,
+                num_cu or _num_cus(lhs.device),
+                kernel_kind="variable_k",
+            )
         return torch.ops.primus_turbo_cpp_extension.ck_grouped_gemm_variable_k(
-            lhs, rhs, group_lens, group_offs, trans_lhs, trans_rhs, num_cu
+            lhs,
+            rhs,
+            group_lens,
+            group_offs,
+            trans_lhs,
+            trans_rhs,
+            num_cu,
+            work_steal,
+            ws_counter,
+            resolved_lpx,
         )
 
 
@@ -222,7 +314,7 @@ class GroupedGEMMTritonBackend(KernelBackend):
         supported &= a.dim() == 2 and b.dim() == 3
         supported &= a.dtype in _COMMON_SUPPORTED_DTYPES and b.dtype in _COMMON_SUPPORTED_DTYPES
         supported &= not trans_a
-        supported &= schedule in _TRITON_SUPPORTED_SCHEDULES
+        supported &= schedule in _WS_SUPPORTED_SCHEDULES
         return supported
 
     @staticmethod
@@ -275,7 +367,7 @@ class GroupedGEMMVariableKTritonBackend(KernelBackend):
         supported &= a.dim() == 2 and b.dim() == 2
         supported &= a.dtype in _COMMON_SUPPORTED_DTYPES and b.dtype in _COMMON_SUPPORTED_DTYPES
         supported &= trans_a and not trans_b
-        supported &= schedule in _TRITON_SUPPORTED_SCHEDULES
+        supported &= schedule in _WS_SUPPORTED_SCHEDULES
         return supported
 
     @staticmethod

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
@@ -106,13 +106,14 @@ class GroupedGEMMCKBackend(KernelBackend):
         resolved_lpx = 0
         if work_steal:
             ws_counter = _get_ck_ws_counter(a.device)
-            # Sync-free: derive total_tiles from tensor metadata
-            # (a.size(0), group_lens.numel()). The approximation is a lower
-            # bound on the exact value; the kernel's bounds check makes any
-            # resulting ws_local_per_xcd correctness-safe.
+            # Sync-free: derive total_tiles from tensor metadata. Use the
+            # transpose-aware M dimension (``can_handle`` already rejects
+            # trans_a=True on this backend, but keep the shape logic honest
+            # so it stays correct if that constraint is ever relaxed).
+            total_m = a.size(1) if trans_a else a.size(0)
             n = b.size(1) if trans_b else b.size(2)
             total_tiles = approximate_ck_standard_total_tiles(
-                a.size(0),
+                total_m,
                 group_lens.numel(),
                 n,
             )

--- a/primus_turbo/pytorch/kernels/grouped_gemm/ws_ck_heuristic.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/ws_ck_heuristic.py
@@ -1,0 +1,141 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""Heuristic for the CK WS kernel's ``ws_local_per_xcd`` parameter.
+
+The CK WS kernel takes a single ``ws_local_per_xcd`` integer:
+
+    local_per_xcd = 0                            -> global-only
+    local_per_xcd = ceil(total_tiles/num_xcds)   -> per-xcd-only
+    in-between                                   -> hierarchical
+
+The high-level API exposes a string ``ws_mode`` (``"auto" | "per-xcd" |
+"global" | "hierarchical"``); this module resolves it to the integer the
+kernel wants. ``"auto"`` applies the empirical-best policy derived from
+the 288-shape Primus-Turbo MoE bench:
+
+    standard kernel (fwd / dgrad):  tpc < 4 -> per-xcd, else global
+    variable-K kernel (wgrad):      tpc < 2 -> per-xcd, else global
+
+(``tpc`` = total_tiles / num_cus, the "tiles per CU" workload density.)
+
+This module must stay in sync with ``NUM_XCDS_WS`` in
+``csrc/kernels/grouped_gemm/grouped_gemm_kernel_ws.hpp``.
+"""
+
+from __future__ import annotations
+
+CK_NUM_XCDS = 8
+
+_KERNEL_STANDARD = "standard"
+_KERNEL_VARIABLE_K = "variable_k"
+
+# Empirical "auto" thresholds: tpc below this -> per-xcd, else global.
+_AUTO_TPC_THRESHOLD = {
+    _KERNEL_STANDARD: 4.0,
+    _KERNEL_VARIABLE_K: 2.0,
+}
+
+
+def resolve_ck_ws_local_per_xcd(
+    ws_mode: str,
+    total_tiles: int,
+    num_cus: int,
+    *,
+    kernel_kind: str = _KERNEL_STANDARD,
+) -> int:
+    """Map ``ws_mode`` (string) to ``ws_local_per_xcd`` (int) for the CK WS kernel.
+
+    Args:
+        ws_mode: ``"auto"``, ``"per-xcd"``, ``"global"``, or ``"hierarchical"``.
+        total_tiles: total persistent-loop tile count (sum across groups).
+        num_cus: grid-x dim the kernel will launch with (e.g. 256 on MI355X).
+        kernel_kind: ``"standard"`` (fwd / dgrad) or ``"variable_k"`` (wgrad).
+
+    Returns:
+        The integer ``ws_local_per_xcd`` value to pass to the kernel.
+    """
+    if total_tiles <= 0 or num_cus <= 0:
+        return 0
+
+    per_xcd_full = (total_tiles + CK_NUM_XCDS - 1) // CK_NUM_XCDS
+
+    if ws_mode == "global":
+        return 0
+    if ws_mode == "per-xcd":
+        return per_xcd_full
+    if ws_mode == "hierarchical":
+        # ~50% per-xcd, ~50% global tail.
+        # Edge case: for total_tiles < CK_NUM_XCDS * 2 (= 16), the integer
+        # division floors to 0 and the ``max(1, ...)`` clamp yields
+        # local_per_xcd=1, meaning phase 1 produces only one claim per XCD.
+        # That is functionally equivalent to per-xcd mode for such tiny
+        # shapes, which is fine -- the kernel bounds-checks local_per_xcd
+        # against the remaining tile count.
+        return max(1, (total_tiles // 2) // CK_NUM_XCDS)
+    if ws_mode == "auto":
+        threshold = _AUTO_TPC_THRESHOLD.get(kernel_kind, _AUTO_TPC_THRESHOLD[_KERNEL_STANDARD])
+        if total_tiles / num_cus < threshold:
+            return per_xcd_full
+        return 0
+    raise ValueError(
+        f"unknown ws_mode={ws_mode!r}; expected one of 'auto', 'per-xcd', 'global', 'hierarchical'"
+    )
+
+
+# Tile shape constants for total_tiles computation. These mirror the CK
+# kernel's BlockM/BlockN -- keep in sync with the tile partitioner template
+# parameters in grouped_gemm_kernel_ws.hpp.
+CK_TILE_M = 256
+CK_TILE_N = 256
+
+
+def approximate_ck_standard_total_tiles(total_m: int, num_groups: int, n: int) -> int:
+    """Sync-free LOWER bound on the standard CK kernel's total_tiles.
+
+    Exact formula (would require reading per-group sizes from the GPU):
+
+        exact      = sum_g ceil(M_g / TILE_M) * num_n_tiles
+
+    This approximation uses only ``total_m = sum(group_lens) = a.size(0)``
+    -- tensor metadata, no GPU sync:
+
+        lower_bnd  = ceil(total_m / TILE_M) * num_n_tiles
+        upper_bnd  = lower_bnd + (num_groups - 1) * num_n_tiles
+
+    The returned value is the LOWER bound. It is exact when group sizes
+    are uniform and underestimates by at most
+    ``(num_groups - 1) * num_n_tiles`` for non-uniform groups.
+
+    Why the lower bound (not midpoint or upper)? The resolved
+    ``ws_local_per_xcd`` drives the kernel's phase-1 budget.
+    Overestimating ``total_tiles`` -> per-xcd budget too large -> CTAs
+    burn atomic claims past the real total (correctness-safe via the
+    kernel's bounds check, but every wasted claim costs ~1 us of
+    serialized atomic time). Underestimating -> phase 1 covers fewer
+    tiles than exist -> phase 2 picks up the remainder via the global
+    counter (no wasted atomics, just a small phase-balance shift).
+    Bias toward "do less in phase 1" is cheap; bias toward "do more"
+    wastes work.
+
+    ``num_groups`` is accepted for documentation (it appears in the
+    upper-bound formula above) but unused in the returned value.
+    """
+    del num_groups  # accepted for documentation only
+    num_n_tiles = (n + CK_TILE_N - 1) // CK_TILE_N
+    return ((total_m + CK_TILE_M - 1) // CK_TILE_M) * num_n_tiles
+
+
+def compute_ck_variable_k_total_tiles(num_groups: int, k: int, n: int) -> int:
+    """Total tiles for the variable-K CK kernel (wgrad).
+
+    Output is [G, K, N] partitioned into [TILE_M, TILE_N] blocks (K plays
+    the M role and N plays the N role). Variable-K's tile count depends
+    only on integer shapes (not per-group values), so this is exact and
+    sync-free.
+    """
+    num_m_tiles = (k + CK_TILE_M - 1) // CK_TILE_M
+    num_n_tiles = (n + CK_TILE_N - 1) // CK_TILE_N
+    return num_groups * num_m_tiles * num_n_tiles

--- a/primus_turbo/pytorch/ops/grouped_gemm.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm.py
@@ -139,11 +139,11 @@ def grouped_gemm(
             * ``"static"`` (default): static-stride persistent kernel.
             * ``"work_steal"``: work-stealing persistent kernel with a kernel-
               aware heuristic that picks per-XCD / global / hierarchical tile
-              claims based on tensor metadata. Triton backend only; explicit
-              selection of a non-Triton backend together with ``"work_steal"``
-              is rejected at dispatch. Internal WS sub-modes are not exposed
-              at this layer; tune via ``grouped_gemm_triton_kernel`` directly
-              when needed. Requires ``num_cu=None`` (see ``num_cu`` above).
+              claims based on tensor metadata. Supported on the Triton and CK
+              backends; HIPBLASLT advertises only ``"static"``. Internal WS
+              sub-modes are not exposed at this layer; tune via the kernel-
+              level entry points when needed. Requires ``num_cu=None`` (see
+              ``num_cu`` above).
 
     Returns:
         torch.Tensor: Output of shape [sum(group_lens), N], same dtype/device as `a`.

--- a/tests/pytorch/ops/test_grouped_gemm.py
+++ b/tests/pytorch/ops/test_grouped_gemm.py
@@ -280,6 +280,13 @@ def test_grouped_gemm_schedule_work_steal(B, M, N_K, dtype, balance, trans_b, ba
     """``schedule="work_steal"`` on each WS-capable backend matches the static
     path bit-for-bit for forward and backward (per-tile accumulator order is
     identical to the static schedule; there is no cross-tile reduction)."""
+    # CK WS is gfx950-only (see GroupedGEMMCKBackend.can_handle): the kernel
+    # body is stubbed out on gfx942 due to the 64 KB LDS budget, and the
+    # backend advertises unsupported so the dispatcher raises. Skip the
+    # combination on non-gfx950 hardware.
+    if backend is BackendType.CK and get_device_compute_capability() != (9, 5):
+        pytest.skip("CK schedule='work_steal' is gfx950-only (LDS budget)")
+
     seed = 42
     torch.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
@@ -431,6 +438,11 @@ def test_grouped_gemm_triton_kernel_ws_num_cu_below_num_xcds(num_cu, ws_mode):
     torch.testing.assert_close(out_ref, out_ws, rtol=0.0, atol=0.0)
 
 
+@pytest.mark.skipif(
+    get_device_compute_capability() != (9, 5),
+    reason="CK WS kernel body is stubbed on non-gfx950 (LDS budget); the "
+    "cpp op would produce a no-op result. See GroupedGEMMCKBackend.can_handle.",
+)
 @pytest.mark.parametrize("num_cu", [4, 6, 7, 8, 16])
 def test_ck_grouped_gemm_op_ws_num_cu_below_num_xcds(num_cu):
     """Regression: ``num_cu < NUM_XCDS_WS`` (=8) on the CK WS kernel used to

--- a/tests/pytorch/ops/test_grouped_gemm.py
+++ b/tests/pytorch/ops/test_grouped_gemm.py
@@ -429,3 +429,46 @@ def test_grouped_gemm_triton_kernel_ws_num_cu_below_num_xcds(num_cu, ws_mode):
         a, b, group_offs, trans_b=True, num_cu=num_cu, work_steal=True, ws_mode=ws_mode
     )
     torch.testing.assert_close(out_ref, out_ws, rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize("num_cu", [4, 6, 7, 8, 16])
+def test_ck_grouped_gemm_op_ws_num_cu_below_num_xcds(num_cu):
+    """Regression: ``num_cu < NUM_XCDS_WS`` (=8) on the CK WS kernel used to
+    silently drop tiles in the gap between ``num_cu * per_xcd`` and
+    ``NUM_XCDS_WS * per_xcd`` (phase 2 starting past where phase 1 actually
+    ended). With the ``active_xcds = min(gridDim.x, NUM_XCDS_WS)`` fix the
+    kernel matches static at any grid size. Mirrors the equivalent Triton
+    regression in ``test_grouped_gemm_triton_kernel_ws_num_cu_below_num_xcds``.
+    (The public API rejects num_cu != None + schedule="work_steal", but the
+    cpp op ``ck_grouped_gemm`` still accepts the combination -- belt-and-
+    braces.)"""
+    from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_impl import (
+        _get_ck_ws_counter,
+    )
+    from primus_turbo.pytorch.kernels.grouped_gemm.ws_ck_heuristic import (
+        approximate_ck_standard_total_tiles,
+        resolve_ck_ws_local_per_xcd,
+    )
+
+    device = "cuda"
+    torch.manual_seed(0)
+    B, M, N, K = 4, 1024, 2048, 1408
+    a = torch.randn((B * M, K), dtype=torch.bfloat16, device=device)
+    b = torch.randn((B, N, K), dtype=torch.bfloat16, device=device)
+    group_lens = torch.full((B,), M, dtype=torch.int64, device=device)
+    group_offs = torch.zeros(B + 1, dtype=torch.int64, device=device)
+    group_offs[1:] = torch.cumsum(group_lens, dim=0)
+
+    # Static reference (no WS).
+    out_ref = torch.ops.primus_turbo_cpp_extension.ck_grouped_gemm(
+        a, b, group_lens, group_offs, False, True, num_cu, False, None, 0
+    )
+    # Force a per-XCD-style local_per_xcd so phase 1 actually runs and the
+    # gap bug (pre-fix) would surface.
+    total_tiles = approximate_ck_standard_total_tiles(a.size(0), B, N)
+    local_per_xcd = resolve_ck_ws_local_per_xcd("per-xcd", total_tiles, num_cu, kernel_kind="standard")
+    counter = _get_ck_ws_counter(a.device)
+    out_ws = torch.ops.primus_turbo_cpp_extension.ck_grouped_gemm(
+        a, b, group_lens, group_offs, False, True, num_cu, True, counter, local_per_xcd
+    )
+    torch.testing.assert_close(out_ref, out_ws, rtol=0.0, atol=0.0)

--- a/tests/pytorch/ops/test_grouped_gemm.py
+++ b/tests/pytorch/ops/test_grouped_gemm.py
@@ -259,12 +259,13 @@ def test_grouped_gemm_with_zero_length_groups(B, M, N_K, dtype, trans_b, backend
 # ---------------------------------------------------------------------------
 # Work-stealing tests
 #
-# Public API: ``schedule="work_steal"`` enables the work-stealing kernel on the
-# Triton backend. The integration test below uses the public API end-to-end
-# (forward + backward via autograd). Per-WS-mode kernel correctness is
-# covered by the lower-level ``grouped_gemm_triton_kernel`` test that follows
-# (the public API exposes only ``"static" | "work_steal"``; internal modes
-# ``"global" / "per-xcd" / "hierarchical"`` are kernel-level tuning knobs).
+# Public API: ``schedule="work_steal"`` enables the work-stealing kernel on
+# the Triton and CK backends. The integration tests use the public API
+# end-to-end (forward + backward via autograd). Per-ws_mode kernel
+# correctness is covered by the lower-level ``grouped_gemm_triton_kernel``
+# test that follows (the public API exposes only ``"static" | "work_steal"``;
+# internal modes ``"global" / "per-xcd" / "hierarchical"`` are kernel-level
+# tuning knobs).
 # ---------------------------------------------------------------------------
 
 
@@ -274,15 +275,16 @@ def test_grouped_gemm_with_zero_length_groups(B, M, N_K, dtype, trans_b, backend
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("balance", [True, False])
 @pytest.mark.parametrize("trans_b", [True, False])
-def test_grouped_gemm_schedule_work_steal_triton(B, M, N_K, dtype, balance, trans_b):
-    """``schedule="work_steal"`` on the Triton backend matches the static path
-    bit-for-bit for forward and backward (per-tile accumulator order is
+@pytest.mark.parametrize("backend", [BackendType.TRITON, BackendType.CK])
+def test_grouped_gemm_schedule_work_steal(B, M, N_K, dtype, balance, trans_b, backend):
+    """``schedule="work_steal"`` on each WS-capable backend matches the static
+    path bit-for-bit for forward and backward (per-tile accumulator order is
     identical to the static schedule; there is no cross-tile reduction)."""
     seed = 42
     torch.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
 
-    GlobalBackendManager.set_grouped_gemm_backend(BackendType.TRITON)
+    GlobalBackendManager.set_grouped_gemm_backend(backend)
     GlobalBackendManager.set_auto_tune(False)
 
     device = "cuda"
@@ -313,11 +315,12 @@ def test_grouped_gemm_schedule_work_steal_triton(B, M, N_K, dtype, balance, tran
     GlobalBackendManager.reset()
 
 
-def test_grouped_gemm_schedule_work_steal_triton_single_group():
+@pytest.mark.parametrize("backend", [BackendType.TRITON, BackendType.CK])
+def test_grouped_gemm_schedule_work_steal_single_group(backend):
     """Single-group degenerate case (G=1): the dispatcher special-cases this
     to call non-grouped gemm; ``schedule`` must be accepted (and ignored)
     in that branch."""
-    GlobalBackendManager.set_grouped_gemm_backend(BackendType.TRITON)
+    GlobalBackendManager.set_grouped_gemm_backend(backend)
     device = "cuda"
     torch.manual_seed(0)
     M, K, N = 1024, 1280, 2560
@@ -331,12 +334,11 @@ def test_grouped_gemm_schedule_work_steal_triton_single_group():
     GlobalBackendManager.reset()
 
 
-@pytest.mark.parametrize("non_triton_backend", [BackendType.CK, BackendType.HIPBLASLT])
-def test_grouped_gemm_schedule_work_steal_rejects_non_triton_backend(non_triton_backend):
-    """Explicit selection of a non-Triton backend together with
-    ``schedule="work_steal"`` must fail at dispatch -- CK and hipblaslt advertise
-    only ``"static"`` via ``can_handle``."""
-    GlobalBackendManager.set_grouped_gemm_backend(non_triton_backend)
+def test_grouped_gemm_schedule_work_steal_rejects_hipblaslt():
+    """Explicit selection of HIPBLASLT together with ``schedule="work_steal"``
+    must fail at dispatch -- hipblaslt has no WS kernel and advertises only
+    ``"static"`` via ``can_handle``."""
+    GlobalBackendManager.set_grouped_gemm_backend(BackendType.HIPBLASLT)
     device = "cuda"
     torch.manual_seed(0)
     B, M, K, N = 4, 1024, 1280, 2560

--- a/tests/pytorch/ops/test_ws_ck_heuristic.py
+++ b/tests/pytorch/ops/test_ws_ck_heuristic.py
@@ -1,0 +1,152 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""Unit tests for primus_turbo.pytorch.kernels.grouped_gemm.ws_ck_heuristic.
+
+Pure Python -- no GPU required. Pins the policy boundaries so future
+re-tuning is intentional rather than accidental.
+"""
+
+import pytest
+
+from primus_turbo.pytorch.kernels.grouped_gemm.ws_ck_heuristic import (
+    CK_NUM_XCDS,
+    CK_TILE_M,
+    CK_TILE_N,
+    approximate_ck_standard_total_tiles,
+    compute_ck_variable_k_total_tiles,
+    resolve_ck_ws_local_per_xcd,
+)
+
+# ---------------------------------------------------------------------------
+# resolve_ck_ws_local_per_xcd
+# ---------------------------------------------------------------------------
+
+
+def test_degenerate_inputs_return_zero():
+    """Non-positive total_tiles or num_cus short-circuits to global mode."""
+    assert resolve_ck_ws_local_per_xcd("auto", 0, 256) == 0
+    assert resolve_ck_ws_local_per_xcd("auto", -1, 256) == 0
+    assert resolve_ck_ws_local_per_xcd("auto", 512, 0) == 0
+    assert resolve_ck_ws_local_per_xcd("per-xcd", 0, 256) == 0
+
+
+def test_explicit_global_returns_zero():
+    """Explicit 'global' always returns 0 regardless of shape."""
+    for total_tiles in (1, 16, 512, 4096):
+        for num_cus in (32, 256):
+            assert resolve_ck_ws_local_per_xcd("global", total_tiles, num_cus) == 0
+
+
+def test_explicit_per_xcd_returns_ceil_divided_by_xcds():
+    """Explicit 'per-xcd' returns ceil(total_tiles / CK_NUM_XCDS)."""
+    # 512 / 8 = 64 exactly
+    assert resolve_ck_ws_local_per_xcd("per-xcd", 512, 256) == 64
+    # 513 / 8 = 64.125 -> ceil = 65
+    assert resolve_ck_ws_local_per_xcd("per-xcd", 513, 256) == 65
+    # 1 / 8 -> ceil = 1
+    assert resolve_ck_ws_local_per_xcd("per-xcd", 1, 256) == 1
+
+
+def test_explicit_hierarchical_clamps_to_at_least_one():
+    """'hierarchical' should never return 0 for positive total_tiles."""
+    # tiny total -> (1 // 2) // 8 = 0 -> clamped to 1
+    assert resolve_ck_ws_local_per_xcd("hierarchical", 1, 256) == 1
+    # 800 // 2 = 400; 400 // 8 = 50
+    assert resolve_ck_ws_local_per_xcd("hierarchical", 800, 256) == 50
+
+
+def test_unknown_ws_mode_raises():
+    """An unrecognized ws_mode string is a programming error."""
+    with pytest.raises(ValueError, match="unknown ws_mode"):
+        resolve_ck_ws_local_per_xcd("bogus", 512, 256)
+    with pytest.raises(ValueError, match="unknown ws_mode"):
+        resolve_ck_ws_local_per_xcd("Global", 512, 256)  # case-sensitive
+
+
+# ---------------------------------------------------------------------------
+# 'auto' heuristic behavior (standard kernel: fwd / dgrad)
+# ---------------------------------------------------------------------------
+
+
+def test_auto_standard_sparse_picks_per_xcd():
+    """tpc < 4 on the standard kernel -> per-xcd."""
+    # tpc = 512 / 256 = 2.0 (< 4) -> per-xcd
+    assert resolve_ck_ws_local_per_xcd("auto", 512, 256, kernel_kind="standard") == 64
+    # tpc = 3 (just under threshold)
+    assert resolve_ck_ws_local_per_xcd("auto", 768, 256, kernel_kind="standard") == 96
+
+
+def test_auto_standard_dense_picks_global():
+    """tpc >= 4 on the standard kernel -> global (returns 0)."""
+    # tpc = 4 exactly -> global
+    assert resolve_ck_ws_local_per_xcd("auto", 1024, 256, kernel_kind="standard") == 0
+    # tpc = 8 -> global
+    assert resolve_ck_ws_local_per_xcd("auto", 2048, 256, kernel_kind="standard") == 0
+
+
+def test_auto_unknown_kernel_kind_falls_back_to_standard_threshold():
+    """Unknown kernel_kind uses the standard-kernel threshold (safe fallback)."""
+    # 512 / 256 = 2 < 4 -> per-xcd (standard behavior)
+    assert resolve_ck_ws_local_per_xcd("auto", 512, 256, kernel_kind="not-a-kernel-kind") == 64
+
+
+# ---------------------------------------------------------------------------
+# 'auto' heuristic behavior (variable-K kernel: wgrad)
+# ---------------------------------------------------------------------------
+
+
+def test_auto_variable_k_sparse_picks_per_xcd():
+    """tpc < 2 on the variable-K kernel -> per-xcd."""
+    # tpc = 256 / 256 = 1.0 (< 2) -> per-xcd
+    assert resolve_ck_ws_local_per_xcd("auto", 256, 256, kernel_kind="variable_k") == 32
+
+
+def test_auto_variable_k_dense_picks_global():
+    """tpc >= 2 on the variable-K kernel -> global (returns 0)."""
+    # tpc = 2 exactly -> global
+    assert resolve_ck_ws_local_per_xcd("auto", 512, 256, kernel_kind="variable_k") == 0
+    # tpc = 4 -> global
+    assert resolve_ck_ws_local_per_xcd("auto", 1024, 256, kernel_kind="variable_k") == 0
+
+
+# ---------------------------------------------------------------------------
+# total_tiles helpers
+# ---------------------------------------------------------------------------
+
+
+def test_approximate_total_tiles_uniform():
+    """Uniform group sizes -> lower bound is exact."""
+    # total_m = 8192, TILE_M = 256 -> 32 m-tiles
+    # n = 2048, TILE_N = 256 -> 8 n-tiles
+    # total = 32 * 8 = 256
+    assert approximate_ck_standard_total_tiles(8192, num_groups=8, n=2048) == 256
+
+
+def test_approximate_total_tiles_ceil_division():
+    """Non-multiples round up (ceil-div)."""
+    # total_m = 300, TILE_M = 256 -> 2 m-tiles; n = 200, TILE_N = 256 -> 1 n-tile
+    assert approximate_ck_standard_total_tiles(300, 1, 200) == 2
+
+
+def test_compute_variable_k_total_tiles():
+    """Variable-K total = G * ceil(K/TILE_M) * ceil(N/TILE_N) (exact)."""
+    # G=8, K=2048, N=2048, TILE_M=TILE_N=256 -> 8 * 8 * 8 = 512
+    assert compute_ck_variable_k_total_tiles(8, 2048, 2048) == 512
+    # G=4, K=300, N=200, TILE_M=256, TILE_N=256 -> 4 * ceil(300/256) * ceil(200/256)
+    #                                            = 4 * 2 * 1 = 8
+    assert compute_ck_variable_k_total_tiles(4, 300, 200) == 8
+
+
+def test_num_xcds_constant_matches_mi355x():
+    """Sanity-check the chiplet count exposed by the module."""
+    assert CK_NUM_XCDS == 8
+
+
+def test_tile_shape_constants_are_256():
+    """CK tile shape constants mirror the C++ TilePartitioner template
+    parameters -- if the C++ side changes, these must be updated in tandem."""
+    assert CK_TILE_M == 256
+    assert CK_TILE_N == 256


### PR DESCRIPTION
## Summary

Adds a work-stealing (WS) variant of the CK grouped-GEMM kernel (forward +
variable-K backward) for AMD MI355X / MI350. Under all-gather × grouped-GEMM
overlap the static-stride persistent kernel suffers a ~1.7–2.0× slowdown
when RCCL channels contend for the same CUs; with WS enabled, fast CUs
absorb work that the RCCL-throttled CUs would have done, recovering most of
the slowdown at ~2-3% isolated overhead on the 288-shape MoE sweep.

Rebased on top of current `main` (which now includes the Triton WS PR
#353, so the public API is `schedule: str = "static" | "work_steal"`).
This PR wires CK into that same API, so users get WS on either backend by
setting `schedule="work_steal"` on `primus_turbo.ops.grouped_gemm(...)`.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

**Kernel** (`csrc/kernels/grouped_gemm/ck/grouped_gemm_kernel_ws.hpp`):
- Vendored work-stealing variant of `ck_tile::GroupedGemmKernel`. Static-
  stride persistent loop replaced by an `atomicAdd`-based tile claim.
- Two-phase scheme: **phase 1** each CTA drains its XCD's local counter
  for up to `local_per_xcd` claims (preserves L2 locality across XCDs);
  **phase 2** the remainder is claimed via a single global counter
  (cross-XCD work-stealing).
- Counter layout `[xcd0..xcd7, global, done]` — 10 int32 slots.
- Last-out CTA self-resets the counter so the next launch sees a clean
  slate; no host-side `counter.zero_()` needed.
- `FindGroupId` binary search reads precomputed `block_start`/`block_end`
  populated by the existing `compute_grouped_gemm_args` kernel.
- **Defensive bound** — `active_xcds = min(gridDim.x, NUM_XCDS_WS)` used
  for both `xcd_id` and `phase1_total`. Without this cap, launches where
  `gridDim.x < NUM_XCDS_WS` (=8) would leave the tiles in the gap between
  phase 1's actual end and phase 2's start unclaimed → silent wrong
  output. Matches the equivalent fix on the Triton side (PR #402).

**Binding + runner** (`csrc/pytorch/grouped_gemm/ck_grouped_gemm.cpp`,
`csrc/kernels/grouped_gemm/ck/ck_grouped_gemm_kernel_template.h`):
- `ck_grouped_gemm` and `ck_grouped_gemm_variable_k` extended with
  `(work_steal, ws_counter, ws_local_per_xcd)` args.
- `CKGroupedGemmRunner` exposes `run_ws()` alongside `run()`.
- `PRIMUS_TURBO_CHECK` on `ws_local_per_xcd` bounds `[0, INT32_MAX]` to
  reject values that would silently truncate on the `int64 → int32` cast
  passed to the kernel.

**Backend + heuristic**
(`primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py`,
`primus_turbo/pytorch/kernels/grouped_gemm/ws_ck_heuristic.py`):
- `GroupedGEMMCKBackend.can_handle` now advertises
  `schedule in ("static", "work_steal")`; `execute` translates
  `schedule="work_steal"` to the internal `work_steal=True` and picks a
  `ws_local_per_xcd` via the sync-free heuristic.
- Heuristic (`ws_ck_heuristic.py`) resolves the `ws_mode` string to the
  kernel's integer `ws_local_per_xcd`, using `tpc = total_tiles / num_cus`
  as the density signal. Uses tensor metadata only (`a.size(0)`,
  `group_lens.numel()`); no GPU sync.
- `total_m` computed as `a.size(1) if trans_a else a.size(0)` for shape
  correctness under transposed inputs (`can_handle` already rejects
  `trans_a=True` on this backend, but the shape logic is now explicit).
- Wrapper-managed per-device counter cache (`_get_ck_ws_counter`); the
  kernel self-resets so it's a one-shot `torch.zeros` per device.

**Public API** (`primus_turbo/pytorch/ops/grouped_gemm.py`):
- No new kwargs. `schedule="work_steal"` on the existing `grouped_gemm(...)`
  op now dispatches to the CK WS path (in addition to the Triton path
  from PR #353).
- Guard: `schedule="work_steal"` combined with an explicit `num_cu != None`
  raises `ValueError`. WS was designed and characterized for full-device
  launches; partial-grid launches would silently under-utilize the WS
  layout even with the `ACTIVE_XCDS` fix.

**Tests**:
- `tests/pytorch/ops/test_grouped_gemm.py`:
  - `test_grouped_gemm_schedule_work_steal` now parametrized over
    `backend ∈ {TRITON, CK}` — 64 cases per backend asserting forward +
    backward bit-equal vs the static reference.
  - `test_grouped_gemm_schedule_work_steal_single_group` — G=1 smoke on
    both backends (dispatcher special-cases to `gemm_impl`).
  - `test_grouped_gemm_schedule_work_steal_rejects_hipblaslt` — explicit
    HIPBLASLT + `schedule="work_steal"` fails at dispatch (only Triton /
    CK advertise WS via `can_handle`).
  - `test_ck_grouped_gemm_op_ws_num_cu_below_num_xcds` — kernel-level
    regression for the `ACTIVE_XCDS` fix (num_cu ∈ {4, 6, 7, 8, 16}).
- `tests/pytorch/ops/test_ws_ck_heuristic.py` (NEW): 15 pure-Python unit
  tests pinning the CK heuristic's mode-resolution behavior (explicit
  modes, `auto` thresholds for both kernel kinds, degenerate inputs,
  `ValueError` path, `total_tiles` helpers, and the tile / chiplet
  constants).

## Perf (MI355X, 288-shape MoE sweep, isolated kernel, clean methodology)

CK WS isolated overhead vs the static-stride reference (`schedule="static"`):

| Metric | Value |
|---|---:|
| Median | +2.7% |
| p10    | +0.0% |
| p90    | +6.3% |
| Max    | +14.5% |

Under overlap on the canonical bench shape (G=32, M=267424, K=1280, N=2560,
NCCL_MAX_NCHANNELS=default), CK WS recovers >30% of the contended-regime
slowdown vs static.

## Checklist

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
