### PR TITLE
[Op][Normalization] Triton BWD Norm Tuning + Persistent grid-stride

### DIFF
--- a/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
+++ b/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
@@ -13,10 +13,8 @@ import torch
 
 from primus_turbo.triton.normalization.rmsnorm_kernel import (
     rmsnorm_bwd_finalize_kernel,
-    rmsnorm_bwd_kernel,
     rmsnorm_bwd_kernel_grid_stride,
     rmsnorm_bwd_kernel_multi_row,
-    rmsnorm_bwd_residual_kernel,
     rmsnorm_bwd_residual_kernel_grid_stride,
     rmsnorm_bwd_residual_kernel_multi_row,
     rmsnorm_fwd_kernel,
@@ -67,15 +65,15 @@ def _num_cus(device_index: int = 0) -> int:
 def _pick_bwd_config(H: int, B: int) -> Tuple[str, int, int, int, int]:
     """Return (mode, BLOCK_H, GRID_OR_ROWS, num_warps, num_stages) for bwd."""
     BLOCK_H = _next_pow2(H)
-    if BLOCK_H <= 256 and B >= 4096:
-        if BLOCK_H <= 128:
-            return "multi", BLOCK_H, 64, 4, 3
-        return "multi", BLOCK_H, 8, 4, 2
     if BLOCK_H <= 256:
-        return "single", BLOCK_H, 1, 1, 1
+        # ROWS targets ~half-wave program count; cap by register budget at BLOCK_H=256.
+        cap = 64 if BLOCK_H <= 128 else 8
+        target = max(1, _num_cus() // 2)
+        ROWS = min(cap, max(1, _next_pow2(B // target)))
+        ns = 3 if BLOCK_H <= 128 else 2
+        return "multi", BLOCK_H, ROWS, 4, ns
 
-    # Half-wave grid when each program would otherwise get few rows and the
-    # row is wide. Threshold scales with device CU count.
+    # Half-wave grid when each program would otherwise get few rows and H is wide.
     rows_per_program = max(1, B // _num_cus())
     wide_row = H >= 16384 or (BLOCK_H == 8192 and H <= 8192)
     half_wave = rows_per_program <= 13 and wide_row
@@ -172,28 +170,7 @@ def rmsnorm_bwd_impl(
     dy2 = _reshape_batch_hidden(dy, H)
     dx = torch.empty_like(x2)
     mode, BLOCK_H, GR, num_warps, num_stages = _pick_bwd_config(H, B)
-    if mode == "single":
-        dg_partial = torch.empty(B, H, device=x2.device, dtype=torch.float32)
-        rmsnorm_bwd_kernel[(B,)](
-            dy2,
-            x2,
-            gamma,
-            rstd,
-            dx,
-            dg_partial,
-            x2.stride(0),
-            x2.stride(1),
-            dy2.stride(0),
-            dy2.stride(1),
-            dx.stride(0),
-            dx.stride(1),
-            dg_partial.stride(0),
-            H=H,
-            BLOCK_H=BLOCK_H,
-            num_warps=num_warps,
-            num_stages=num_stages,
-        )
-    elif mode == "multi":
+    if mode == "multi":
         ROWS = GR
         num_programs = (B + ROWS - 1) // ROWS
         dg_partial = torch.empty(num_programs, H, device=x2.device, dtype=torch.float32)
@@ -338,31 +315,7 @@ def rmsnorm_bwd_residual_impl(
         dxpr2 = _reshape_batch_hidden(dxpr, H)
     dx = torch.empty_like(x_plus_r)
     mode, BLOCK_H, GR, num_warps, num_stages = _pick_bwd_config(H, B)
-    if mode == "single":
-        dg_partial = torch.empty(B, H, device=x_plus_r.device, dtype=torch.float32)
-        rmsnorm_bwd_residual_kernel[(B,)](
-            dy2,
-            dxpr2,
-            x_plus_r,
-            gamma,
-            rstd,
-            dx,
-            dg_partial,
-            x_plus_r.stride(0),
-            x_plus_r.stride(1),
-            dy2.stride(0),
-            dy2.stride(1),
-            dxpr2.stride(0),
-            dxpr2.stride(1),
-            dx.stride(0),
-            dx.stride(1),
-            dg_partial.stride(0),
-            H=H,
-            BLOCK_H=BLOCK_H,
-            num_warps=num_warps,
-            num_stages=num_stages,
-        )
-    elif mode == "multi":
+    if mode == "multi":
         ROWS = GR
         num_programs = (B + ROWS - 1) // ROWS
         dg_partial = torch.empty(num_programs, H, device=x_plus_r.device, dtype=torch.float32)

--- a/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
+++ b/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
@@ -309,8 +309,6 @@ def rmsnorm_bwd_impl(
             H=H,
             BLOCK_H=BLOCK_H,
             num_programs=num_programs,
-            num_warps=num_warps,
-            num_stages=num_stages,
         )
     dg = _finalize_dgamma(dg_partial, gamma.dtype)
     return dx, dg
@@ -486,8 +484,6 @@ def rmsnorm_bwd_residual_impl(
             H=H,
             BLOCK_H=BLOCK_H,
             num_programs=num_programs,
-            num_warps=num_warps,
-            num_stages=num_stages,
         )
     dg = _finalize_dgamma(dg_partial, gamma.dtype)
     return dx, dg

--- a/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
+++ b/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
@@ -45,11 +45,7 @@ def _reshape_batch_hidden(x: torch.Tensor, H: int) -> torch.Tensor:
 
 
 def _pick_config(H: int, B: int) -> Tuple[int, int, int, int]:
-    """Return (BLOCK_H, ROWS_PER_BLOCK, num_warps, num_stages) for fwd.
-
-    Multi-row mode (ROWS_PER_BLOCK > 1) wins when H is small AND B is huge,
-    because the grid size of one program per row becomes the bottleneck.
-    """
+    """Return (BLOCK_H, ROWS_PER_BLOCK, num_warps, num_stages) for fwd."""
     BLOCK_H = _next_pow2(H)
     if BLOCK_H <= 256 and B >= 4096:
         ROWS = 16 if BLOCK_H <= 128 else 8
@@ -69,32 +65,26 @@ def _num_cus(device_index: int = 0) -> int:
 
 
 def _pick_bwd_config(H: int, B: int) -> Tuple[str, int, int, int, int]:
-    """Pick (mode, BLOCK_H, GRID_OR_ROWS, num_warps, num_stages) for bwd.
-
-    Modes: "multi" (2D-tile for small H + huge B), "single" (one row per
-    program for tiny H/B), "grid" (persistent grid-stride for everything
-    wider; num_warps/num_stages are unused — picked by @triton.autotune).
-    """
+    """Return (mode, BLOCK_H, GRID_OR_ROWS, num_warps, num_stages) for bwd."""
     BLOCK_H = _next_pow2(H)
     if BLOCK_H <= 256 and B >= 4096:
-        # ROWS=64 at BLOCK_H<=128 keeps the program count <= ~2 waves even at
-        # B=32768, which slashes the dg_partial volume and finalize time.
         if BLOCK_H <= 128:
             return "multi", BLOCK_H, 64, 4, 3
         return "multi", BLOCK_H, 8, 4, 2
     if BLOCK_H <= 256:
         return "single", BLOCK_H, 1, 1, 1
 
-    # Half-wave grid wins when B is small AND (H==8192 or H>=16384): each
-    # program covers more rows, amortising the dgamma store and shrinking
-    # dg_partial. H=12288 (BLOCK_H rounds to 16384) prefers full wave.
-    half_wave = B <= 4096 and (H >= 16384 or (BLOCK_H == 8192 and H <= 8192))
+    # Half-wave grid when each program would otherwise get few rows and the
+    # row is wide. Threshold scales with device CU count.
+    rows_per_program = max(1, B // _num_cus())
+    wide_row = H >= 16384 or (BLOCK_H == 8192 and H <= 8192)
+    half_wave = rows_per_program <= 13 and wide_row
     grid = min(B, _num_cus() // 2 if half_wave else _num_cus())
     return "grid", BLOCK_H, grid, 0, 0
 
 
 def _finalize_dgamma(dg_partial: torch.Tensor, gamma_dtype: torch.dtype) -> torch.Tensor:
-    """Reduce [n_parts, H] fp32 partials to dgamma[H] via a coalesced col-tile."""
+    """Reduce (n_parts, H) fp32 partials to dgamma[H]."""
     n_parts, H = dg_partial.shape
     dg = torch.empty(H, device=dg_partial.device, dtype=gamma_dtype)
     BLOCK_H = 64 if H >= 64 else _next_pow2(H)
@@ -176,12 +166,7 @@ def rmsnorm_bwd_impl(
     num_warps: int,
     num_stages: int,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Backward launcher. Returns ``(dx [B, H], dgamma [H])``.
-
-    The fwd's chosen ``(BLOCK_H, ROWS, num_warps, num_stages)`` are accepted
-    for API compatibility but ignored — bwd re-picks a config tuned for its
-    own arithmetic intensity (see ``_pick_bwd_config``).
-    """
+    """Backward launcher. Returns (dx [B, H], dgamma [H])."""
     H = gamma.shape[0]
     B = x2.shape[0]
     dy2 = _reshape_batch_hidden(dy, H)

--- a/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
+++ b/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
@@ -63,95 +63,36 @@ def _pick_config(H: int, B: int) -> Tuple[int, int, int, int]:
     return BLOCK_H, 1, 16, 2
 
 
-# One wave per CU saturates the device for the grid-stride bwd kernel;
-# pushing to 2 waves spreads dg accumulators thinner and inflates the
-# finalize input. CU count is queried per-device and cached.
 @functools.lru_cache(maxsize=None)
 def _num_cus(device_index: int = 0) -> int:
     return torch.cuda.get_device_properties(device_index).multi_processor_count
 
 
 def _pick_bwd_config(H: int, B: int) -> Tuple[str, int, int, int, int]:
-    """Return (mode, BLOCK_H, GRID_OR_ROWS, num_warps, num_stages) for bwd.
+    """Pick (mode, BLOCK_H, GRID_OR_ROWS, num_warps, num_stages) for bwd.
 
-    Modes:
-    - ``"multi"``: multi-row 2D-tile kernel. GRID_OR_ROWS is ROWS_PER_BLOCK.
-      Good for small H + huge B (q-norm in MoE attention) where launch cost
-      and 2D-tile coalescing both pay off.
-    - ``"grid"``: persistent grid-stride kernel. GRID_OR_ROWS is the number
-      of programs. Each program loops over rows of stride num_programs while
-      keeping the dgamma accumulator live in registers across the loop. This
-      matches the HIP stage-0 approach and minimises the (n_parts, H)
-      dg_partial buffer (n_parts == grid_size, not B).
-    - ``"single"``: one-program-per-row fallback for tiny H/B.
+    Modes: "multi" (2D-tile for small H + huge B), "single" (one row per
+    program for tiny H/B), "grid" (persistent grid-stride for everything
+    wider; num_warps/num_stages are unused — picked by @triton.autotune).
     """
     BLOCK_H = _next_pow2(H)
-
-    # Small-H + huge-B: multi-row is great here (tile 2D in one shot).
     if BLOCK_H <= 256 and B >= 4096:
-        ROWS = 16 if BLOCK_H <= 128 else 8
-        return "multi", BLOCK_H, ROWS, 4, 2
+        return "multi", BLOCK_H, 16 if BLOCK_H <= 128 else 8, 4, 2
     if BLOCK_H <= 256:
         return "single", BLOCK_H, 1, 1, 1
 
-    # Grid-stride for everything wider. Tuned empirically on MI325X:
-    # - grid=304 (= NUM_CUS, 1 wave) is the default — saturates the device.
-    # - grid=152 (= NUM_CUS/2) wins for H=8192 with small B (4096): each
-    #   program gets more rows to chew so the dgamma write amortises and the
-    #   dg_partial cache footprint shrinks.
-    if H >= 16384 and B <= 4096:
-        # Native huge H + small B: half-wave grid (152) wins on MI325X because
-        # each program covers ~27 rows so the dgamma store amortises better
-        # and dg_partial halves to (152, H), making the finalize cheaper.
-        # Sweep on N=4096,C=16384 showed grid=152/nw=8/ns=1 at ~120µs vs
-        # ~126µs for full-wave (grid=304). Gated on the *actual* H (not the
-        # pow2-rounded BLOCK_H) because H=12288 prefers full wave.
-        grid = min(B, _num_cus() // 2)
-        num_warps = 8
-        num_stages = 1
-    elif BLOCK_H >= 16384 and B <= 4096:
-        # H in (8192, 16384) and small B (e.g. H=12288). Full wave wins here.
-        grid = min(B, _num_cus())
-        num_warps = 8
-        num_stages = 2
-    elif BLOCK_H >= 8192 and B <= 4096:
-        # H=8192, small B: half-wave gives each program more rows to chew so
-        # the dgamma write amortises better.
-        grid = min(B, _num_cus() // 2)
-        num_warps = 8
-        num_stages = 1
-    elif BLOCK_H >= 8192:
-        # Wide H, larger B: full wave, drop ns to relieve register pressure.
-        grid = min(B, _num_cus())
-        num_warps = 4
-        num_stages = 2
-    else:
-        # H in (256, 4096]: full wave, nw=8 amortises BLOCK_H per program.
-        grid = min(B, _num_cus())
-        num_warps = 8 if BLOCK_H >= 2048 else 4
-        num_stages = 2
-
-    return "grid", BLOCK_H, grid, num_warps, num_stages
+    # Half-wave grid wins when B is small AND (H==8192 or H>=16384): each
+    # program covers more rows, amortising the dgamma store and shrinking
+    # dg_partial. H=12288 (BLOCK_H rounds to 16384) prefers full wave.
+    half_wave = B <= 4096 and (H >= 16384 or (BLOCK_H == 8192 and H <= 8192))
+    grid = min(B, _num_cus() // 2 if half_wave else _num_cus())
+    return "grid", BLOCK_H, grid, 0, 0
 
 
 def _finalize_dgamma(dg_partial: torch.Tensor, gamma_dtype: torch.dtype) -> torch.Tensor:
-    """Reduce a [n_parts, H] fp32 partial buffer to dgamma[H] in ``gamma_dtype``.
-
-    Uses a column-major coalesced Triton reduction (one program per BLOCK_H
-    tile of H, walks n_parts rows in BLOCK_N-sized chunks with tl.sum tree
-    reduction). Tuned on MI325X: a (64,64) tile with nw=2 dominates the
-    previous (256,16) tile across every shape we ship — the smaller column
-    tile lets more programs run concurrently (more CUs occupied) while the
-    larger BLOCK_N=64 row chunk amortises the launch + dgamma write per
-    program. Also beats ``dg_partial.sum(dim=0).to(...)`` at every (n_parts,
-    H) we care about.
-    """
+    """Reduce [n_parts, H] fp32 partials to dgamma[H] via a coalesced col-tile."""
     n_parts, H = dg_partial.shape
     dg = torch.empty(H, device=dg_partial.device, dtype=gamma_dtype)
-    # (BLOCK_H=64, BLOCK_N=64, nw=2) is the universal winner on MI300/325X
-    # across every (n_parts, H) we sweep. Clamp BLOCK_H to next_pow2(H) so
-    # tiny H doesn't over-pad, and clamp BLOCK_N to a power of two >= 1 so
-    # tl.sum's tree reduction stays legal when n_parts is small.
     BLOCK_H = 64 if H >= 64 else _next_pow2(H)
     BLOCK_N = 64 if n_parts >= 64 else _next_pow2(max(n_parts, 1))
     grid = ((H + BLOCK_H - 1) // BLOCK_H,)

--- a/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
+++ b/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
@@ -6,6 +6,7 @@
 """Python-side wrappers that launch the Triton RMSNorm kernels."""
 from __future__ import annotations
 
+import functools
 from typing import Optional, Tuple
 
 import torch
@@ -62,10 +63,12 @@ def _pick_config(H: int, B: int) -> Tuple[int, int, int, int]:
     return BLOCK_H, 1, 16, 2
 
 
-# MI300/MI325X have 304 CUs. One wave per CU saturates the device for this
-# grid-stride kernel; pushing to 2 waves spreads dg accumulators thinner and
-# inflates the finalize input.
-_NUM_CUS = 304
+# One wave per CU saturates the device for the grid-stride bwd kernel;
+# pushing to 2 waves spreads dg accumulators thinner and inflates the
+# finalize input. CU count is queried per-device and cached.
+@functools.lru_cache(maxsize=None)
+def _num_cus(device_index: int = 0) -> int:
+    return torch.cuda.get_device_properties(device_index).multi_processor_count
 
 
 def _pick_bwd_config(H: int, B: int) -> Tuple[str, int, int, int, int]:
@@ -103,28 +106,28 @@ def _pick_bwd_config(H: int, B: int) -> Tuple[str, int, int, int, int]:
         # Sweep on N=4096,C=16384 showed grid=152/nw=8/ns=1 at ~120µs vs
         # ~126µs for full-wave (grid=304). Gated on the *actual* H (not the
         # pow2-rounded BLOCK_H) because H=12288 prefers full wave.
-        grid = min(B, _NUM_CUS // 2)
+        grid = min(B, _num_cus() // 2)
         num_warps = 8
         num_stages = 1
     elif BLOCK_H >= 16384 and B <= 4096:
         # H in (8192, 16384) and small B (e.g. H=12288). Full wave wins here.
-        grid = min(B, _NUM_CUS)
+        grid = min(B, _num_cus())
         num_warps = 8
         num_stages = 2
     elif BLOCK_H >= 8192 and B <= 4096:
         # H=8192, small B: half-wave gives each program more rows to chew so
         # the dgamma write amortises better.
-        grid = min(B, _NUM_CUS // 2)
+        grid = min(B, _num_cus() // 2)
         num_warps = 8
         num_stages = 1
     elif BLOCK_H >= 8192:
         # Wide H, larger B: full wave, drop ns to relieve register pressure.
-        grid = min(B, _NUM_CUS)
+        grid = min(B, _num_cus())
         num_warps = 4
         num_stages = 2
     else:
         # H in (256, 4096]: full wave, nw=8 amortises BLOCK_H per program.
-        grid = min(B, _NUM_CUS)
+        grid = min(B, _num_cus())
         num_warps = 8 if BLOCK_H >= 2048 else 4
         num_stages = 2
 

--- a/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
+++ b/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
@@ -96,9 +96,18 @@ def _pick_bwd_config(H: int, B: int) -> Tuple[str, int, int, int, int]:
     # - grid=152 (= NUM_CUS/2) wins for H=8192 with small B (4096): each
     #   program gets more rows to chew so the dgamma write amortises and the
     #   dg_partial cache footprint shrinks.
-    if BLOCK_H >= 16384 and B <= 4096:
-        # Very wide H + small B: full wave, ns=2 lets the compiler hide load
-        # latency despite the huge BLOCK_H.
+    if H >= 16384 and B <= 4096:
+        # Native huge H + small B: half-wave grid (152) wins on MI325X because
+        # each program covers ~27 rows so the dgamma store amortises better
+        # and dg_partial halves to (152, H), making the finalize cheaper.
+        # Sweep on N=4096,C=16384 showed grid=152/nw=8/ns=1 at ~120µs vs
+        # ~126µs for full-wave (grid=304). Gated on the *actual* H (not the
+        # pow2-rounded BLOCK_H) because H=12288 prefers full wave.
+        grid = min(B, _NUM_CUS // 2)
+        num_warps = 8
+        num_stages = 1
+    elif BLOCK_H >= 16384 and B <= 4096:
+        # H in (8192, 16384) and small B (e.g. H=12288). Full wave wins here.
         grid = min(B, _NUM_CUS)
         num_warps = 8
         num_stages = 2
@@ -127,16 +136,21 @@ def _finalize_dgamma(dg_partial: torch.Tensor, gamma_dtype: torch.dtype) -> torc
 
     Uses a column-major coalesced Triton reduction (one program per BLOCK_H
     tile of H, walks n_parts rows in BLOCK_N-sized chunks with tl.sum tree
-    reduction). Much faster than the generic ``dg_partial.sum(dim=0).to(...)``
-    when n_parts is large.
+    reduction). Tuned on MI325X: a (64,64) tile with nw=2 dominates the
+    previous (256,16) tile across every shape we ship — the smaller column
+    tile lets more programs run concurrently (more CUs occupied) while the
+    larger BLOCK_N=64 row chunk amortises the launch + dgamma write per
+    program. Also beats ``dg_partial.sum(dim=0).to(...)`` at every (n_parts,
+    H) we care about.
     """
     n_parts, H = dg_partial.shape
     dg = torch.empty(H, device=dg_partial.device, dtype=gamma_dtype)
-    # 256 hits the sweet spot for coalesced bf16/fp16 stores on MI300/325X.
-    BLOCK_H = 256 if H >= 256 else _next_pow2(H)
-    # BLOCK_N=16 gives a (16,256)=4KB fp32 tile per iter, keeps reg pressure
-    # tiny, and bounds the sequential add chain to ceil(n_parts/16) levels.
-    BLOCK_N = 16 if n_parts >= 16 else _next_pow2(max(n_parts, 1))
+    # (BLOCK_H=64, BLOCK_N=64, nw=2) is the universal winner on MI300/325X
+    # across every (n_parts, H) we sweep. Clamp BLOCK_H to next_pow2(H) so
+    # tiny H doesn't over-pad, and clamp BLOCK_N to a power of two >= 1 so
+    # tl.sum's tree reduction stays legal when n_parts is small.
+    BLOCK_H = 64 if H >= 64 else _next_pow2(H)
+    BLOCK_N = 64 if n_parts >= 64 else _next_pow2(max(n_parts, 1))
     grid = ((H + BLOCK_H - 1) // BLOCK_H,)
     rmsnorm_bwd_finalize_kernel[grid](
         dg_partial,
@@ -145,7 +159,7 @@ def _finalize_dgamma(dg_partial: torch.Tensor, gamma_dtype: torch.dtype) -> torc
         H=H,
         BLOCK_H=BLOCK_H,
         BLOCK_N=BLOCK_N,
-        num_warps=4,
+        num_warps=2,
         num_stages=1,
     )
     return dg

--- a/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
+++ b/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
@@ -11,9 +11,12 @@ from typing import Optional, Tuple
 import torch
 
 from primus_turbo.triton.normalization.rmsnorm_kernel import (
+    rmsnorm_bwd_finalize_kernel,
     rmsnorm_bwd_kernel,
+    rmsnorm_bwd_kernel_grid_stride,
     rmsnorm_bwd_kernel_multi_row,
     rmsnorm_bwd_residual_kernel,
+    rmsnorm_bwd_residual_kernel_grid_stride,
     rmsnorm_bwd_residual_kernel_multi_row,
     rmsnorm_fwd_kernel,
     rmsnorm_fwd_kernel_multi_row,
@@ -41,7 +44,7 @@ def _reshape_batch_hidden(x: torch.Tensor, H: int) -> torch.Tensor:
 
 
 def _pick_config(H: int, B: int) -> Tuple[int, int, int, int]:
-    """Return (BLOCK_H, ROWS_PER_BLOCK, num_warps, num_stages).
+    """Return (BLOCK_H, ROWS_PER_BLOCK, num_warps, num_stages) for fwd.
 
     Multi-row mode (ROWS_PER_BLOCK > 1) wins when H is small AND B is huge,
     because the grid size of one program per row becomes the bottleneck.
@@ -57,6 +60,95 @@ def _pick_config(H: int, B: int) -> Tuple[int, int, int, int]:
     if BLOCK_H <= 4096:
         return BLOCK_H, 1, 8, 2
     return BLOCK_H, 1, 16, 2
+
+
+# MI300/MI325X have 304 CUs. One wave per CU saturates the device for this
+# grid-stride kernel; pushing to 2 waves spreads dg accumulators thinner and
+# inflates the finalize input.
+_NUM_CUS = 304
+
+
+def _pick_bwd_config(H: int, B: int) -> Tuple[str, int, int, int, int]:
+    """Return (mode, BLOCK_H, GRID_OR_ROWS, num_warps, num_stages) for bwd.
+
+    Modes:
+    - ``"multi"``: multi-row 2D-tile kernel. GRID_OR_ROWS is ROWS_PER_BLOCK.
+      Good for small H + huge B (q-norm in MoE attention) where launch cost
+      and 2D-tile coalescing both pay off.
+    - ``"grid"``: persistent grid-stride kernel. GRID_OR_ROWS is the number
+      of programs. Each program loops over rows of stride num_programs while
+      keeping the dgamma accumulator live in registers across the loop. This
+      matches the HIP stage-0 approach and minimises the (n_parts, H)
+      dg_partial buffer (n_parts == grid_size, not B).
+    - ``"single"``: one-program-per-row fallback for tiny H/B.
+    """
+    BLOCK_H = _next_pow2(H)
+
+    # Small-H + huge-B: multi-row is great here (tile 2D in one shot).
+    if BLOCK_H <= 256 and B >= 4096:
+        ROWS = 16 if BLOCK_H <= 128 else 8
+        return "multi", BLOCK_H, ROWS, 4, 2
+    if BLOCK_H <= 256:
+        return "single", BLOCK_H, 1, 1, 1
+
+    # Grid-stride for everything wider. Tuned empirically on MI325X:
+    # - grid=304 (= NUM_CUS, 1 wave) is the default — saturates the device.
+    # - grid=152 (= NUM_CUS/2) wins for H=8192 with small B (4096): each
+    #   program gets more rows to chew so the dgamma write amortises and the
+    #   dg_partial cache footprint shrinks.
+    if BLOCK_H >= 16384 and B <= 4096:
+        # Very wide H + small B: full wave, ns=2 lets the compiler hide load
+        # latency despite the huge BLOCK_H.
+        grid = min(B, _NUM_CUS)
+        num_warps = 8
+        num_stages = 2
+    elif BLOCK_H >= 8192 and B <= 4096:
+        # H=8192, small B: half-wave gives each program more rows to chew so
+        # the dgamma write amortises better.
+        grid = min(B, _NUM_CUS // 2)
+        num_warps = 8
+        num_stages = 1
+    elif BLOCK_H >= 8192:
+        # Wide H, larger B: full wave, drop ns to relieve register pressure.
+        grid = min(B, _NUM_CUS)
+        num_warps = 4
+        num_stages = 2
+    else:
+        # H in (256, 4096]: full wave, nw=8 amortises BLOCK_H per program.
+        grid = min(B, _NUM_CUS)
+        num_warps = 8 if BLOCK_H >= 2048 else 4
+        num_stages = 2
+
+    return "grid", BLOCK_H, grid, num_warps, num_stages
+
+
+def _finalize_dgamma(dg_partial: torch.Tensor, gamma_dtype: torch.dtype) -> torch.Tensor:
+    """Reduce a [n_parts, H] fp32 partial buffer to dgamma[H] in ``gamma_dtype``.
+
+    Uses a column-major coalesced Triton reduction (one program per BLOCK_H
+    tile of H, walks n_parts rows in BLOCK_N-sized chunks with tl.sum tree
+    reduction). Much faster than the generic ``dg_partial.sum(dim=0).to(...)``
+    when n_parts is large.
+    """
+    n_parts, H = dg_partial.shape
+    dg = torch.empty(H, device=dg_partial.device, dtype=gamma_dtype)
+    # 256 hits the sweet spot for coalesced bf16/fp16 stores on MI300/325X.
+    BLOCK_H = 256 if H >= 256 else _next_pow2(H)
+    # BLOCK_N=16 gives a (16,256)=4KB fp32 tile per iter, keeps reg pressure
+    # tiny, and bounds the sequential add chain to ceil(n_parts/16) levels.
+    BLOCK_N = 16 if n_parts >= 16 else _next_pow2(max(n_parts, 1))
+    grid = ((H + BLOCK_H - 1) // BLOCK_H,)
+    rmsnorm_bwd_finalize_kernel[grid](
+        dg_partial,
+        dg,
+        n_parts,
+        H=H,
+        BLOCK_H=BLOCK_H,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=1,
+    )
+    return dg
 
 
 def rmsnorm_fwd_impl(
@@ -122,12 +214,18 @@ def rmsnorm_bwd_impl(
     num_warps: int,
     num_stages: int,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Backward launcher. Returns ``(dx [B, H], dgamma [H])``."""
+    """Backward launcher. Returns ``(dx [B, H], dgamma [H])``.
+
+    The fwd's chosen ``(BLOCK_H, ROWS, num_warps, num_stages)`` are accepted
+    for API compatibility but ignored — bwd re-picks a config tuned for its
+    own arithmetic intensity (see ``_pick_bwd_config``).
+    """
     H = gamma.shape[0]
     B = x2.shape[0]
     dy2 = _reshape_batch_hidden(dy, H)
     dx = torch.empty_like(x2)
-    if ROWS == 1:
+    mode, BLOCK_H, GR, num_warps, num_stages = _pick_bwd_config(H, B)
+    if mode == "single":
         dg_partial = torch.empty(B, H, device=x2.device, dtype=torch.float32)
         rmsnorm_bwd_kernel[(B,)](
             dy2,
@@ -148,11 +246,11 @@ def rmsnorm_bwd_impl(
             num_warps=num_warps,
             num_stages=num_stages,
         )
-    else:
+    elif mode == "multi":
+        ROWS = GR
         num_programs = (B + ROWS - 1) // ROWS
         dg_partial = torch.empty(num_programs, H, device=x2.device, dtype=torch.float32)
-        grid = (num_programs,)
-        rmsnorm_bwd_kernel_multi_row[grid](
+        rmsnorm_bwd_kernel_multi_row[(num_programs,)](
             dy2,
             x2,
             gamma,
@@ -173,7 +271,31 @@ def rmsnorm_bwd_impl(
             num_warps=num_warps,
             num_stages=num_stages,
         )
-    dg = dg_partial.sum(dim=0).to(gamma.dtype)
+    else:  # "grid": persistent grid-stride
+        num_programs = GR
+        dg_partial = torch.empty(num_programs, H, device=x2.device, dtype=torch.float32)
+        rmsnorm_bwd_kernel_grid_stride[(num_programs,)](
+            dy2,
+            x2,
+            gamma,
+            rstd,
+            dx,
+            dg_partial,
+            x2.stride(0),
+            x2.stride(1),
+            dy2.stride(0),
+            dy2.stride(1),
+            dx.stride(0),
+            dx.stride(1),
+            dg_partial.stride(0),
+            B=B,
+            H=H,
+            BLOCK_H=BLOCK_H,
+            num_programs=num_programs,
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+    dg = _finalize_dgamma(dg_partial, gamma.dtype)
     return dx, dg
 
 
@@ -270,7 +392,8 @@ def rmsnorm_bwd_residual_impl(
     else:
         dxpr2 = _reshape_batch_hidden(dxpr, H)
     dx = torch.empty_like(x_plus_r)
-    if ROWS == 1:
+    mode, BLOCK_H, GR, num_warps, num_stages = _pick_bwd_config(H, B)
+    if mode == "single":
         dg_partial = torch.empty(B, H, device=x_plus_r.device, dtype=torch.float32)
         rmsnorm_bwd_residual_kernel[(B,)](
             dy2,
@@ -294,11 +417,11 @@ def rmsnorm_bwd_residual_impl(
             num_warps=num_warps,
             num_stages=num_stages,
         )
-    else:
+    elif mode == "multi":
+        ROWS = GR
         num_programs = (B + ROWS - 1) // ROWS
         dg_partial = torch.empty(num_programs, H, device=x_plus_r.device, dtype=torch.float32)
-        grid = (num_programs,)
-        rmsnorm_bwd_residual_kernel_multi_row[grid](
+        rmsnorm_bwd_residual_kernel_multi_row[(num_programs,)](
             dy2,
             dxpr2,
             x_plus_r,
@@ -322,5 +445,32 @@ def rmsnorm_bwd_residual_impl(
             num_warps=num_warps,
             num_stages=num_stages,
         )
-    dg = dg_partial.sum(dim=0).to(gamma.dtype)
+    else:  # "grid": persistent grid-stride
+        num_programs = GR
+        dg_partial = torch.empty(num_programs, H, device=x_plus_r.device, dtype=torch.float32)
+        rmsnorm_bwd_residual_kernel_grid_stride[(num_programs,)](
+            dy2,
+            dxpr2,
+            x_plus_r,
+            gamma,
+            rstd,
+            dx,
+            dg_partial,
+            x_plus_r.stride(0),
+            x_plus_r.stride(1),
+            dy2.stride(0),
+            dy2.stride(1),
+            dxpr2.stride(0),
+            dxpr2.stride(1),
+            dx.stride(0),
+            dx.stride(1),
+            dg_partial.stride(0),
+            B=B,
+            H=H,
+            BLOCK_H=BLOCK_H,
+            num_programs=num_programs,
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+    dg = _finalize_dgamma(dg_partial, gamma.dtype)
     return dx, dg

--- a/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
+++ b/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
@@ -77,7 +77,11 @@ def _pick_bwd_config(H: int, B: int) -> Tuple[str, int, int, int, int]:
     """
     BLOCK_H = _next_pow2(H)
     if BLOCK_H <= 256 and B >= 4096:
-        return "multi", BLOCK_H, 16 if BLOCK_H <= 128 else 8, 4, 2
+        # ROWS=64 at BLOCK_H<=128 keeps the program count <= ~2 waves even at
+        # B=32768, which slashes the dg_partial volume and finalize time.
+        if BLOCK_H <= 128:
+            return "multi", BLOCK_H, 64, 4, 3
+        return "multi", BLOCK_H, 8, 4, 2
     if BLOCK_H <= 256:
         return "single", BLOCK_H, 1, 1, 1
 

--- a/primus_turbo/triton/normalization/rmsnorm_kernel.py
+++ b/primus_turbo/triton/normalization/rmsnorm_kernel.py
@@ -359,6 +359,156 @@ def rmsnorm_bwd_residual_kernel(
     tl.store(dgp_ptrs, dgp, mask=mask)
 
 
+# ---------------------------------------------------------------------------
+# Backward — grid-stride variant. Each program processes one row per loop
+# step and grid-strides (row += num_programs) until it has covered its
+# share of B. A per-program fp32 dgamma accumulator is kept live in
+# registers across all rows and a single partial slab (one per program) is
+# written at exit. This matches the HIP stage-0 pattern and drastically
+# shrinks the dg_partial buffer (n_parts == grid_size, not B).
+# ---------------------------------------------------------------------------
+@triton.jit
+def rmsnorm_bwd_kernel_grid_stride(
+    DY_ptr,
+    X_ptr,
+    G_ptr,
+    RSTD_ptr,
+    DX_ptr,
+    DG_PART_ptr,
+    stride_xb,
+    stride_xh,
+    stride_dyb,
+    stride_dyh,
+    stride_dxb,
+    stride_dxh,
+    stride_dgp,
+    B,
+    H: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    num_programs: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    h_offs = tl.arange(0, BLOCK_H)
+    h_mask = h_offs < H
+
+    # Load gamma once; reused across every row this program touches.
+    g = tl.load(G_ptr + h_offs, mask=h_mask, other=0.0).to(tl.float32)
+
+    # Per-program dgamma accumulator stays in registers/LDS for the whole loop.
+    dg_acc = tl.zeros((BLOCK_H,), dtype=tl.float32)
+
+    # Grid-stride over rows. Each program covers ceil(B / num_programs) rows.
+    for row in range(pid, B, num_programs):
+        x_ptrs = X_ptr + row * stride_xb + h_offs * stride_xh
+        dy_ptrs = DY_ptr + row * stride_dyb + h_offs * stride_dyh
+        dx_ptrs = DX_ptr + row * stride_dxb + h_offs * stride_dxh
+
+        x = tl.load(x_ptrs, mask=h_mask, other=0.0).to(tl.float32)
+        dy = tl.load(dy_ptrs, mask=h_mask, other=0.0).to(tl.float32)
+        rstd = tl.load(RSTD_ptr + row).to(tl.float32)
+
+        x_hat = x * rstd
+        dxhat = dy * g
+        m = tl.sum(dxhat * x_hat, axis=0) / H
+        dx = (dxhat - x_hat * m) * rstd
+        tl.store(dx_ptrs, dx.to(DX_ptr.dtype.element_ty), mask=h_mask)
+
+        dg_acc += dy * x_hat
+
+    dgp_ptrs = DG_PART_ptr + pid * stride_dgp + h_offs
+    tl.store(dgp_ptrs, dg_acc, mask=h_mask)
+
+
+@triton.jit
+def rmsnorm_bwd_residual_kernel_grid_stride(
+    DY_ptr,
+    DXPR_ptr,
+    XPR_ptr,
+    G_ptr,
+    RSTD_ptr,
+    DX_ptr,
+    DG_PART_ptr,
+    stride_xprb,
+    stride_xprh,
+    stride_dyb,
+    stride_dyh,
+    stride_dxprb,
+    stride_dxprh,
+    stride_dxb,
+    stride_dxh,
+    stride_dgp,
+    B,
+    H: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    num_programs: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    h_offs = tl.arange(0, BLOCK_H)
+    h_mask = h_offs < H
+
+    g = tl.load(G_ptr + h_offs, mask=h_mask, other=0.0).to(tl.float32)
+    dg_acc = tl.zeros((BLOCK_H,), dtype=tl.float32)
+
+    for row in range(pid, B, num_programs):
+        xpr_ptrs = XPR_ptr + row * stride_xprb + h_offs * stride_xprh
+        dy_ptrs = DY_ptr + row * stride_dyb + h_offs * stride_dyh
+        dxpr_ptrs = DXPR_ptr + row * stride_dxprb + h_offs * stride_dxprh
+        dx_ptrs = DX_ptr + row * stride_dxb + h_offs * stride_dxh
+
+        xpr = tl.load(xpr_ptrs, mask=h_mask, other=0.0).to(tl.float32)
+        dy = tl.load(dy_ptrs, mask=h_mask, other=0.0).to(tl.float32)
+        dxpr = tl.load(dxpr_ptrs, mask=h_mask, other=0.0).to(tl.float32)
+        rstd = tl.load(RSTD_ptr + row).to(tl.float32)
+
+        x_hat = xpr * rstd
+        dxhat = dy * g
+        m = tl.sum(dxhat * x_hat, axis=0) / H
+        dx_norm = (dxhat - x_hat * m) * rstd
+        dx = dx_norm + dxpr
+        tl.store(dx_ptrs, dx.to(DX_ptr.dtype.element_ty), mask=h_mask)
+
+        dg_acc += dy * x_hat
+
+    dgp_ptrs = DG_PART_ptr + pid * stride_dgp + h_offs
+    tl.store(dgp_ptrs, dg_acc, mask=h_mask)
+
+
+# ---------------------------------------------------------------------------
+# Backward — finalize: reduce the (n_parts, H) fp32 partial buffer down to
+# the final dgamma[H] in the gamma dtype. Each program owns BLOCK_H columns
+# and walks the n_parts rows. Coalesced column loads, single launch.
+# ---------------------------------------------------------------------------
+@triton.jit
+def rmsnorm_bwd_finalize_kernel(
+    DGP_ptr,
+    DG_ptr,
+    n_parts,
+    H: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Tree-reduce a (n_parts, H) fp32 partial buffer to dgamma[H].
+
+    Tiling: each program owns one BLOCK_H column tile. It walks the rows in
+    chunks of BLOCK_N, loads a (BLOCK_N, BLOCK_H) tile, and uses ``tl.sum``
+    along axis=0 — that gives a tree reduction inside the tile and keeps the
+    error chain depth ~ log2(n_parts) instead of linear, matching PyTorch's
+    ``sum(dim=0)`` fp32 accuracy.
+    """
+    pid = tl.program_id(0)
+    h_offs = pid * BLOCK_H + tl.arange(0, BLOCK_H)
+    h_mask = h_offs < H
+    acc = tl.zeros((BLOCK_H,), dtype=tl.float32)
+    n_offs = tl.arange(0, BLOCK_N)
+    for p in range(0, n_parts, BLOCK_N):
+        rows = p + n_offs
+        row_mask = rows < n_parts
+        ptrs = DGP_ptr + rows[:, None] * H + h_offs[None, :]
+        tile = tl.load(ptrs, mask=row_mask[:, None] & h_mask[None, :], other=0.0)
+        acc += tl.sum(tile, axis=0)
+    tl.store(DG_ptr + h_offs, acc.to(DG_ptr.dtype.element_ty), mask=h_mask)
+
+
 @triton.jit
 def rmsnorm_bwd_residual_kernel_multi_row(
     DY_ptr,

--- a/primus_turbo/triton/normalization/rmsnorm_kernel.py
+++ b/primus_turbo/triton/normalization/rmsnorm_kernel.py
@@ -29,11 +29,7 @@ from __future__ import annotations
 import triton
 import triton.language as tl
 
-# Autotune candidates for the grid-stride bwd kernels. Covers every
-# (num_warps, num_stages) combination the prior hand-tuned MI325X dispatch
-# ever picked. Triton picks the winner per (BLOCK_H, B, num_programs) at
-# first JIT and caches the choice. Drop-in re-tuning on other arches with
-# no source edits.
+# Grid-stride bwd autotune set. Picked per (BLOCK_H, B, num_programs) at JIT.
 _GRID_STRIDE_BWD_CONFIGS = [
     triton.Config({}, num_warps=4, num_stages=1),
     triton.Config({}, num_warps=4, num_stages=2),

--- a/primus_turbo/triton/normalization/rmsnorm_kernel.py
+++ b/primus_turbo/triton/normalization/rmsnorm_kernel.py
@@ -38,7 +38,9 @@ _GRID_STRIDE_BWD_CONFIGS = [
 ]
 
 
-# Forward — one row per program. Used when H is large.
+# ---------------------------------------------------------------------------
+# Forward — one row per program.
+# ---------------------------------------------------------------------------
 @triton.jit
 def rmsnorm_fwd_kernel(
     X_ptr,
@@ -69,7 +71,9 @@ def rmsnorm_fwd_kernel(
     tl.store(RSTD_ptr + row, rstd)
 
 
+# ---------------------------------------------------------------------------
 # Forward — N rows per program.
+# ---------------------------------------------------------------------------
 @triton.jit
 def rmsnorm_fwd_kernel_multi_row(
     X_ptr,
@@ -109,7 +113,9 @@ def rmsnorm_fwd_kernel_multi_row(
     tl.store(RSTD_ptr + row_offs, rstd, mask=row_mask)
 
 
+# ---------------------------------------------------------------------------
 # Forward — fused residual add.
+# ---------------------------------------------------------------------------
 @triton.jit
 def rmsnorm_fwd_residual_kernel(
     X_ptr,
@@ -152,6 +158,9 @@ def rmsnorm_fwd_residual_kernel(
     tl.store(RSTD_ptr + row, rstd)
 
 
+# ---------------------------------------------------------------------------
+# Forward — fused residual add, N rows per program.
+# ---------------------------------------------------------------------------
 @triton.jit
 def rmsnorm_fwd_residual_kernel_multi_row(
     X_ptr,
@@ -203,6 +212,10 @@ def rmsnorm_fwd_residual_kernel_multi_row(
     tl.store(RSTD_ptr + row_offs, rstd, mask=row_mask)
 
 
+# ---------------------------------------------------------------------------
+# Backward — 2D tile over (ROWS_PER_BLOCK, BLOCK_H). Writes one partial
+# dgamma slab per program.
+# ---------------------------------------------------------------------------
 @triton.jit
 def rmsnorm_bwd_kernel_multi_row(
     DY_ptr,
@@ -257,7 +270,10 @@ def rmsnorm_bwd_kernel_multi_row(
     tl.store(dgp_ptrs, dgp_row, mask=h_mask)
 
 
-# Backward — persistent grid-stride. dgamma accumulator stays in registers; n_parts = num_programs.
+# ---------------------------------------------------------------------------
+# Backward — persistent grid-stride. dgamma accumulator stays in registers
+# across the row loop; n_parts == num_programs (not B).
+# ---------------------------------------------------------------------------
 @triton.autotune(configs=_GRID_STRIDE_BWD_CONFIGS, key=["BLOCK_H", "B", "num_programs"])
 @triton.jit
 def rmsnorm_bwd_kernel_grid_stride(
@@ -307,6 +323,9 @@ def rmsnorm_bwd_kernel_grid_stride(
     tl.store(dgp_ptrs, dg_acc, mask=h_mask)
 
 
+# ---------------------------------------------------------------------------
+# Backward — persistent grid-stride, fused residual variant.
+# ---------------------------------------------------------------------------
 @triton.autotune(configs=_GRID_STRIDE_BWD_CONFIGS, key=["BLOCK_H", "B", "num_programs"])
 @triton.jit
 def rmsnorm_bwd_residual_kernel_grid_stride(
@@ -362,7 +381,9 @@ def rmsnorm_bwd_residual_kernel_grid_stride(
     tl.store(dgp_ptrs, dg_acc, mask=h_mask)
 
 
+# ---------------------------------------------------------------------------
 # Backward finalize — reduces (n_parts, H) fp32 partials to dgamma[H].
+# ---------------------------------------------------------------------------
 @triton.jit
 def rmsnorm_bwd_finalize_kernel(
     DGP_ptr,
@@ -386,6 +407,9 @@ def rmsnorm_bwd_finalize_kernel(
     tl.store(DG_ptr + h_offs, acc.to(DG_ptr.dtype.element_ty), mask=h_mask)
 
 
+# ---------------------------------------------------------------------------
+# Backward — 2D tile, fused residual variant.
+# ---------------------------------------------------------------------------
 @triton.jit
 def rmsnorm_bwd_residual_kernel_multi_row(
     DY_ptr,

--- a/primus_turbo/triton/normalization/rmsnorm_kernel.py
+++ b/primus_turbo/triton/normalization/rmsnorm_kernel.py
@@ -29,6 +29,18 @@ from __future__ import annotations
 import triton
 import triton.language as tl
 
+# Autotune candidates for the grid-stride bwd kernels. Covers every
+# (num_warps, num_stages) combination the prior hand-tuned MI325X dispatch
+# ever picked. Triton picks the winner per (BLOCK_H, B, num_programs) at
+# first JIT and caches the choice. Drop-in re-tuning on other arches with
+# no source edits.
+_GRID_STRIDE_BWD_CONFIGS = [
+    triton.Config({}, num_warps=4, num_stages=1),
+    triton.Config({}, num_warps=4, num_stages=2),
+    triton.Config({}, num_warps=8, num_stages=1),
+    triton.Config({}, num_warps=8, num_stages=2),
+]
+
 
 # ---------------------------------------------------------------------------
 # Forward kernel — one row per program. Used when H is large.
@@ -367,6 +379,7 @@ def rmsnorm_bwd_residual_kernel(
 # written at exit. This matches the HIP stage-0 pattern and drastically
 # shrinks the dg_partial buffer (n_parts == grid_size, not B).
 # ---------------------------------------------------------------------------
+@triton.autotune(configs=_GRID_STRIDE_BWD_CONFIGS, key=["BLOCK_H", "B", "num_programs"])
 @triton.jit
 def rmsnorm_bwd_kernel_grid_stride(
     DY_ptr,
@@ -419,6 +432,7 @@ def rmsnorm_bwd_kernel_grid_stride(
     tl.store(dgp_ptrs, dg_acc, mask=h_mask)
 
 
+@triton.autotune(configs=_GRID_STRIDE_BWD_CONFIGS, key=["BLOCK_H", "B", "num_programs"])
 @triton.jit
 def rmsnorm_bwd_residual_kernel_grid_stride(
     DY_ptr,

--- a/primus_turbo/triton/normalization/rmsnorm_kernel.py
+++ b/primus_turbo/triton/normalization/rmsnorm_kernel.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import triton
 import triton.language as tl
 
-# Grid-stride bwd autotune set. Picked per (BLOCK_H, B, num_programs) at JIT.
+# Autotune candidates for the grid-stride bwd kernels.
 _GRID_STRIDE_BWD_CONFIGS = [
     triton.Config({}, num_warps=4, num_stages=1),
     triton.Config({}, num_warps=4, num_stages=2),
@@ -38,9 +38,7 @@ _GRID_STRIDE_BWD_CONFIGS = [
 ]
 
 
-# ---------------------------------------------------------------------------
-# Forward kernel — one row per program. Used when H is large.
-# ---------------------------------------------------------------------------
+# Forward — one row per program. Used when H is large.
 @triton.jit
 def rmsnorm_fwd_kernel(
     X_ptr,
@@ -71,10 +69,7 @@ def rmsnorm_fwd_kernel(
     tl.store(RSTD_ptr + row, rstd)
 
 
-# ---------------------------------------------------------------------------
-# Forward kernel — N rows per program (small H, huge B). Reduces grid size,
-# which is critical when the launch / scheduling cost dominates.
-# ---------------------------------------------------------------------------
+# Forward — N rows per program.
 @triton.jit
 def rmsnorm_fwd_kernel_multi_row(
     X_ptr,
@@ -114,13 +109,7 @@ def rmsnorm_fwd_kernel_multi_row(
     tl.store(RSTD_ptr + row_offs, rstd, mask=row_mask)
 
 
-# ---------------------------------------------------------------------------
-# Forward kernel — fused residual add. Computes
-#     x_plus_r = x + residual
-#     y        = rmsnorm(x_plus_r) * gamma
-# in one pass and exposes ``x_plus_r`` for the next residual add. Saves
-# ``x_plus_r`` (input dtype) and ``rstd`` (fp32) for backward.
-# ---------------------------------------------------------------------------
+# Forward — fused residual add.
 @triton.jit
 def rmsnorm_fwd_residual_kernel(
     X_ptr,
@@ -214,9 +203,7 @@ def rmsnorm_fwd_residual_kernel_multi_row(
     tl.store(RSTD_ptr + row_offs, rstd, mask=row_mask)
 
 
-# ---------------------------------------------------------------------------
-# Backward — stage 0: per-row dx + per-row (or per-program) partial dgamma.
-# ---------------------------------------------------------------------------
+# Backward — one row per program.
 @triton.jit
 def rmsnorm_bwd_kernel(
     DY_ptr,
@@ -314,10 +301,7 @@ def rmsnorm_bwd_kernel_multi_row(
     tl.store(dgp_ptrs, dgp_row, mask=h_mask)
 
 
-# ---------------------------------------------------------------------------
-# Backward — fused residual variant. Adds the gradient that flows through
-# ``x_plus_r`` (consumed by the next residual add) to the standard RMSNorm dx.
-# ---------------------------------------------------------------------------
+# Backward — fused residual.
 @triton.jit
 def rmsnorm_bwd_residual_kernel(
     DY_ptr,
@@ -367,14 +351,7 @@ def rmsnorm_bwd_residual_kernel(
     tl.store(dgp_ptrs, dgp, mask=mask)
 
 
-# ---------------------------------------------------------------------------
-# Backward — grid-stride variant. Each program processes one row per loop
-# step and grid-strides (row += num_programs) until it has covered its
-# share of B. A per-program fp32 dgamma accumulator is kept live in
-# registers across all rows and a single partial slab (one per program) is
-# written at exit. This matches the HIP stage-0 pattern and drastically
-# shrinks the dg_partial buffer (n_parts == grid_size, not B).
-# ---------------------------------------------------------------------------
+# Backward — persistent grid-stride. dgamma accumulator stays in registers; n_parts = num_programs.
 @triton.autotune(configs=_GRID_STRIDE_BWD_CONFIGS, key=["BLOCK_H", "B", "num_programs"])
 @triton.jit
 def rmsnorm_bwd_kernel_grid_stride(
@@ -400,13 +377,9 @@ def rmsnorm_bwd_kernel_grid_stride(
     h_offs = tl.arange(0, BLOCK_H)
     h_mask = h_offs < H
 
-    # Load gamma once; reused across every row this program touches.
     g = tl.load(G_ptr + h_offs, mask=h_mask, other=0.0).to(tl.float32)
-
-    # Per-program dgamma accumulator stays in registers/LDS for the whole loop.
     dg_acc = tl.zeros((BLOCK_H,), dtype=tl.float32)
 
-    # Grid-stride over rows. Each program covers ceil(B / num_programs) rows.
     for row in range(pid, B, num_programs):
         x_ptrs = X_ptr + row * stride_xb + h_offs * stride_xh
         dy_ptrs = DY_ptr + row * stride_dyb + h_offs * stride_dyh
@@ -483,11 +456,7 @@ def rmsnorm_bwd_residual_kernel_grid_stride(
     tl.store(dgp_ptrs, dg_acc, mask=h_mask)
 
 
-# ---------------------------------------------------------------------------
-# Backward — finalize: reduce the (n_parts, H) fp32 partial buffer down to
-# the final dgamma[H] in the gamma dtype. Each program owns BLOCK_H columns
-# and walks the n_parts rows. Coalesced column loads, single launch.
-# ---------------------------------------------------------------------------
+# Backward finalize — reduces (n_parts, H) fp32 partials to dgamma[H].
 @triton.jit
 def rmsnorm_bwd_finalize_kernel(
     DGP_ptr,
@@ -497,14 +466,6 @@ def rmsnorm_bwd_finalize_kernel(
     BLOCK_H: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
-    """Tree-reduce a (n_parts, H) fp32 partial buffer to dgamma[H].
-
-    Tiling: each program owns one BLOCK_H column tile. It walks the rows in
-    chunks of BLOCK_N, loads a (BLOCK_N, BLOCK_H) tile, and uses ``tl.sum``
-    along axis=0 — that gives a tree reduction inside the tile and keeps the
-    error chain depth ~ log2(n_parts) instead of linear, matching PyTorch's
-    ``sum(dim=0)`` fp32 accuracy.
-    """
     pid = tl.program_id(0)
     h_offs = pid * BLOCK_H + tl.arange(0, BLOCK_H)
     h_mask = h_offs < H

--- a/primus_turbo/triton/normalization/rmsnorm_kernel.py
+++ b/primus_turbo/triton/normalization/rmsnorm_kernel.py
@@ -203,50 +203,6 @@ def rmsnorm_fwd_residual_kernel_multi_row(
     tl.store(RSTD_ptr + row_offs, rstd, mask=row_mask)
 
 
-# Backward — one row per program.
-@triton.jit
-def rmsnorm_bwd_kernel(
-    DY_ptr,
-    X_ptr,
-    G_ptr,
-    RSTD_ptr,
-    DX_ptr,
-    DG_PART_ptr,
-    stride_xb,
-    stride_xh,
-    stride_dyb,
-    stride_dyh,
-    stride_dxb,
-    stride_dxh,
-    stride_dgb,
-    H: tl.constexpr,
-    BLOCK_H: tl.constexpr,
-):
-    row = tl.program_id(0)
-    offs = tl.arange(0, BLOCK_H)
-    mask = offs < H
-
-    x_ptrs = X_ptr + row * stride_xb + offs * stride_xh
-    dy_ptrs = DY_ptr + row * stride_dyb + offs * stride_dyh
-    dx_ptrs = DX_ptr + row * stride_dxb + offs * stride_dxh
-    dgp_ptrs = DG_PART_ptr + row * stride_dgb + offs
-    g_ptrs = G_ptr + offs
-
-    x = tl.load(x_ptrs, mask=mask, other=0.0).to(tl.float32)
-    dy = tl.load(dy_ptrs, mask=mask, other=0.0).to(tl.float32)
-    g = tl.load(g_ptrs, mask=mask, other=0.0).to(tl.float32)
-    rstd = tl.load(RSTD_ptr + row).to(tl.float32)
-
-    x_hat = x * rstd
-    dxhat = dy * g
-    m = tl.sum(dxhat * x_hat, axis=0) / H
-    dx = (dxhat - x_hat * m) * rstd
-    dgp = dy * x_hat
-
-    tl.store(dx_ptrs, dx.to(DX_ptr.dtype.element_ty), mask=mask)
-    tl.store(dgp_ptrs, dgp, mask=mask)
-
-
 @triton.jit
 def rmsnorm_bwd_kernel_multi_row(
     DY_ptr,
@@ -299,56 +255,6 @@ def rmsnorm_bwd_kernel_multi_row(
     dgp_block = (dy * x_hat) * row_mask[:, None].to(tl.float32)
     dgp_row = tl.sum(dgp_block, axis=0)
     tl.store(dgp_ptrs, dgp_row, mask=h_mask)
-
-
-# Backward — fused residual.
-@triton.jit
-def rmsnorm_bwd_residual_kernel(
-    DY_ptr,
-    DXPR_ptr,
-    XPR_ptr,
-    G_ptr,
-    RSTD_ptr,
-    DX_ptr,
-    DG_PART_ptr,
-    stride_xprb,
-    stride_xprh,
-    stride_dyb,
-    stride_dyh,
-    stride_dxprb,
-    stride_dxprh,
-    stride_dxb,
-    stride_dxh,
-    stride_dgb,
-    H: tl.constexpr,
-    BLOCK_H: tl.constexpr,
-):
-    row = tl.program_id(0)
-    offs = tl.arange(0, BLOCK_H)
-    mask = offs < H
-
-    xpr_ptrs = XPR_ptr + row * stride_xprb + offs * stride_xprh
-    dy_ptrs = DY_ptr + row * stride_dyb + offs * stride_dyh
-    dxpr_ptrs = DXPR_ptr + row * stride_dxprb + offs * stride_dxprh
-    dx_ptrs = DX_ptr + row * stride_dxb + offs * stride_dxh
-    dgp_ptrs = DG_PART_ptr + row * stride_dgb + offs
-    g_ptrs = G_ptr + offs
-
-    xpr = tl.load(xpr_ptrs, mask=mask, other=0.0).to(tl.float32)
-    dy = tl.load(dy_ptrs, mask=mask, other=0.0).to(tl.float32)
-    dxpr = tl.load(dxpr_ptrs, mask=mask, other=0.0).to(tl.float32)
-    g = tl.load(g_ptrs, mask=mask, other=0.0).to(tl.float32)
-    rstd = tl.load(RSTD_ptr + row).to(tl.float32)
-
-    x_hat = xpr * rstd
-    dxhat = dy * g
-    m = tl.sum(dxhat * x_hat, axis=0) / H
-    dx_norm = (dxhat - x_hat * m) * rstd
-    dx = dx_norm + dxpr
-    dgp = dy * x_hat
-
-    tl.store(dx_ptrs, dx.to(DX_ptr.dtype.element_ty), mask=mask)
-    tl.store(dgp_ptrs, dgp, mask=mask)
 
 
 # Backward — persistent grid-stride. dgamma accumulator stays in registers; n_parts = num_programs.


### PR DESCRIPTION
# Triton BWD norm optimization

## Changes

- Persistent grid-stride: Program owns a slice of rows, loops with stride=num_programs, keeps the fp32 dgamma accumulator live in registers.
- Separate dgamma finalize kernel
- Triton autotuning on bwd
- CU-scaled dispatch: grid size and multi-row ROWS computed from `torch.cuda.get_device_properties(0).multi_processor_count`
- Multi-row ROWs tuned for small hidden shapes

114/114 tests pass
- tests/pytorch/ops/test_normalization.py 
- tests/pytorch/modules/test_normalization.py 

### Backward speedup vs upstream Triton (bf16, MI325X, min-of-13)
For N=n_tokens, C=hidden dim (N, C)

  | Shape (N × C) | Upstream | This PR | Speedup |
  |---|---:|---:|---:|
  | 8192 × 128 | 134.8 µs | 51.4 µs | 2.62× |
  | 8192 × 512 | 57.6 | 50.8 | 1.13× |
  | 8192 × 1024 | 56.9 | 50.4 | 1.13× |
  | 8192 × 2048 | 74.1 | 48.6 | 1.52× |
  | 8192 × 4096 | 111.7 | 54.5 | 2.05× |
  | 4096 × 5120 | 81.3 | 48.8 | 1.67× |
  | 8192 × 5120 | 139.9 | 78.8 | 1.78× |
  | 16384 × 4096 | 213.1 | 105.8 | 2.01× |
  | 16384 × 8192 | 440.7 | 207.4 | 2.13× |
  | 32768 × 4096 | 437.1 | 206.4 | 2.12× |
  | 4096 × 8192 | 112.6 | 59.1 | 1.91× |
  | 4096 × 12288 | 338.5 | 78.0 | 4.34× |
  | 4096 × 16384 | 387.0 | 115.0 | 3.37× |


## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [x] Code refactoring

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
