### PR TITLE
fix(moe): declare probs layout explicitly in moe_permute

### DIFF
--- a/primus_turbo/pytorch/modules/moe/token_dispatcher.py
+++ b/primus_turbo/pytorch/modules/moe/token_dispatcher.py
@@ -310,6 +310,7 @@ class DeepEPTokenDispatcher(TokenDispatcher):
             pad_multiple=self.pad_multiple,
             num_permuted_tokens=self.permute_max_token_num,
             probs=dispatched_probs,
+            probs_layout="topk",  # dispatched_probs is [num_dispatched, router_topk]
         )
 
         if not self.deepep_use_cuda_num_tokens_per_expert:

--- a/primus_turbo/pytorch/ops/moe/moe_permute.py
+++ b/primus_turbo/pytorch/ops/moe/moe_permute.py
@@ -30,6 +30,7 @@ class _MoEPermute(torch.autograd.Function):
         probs: Optional[torch.Tensor] = None,
         scales_per_token: int = 0,
         use_fp8: bool = False,
+        probs_topk_stride: int = 0,
     ) -> Tuple[
         torch.Tensor,
         torch.Tensor,
@@ -43,25 +44,7 @@ class _MoEPermute(torch.autograd.Function):
         hidden_size = int(tokens.shape[-1])
         num_dispatched = int(tokens.shape[0])
 
-        # Infer probs_stride from row width: num_local_experts → multihot (0); num_topk → topk-aligned.
-        if probs is None:
-            probs_topk_stride = 0
-        else:
-            w = int(probs.shape[1])
-            if w == num_local_experts == num_topk and num_topk > 0:
-                raise ValueError(
-                    f"moe_permute: ambiguous probs layout (num_local_experts == num_topk == {num_topk}); "
-                    "reshape or pad probs so its row width is distinct from both"
-                )
-            if w == num_local_experts:
-                probs_topk_stride = 0
-            elif num_topk > 0 and w == num_topk:
-                probs_topk_stride = num_topk
-            else:
-                raise ValueError(
-                    f"moe_permute: probs.shape[1]={w} must equal num_local_experts="
-                    f"{num_local_experts} or num_topk={num_topk}"
-                )
+        probs_topk_stride = int(probs_topk_stride) if probs is not None else 0
         probs_row_width = probs_topk_stride if probs_topk_stride > 0 else num_local_experts
 
         ctx.num_dispatched = num_dispatched
@@ -226,6 +209,7 @@ class _MoEPermute(torch.autograd.Function):
             grad_probs,  # probs
             None,  # scales_per_token
             None,  # use_fp8
+            None,  # probs_topk_stride
         )
 
 
