### PR TITLE
Add JAX vmap batching rules for MoE/grouped-GEMM primitives (pipeline-parallel support)

### DIFF
--- a/csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu
+++ b/csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu
@@ -113,8 +113,7 @@ public:
             if (num_stream_used > 1) {
                 PRIMUS_TURBO_CHECK_HIP(hipEventRecord(sync_event_, params.stream));
                 for (size_t s = 1; s < num_stream_used; ++s) {
-                    PRIMUS_TURBO_CHECK_HIP(
-                        hipStreamWaitEvent(compute_streams_[s], sync_event_, 0));
+                    PRIMUS_TURBO_CHECK_HIP(hipStreamWaitEvent(compute_streams_[s], sync_event_, 0));
                 }
             }
 
@@ -124,11 +123,9 @@ public:
                 // PyTorch current stream/handle, which is already bound
                 // one-to-one). Extra slots use our internal streams bound via
                 // hipblasSetStream above.
-                auto       stream     = (stream_idx == 0) ? params.stream
-                                                          : compute_streams_[stream_idx];
-                auto       handle     = (stream_idx == 0) ? params.handle
-                                                          : handles_[stream_idx];
-                auto       workspace  = workspaces_[stream_idx];
+                auto stream    = (stream_idx == 0) ? params.stream : compute_streams_[stream_idx];
+                auto handle    = (stream_idx == 0) ? params.handle : handles_[stream_idx];
+                auto workspace = workspaces_[stream_idx];
                 // clang-format off
                 hipblaslt_gemm_impl(
                     gemm_ptrs_[idx].b_ptr, params.b_type, rows_b_[idx], cols_b_[idx], ld_b_[idx],

--- a/primus_turbo/jax/primitive/_batching.py
+++ b/primus_turbo/jax/primitive/_batching.py
@@ -90,9 +90,7 @@ def make_ipc_batchers(prim, num_outputs):
         bs = axis_data.size
         args_b = [broadcast_to_batch(a, ax, bs) for a, ax in zip(args, axes)]
         local_idx = jax.lax.axis_index(spmd_name)
-        args_local = [
-            jax.lax.dynamic_index_in_dim(a, local_idx, axis=0, keepdims=False) for a in args_b
-        ]
+        args_local = [jax.lax.dynamic_index_in_dim(a, local_idx, axis=0, keepdims=False) for a in args_b]
         out_local = prim.bind(*args_local, **kwargs)
         stacked = tuple(jnp.broadcast_to(o[None], (bs,) + o.shape) for o in out_local)
         return stacked, batched_dims
@@ -120,9 +118,7 @@ def make_grouped_gemm_spmd_rule(prim, plain_rule, int64_arg_indices=(2, 3)):
         bs = axis_data.size
         args_b = [broadcast_to_batch(a, ax, bs) for a, ax in zip(args, axes)]
         local_idx = jax.lax.axis_index(spmd_name)
-        args_local = [
-            jax.lax.dynamic_index_in_dim(a, local_idx, axis=0, keepdims=False) for a in args_b
-        ]
+        args_local = [jax.lax.dynamic_index_in_dim(a, local_idx, axis=0, keepdims=False) for a in args_b]
         with jax.experimental.enable_x64():
             for i in int64_arg_indices:
                 args_local[i] = args_local[i].astype(jnp.int64)

--- a/primus_turbo/jax/primitive/_batching.py
+++ b/primus_turbo/jax/primitive/_batching.py
@@ -1,0 +1,134 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""Shared JAX batching rules for running Primus-Turbo primitives under
+MaxText pipeline parallelism.
+
+MaxText builds its pipeline-parallel layer stack by wrapping each layer in
+``nn.vmap(spmd_axis_name="stage")`` composed with an outer ``shard_map``. For
+our custom primitives to trace through that stack, every primitive must
+register a batching rule in BOTH:
+
+  * ``batching.primitive_batchers``        - plain ``jax.vmap`` (no spmd axis);
+  * ``batching.fancy_primitive_batchers``  - the ``axis_data``-aware variant,
+    which JAX *requires* whenever ``spmd_axis_name`` is set (it raises
+    otherwise).
+
+The SPMD-aware path is also a memory win. Under the vmap-of-shard_map
+composition JAX's ``_shard_map_batch`` divides ``axis_data.size`` by the mesh
+stage dim (typically landing at 1 per device), so we can dynamic-slice the
+single local stage via ``axis_index(spmd_name)`` and broadcast the result back.
+XLA folds that dynamic-index + broadcast pair into metadata in shard_map manual
+mode, producing a tighter HLO than the scan/reshape-of-batch-1 fallback
+(empirically ~30 GB less HBM temp on DS3-671B sgd-pp8 pdbs=8).
+
+When there is no ``spmd_axis_name`` the fancy rule degrades to the plain rule.
+"""
+
+import jax
+import jax.numpy as jnp
+
+__all__ = [
+    "broadcast_to_batch",
+    "spmd_name_or_none",
+    "make_ipc_batchers",
+    "make_grouped_gemm_spmd_rule",
+]
+
+
+def broadcast_to_batch(arg, ax, batch_size):
+    """Move ``ax`` of ``arg`` to position 0, or broadcast a new leading dim of
+    ``batch_size`` when ``ax`` is None (the arg is not batched)."""
+    if ax is None:
+        return jnp.broadcast_to(jnp.expand_dims(arg, 0), (batch_size,) + arg.shape)
+    if ax != 0:
+        arg = jnp.moveaxis(arg, ax, 0)
+    return arg
+
+
+def spmd_name_or_none(axis_data):
+    """Return the (single) ``spmd_axis_name`` as a str, or None when batching
+    without one."""
+    spmd = getattr(axis_data, "spmd_name", None)
+    if isinstance(spmd, (list, tuple)):
+        return spmd[0] if spmd else None
+    return spmd
+
+
+def make_ipc_batchers(prim, num_outputs):
+    """Build ``(plain, fancy)`` batchers for a cross-rank IPC primitive.
+
+    IPC primitives (dispatch / combine) carry per-rank state that cannot be
+    merged across the batch axis, so the plain rule scans the primitive over the
+    batch one microbatch at a time. The fancy rule takes the SPMD dynamic-slice
+    fast path described in the module docstring, falling back to the scan when
+    there is no ``spmd_axis_name``.
+    """
+    none_dims = (None,) * num_outputs
+    batched_dims = (0,) * num_outputs
+
+    def plain_rule(args, axes, **kwargs):
+        if all(ax is None for ax in axes):
+            return prim.bind(*args, **kwargs), none_dims
+        bs = next(a.shape[ax] for a, ax in zip(args, axes) if ax is not None)
+        args_b = [broadcast_to_batch(a, ax, bs) for a, ax in zip(args, axes)]
+
+        def body(_, slice_args):
+            return None, prim.bind(*slice_args, **kwargs)
+
+        _, outputs = jax.lax.scan(body, None, tuple(args_b))
+        return outputs, batched_dims
+
+    def fancy_rule(axis_data, args, axes, **kwargs):
+        spmd_name = spmd_name_or_none(axis_data)
+        if spmd_name is None:
+            return plain_rule(args, axes, **kwargs)
+        if all(ax is None for ax in axes):
+            return prim.bind(*args, **kwargs), none_dims
+        bs = axis_data.size
+        args_b = [broadcast_to_batch(a, ax, bs) for a, ax in zip(args, axes)]
+        local_idx = jax.lax.axis_index(spmd_name)
+        args_local = [
+            jax.lax.dynamic_index_in_dim(a, local_idx, axis=0, keepdims=False) for a in args_b
+        ]
+        out_local = prim.bind(*args_local, **kwargs)
+        stacked = tuple(jnp.broadcast_to(o[None], (bs,) + o.shape) for o in out_local)
+        return stacked, batched_dims
+
+    return plain_rule, fancy_rule
+
+
+def make_grouped_gemm_spmd_rule(prim, plain_rule, int64_arg_indices=(2, 3)):
+    """Build the fancy batcher for a grouped-GEMM primitive (4 inputs ``a, b,
+    group_lens, group_offs``; 2 outputs ``out, workspace``).
+
+    Falls back to ``plain_rule`` (the per-primitive reshape-merge rule) when
+    there is no ``spmd_axis_name``. On the SPMD path it dynamic-slices the local
+    stage and re-casts the int64-required args (the C++ kernel hard-requires
+    int64 for ``group_lens`` / ``group_offs``) inside ``enable_x64`` so the cast
+    survives a non-x64 trace context.
+    """
+
+    def fancy_rule(axis_data, args, axes, **kwargs):
+        spmd_name = spmd_name_or_none(axis_data)
+        if spmd_name is None:
+            return plain_rule(args, axes, **kwargs)
+        if all(ax is None for ax in axes):
+            return prim.bind(*args, **kwargs), (None, None)
+        bs = axis_data.size
+        args_b = [broadcast_to_batch(a, ax, bs) for a, ax in zip(args, axes)]
+        local_idx = jax.lax.axis_index(spmd_name)
+        args_local = [
+            jax.lax.dynamic_index_in_dim(a, local_idx, axis=0, keepdims=False) for a in args_b
+        ]
+        with jax.experimental.enable_x64():
+            for i in int64_arg_indices:
+                args_local[i] = args_local[i].astype(jnp.int64)
+        out_local, ws_local = prim.bind(*args_local, **kwargs)
+        out = jnp.broadcast_to(out_local[None], (bs,) + out_local.shape)
+        ws = jnp.broadcast_to(ws_local[None], (bs,) + ws_local.shape)
+        return (out, ws), (0, 0)
+
+    return fancy_rule

--- a/primus_turbo/jax/primitive/grouped_gemm/grouped_gemm.py
+++ b/primus_turbo/jax/primitive/grouped_gemm/grouped_gemm.py
@@ -108,8 +108,8 @@ from primus_turbo.jax.primitive._batching import (
     make_grouped_gemm_spmd_rule,
 )
 
-
 # ---- compute_group_offs ------------------------------------------------------
+
 
 def _compute_group_offs_batch_rule(args, axes):
     """Batched `cumsum` (prepended with 0).  Computed in pure JAX rather than by
@@ -143,6 +143,7 @@ batching.fancy_primitive_batchers[compute_group_offs_p] = (
 
 # ---- ck_grouped_gemm ---------------------------------------------------------
 
+
 def _ck_grouped_gemm_merge_rule(args, axes, **kwargs):
     """Plain-vmap rule: merge the batch into the leading token dim, run one
     grouped-GEMM, then un-merge.  `group_offs` is recomputed from the merged
@@ -153,22 +154,18 @@ def _ck_grouped_gemm_merge_rule(args, axes, **kwargs):
         return ck_grouped_gemm_p.bind(*args, **kwargs), (None, None)
 
     bs = next(arg.shape[ax] for arg, ax in zip(args, axes) if ax is not None)
-    a_b = broadcast_to_batch(a, a_ax, bs)              # (B, m_total, k)
-    b_b = broadcast_to_batch(b, b_ax, bs)              # (B, G, k, n)
-    gl_b = broadcast_to_batch(group_lens, gl_ax, bs)   # (B, G)
+    a_b = broadcast_to_batch(a, a_ax, bs)  # (B, m_total, k)
+    b_b = broadcast_to_batch(b, b_ax, bs)  # (B, G, k, n)
+    gl_b = broadcast_to_batch(group_lens, gl_ax, bs)  # (B, G)
 
-    a_merged = a_b.reshape((-1,) + a_b.shape[2:])       # (B*m_total, k)
-    b_merged = b_b.reshape((-1,) + b_b.shape[2:])       # (B*G, k, n)
+    a_merged = a_b.reshape((-1,) + a_b.shape[2:])  # (B*m_total, k)
+    b_merged = b_b.reshape((-1,) + b_b.shape[2:])  # (B*G, k, n)
     with jax.experimental.enable_x64():
         gl_merged = gl_b.reshape(-1).astype(jnp.int64)
         zeros = jnp.zeros((1,), dtype=jnp.int64)
-        go_merged = jnp.concatenate(
-            [zeros, jax.lax.cumsum(gl_merged, axis=0)], axis=0
-        ).astype(jnp.int64)
+        go_merged = jnp.concatenate([zeros, jax.lax.cumsum(gl_merged, axis=0)], axis=0).astype(jnp.int64)
 
-    out_merged, ws = ck_grouped_gemm_p.bind(
-        a_merged, b_merged, gl_merged, go_merged, **kwargs
-    )
+    out_merged, ws = ck_grouped_gemm_p.bind(a_merged, b_merged, gl_merged, go_merged, **kwargs)
     out = out_merged.reshape(a_b.shape[:2] + (out_merged.shape[-1],))
     return (out, ws), (0, None)
 
@@ -181,6 +178,7 @@ batching.fancy_primitive_batchers[ck_grouped_gemm_p] = make_grouped_gemm_spmd_ru
 
 # ---- ck_grouped_gemm_variable_k ---------------------------------------------
 
+
 def _ck_grouped_gemm_variable_k_merge_rule(args, axes, **kwargs):
     """Plain-vmap rule for the variable-K kernel (groups vary along the K axis;
     output is (G, m, n) per call).  Merge the batch into the leading K dim, run
@@ -191,22 +189,18 @@ def _ck_grouped_gemm_variable_k_merge_rule(args, axes, **kwargs):
         return ck_grouped_gemm_variable_k_p.bind(*args, **kwargs), (None, None)
 
     bs = next(arg.shape[ax] for arg, ax in zip(args, axes) if ax is not None)
-    a_b = broadcast_to_batch(a, a_ax, bs)              # (B, k_total, m)
-    b_b = broadcast_to_batch(b, b_ax, bs)              # (B, k_total, n)
-    gl_b = broadcast_to_batch(group_lens, gl_ax, bs)   # (B, G)
+    a_b = broadcast_to_batch(a, a_ax, bs)  # (B, k_total, m)
+    b_b = broadcast_to_batch(b, b_ax, bs)  # (B, k_total, n)
+    gl_b = broadcast_to_batch(group_lens, gl_ax, bs)  # (B, G)
 
-    a_merged = a_b.reshape((-1,) + a_b.shape[2:])       # (B*k_total, m)
-    b_merged = b_b.reshape((-1,) + b_b.shape[2:])       # (B*k_total, n)
+    a_merged = a_b.reshape((-1,) + a_b.shape[2:])  # (B*k_total, m)
+    b_merged = b_b.reshape((-1,) + b_b.shape[2:])  # (B*k_total, n)
     with jax.experimental.enable_x64():
         gl_merged = gl_b.reshape(-1).astype(jnp.int64)
         zeros = jnp.zeros((1,), dtype=jnp.int64)
-        go_merged = jnp.concatenate(
-            [zeros, jax.lax.cumsum(gl_merged, axis=0)], axis=0
-        ).astype(jnp.int64)
+        go_merged = jnp.concatenate([zeros, jax.lax.cumsum(gl_merged, axis=0)], axis=0).astype(jnp.int64)
 
-    out_merged, ws = ck_grouped_gemm_variable_k_p.bind(
-        a_merged, b_merged, gl_merged, go_merged, **kwargs
-    )
+    out_merged, ws = ck_grouped_gemm_variable_k_p.bind(a_merged, b_merged, gl_merged, go_merged, **kwargs)
     out = out_merged.reshape((bs, -1) + out_merged.shape[1:])
     return (out, ws), (0, None)
 

--- a/primus_turbo/jax/primitive/grouped_gemm/grouped_gemm.py
+++ b/primus_turbo/jax/primitive/grouped_gemm/grouped_gemm.py
@@ -97,7 +97,124 @@ LOWERING_TABLE[compute_group_offs_p] = jax.ffi.ffi_lowering("compute_group_offs"
 # ----------------------------------------
 # Step-5: batching
 # ----------------------------------------
-# TODO: Add batching support if needed
+# Grouped-GEMM batching for pipeline parallelism.  The plain-vmap rule merges the
+# batch into the leading (token / group / K) dim so one kernel call covers the
+# whole batch; the SPMD-aware rule dynamic-slices the local stage instead.  See
+# primus_turbo.jax.primitive._batching for the shared helpers and rationale.
+from jax.interpreters import batching
+
+from primus_turbo.jax.primitive._batching import (
+    broadcast_to_batch,
+    make_grouped_gemm_spmd_rule,
+)
+
+
+# ---- compute_group_offs ------------------------------------------------------
+
+def _compute_group_offs_batch_rule(args, axes):
+    """Batched `cumsum` (prepended with 0).  Computed in pure JAX rather than by
+    scanning the primitive, since it is a cheap, shape-stable index computation.
+
+    The C++ kernel hard-requires int64 for `group_offs`, so the cast is wrapped in
+    `enable_x64()` to survive a non-x64 trace context.
+    """
+    (group_lens,) = args
+    (axis,) = axes
+    if axis is None:
+        return compute_group_offs_p.bind(group_lens), None
+    if axis != 0:
+        group_lens = jnp.moveaxis(group_lens, axis, 0)
+    with jax.experimental.enable_x64():
+        group_lens = group_lens.astype(jnp.int64)
+        last_axis = group_lens.ndim - 1
+        zeros = jnp.zeros(group_lens.shape[:-1] + (1,), dtype=jnp.int64)
+        cum = jax.lax.cumsum(group_lens, axis=last_axis)
+        out = jnp.concatenate([zeros, cum], axis=last_axis).astype(jnp.int64)
+    return out, 0
+
+
+batching.primitive_batchers[compute_group_offs_p] = _compute_group_offs_batch_rule
+# cumsum is cheap and shape-stable, so the SPMD path needs no dynamic-slice; the
+# fancy batcher (required once spmd_axis_name is set) just reuses the plain rule.
+batching.fancy_primitive_batchers[compute_group_offs_p] = (
+    lambda axis_data, args, axes: _compute_group_offs_batch_rule(args, axes)
+)
+
+
+# ---- ck_grouped_gemm ---------------------------------------------------------
+
+def _ck_grouped_gemm_merge_rule(args, axes, **kwargs):
+    """Plain-vmap rule: merge the batch into the leading token dim, run one
+    grouped-GEMM, then un-merge.  `group_offs` is recomputed from the merged
+    `group_lens` (int64, per the kernel contract)."""
+    a, b, group_lens, group_offs = args
+    a_ax, b_ax, gl_ax, go_ax = axes
+    if all(ax is None for ax in axes):
+        return ck_grouped_gemm_p.bind(*args, **kwargs), (None, None)
+
+    bs = next(arg.shape[ax] for arg, ax in zip(args, axes) if ax is not None)
+    a_b = broadcast_to_batch(a, a_ax, bs)              # (B, m_total, k)
+    b_b = broadcast_to_batch(b, b_ax, bs)              # (B, G, k, n)
+    gl_b = broadcast_to_batch(group_lens, gl_ax, bs)   # (B, G)
+
+    a_merged = a_b.reshape((-1,) + a_b.shape[2:])       # (B*m_total, k)
+    b_merged = b_b.reshape((-1,) + b_b.shape[2:])       # (B*G, k, n)
+    with jax.experimental.enable_x64():
+        gl_merged = gl_b.reshape(-1).astype(jnp.int64)
+        zeros = jnp.zeros((1,), dtype=jnp.int64)
+        go_merged = jnp.concatenate(
+            [zeros, jax.lax.cumsum(gl_merged, axis=0)], axis=0
+        ).astype(jnp.int64)
+
+    out_merged, ws = ck_grouped_gemm_p.bind(
+        a_merged, b_merged, gl_merged, go_merged, **kwargs
+    )
+    out = out_merged.reshape(a_b.shape[:2] + (out_merged.shape[-1],))
+    return (out, ws), (0, None)
+
+
+batching.primitive_batchers[ck_grouped_gemm_p] = _ck_grouped_gemm_merge_rule
+batching.fancy_primitive_batchers[ck_grouped_gemm_p] = make_grouped_gemm_spmd_rule(
+    ck_grouped_gemm_p, _ck_grouped_gemm_merge_rule
+)
+
+
+# ---- ck_grouped_gemm_variable_k ---------------------------------------------
+
+def _ck_grouped_gemm_variable_k_merge_rule(args, axes, **kwargs):
+    """Plain-vmap rule for the variable-K kernel (groups vary along the K axis;
+    output is (G, m, n) per call).  Merge the batch into the leading K dim, run
+    once, then un-merge."""
+    a, b, group_lens, group_offs = args
+    a_ax, b_ax, gl_ax, go_ax = axes
+    if all(ax is None for ax in axes):
+        return ck_grouped_gemm_variable_k_p.bind(*args, **kwargs), (None, None)
+
+    bs = next(arg.shape[ax] for arg, ax in zip(args, axes) if ax is not None)
+    a_b = broadcast_to_batch(a, a_ax, bs)              # (B, k_total, m)
+    b_b = broadcast_to_batch(b, b_ax, bs)              # (B, k_total, n)
+    gl_b = broadcast_to_batch(group_lens, gl_ax, bs)   # (B, G)
+
+    a_merged = a_b.reshape((-1,) + a_b.shape[2:])       # (B*k_total, m)
+    b_merged = b_b.reshape((-1,) + b_b.shape[2:])       # (B*k_total, n)
+    with jax.experimental.enable_x64():
+        gl_merged = gl_b.reshape(-1).astype(jnp.int64)
+        zeros = jnp.zeros((1,), dtype=jnp.int64)
+        go_merged = jnp.concatenate(
+            [zeros, jax.lax.cumsum(gl_merged, axis=0)], axis=0
+        ).astype(jnp.int64)
+
+    out_merged, ws = ck_grouped_gemm_variable_k_p.bind(
+        a_merged, b_merged, gl_merged, go_merged, **kwargs
+    )
+    out = out_merged.reshape((bs, -1) + out_merged.shape[1:])
+    return (out, ws), (0, None)
+
+
+batching.primitive_batchers[ck_grouped_gemm_variable_k_p] = _ck_grouped_gemm_variable_k_merge_rule
+batching.fancy_primitive_batchers[ck_grouped_gemm_variable_k_p] = make_grouped_gemm_spmd_rule(
+    ck_grouped_gemm_variable_k_p, _ck_grouped_gemm_variable_k_merge_rule
+)
 
 
 __all__ = [

--- a/primus_turbo/jax/primitive/moe/moe_combine.py
+++ b/primus_turbo/jax/primitive/moe/moe_combine.py
@@ -131,7 +131,18 @@ LOWERING_TABLE[moe_internode_combine_p] = _moe_internode_combine_lowering
 # ----------------------------------------
 # Step-5: batching
 # ----------------------------------------
-# TODO
+# moe_combine is a cross-rank IPC primitive (same family as moe_dispatch).  Its
+# 2 outputs (recv_x, recv_topk_weights) carry per-rank state that cannot be
+# merged across the batch axis.  See primus_turbo.jax.primitive._batching for
+# the shared factory and the pipeline-parallel rationale.
+from jax.interpreters import batching
+
+from primus_turbo.jax.primitive._batching import make_ipc_batchers
+
+(
+    batching.primitive_batchers[moe_combine_p],
+    batching.fancy_primitive_batchers[moe_combine_p],
+) = make_ipc_batchers(moe_combine_p, num_outputs=2)
 
 
 __all__ = ["moe_combine_p", "moe_internode_combine_p"]

--- a/primus_turbo/jax/primitive/moe/moe_dispatch.py
+++ b/primus_turbo/jax/primitive/moe/moe_dispatch.py
@@ -292,7 +292,23 @@ LOWERING_TABLE[moe_internode_cached_dispatch_p] = _moe_internode_cached_dispatch
 # ----------------------------------------
 # Step-5: batching
 # ----------------------------------------
-# TODO
+# Cross-rank IPC primitives: their per-rank outputs (12 for moe_dispatch, 5 for
+# moe_cached_dispatch) cannot be merged across the batch axis, so the plain rule
+# scans per microbatch.  See primus_turbo.jax.primitive._batching for the shared
+# scan / SPMD-aware factory and the pipeline-parallel rationale.
+from jax.interpreters import batching
+
+from primus_turbo.jax.primitive._batching import make_ipc_batchers
+
+(
+    batching.primitive_batchers[moe_dispatch_p],
+    batching.fancy_primitive_batchers[moe_dispatch_p],
+) = make_ipc_batchers(moe_dispatch_p, num_outputs=12)
+
+(
+    batching.primitive_batchers[moe_cached_dispatch_p],
+    batching.fancy_primitive_batchers[moe_cached_dispatch_p],
+) = make_ipc_batchers(moe_cached_dispatch_p, num_outputs=5)
 
 
 __all__ = [


### PR DESCRIPTION
# Description

MaxText builds its pipeline-parallel layer stack with nn.vmap(spmd_axis_name="stage") composed with an outer shard_map. For the Primus-Turbo JAX primitives to trace through that stack, each must register a batching rule in both batching.primitive_batchers (plain jax.vmap) and batching.fancy_primitive_batchers (required once spmd_axis_name is set). These were previously TODO stubs, so vmap (and therefore pipeline parallelism) could not trace through them.

A shared module (primus_turbo/jax/primitive/_batching.py) holds the common logic and rationale:
- make_ipc_batchers(prim, num_outputs): a scan-per-microbatch plain rule plus an SPMD-aware fast path, for the cross-rank IPC primitives (moe_dispatch, moe_cached_dispatch, moe_combine), whose per-rank outputs cannot be merged across the batch axis.
- make_grouped_gemm_spmd_rule(prim, plain_rule): the SPMD fast path for the grouped-GEMM primitives, whose plain rule merges the batch into the leading token/group/K dim and runs a single kernel call.

The SPMD path dynamic-slices the single local stage via axis_index(spmd_name) and broadcasts back, which XLA folds to metadata in shard_map manual mode: empirically ~30 GB less HBM temp than the scan/reshape fallback on DS3-671B sgd-pp8 pdbs=8. compute_group_offs is a cheap cumsum and needs no SPMD special-casing.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
