### PR TITLE
refactor(moe): rename num_permuted_tokens to permute_max_token_num in DeepEPTokenDispatcher

### DIFF
--- a/csrc/include/primus_turbo/moe_permute.h
+++ b/csrc/include/primus_turbo/moe_permute.h
@@ -13,7 +13,7 @@ template <typename expert_map_t>
 void permute_preprocessing_impl(const expert_map_t *expert_map, int num_topk,
                                 int *num_dispatched_tokens_out, int num_local_experts,
                                 int max_num_dispatched_tokens, int pad_multiple,
-                                int32_t *tokens_per_expert, int *row_id_map, int *overflow_flag,
+                                int64_t *tokens_per_expert, int *row_id_map, int *overflow_flag,
                                 int64_t num_permuted_tokens, int probs_topk_stride,
                                 hipStream_t stream);
 

--- a/csrc/kernels/moe_permute/moe_permute.cu
+++ b/csrc/kernels/moe_permute/moe_permute.cu
@@ -83,7 +83,7 @@ template <int kNumThreads, typename expert_map_t>
 __launch_bounds__(kNumThreads, 1) __global__
     void permute_preprocessing_kernel(const expert_map_t *expert_map, int max_num_dispatched_tokens,
                                       int *num_dispatched_tokens_out, int num_experts, int num_topk,
-                                      int pad_multiple, int32_t *tokens_per_expert, int *row_id_map,
+                                      int pad_multiple, int64_t *tokens_per_expert, int *row_id_map,
                                       int *overflow_flag, int64_t num_permuted_tokens,
                                       int probs_topk_stride, TempStorageLayout layout) {
     using BlockScan   = hipcub::BlockScan<int32_t, kNumThreads>;
@@ -304,10 +304,10 @@ __launch_bounds__(kNumThreads, 1) __global__
 
     if (block_id == grid_size - 1) {
         if (thread_id < E) {
-            const int tokens_for_expert = s_acc[thread_id] + s_num_padded[thread_id];
-            const int overflow          = tokens_for_expert + s_tpe_prefix[thread_id] - npt;
-            tokens_per_expert[thread_id] =
-                (overflow < 0) ? tokens_for_expert : max(0, tokens_for_expert - overflow);
+            const int tokens_for_expert  = s_acc[thread_id] + s_num_padded[thread_id];
+            const int overflow           = tokens_for_expert + s_tpe_prefix[thread_id] - npt;
+            tokens_per_expert[thread_id] = static_cast<int64_t>(
+                (overflow < 0) ? tokens_for_expert : max(0, tokens_for_expert - overflow));
         }
         if (thread_id == 0)
             *num_dispatched_tokens_out = s_total_dispatched;
@@ -364,7 +364,7 @@ template <typename expert_map_t>
 void permute_preprocessing_impl(const expert_map_t *expert_map, int num_topk,
                                 int *num_dispatched_tokens_out, int num_local_experts,
                                 int max_num_dispatched_tokens, int pad_multiple,
-                                int32_t *tokens_per_expert, int *row_id_map, int *overflow_flag,
+                                int64_t *tokens_per_expert, int *row_id_map, int *overflow_flag,
                                 int64_t num_permuted_tokens, int probs_topk_stride,
                                 hipStream_t stream) {
     constexpr int kNumThreads = 512;
@@ -384,7 +384,7 @@ void permute_preprocessing_impl(const expert_map_t *expert_map, int num_topk,
 
     int device_id = 0;
     PRIMUS_TURBO_CHECK_HIP(hipGetDevice(&device_id));
-    const int num_cu = get_multi_processor_count(device_id);
+    const int        num_cu              = get_multi_processor_count(device_id);
     static const int max_shmem_per_block = get_max_shmem_per_block(device_id);
 
     const int num_token_tiles = (max_num_dispatched_tokens + kNumThreads - 1) / kNumThreads;
@@ -674,7 +674,8 @@ void unpermute_impl(const dtype_t *permuted_tokens, dtype_t *tokens, const prob_
 
     const int effective_probs_stride = probs_stride > 0 ? probs_stride : num_local_experts;
 
-    // unpermute_kernel_e1 hard-codes probs row width 1 (multihot only); topk path uses num_topk at E=1.
+    // unpermute_kernel_e1 hard-codes probs row width 1 (multihot only); topk path uses num_topk at
+    // E=1.
     if (num_local_experts == 1 && effective_probs_stride == 1) {
         constexpr int num_warps_e1  = kE1NumThreads / kWarpSize;
         const int     blocks_needed = (num_dispatched_max + num_warps_e1 - 1) / num_warps_e1;

--- a/csrc/pytorch/moe_permute/moe_permute.cpp
+++ b/csrc/pytorch/moe_permute/moe_permute.cpp
@@ -65,11 +65,12 @@ permute_preprocessing(torch::Tensor expert_map, int64_t num_local_experts, int64
     auto max_num_dispatched_tokens = expert_map.size(0);
     auto device                    = expert_map.device();
     auto int_opts                  = at::TensorOptions().dtype(at::kInt).device(device);
+    auto long_opts                 = at::TensorOptions().dtype(at::kLong).device(device);
 
     auto row_id_map = at::empty(
         {static_cast<int64_t>(max_num_dispatched_tokens + pad_multiple), 2 * num_local_experts + 1},
         int_opts);
-    auto tokens_per_expert = at::empty({num_local_experts}, int_opts);
+    auto tokens_per_expert = at::empty({num_local_experts}, long_opts);
     auto overflow_flag     = at::empty({1}, int_opts);
     // ``at::zeros`` keeps the init CUDA-graph-capturable (no host sync).
     auto num_dispatched_tokens = at::zeros({1}, int_opts);
@@ -81,7 +82,7 @@ permute_preprocessing(torch::Tensor expert_map, int64_t num_local_experts, int64
         reinterpret_cast<expert_map_type *>(expert_map.data_ptr()), num_topk,                      \
         num_dispatched_tokens.data_ptr<int>(), static_cast<int>(num_local_experts),                \
         static_cast<int>(max_num_dispatched_tokens), static_cast<int>(pad_multiple),               \
-        tokens_per_expert.data_ptr<int>(), row_id_map.data_ptr<int>(),                             \
+        tokens_per_expert.data_ptr<int64_t>(), row_id_map.data_ptr<int>(),                         \
         overflow_flag.data_ptr<int>(), static_cast<int64_t>(num_permuted_tokens),                  \
         static_cast<int>(probs_topk_stride), stream);
 

--- a/csrc/pytorch/moe_permute/moe_permute_meta.cpp
+++ b/csrc/pytorch/moe_permute/moe_permute_meta.cpp
@@ -11,10 +11,11 @@ permute_preprocessing_meta(torch::Tensor expert_map, int64_t num_local_experts,
                            int64_t /*num_topk*/, int64_t     pad_multiple,
                            int64_t /*num_permuted_tokens*/, int64_t /*probs_topk_stride*/) {
     auto int_opts                  = at::TensorOptions().dtype(at::kInt).device(at::kMeta);
+    auto long_opts                 = at::TensorOptions().dtype(at::kLong).device(at::kMeta);
     auto max_num_dispatched_tokens = expert_map.sizes()[0];
     auto row_id_map =
         at::empty({max_num_dispatched_tokens + pad_multiple, 2 * num_local_experts + 1}, int_opts);
-    auto tokens_per_expert     = at::empty({num_local_experts}, int_opts);
+    auto tokens_per_expert     = at::empty({num_local_experts}, long_opts);
     auto overflow_flag         = at::empty({1}, int_opts);
     auto num_dispatched_tokens = at::empty({1}, int_opts);
     return {row_id_map, tokens_per_expert, overflow_flag, num_dispatched_tokens};

--- a/primus_turbo/pytorch/modules/moe/token_dispatcher.py
+++ b/primus_turbo/pytorch/modules/moe/token_dispatcher.py
@@ -112,7 +112,7 @@ class DeepEPTokenDispatcher(TokenDispatcher):
     ``pad_multiple`` padding.
 
     Fully nosync / CUDA-graph capturable requires all three:
-    ``deepep_num_worst_tokens > 0``, ``num_permuted_tokens > 0``,
+    ``deepep_num_worst_tokens > 0``, ``permute_max_token_num > 0``,
     ``deepep_use_cuda_num_tokens_per_expert=True``.
 
     Args:
@@ -122,7 +122,7 @@ class DeepEPTokenDispatcher(TokenDispatcher):
         permute_fusion: deprecated; ``moe_permute`` is always fused.
         pad_multiple: pad per-expert permuted count to this multiple
             (set to grouped-GEMM ``BLOCK_M``).
-        num_permuted_tokens: caller-provided cap; ``> 0`` removes the sum-item host sync.
+        permute_max_token_num: caller-provided cap; ``> 0`` removes the sum-item host sync.
         deepep_use_comm_stream: when False, pin EP kernels to the current stream.
         deepep_num_worst_tokens: ``> 0`` enables worst-case allocation mode.
         deepep_use_cuda_num_tokens_per_expert: keep ``tokens_per_expert`` on device.
@@ -142,7 +142,7 @@ class DeepEPTokenDispatcher(TokenDispatcher):
         expert_capacity_factor: Optional[float] = None,
         permute_fusion: Optional[bool] = None,
         pad_multiple: int = 0,
-        num_permuted_tokens: int = -1,
+        permute_max_token_num: int = -1,
         deepep_async_finish: bool = True,
         deepep_allocate_on_comm_stream: bool = True,
         deepep_use_comm_stream: bool = False,
@@ -181,7 +181,7 @@ class DeepEPTokenDispatcher(TokenDispatcher):
         self.capacity_factor = expert_capacity_factor
 
         self.pad_multiple = pad_multiple
-        self.num_permuted_tokens = num_permuted_tokens
+        self.permute_max_token_num = permute_max_token_num
 
         self.deepep_async_finish = deepep_async_finish
         self.deepep_allocate_on_comm_stream = deepep_allocate_on_comm_stream
@@ -290,8 +290,6 @@ class DeepEPTokenDispatcher(TokenDispatcher):
 
     def _post_dispatch(self, hidden_states, dispatched_probs):
         # Both dispatcher and moe_permute use -1 to mean "unspecified" (sync path).
-        num_permuted_tokens = self.num_permuted_tokens
-
         self.hidden_shape_before_permute = hidden_states.shape
         assert dispatched_probs.dtype == torch.float32, "DeepEP only supports float32 probs"
 
@@ -310,7 +308,7 @@ class DeepEPTokenDispatcher(TokenDispatcher):
             num_local_experts=self.num_local_experts,
             num_topk=self.router_topk,
             pad_multiple=self.pad_multiple,
-            num_permuted_tokens=num_permuted_tokens,
+            num_permuted_tokens=self.permute_max_token_num,
             probs=dispatched_probs,
         )
 

--- a/primus_turbo/pytorch/ops/moe/moe_permute.py
+++ b/primus_turbo/pytorch/ops/moe/moe_permute.py
@@ -84,7 +84,7 @@ class _MoEPermute(torch.autograd.Function):
         if num_dispatched == 0:
             int_opts = dict(dtype=torch.int32, device=device)
             row_id_map = torch.zeros((pad_multiple, 2 * num_local_experts + 1), **int_opts)
-            tokens_per_expert = torch.zeros((num_local_experts,), **int_opts)
+            tokens_per_expert = torch.zeros((num_local_experts,), dtype=torch.int64, device=device)
             overflow_flag = torch.zeros((1,), **int_opts)
             num_dispatched_tokens = torch.zeros((1,), **int_opts)
             permuted_tokens = tokens.new_empty((0, hidden_size))

--- a/tests/pytorch/modules/test_token_dispatcher.py
+++ b/tests/pytorch/modules/test_token_dispatcher.py
@@ -85,7 +85,7 @@ def _run_dispatch_combine(
     permute_fusion=None,
     deepep_use_cuda_num_tokens_per_expert=False,
     deepep_num_worst_tokens=0,
-    num_permuted_tokens=0,
+    permute_max_token_num=0,
     pad_multiple=0,
     expert_capacity_factor=None,
     deepep_use_comm_stream=False,
@@ -109,7 +109,7 @@ def _run_dispatch_combine(
         permute_fusion=permute_fusion,
         deepep_use_cuda_num_tokens_per_expert=deepep_use_cuda_num_tokens_per_expert,
         deepep_num_worst_tokens=deepep_num_worst_tokens,
-        num_permuted_tokens=num_permuted_tokens,
+        permute_max_token_num=permute_max_token_num,
         pad_multiple=pad_multiple,
         expert_capacity_factor=expert_capacity_factor,
         deepep_use_comm_stream=deepep_use_comm_stream,
@@ -191,8 +191,8 @@ class TestTokenDispatcher(MultiProcContinuousTest):
     # ------------------------------------------------------------------
 
     @parametrize("backend", _get_backends())
-    @parametrize("num_permuted_tokens", [0, NUM_TOKENS * 8 * ROUTER_TOPK])
-    def test_worst_tokens(self, backend, num_permuted_tokens):
+    @parametrize("permute_max_token_num", [0, NUM_TOKENS * 8 * ROUTER_TOPK])
+    def test_worst_tokens(self, backend, permute_max_token_num):
         self._bind_device()
         with patch.dict(os.environ, {"PRIMUS_TURBO_MOE_DISPATCH_COMBINE_BACKEND": backend}):
             _run_dispatch_combine(
@@ -200,7 +200,7 @@ class TestTokenDispatcher(MultiProcContinuousTest):
                 dist.group.WORLD,
                 deepep_use_cuda_num_tokens_per_expert=True,
                 deepep_num_worst_tokens=NUM_TOKENS * 8,
-                num_permuted_tokens=num_permuted_tokens,
+                permute_max_token_num=permute_max_token_num,
             )
 
     # ------------------------------------------------------------------
@@ -355,7 +355,7 @@ class TestTokenDispatcherCudaGraph(MultiProcContinuousTest):
             {"PRIMUS_TURBO_MOE_DISPATCH_COMBINE_BACKEND": backend},
         ):
             num_worst_tokens = NUM_TOKENS * 8
-            num_permuted_tokens = NUM_TOKENS * 8 * ROUTER_TOPK
+            permute_max_token_num = NUM_TOKENS * 8 * ROUTER_TOPK
 
             # clear buffer for reset
             # a trick to reset the backend instance
@@ -369,7 +369,7 @@ class TestTokenDispatcherCudaGraph(MultiProcContinuousTest):
                 dist.group.WORLD,
                 deepep_use_cuda_num_tokens_per_expert=True,
                 deepep_num_worst_tokens=num_worst_tokens,
-                num_permuted_tokens=num_permuted_tokens,
+                permute_max_token_num=permute_max_token_num,
             )
 
             hidden_states = torch.randn((NUM_TOKENS, HIDDEN_SIZE), dtype=torch.bfloat16, device="cuda")

--- a/tests/pytorch/ops/test_moe_permute.py
+++ b/tests/pytorch/ops/test_moe_permute.py
@@ -108,7 +108,7 @@ def test_moe_permutation(num_topk, expert_map_kind, num_tokens, num_experts, hid
     assert int(ndtt.item()) == num_tokens
     torch.testing.assert_close(
         tokens_per_expert.cpu(),
-        routing_map.sum(dim=0).to(torch.int32).cpu(),
+        routing_map.sum(dim=0).to(torch.int64).cpu(),
     )
     permuted_tokens.backward(grad_perm, retain_graph=True)
 


### PR DESCRIPTION
# Description

Change `tokens_per_expert` from the C++ `moe_permute` (`permute_preprocessing`)
path from `int32` to `int64`, so it can be fed to grouped GEMM (`group_lens` is
`int64`) directly and matches the Triton path which already emits `int64`.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

- Kernel/headers: `permute_preprocessing` signatures `int32_t*` → `int64_t*`.
- PyTorch binding + meta: allocate `tokens_per_expert` as `int64`.
- `moe_permute.py`: zero-dispatch fast path returns `int64`.
- Update `test_moe_permute.py` reference dtype.

# Checklist:

- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