@@ -362,6 +346,7 @@ def moe_permute(
     num_permuted_tokens: int = -1,
     scaling_factor: Optional[torch.Tensor] = None,
     probs: Optional[torch.Tensor] = None,
+    probs_layout: str = "topk",
     scales_per_token: int = 0,
     use_fp8: bool = False,
 ) -> Tuple[
@@ -379,6 +364,13 @@ def moe_permute(
     num_dispatched_tokens, permuted_scaling_factor, permuted_probs). Pass
     ``num_dispatched_tokens`` straight to ``moe_unpermute``.
     """
+    if probs_layout not in ("routing_map", "topk"):
+        raise ValueError(f"moe_permute: probs_layout must be 'routing_map' or 'topk', got {probs_layout!r}")
+    if probs_layout == "topk" and num_topk <= 0:
+        raise ValueError("moe_permute: probs_layout='topk' requires num_topk > 0")
+
+    probs_topk_stride = num_topk if probs_layout == "topk" else 0
+
     return _MoEPermute.apply(
         tokens,
         expert_map,
@@ -390,6 +382,7 @@ def moe_permute(
         probs,
         scales_per_token,
         use_fp8,
+        probs_topk_stride,
     )
 
 

--- a/tests/pytorch/ops/test_moe_permute.py
+++ b/tests/pytorch/ops/test_moe_permute.py
@@ -103,6 +103,7 @@ def test_moe_permutation(num_topk, expert_map_kind, num_tokens, num_experts, hid
         expert_map,
         num_local_experts=num_experts,
         num_topk=0 if expert_map_kind == "routing_map" else num_topk,
+        probs_layout="routing_map",
     )
     assert int(overflow_flag.item()) == 0
     assert int(ndtt.item()) == num_tokens
@@ -154,12 +155,14 @@ def test_moe_permute_pad_multiple(num_topk, pad_multiple):
         routing_map,
         num_local_experts=num_experts,
         pad_multiple=0,
+        probs_layout="routing_map",
     )
     _, _, padded_per_expert, _, _, _, _ = moe_permute(
         tokens,
         routing_map,
         num_local_experts=num_experts,
         pad_multiple=pad_multiple,
+        probs_layout="routing_map",
     )
 
     expected = ((base_per_expert + pad_multiple - 1) // pad_multiple) * pad_multiple
@@ -217,6 +220,7 @@ def test_overflow_flag(pad_multiple, cap_kind, expected):
         num_local_experts=num_experts,
         pad_multiple=pad_multiple,
         num_permuted_tokens=cap,
+        probs_layout="routing_map",
     )
     torch.cuda.synchronize()
 
@@ -256,6 +260,7 @@ def test_moe_permute_empty_input(with_probs, pad_multiple):
         num_local_experts=num_experts,
         pad_multiple=pad_multiple,
         probs=probs,
+        probs_layout="routing_map",
     )
 
     assert permuted_tokens.shape == (0, hidden_size)
@@ -324,6 +329,7 @@ def test_moe_permute_with_probs_fwd_bwd(num_topk, pad_multiple):
         num_local_experts=num_experts,
         pad_multiple=pad_multiple,
         probs=probs,
+        probs_layout="routing_map",
     )
     assert int(overflow_flag.item()) == 0
     assert permuted_probs is not None
@@ -372,6 +378,7 @@ def test_moe_unpermute_with_probs_fwd_bwd():
         routing_map,
         num_local_experts=num_experts,
         probs=probs,
+        probs_layout="routing_map",
     )
 
     permuted_probs = permuted_probs.detach().clone().requires_grad_(True)
@@ -433,6 +440,7 @@ def test_moe_permute_fp16_fwd_bwd(num_topk):
         tokens_turbo,
         routing_map,
         num_local_experts=num_experts,
+        probs_layout="routing_map",
     )
     assert int(overflow_flag.item()) == 0
     permuted_tokens.backward(grad_perm, retain_graph=True)
@@ -482,6 +490,7 @@ def test_moe_permute_pad_multiple_fwd_bwd(num_topk, pad_multiple):
         routing_map,
         num_local_experts=num_experts,
         pad_multiple=0,
+        probs_layout="routing_map",
     )
     grad_perm_ref = torch.randn_like(perm_ref)
     perm_ref.backward(grad_perm_ref, retain_graph=True)
@@ -506,6 +515,7 @@ def test_moe_permute_pad_multiple_fwd_bwd(num_topk, pad_multiple):
         routing_map,
         num_local_experts=num_experts,
         pad_multiple=pad_multiple,
+        probs_layout="routing_map",
     )
     src_token_pad, _src_expert_pad, total_pad = expected_permuted_layout(routing_map, pad_multiple)
     real_mask_pad = src_token_pad >= 0


### PR DESCRIPTION
# Description

`moe_permute` used to infer the probs stride from `probs.shape[1]`
(`num_local_experts` => multihot, `num_topk` => topk-aligned). The two widths
collide when `num_local_experts == num_topk`, a common case under large EP, so
the layout is genuinely ambiguous.

This PR drops the inference and makes the caller declare the layout via a new
`probs_layout` argument.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

- `moe_permute(..., probs_layout=...)`: `"routing_map"` => `[T, num_local_experts]`, `"topk"` => `[T, num_topk]`.
- Validate the layout name, require `num_topk > 0` for `"topk"`, and check `probs` width against the declared layout.
- Update all call sites (DeepEP dispatcher passes `"topk"`; tests pass `"routing_map"`).

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
