### PR TITLE
feat: refactor origama and triton knobs

### DIFF
--- a/primus_turbo/pytorch/core/backend.py
+++ b/primus_turbo/pytorch/core/backend.py
@@ -21,7 +21,7 @@ from primus_turbo.common.constants import (
     ENV_MOE_DISPATCH_COMBINE_BACKEND,
 )
 from primus_turbo.common.logger import logger
-from primus_turbo.triton.gemm.gemm_kernel import clear_origami_caches
+from primus_turbo.triton.utils.origami import origami_clear_caches
 
 try:
     HAVE_DEEP_EP = True
@@ -249,7 +249,7 @@ class GlobalBackendManager:
         cls._grouped_gemm_backend = None
         cls._auto_tune = None
         AutoKernelDispatcher.clear_all_caches()
-        clear_origami_caches()
+        origami_clear_caches()
 
 
 class KernelBackend(ABC):

--- a/primus_turbo/pytorch/core/utils.py
+++ b/primus_turbo/pytorch/core/utils.py
@@ -19,3 +19,18 @@ def _get_device_compute_capability(device: torch.device) -> Tuple[int, int]:
 def get_device_compute_capability() -> Tuple[int, int]:
     """CUDA compute capability of current GPU"""
     return _get_device_compute_capability(torch.cuda.current_device())
+
+
+def is_gfx950() -> bool:
+    return get_device_compute_capability() == (9, 5)
+
+
+def is_gfx942() -> bool:
+    return get_device_compute_capability() == (9, 4)
+
+
+@functools.lru_cache
+def get_num_cus() -> int:
+    props = torch.cuda.get_device_properties(torch.cuda.current_device())
+
+    return props.multi_processor_count

--- a/primus_turbo/triton/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_fp8_kernel.py
@@ -46,7 +46,7 @@ import triton.language as tl
 from primus_turbo.pytorch.core.utils import is_gfx950
 from primus_turbo.triton.gemm.gemm_kernel import NUM_XCDS, _chiplet_transform_chunked
 from primus_turbo.triton.utils.origami import (
-    _compute_sk_grid,
+    origama_compute_sk_grid,
     origama_hardware_info,
     origama_select_params,
 )
@@ -109,7 +109,7 @@ def offline_select_fp8(M, N, K, s_ak, s_bk):
     # tiles <= ~5 waves (cu*5): sk_grid for wave efficiency
     # tiles > ~5 waves: data-parallel (avoids regression at tiles>=1792)
     if total_tiles <= cu_count * 5:
-        num_sms = _compute_sk_grid(M, N, K, BM, BN, BK, cu_count)
+        num_sms = origama_compute_sk_grid(M, N, K, BM, BN, BK, cu_count)
     else:
         num_sms = total_tiles
 
@@ -350,7 +350,7 @@ def gemm_fp8_tensorwise_triton_kernel(
             if min(om, on) >= 128 and ok == block_k:
                 block_m, block_n, group_m = om, on, ogm
 
-        num_sms = _compute_sk_grid(M, N, K, block_m, block_n, block_k, cu_count)
+        num_sms = origama_compute_sk_grid(M, N, K, block_m, block_n, block_k, cu_count)
     else:
         # gfx942 path
         block_m, block_n, block_k, group_m, num_sms, chunk_size, cache_a, cache_b = offline_select_fp8(
@@ -656,7 +656,7 @@ def gemm_fp8_rowwise_triton_kernel(
             if min(om, on) >= 128 and ok == block_k:
                 block_m, block_n, group_m = om, on, ogm
 
-        num_sms = _compute_sk_grid(M, N, K, block_m, block_n, block_k, cu_count)
+        num_sms = origama_compute_sk_grid(M, N, K, block_m, block_n, block_k, cu_count)
     else:
         # gfx942 path
         block_m, block_n, block_k, group_m, num_sms, chunk_size, cache_a, cache_b = offline_select_fp8(

--- a/primus_turbo/triton/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_fp8_kernel.py
@@ -43,15 +43,14 @@ import torch
 import triton
 import triton.language as tl
 
-from primus_turbo.triton.gemm.gemm_kernel import (
-    NUM_XCDS,
-    _chiplet_transform_chunked,
+from primus_turbo.pytorch.core.utils import is_gfx950
+from primus_turbo.triton.gemm.gemm_kernel import NUM_XCDS, _chiplet_transform_chunked
+from primus_turbo.triton.utils.origami import (
     _compute_sk_grid,
-    _get_hardware,
-    _is_gfx950,
-    _select_params_origami,
-    _set_knobs_gfx950,
+    origama_hardware_info,
+    origama_select_params,
 )
+from primus_turbo.triton.utils.triton_knobs_helper import set_triton_knobs_gfx950
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # AMD knobs helper (blockwise-specific)
@@ -104,7 +103,7 @@ def offline_select_fp8(M, N, K, s_ak, s_bk):
     tiles_n = (N + BN - 1) // BN
     total_tiles = tiles_m * tiles_n
 
-    cu_count = _get_hardware().N_CU
+    cu_count = origama_hardware_info().N_CU
 
     # ── NUM_SMS ──
     # tiles <= ~5 waves (cu*5): sk_grid for wave efficiency
@@ -320,8 +319,8 @@ def gemm_fp8_tensorwise_triton_kernel(
     s_ak = A_view.stride(1)
     s_bk = B_view.stride(0)
 
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_triton_knobs_gfx950()
 
         # gfx950 FP8: uniform 256×256×128 / stages=2 across all layouts (164-entry tuning).
         block_m, block_n, block_k = 256, 256, 128
@@ -334,9 +333,9 @@ def gemm_fp8_tensorwise_triton_kernel(
         is_tn = s_ak == 1 and s_bk == 1
         group_m = 8 if min_tile < 16 else (4 if is_tn else 5)
 
-        cu_count = _get_hardware().N_CU
+        cu_count = origama_hardware_info().N_CU
 
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             M,
             N,
             K,
@@ -358,7 +357,7 @@ def gemm_fp8_tensorwise_triton_kernel(
             M, N, K, s_ak, s_bk
         )
         waves_per_eu = 0
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             M,
             N,
             K,
@@ -626,8 +625,8 @@ def gemm_fp8_rowwise_triton_kernel(
     s_ak = A_view.stride(1)
     s_bk = B_view.stride(0)
 
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_triton_knobs_gfx950()
 
         # gfx950 FP8: uniform 256×256×128 / stages=2 across all layouts.
         block_m, block_n, block_k = 256, 256, 128
@@ -640,9 +639,9 @@ def gemm_fp8_rowwise_triton_kernel(
         is_tn = s_ak == 1 and s_bk == 1
         group_m = 8 if min_tile < 16 else (4 if is_tn else 5)
 
-        cu_count = _get_hardware().N_CU
+        cu_count = origama_hardware_info().N_CU
 
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             M,
             N,
             K,
@@ -664,7 +663,7 @@ def gemm_fp8_rowwise_triton_kernel(
             M, N, K, s_ak, s_bk
         )
         waves_per_eu = 0
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             M,
             N,
             K,
@@ -760,7 +759,7 @@ def _get_blockwise_autotune_configs(
             ``None`` keeps the original search space.
     """
     configs = []
-    if _is_gfx950():
+    if is_gfx950():
         num_stage_values = [1, 2, 3] if allow_num_stages_3 else [1, 2]
         block_n_values = [64, 128]
     else:
@@ -1081,8 +1080,8 @@ def gemm_fp8_blockwise_triton_kernel(
     # AMD knobs: gfx950 always sets the gfx950 knobs; on gfx942 NT/NN benefit
     # from use_async_copy/scalarize_packed_fops while TN/wgrad regresses 5-8%.
     is_tn = trans_a and not trans_b
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_triton_knobs_gfx950()
     else:
         _set_amd_knobs(enable=not is_tn)
 

--- a/primus_turbo/triton/gemm/gemm_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_kernel.py
@@ -25,194 +25,23 @@ Environment variable: PRIMUS_TURBO_GEMM_BACKEND=TRITON activates these kernels.
 
 from __future__ import annotations
 
-import atexit
-import functools
-import math
-import os
-from dataclasses import dataclass
-
 import torch
 import triton
 import triton.language as tl
 
-try:
-    import origami
-except ModuleNotFoundError:
-    origami = None
-
-# Map torch dtypes to origami string (for problem_t). Align with TensorAtlas heuristics/selector.py.
-_ORIGAMI_DTYPE_TO_STR = {
-    torch.float32: "f32",
-    torch.float16: "f16",
-    torch.bfloat16: "bf16",
-}
-for _k in ("float8_e4m3fn", "float8_e5m2", "float8_e4m3fnuz", "float8_e5m2fnuz"):
-    if hasattr(torch, _k):
-        _ORIGAMI_DTYPE_TO_STR[getattr(torch, _k)] = "f8"
-
-# FP8 dtypes: torch.finfo can be unsupported/buggy, so we treat them explicitly.
-_ORIGAMI_FP8_DTYPES = tuple(
-    d
-    for d in (
-        getattr(torch, "float8_e4m3fn", None),
-        getattr(torch, "float8_e5m2", None),
-        getattr(torch, "float8_e4m3fnuz", None),
-        getattr(torch, "float8_e5m2fnuz", None),
-    )
-    if d is not None
+from primus_turbo.pytorch.core.utils import is_gfx950
+from primus_turbo.triton.utils.origami import (
+    origama_compute_sk_grid,
+    origama_hardware_info,
+    origama_select_params,
 )
-
-
-def _dtype_bits(dtype):
-    """Element bits for LDS/MI dim; safe for FP8 (finfo not fully supported)."""
-    if _ORIGAMI_FP8_DTYPES and dtype in _ORIGAMI_FP8_DTYPES:
-        return 8
-    try:
-        if dtype.is_floating_point:
-            return torch.finfo(dtype).bits
-        return torch.iinfo(dtype).bits
-    except (TypeError, AttributeError):
-        return 16
-
+from primus_turbo.triton.utils.triton_knobs_helper import set_triton_knobs_gfx950
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Hardware constants & chiplet transform
 # ═══════════════════════════════════════════════════════════════════════════════
-
+# TODO(ruibin): remove this once we have a better way to determine the number of XCDs
 NUM_XCDS = 8
-
-# Per-architecture defaults for LDS capacity (bytes) and max compute clock (KHz).
-# Used by _get_hardware to avoid calling origami.get_hardware_for_device() which
-# internally invokes HIP C APIs that can segfault in certain Docker / distributed
-# training environments due to HIP runtime double-initialization conflicts.
-_ARCH_HW_DEFAULTS: dict[str, tuple[int, int]] = {
-    "gfx950": (163840, 2400000),  # MI350X / MI355X  — 160 KB LDS, 2.4 GHz
-    "gfx942": (65536, 2100000),  # MI300X / MI300A  —  64 KB LDS, 2.1 GHz
-}
-
-
-@dataclass(frozen=True)
-class _FallbackHardware:
-    N_CU: int
-    lds_capacity: int
-    l2_cache_size: int = 0
-    clock_khz: int = 0
-
-
-@functools.lru_cache(maxsize=8)
-def _get_hardware(device_id=None):
-    """Cached hardware descriptor for Triton GEMM config selection.
-
-    When origami is available, return its hardware_t object and keep the
-    existing analytical selector behavior. Otherwise, fall back to a lightweight
-    descriptor built from torch device properties so offline heuristics still
-    work without the optional origami dependency.
-    """
-    if device_id is None:
-        device_id = torch.cuda.current_device()
-
-    props = torch.cuda.get_device_properties(device_id)
-    arch_full = getattr(props, "gcnArchName", "")  # e.g. "gfx950:sramecc+:xnack-"
-    arch_base = arch_full.split(":")[0]  # e.g. "gfx950"
-    default_lds_capacity, default_clock_khz = _ARCH_HW_DEFAULTS.get(
-        arch_base,
-        (getattr(props, "shared_memory_per_block", 65536), getattr(props, "clock_rate", 0)),
-    )
-
-    if origami is None:
-        return _FallbackHardware(
-            N_CU=props.multi_processor_count,
-            lds_capacity=default_lds_capacity,
-            l2_cache_size=getattr(props, "L2_cache_size", 0),
-            clock_khz=default_clock_khz,
-        )
-
-    arch_enum = getattr(origami.architecture_t, arch_base, None)
-
-    if arch_enum is not None and arch_base in _ARCH_HW_DEFAULTS:
-        return origami.get_hardware_for_arch(
-            arch_enum,
-            props.multi_processor_count,
-            default_lds_capacity,
-            props.L2_cache_size,
-            default_clock_khz,
-        )
-
-    return origami.get_hardware_for_device(device_id)
-
-
-def clear_origami_caches() -> None:
-    """Release cached nanobind-backed origami objects before interpreter shutdown."""
-    _get_hardware.cache_clear()
-    _select_params_origami.cache_clear()
-
-
-_SK_TILE_FRACTIONS = [0.0, 1.0 / 2.0, 1.0 / 8.0, 1.0 / 5.0, 1.0 / 4.0, 1.0 / 3.0]
-_SK_SPLIT_FACTORS = [8, 6, 4, 3, 2, 1]
-_SK_MAX_WORKSPACE = 128 * 1024 * 1024
-
-
-def _compute_sk_grid(M, N, K, BLK_M, BLK_N, BLK_K, cu_count, elem_bytes_out=2):
-    tiles = math.ceil(M / BLK_M) * math.ceil(N / BLK_N)
-    sk_grid = tiles
-    iters_per_tile = max(1, math.ceil(K / BLK_K))
-
-    if tiles > cu_count:
-        min_even_tiles = tiles / cu_count
-        for frac in _SK_TILE_FRACTIONS:
-            frac_grid = int((tiles / (min_even_tiles + frac)) + 0.5)
-            partial_size = BLK_M * BLK_N * elem_bytes_out * frac_grid
-            if tiles % frac_grid != 0 and partial_size > _SK_MAX_WORKSPACE:
-                continue
-            if frac_grid <= cu_count:
-                sk_grid = frac_grid
-                break
-    elif tiles < cu_count:
-        for factor in _SK_SPLIT_FACTORS:
-            split_grid = tiles * factor
-            iters_per_cu = iters_per_tile // factor
-            if split_grid <= cu_count and iters_per_cu >= 8:
-                sk_grid = split_grid
-                break
-
-    if tiles % sk_grid != 0:
-        sk_grid = tiles
-
-    if tiles >= cu_count and cu_count in (304, 80, 64):
-        last_wave_remainder = tiles % cu_count
-        if 0 < last_wave_remainder < 128:
-            sk_grid = 256 if cu_count == 304 else 64
-
-    return sk_grid
-
-
-@functools.lru_cache(maxsize=1)
-def _is_gfx950() -> bool:
-    """Check if current GPU is gfx950 (CDNA4 / MI350X / MI355X)."""
-    try:
-        target = triton.runtime.driver.active.get_current_target()
-        return target is not None and target.backend == "hip" and target.arch == "gfx950"
-    except (AttributeError, TypeError):
-        return False
-
-
-_KNOBS_SET = False
-
-
-def _set_knobs_gfx950():
-    """Enable AMD compiler knobs for gfx950 (async_copy, block_pingpong, scalarize)."""
-    global _KNOBS_SET
-    if _KNOBS_SET:
-        return
-    _KNOBS_SET = True
-    if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
-        triton.knobs.amd.use_async_copy = True
-        triton.knobs.amd.scalarize_packed_fops = True
-        triton.knobs.amd.use_block_pingpong = True
-    else:
-        os.environ.setdefault("TRITON_HIP_USE_ASYNC_COPY", "1")
-        os.environ.setdefault("AMDGCN_SCALARIZE_PACKED_FOPS", "1")
-        os.environ.setdefault("TRITON_HIP_USE_BLOCK_PINGPONG", "1")
 
 
 @triton.jit
@@ -236,7 +65,9 @@ def _chiplet_transform_chunked(
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-def offline_select_bf16(M, N, K, s_ak, s_bk):
+def offline_select_bf16(
+    M: int, N: int, K: int, s_ak: int, s_bk: int
+) -> tuple[int, int, int, int, int, int, str, str]:
     """BF16 config selection from MI300X bench data (out_bf16_gemm.yaml, 186 entries).
 
     Stride → layout:
@@ -254,13 +85,13 @@ def offline_select_bf16(M, N, K, s_ak, s_bk):
     tiles_n = (N + BN - 1) // BN
     total_tiles = tiles_m * tiles_n
 
-    cu_count = _get_hardware().N_CU
+    cu_count = origama_hardware_info().N_CU
 
     # ── NUM_SMS ──
     # Small grids: sk_grid for wave efficiency (persistent, NUM_SMS=256/304)
     # Large grids: data-parallel (NUM_SMS=total_tiles) to keep all CUs busy
     if total_tiles <= cu_count * 4:
-        num_sms = _compute_sk_grid(M, N, K, BM, BN, BK, cu_count)
+        num_sms = origama_compute_sk_grid(M, N, K, BM, BN, BK, cu_count)
     else:
         num_sms = total_tiles
 
@@ -279,214 +110,6 @@ def offline_select_bf16(M, N, K, s_ak, s_bk):
         chunk = 64 if total_tiles > 1024 else 32
 
     return BM, BN, BK, group_m, num_sms, chunk, ".ca", ".ca"
-
-
-# ─── Origami analytical config selection (aligned with TensorAtlas / tritonBLAS) ───
-
-
-def _estimate_lds_bytes(block_m, block_n, block_k, elem_bytes_a, elem_bytes_b, num_stages=2):
-    """LDS usage for Triton matmul tile without async_copy."""
-    lds_a = block_m * block_k * elem_bytes_a
-    lds_b = block_k * block_n * elem_bytes_b
-    base_buffers = max(1, num_stages - 1)
-    return (lds_a + lds_b) * base_buffers
-
-
-def _padded_size_32_4(unpadded_size):
-    """Triton [[32, 4]] PaddedSharedEncoding — bank-conflict avoidance padding."""
-    block_padding = (unpadded_size >> 5) << 2
-    if (unpadded_size & 31) == 0 and block_padding >= 4:
-        block_padding -= 4
-    return unpadded_size + block_padding
-
-
-def _padded_size_pow2(unpadded_size, interval, padding):
-    """Triton PaddedSharedEncodingAttr.getPaddedSize for a single (interval, padding) pair."""
-    log2_interval = (interval - 1).bit_length()
-    log2_padding = (padding - 1).bit_length() if padding else 0
-    bp = (unpadded_size >> log2_interval) << log2_padding
-    if unpadded_size % interval == 0 and bp >= padding:
-        bp -= padding
-    return unpadded_size + bp
-
-
-def _estimate_lds_bytes_async_copy(block_m, block_n, block_k, elem_bytes_a, elem_bytes_b, num_stages):
-    """LDS usage with async_copy (PaddedSharedEncoding + num_stages buffers).
-
-    Matches tritonBLAS origami.estimate_triton_lds_bytes / triton_bench calculate_lds_usage.
-    """
-    elem_a = block_m * block_k
-    elem_b = block_k * block_n
-    padded_a = _padded_size_32_4(elem_a)
-    padded_b = _padded_size_32_4(elem_b)
-    if block_k & (block_k - 1) == 0:
-        pa = _padded_size_pow2(elem_a, block_k, 8)
-        if pa > padded_a:
-            padded_a = pa
-    if block_n & (block_n - 1) == 0:
-        pb = _padded_size_pow2(elem_b, block_n, 8)
-        if pb > padded_b:
-            padded_b = pb
-    return num_stages * (padded_a * elem_bytes_a + padded_b * elem_bytes_b)
-
-
-def _calculate_lds_usage(block_m, block_n, block_k, elem_bytes_a, elem_bytes_b, num_stages):
-    """LDS usage with auto-detection of async_copy mode."""
-    if _is_gfx950():
-        return _estimate_lds_bytes_async_copy(
-            block_m, block_n, block_k, elem_bytes_a, elem_bytes_b, num_stages
-        )
-    return _estimate_lds_bytes(block_m, block_n, block_k, elem_bytes_a, elem_bytes_b, num_stages)
-
-
-def _infer_mi_dim(hardware, element_size_a, element_size_b):
-    """Infer matrix instruction dimensions from hardware and dtypes. Align with TensorAtlas."""
-    n_cu = hardware.N_CU
-    max_bits = max(element_size_a, element_size_b)
-    # gfx950
-    if n_cu == 256:
-        if max_bits == 32:
-            return [16, 16, 4]
-        if max_bits == 16:
-            return [16, 16, 32]
-        if max_bits <= 8:
-            return [16, 16, 128]
-    # gfx942 (304, 80, 64 CUs)
-    if n_cu in (304, 80, 64):
-        if max_bits == 32:
-            return [16, 16, 4]
-        if max_bits == 16:
-            return [16, 16, 16]
-        if max_bits == 8:
-            return [16, 16, 32]
-    return [16, 16, 16]
-
-
-def _get_valid_tiles(hardware, block_mn_range, block_k_range, mi_dim, elem_bytes_a, elem_bytes_b):
-    """Valid (blk_m, blk_n, blk_k, mi_m, mi_n, mi_k, occ) passing LDS check.
-
-    Uses async_copy-aware LDS estimate on gfx950 with num_stages=2.
-    Tiles passing here may still exceed LDS at higher num_stages; callers
-    should verify with _calculate_lds_usage for their actual num_stages.
-    """
-    lds_cap = hardware.lds_capacity
-    use_async = _is_gfx950()
-    valid = []
-    for bm, bn, bk in (
-        (bm, bn, bk) for bm in block_mn_range for bn in block_mn_range for bk in block_k_range
-    ):
-        if use_async:
-            lds = _estimate_lds_bytes_async_copy(bm, bn, bk, elem_bytes_a, elem_bytes_b, num_stages=2)
-        else:
-            lds = _estimate_lds_bytes(bm, bn, bk, elem_bytes_a, elem_bytes_b, num_stages=2)
-        if lds <= lds_cap:
-            valid.append((bm, bn, bk, mi_dim[0], mi_dim[1], mi_dim[2], 1))
-    return valid
-
-
-def _make_problem(M, N, K, a_dtype, b_dtype, c_dtype, mi_dtype_str, trans_a, trans_b, mx_block_size=0):
-    """Build origami problem_t for rank_configs / select_workgroup_mapping.
-
-    trans_a, trans_b: logical op(A) @ op(B). NT = (False, True), TN/CRR = (True, False), NN/RRR = (False, False).
-    """
-    problem = origami.problem_t()
-    problem.size = origami.dim3_t(M, N, K)
-    problem.batch = 1
-    # Per your convention: trans_a=True -> origami N, trans_a=False -> origami T
-    problem.a_transpose = origami.transpose_t.N if trans_a else origami.transpose_t.T
-    problem.b_transpose = origami.transpose_t.N if trans_b else origami.transpose_t.T
-    problem.a_dtype = origami.string_to_datatype(_ORIGAMI_DTYPE_TO_STR.get(a_dtype, "bf16"))
-    problem.b_dtype = origami.string_to_datatype(_ORIGAMI_DTYPE_TO_STR.get(b_dtype, "bf16"))
-    problem.c_dtype = origami.string_to_datatype(_ORIGAMI_DTYPE_TO_STR.get(c_dtype, "bf16"))
-    problem.d_dtype = problem.c_dtype
-    problem.mi_dtype = origami.string_to_datatype(mi_dtype_str)
-    problem.a_mx_block_size = mx_block_size
-    problem.b_mx_block_size = mx_block_size
-    return problem
-
-
-def _tiles_to_configs(valid_tiles, streamk=True):
-    """Convert valid_tiles to origami config_t list."""
-    grid_sel = origami.grid_selection_t.k_split_aware if streamk else origami.grid_selection_t.data_parallel
-    configs = []
-    for blk_m, blk_n, blk_k, mi_m, mi_n, mi_k, occ in valid_tiles:
-        cfg = origami.config_t()
-        cfg.mt = origami.dim3_t(blk_m, blk_n, blk_k)
-        cfg.mi = origami.dim3_t(mi_m, mi_n, mi_k)
-        cfg.occupancy = occ
-        cfg.grid_selection = grid_sel
-        configs.append(cfg)
-    return configs
-
-
-def _safe_rank_configs(problem, hardware, configs):
-    """rank_configs that returns [] instead of raising on unsupported problems."""
-    try:
-        return origami.rank_configs(problem, hardware, configs)
-    except RuntimeError:
-        return []
-
-
-@functools.lru_cache(maxsize=4096)
-def _select_params_origami(M, N, K, out_dtype, a_dtype=None, b_dtype=None, trans_a=False, trans_b=True):
-    """Use origami rank_configs + select_workgroup_mapping (align with TensorAtlas selector.py).
-
-    trans_a, trans_b: logical layout (op(A) @ op(B)). Forward NT = (False, True);
-    backward grad_a (NN) = (False, False); backward grad_b (TN) = (True, False).
-    Returns (block_m, block_n, block_k, group_size_m, cache_a, cache_b) or None.
-    """
-    if origami is None:
-        return None
-
-    a_dtype = a_dtype if a_dtype is not None else out_dtype
-    b_dtype = b_dtype if b_dtype is not None else out_dtype
-
-    hardware = _get_hardware()
-
-    elem_bits_a = _dtype_bits(a_dtype)
-    elem_bits_b = _dtype_bits(b_dtype)
-    elem_bytes_a = elem_bits_a // 8
-    elem_bytes_b = elem_bits_b // 8
-
-    input_dtype_for_mi = a_dtype if elem_bits_a <= elem_bits_b else b_dtype
-    mi_dtype_str = _ORIGAMI_DTYPE_TO_STR.get(input_dtype_for_mi, _ORIGAMI_DTYPE_TO_STR.get(out_dtype, "bf16"))
-
-    mi_dim = _infer_mi_dim(hardware, elem_bits_a, elem_bits_b)
-    block_mn_range = [64, 128, 256]
-    block_k_range = [64, 128, 256]
-    valid_tiles = _get_valid_tiles(
-        hardware, block_mn_range, block_k_range, mi_dim, elem_bytes_a, elem_bytes_b
-    )
-    if not valid_tiles:
-        return None
-
-    problem = _make_problem(M, N, K, a_dtype, b_dtype, out_dtype, mi_dtype_str, trans_a, trans_b)
-    configs = _tiles_to_configs(valid_tiles, streamk=True)
-
-    ranked = _safe_rank_configs(problem, hardware, configs)
-    if not ranked:
-        return None
-    best_result = ranked[0]
-    best_cfg = best_result.config if hasattr(best_result, "config") else best_result
-    BLK_M = best_cfg.mt.m
-    BLK_N = best_cfg.mt.n
-    BLK_K = best_cfg.mt.k
-
-    elem_bytes_out = _dtype_bits(out_dtype) // 8
-    sk_grid = _compute_sk_grid(M, N, K, BLK_M, BLK_N, BLK_K, hardware.N_CU, elem_bytes_out)
-    wgm_result = origami.select_workgroup_mapping(problem, hardware, best_cfg, sk_grid)
-    gsize_m = abs(wgm_result.wgm)
-
-    _CACHE_HINT_TO_MODIFIER = {0: ".ca", 1: ".cg", 2: ".cv"}
-    cache_a = _CACHE_HINT_TO_MODIFIER.get(getattr(best_cfg, "cache_hints_a", 0), None)
-    cache_b = _CACHE_HINT_TO_MODIFIER.get(getattr(best_cfg, "cache_hints_b", 0), None)
-    # print(
-    #     f"BLK_M: {BLK_M}, BLK_N: {BLK_N}, BLK_K: {BLK_K}, gsize_m: {gsize_m}, cache_a: {cache_a}, cache_b: {cache_b}"
-    # )
-    return BLK_M, BLK_N, BLK_K, gsize_m, cache_a, cache_b
-
-
-atexit.register(clear_origami_caches)
 
 
 @triton.jit()
@@ -689,8 +312,8 @@ def gemm_triton_kernel(
     s_ak = A_view.stride(1)
     s_bk = B_view.stride(0)
 
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_triton_knobs_gfx950()
 
         # gfx950 BF16 config from 164-entry tuning data.
         # TN layout with large K → BLK_K=64, stages=2; all other cases → 32/3.
@@ -708,9 +331,9 @@ def gemm_triton_kernel(
         min_tile = min(tiles_m, tiles_n)
         group_m = 7 if min_tile < 16 else 4
 
-        cu_count = _get_hardware().N_CU
+        cu_count = origama_hardware_info().N_CU
 
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             M,
             N,
             K,
@@ -735,14 +358,14 @@ def gemm_triton_kernel(
                 if tm * new_tn >= 2 * cu_count:
                     BLOCK_N, group_m = 128, 8
 
-        num_sms = _compute_sk_grid(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, cu_count)
+        num_sms = origama_compute_sk_grid(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, cu_count)
     else:
         # ── gfx942 path (unchanged) ──────────────────────────────────────────
         BLOCK_M, BLOCK_N, BLOCK_K, group_m, num_sms, chunk_size, cache_a, cache_b = offline_select_bf16(
             M, N, K, s_ak, s_bk
         )
         num_stages, waves_per_eu = 2, 0
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             M,
             N,
             K,

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -36,19 +36,18 @@ import torch
 import triton
 import triton.language as tl
 
-from primus_turbo.triton.gemm.gemm_kernel import (
-    _calculate_lds_usage,
-    _get_hardware,
-    _is_gfx950,
-    _select_params_origami,
-    _set_knobs_gfx950,
-)
+from primus_turbo.pytorch.core.utils import get_num_cus, is_gfx950
 from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
     NUM_XCDS,
     _chiplet_transform_chunked,
-    _get_num_cus,
     _grouped_variable_k_gemm_kernel,
 )
+from primus_turbo.triton.utils.origami import (
+    origama_calculate_lds_usage,
+    origama_hardware_info,
+    origama_select_params,
+)
+from primus_turbo.triton.utils.triton_knobs_helper import set_triton_knobs_gfx950
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # AMD knobs helper
@@ -85,7 +84,7 @@ def offline_select_gg_fp8(M_total, G, N, K, s_ak, s_bk):
     else:
         group_m = 5
 
-    cu_count = _get_num_cus()
+    cu_count = get_num_cus()
     num_sms = min(total_tiles, cu_count)
     chunk = 64 if num_sms >= NUM_XCDS * 64 else 32
 
@@ -113,7 +112,7 @@ def _get_gg_fp8_tw_fwd_config(
     stride_bk,
 ):
     """Cached kernel config for FP8 tensorwise grouped GEMM forward."""
-    if _is_gfx950():
+    if is_gfx950():
         blk_m, blk_n = 256, 256
         blk_k = 128
         num_stages_val = 2
@@ -122,7 +121,7 @@ def _get_gg_fp8_tw_fwd_config(
         chunk_size = 32
         grid_sms = num_sms
 
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             avg_m,
             N,
             K,
@@ -140,8 +139,8 @@ def _get_gg_fp8_tw_fwd_config(
                 cache_a, cache_b = oc_a, oc_b
             elif tiles_default < num_sms and min(om, on) >= 64:
                 proposed_stages = 2 if ok >= 128 else 3
-                lds = _calculate_lds_usage(om, on, ok, 1, 1, proposed_stages)
-                if lds <= _get_hardware().lds_capacity:
+                lds = origama_calculate_lds_usage(om, on, ok, 1, 1, proposed_stages)
+                if lds <= origama_hardware_info().lds_capacity:
                     blk_m, blk_n, blk_k = om, on, ok
                     group_m = ogm
                     cache_a, cache_b = oc_a, oc_b
@@ -152,7 +151,7 @@ def _get_gg_fp8_tw_fwd_config(
         )
         num_stages_val = 2
 
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             avg_m,
             N,
             K,
@@ -175,14 +174,14 @@ def _get_gg_fp8_tw_fwd_config(
 @functools.lru_cache(maxsize=256)
 def _get_gg_fp8_tw_vk_config(OUT_M, OUT_N, avg_k, a_dtype, b_dtype, G, num_sms):
     """Cached kernel config for FP8 tensorwise grouped GEMM variable-K backward."""
-    if _is_gfx950():
+    if is_gfx950():
         blk_m, blk_n = 256, 256
         blk_k, num_stages_val = 64, 3
         group_m = 4
         cache_a, cache_b = ".ca", ".ca"
         chunk_size = 32
 
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             OUT_M,
             OUT_N,
             avg_k,
@@ -201,8 +200,8 @@ def _get_gg_fp8_tw_vk_config(OUT_M, OUT_N, avg_k, a_dtype, b_dtype, G, num_sms):
                 cache_a, cache_b = oc_a, oc_b
             elif tiles_default < num_sms and min(om, on) >= 64:
                 proposed_stages = 2 if ok >= 128 else 3
-                lds = _calculate_lds_usage(om, on, ok, 1, 1, proposed_stages)
-                if lds <= _get_hardware().lds_capacity:
+                lds = origama_calculate_lds_usage(om, on, ok, 1, 1, proposed_stages)
+                if lds <= origama_hardware_info().lds_capacity:
                     blk_m, blk_n, blk_k = om, on, ok
                     group_m = ogm
                     cache_a, cache_b = oc_a, oc_b
@@ -233,7 +232,7 @@ def _get_gg_fp8_rw_fwd_config(
     stride_bk,
 ):
     """Cached kernel config for FP8 rowwise grouped GEMM forward."""
-    if _is_gfx950():
+    if is_gfx950():
         blk_m, blk_n = 256, 256
         blk_k = 128
         num_stages_val = 2
@@ -241,7 +240,7 @@ def _get_gg_fp8_rw_fwd_config(
         cache_a, cache_b = ".ca", ".ca"
         chunk_size = 32
 
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             avg_m,
             N,
             K,
@@ -259,8 +258,8 @@ def _get_gg_fp8_rw_fwd_config(
                 cache_a, cache_b = oc_a, oc_b
             elif tiles_default < num_sms and min(om, on) >= 64:
                 proposed_stages = 2 if ok >= 128 else 3
-                lds = _calculate_lds_usage(om, on, ok, 1, 1, proposed_stages)
-                if lds <= _get_hardware().lds_capacity:
+                lds = origama_calculate_lds_usage(om, on, ok, 1, 1, proposed_stages)
+                if lds <= origama_hardware_info().lds_capacity:
                     blk_m, blk_n, blk_k = om, on, ok
                     group_m = ogm
                     cache_a, cache_b = oc_a, oc_b
@@ -282,14 +281,14 @@ def _get_gg_fp8_rw_fwd_config(
 @functools.lru_cache(maxsize=256)
 def _get_gg_fp8_rw_vk_config(OUT_M, OUT_N, avg_k, a_dtype, b_dtype, G, num_sms):
     """Cached kernel config for FP8 rowwise grouped GEMM variable-K backward."""
-    if _is_gfx950():
+    if is_gfx950():
         blk_m, blk_n = 256, 256
         blk_k, num_stages_val = 64, 3
         group_m = 4
         cache_a, cache_b = ".ca", ".ca"
         chunk_size = 32
 
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             OUT_M,
             OUT_N,
             avg_k,
@@ -308,8 +307,8 @@ def _get_gg_fp8_rw_vk_config(OUT_M, OUT_N, avg_k, a_dtype, b_dtype, G, num_sms):
                 cache_a, cache_b = oc_a, oc_b
             elif tiles_default < num_sms and min(om, on) >= 64:
                 proposed_stages = 2 if ok >= 128 else 3
-                lds = _calculate_lds_usage(om, on, ok, 1, 1, proposed_stages)
-                if lds <= _get_hardware().lds_capacity:
+                lds = origama_calculate_lds_usage(om, on, ok, 1, 1, proposed_stages)
+                if lds <= origama_hardware_info().lds_capacity:
                     blk_m, blk_n, blk_k = om, on, ok
                     group_m = ogm
                     cache_a, cache_b = oc_a, oc_b
@@ -542,10 +541,10 @@ def grouped_gemm_fp8_tensorwise_triton_kernel(
     out = torch.empty((M_total, N), device=a.device, dtype=out_dtype)
 
     # Kernel config (cached — origami + LDS check run only on first call per shape)
-    num_sms = _get_num_cus()
+    num_sms = get_num_cus()
     avg_m = max(M_total // max(G, 1), 256)
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_triton_knobs_gfx950()
     blk_m, blk_n, blk_k, group_m, cache_a, cache_b, num_stages_val, chunk_size, num_sms = (
         _get_gg_fp8_tw_fwd_config(
             avg_m,
@@ -634,10 +633,10 @@ def grouped_gemm_fp8_tensorwise_variable_k_triton_kernel(
     G = group_offs.shape[0] - 1
 
     out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)
-    num_sms = _get_num_cus()
+    num_sms = get_num_cus()
 
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_triton_knobs_gfx950()
     avg_m_g = max(lhs.shape[0] // max(G, 1), 256)
     blk_m, blk_n, blk_k, group_m, cache_a, cache_b, num_stages_val, chunk_size = _get_gg_fp8_tw_vk_config(
         OUT_M, OUT_N, avg_m_g, lhs.dtype, rhs.dtype, G, num_sms
@@ -896,10 +895,10 @@ def grouped_gemm_fp8_rowwise_triton_kernel(
     out = torch.empty((M_total, N), device=a.device, dtype=out_dtype)
 
     # Kernel config (cached — origami + LDS check run only on first call per shape)
-    num_sms = _get_num_cus()
+    num_sms = get_num_cus()
     avg_m = max(M_total // max(G, 1), 256)
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_triton_knobs_gfx950()
     blk_m, blk_n, blk_k, group_m, cache_a, cache_b, num_stages_val, chunk_size = _get_gg_fp8_rw_fwd_config(
         avg_m,
         N,
@@ -1137,10 +1136,10 @@ def grouped_gemm_fp8_rowwise_variable_k_triton_kernel(
     G = group_offs.shape[0] - 1
 
     out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)
-    num_sms = _get_num_cus()
+    num_sms = get_num_cus()
 
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_triton_knobs_gfx950()
     avg_m_g = max(lhs.shape[0] // max(G, 1), 256)
     blk_m, blk_n, blk_k, group_m, cache_a, cache_b, num_stages_val, chunk_size = _get_gg_fp8_rw_vk_config(
         OUT_M, OUT_N, avg_m_g, lhs.dtype, rhs.dtype, G, num_sms
@@ -1542,8 +1541,8 @@ def grouped_gemm_fp8_blockwise_triton_kernel(
     Returns:
         [M_total, N] output in out_dtype.
     """
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_triton_knobs_gfx950()
     else:
         _set_amd_knobs(enable=True)
 
@@ -1572,7 +1571,7 @@ def grouped_gemm_fp8_blockwise_triton_kernel(
 
     out = torch.empty((M_total, N), device=a.device, dtype=out_dtype)
     A_scales_t = a_scales.T.contiguous()
-    num_sms = _get_num_cus()
+    num_sms = get_num_cus()
 
     blk_m = 256
     blk_n = 128  # Keep 128 to match B_scale block alignment
@@ -1653,8 +1652,8 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
     Returns:
         [G, OUT_M, OUT_N] output.
     """
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_triton_knobs_gfx950()
     else:
         _set_amd_knobs(enable=False)
 
@@ -1665,7 +1664,7 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
     G = group_offs.shape[0] - 1
 
     out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)
-    num_sms = _get_num_cus()
+    num_sms = get_num_cus()
 
     # Use 128x128 tiles to reduce register pressure from double-accumulator
     # (partial + acc both need full tile VGPRs for blockwise scale application).

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
@@ -28,27 +28,15 @@ import torch
 import triton
 import triton.language as tl
 
-from primus_turbo.triton.gemm.gemm_kernel import (
-    _is_gfx950,
-    _select_params_origami,
-    _set_knobs_gfx950,
-)
+from primus_turbo.pytorch.core.utils import get_num_cus, is_gfx950
+from primus_turbo.triton.utils.origami import origama_select_params
+from primus_turbo.triton.utils.triton_knobs_helper import set_triton_knobs_gfx950
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Hardware constants (lazy init)
 # ═══════════════════════════════════════════════════════════════════════════════
 
 NUM_XCDS = 8
-_NUM_CUS: int | None = None
-
-
-def _get_num_cus() -> int:
-    """Lazy initialization of CU count (avoids import-time CUDA calls)."""
-    global _NUM_CUS
-    if _NUM_CUS is None:
-        _NUM_CUS = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
-    return _NUM_CUS
-
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Cached config selection (avoids per-call origami / LDS overhead)
@@ -58,7 +46,7 @@ def _get_num_cus() -> int:
 @functools.lru_cache(maxsize=256)
 def _get_gg_bf16_fwd_config(avg_m, N, K, dtype_a, dtype_b, trans_b, G, num_sms):
     """Cached kernel config for BF16 grouped GEMM forward."""
-    if _is_gfx950():
+    if is_gfx950():
         is_tn = not trans_b
         BLOCK_M, BLOCK_N = 256, 256
         if is_tn:
@@ -69,7 +57,7 @@ def _get_gg_bf16_fwd_config(avg_m, N, K, dtype_a, dtype_b, trans_b, G, num_sms):
         cache_a, cache_b = ".ca", ".ca"
         chunk_size = 32
 
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             avg_m,
             N,
             K,
@@ -91,7 +79,7 @@ def _get_gg_bf16_fwd_config(avg_m, N, K, dtype_a, dtype_b, trans_b, G, num_sms):
         cache_a, cache_b = ".ca", ".ca"
         chunk_size = 64 if num_sms >= NUM_XCDS * 64 else 32
 
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             avg_m,
             N,
             K,
@@ -112,14 +100,14 @@ def _get_gg_bf16_fwd_config(avg_m, N, K, dtype_a, dtype_b, trans_b, G, num_sms):
 @functools.lru_cache(maxsize=256)
 def _get_gg_bf16_vk_config(OUT_M, OUT_N, avg_k, dtype_lhs, dtype_rhs, G, num_sms):
     """Cached kernel config for BF16 grouped GEMM variable-K backward."""
-    if _is_gfx950():
+    if is_gfx950():
         BLOCK_M, BLOCK_N = 256, 256
         BLOCK_K, num_stages_val = 32, 3
         group_m = 4
         cache_a, cache_b = ".ca", ".ca"
         chunk_size = 32
 
-        origami_params = _select_params_origami(
+        origami_params = origama_select_params(
             OUT_M,
             OUT_N,
             avg_k,
@@ -379,10 +367,10 @@ def grouped_gemm_triton_kernel(
     out = torch.empty((M_total, N), device=a.device, dtype=a.dtype)
 
     # Kernel config (cached — origami + LDS check run only on first call per shape)
-    num_sms = _get_num_cus()
+    num_sms = get_num_cus()
     avg_m = max(M_total // max(G, 1), 256)
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_triton_knobs_gfx950()
     BLOCK_M, BLOCK_N, BLOCK_K, group_m, cache_a, cache_b, num_stages_val, chunk_size = (
         _get_gg_bf16_fwd_config(avg_m, N, K, a.dtype, b.dtype, trans_b, G, num_sms)
     )
@@ -615,11 +603,11 @@ def grouped_gemm_variable_k_triton_kernel(
     G = group_offs.shape[0] - 1
 
     out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=lhs.dtype)
-    num_sms = _get_num_cus()
+    num_sms = get_num_cus()
     dummy_scale = torch.empty(1, device=lhs.device, dtype=torch.float32)
 
-    if _is_gfx950():
-        _set_knobs_gfx950()
+    if is_gfx950():
+        set_triton_knobs_gfx950()
     avg_m_g = max(lhs.shape[0] // max(G, 1), 256)
     BLOCK_M, BLOCK_N, BLOCK_K, group_m, cache_a, cache_b, num_stages_val, chunk_size = _get_gg_bf16_vk_config(
         OUT_M, OUT_N, avg_m_g, lhs.dtype, rhs.dtype, G, num_sms

--- a/primus_turbo/triton/utils/origami.py
+++ b/primus_turbo/triton/utils/origami.py
@@ -1,0 +1,465 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Origami analytical GEMM config selection utilities (shared across Triton kernels).
+
+The optional ``origami`` dependency is imported lazily; when it is unavailable the
+selector returns ``None`` and a lightweight fallback hardware descriptor is used so
+the offline heuristics keep working.
+"""
+
+from __future__ import annotations
+
+import atexit
+import functools
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from primus_turbo.pytorch.core.utils import is_gfx950
+
+try:
+    import origami
+except ModuleNotFoundError:
+    origami = None
+
+
+__all__ = [
+    "origama_select_params",
+    "origama_hardware_info",
+    "origama_calculate_lds_usage",
+    "origama_compute_sk_grid",
+    "origami_clear_caches",
+]
+
+
+# Map torch dtypes to origami string (for problem_t). Align with TensorAtlas heuristics/selector.py.
+_ORIGAMI_DTYPE_TO_STR = {
+    torch.float32: "f32",
+    torch.float16: "f16",
+    torch.bfloat16: "bf16",
+}
+for _k in ("float8_e4m3fn", "float8_e5m2", "float8_e4m3fnuz", "float8_e5m2fnuz"):
+    if hasattr(torch, _k):
+        _ORIGAMI_DTYPE_TO_STR[getattr(torch, _k)] = "f8"
+
+# FP8 dtypes: torch.finfo can be unsupported/buggy, so we treat them explicitly.
+_ORIGAMI_FP8_DTYPES = tuple(
+    d
+    for d in (
+        getattr(torch, "float8_e4m3fn", None),
+        getattr(torch, "float8_e5m2", None),
+        getattr(torch, "float8_e4m3fnuz", None),
+        getattr(torch, "float8_e5m2fnuz", None),
+    )
+    if d is not None
+)
+
+
+def _dtype_bits(dtype: torch.dtype) -> int:
+    """Element bits for LDS/MI dim; safe for FP8 (finfo not fully supported)."""
+    if _ORIGAMI_FP8_DTYPES and dtype in _ORIGAMI_FP8_DTYPES:
+        return 8
+    try:
+        if dtype.is_floating_point:
+            return torch.finfo(dtype).bits
+        return torch.iinfo(dtype).bits
+    except (TypeError, AttributeError):
+        return 16
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Hardware descriptors
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Per-architecture defaults for LDS capacity (bytes) and max compute clock (KHz).
+# Used by origama_hardware_info to avoid calling origami.get_hardware_for_device() which
+# internally invokes HIP C APIs that can segfault in certain Docker / distributed
+# training environments due to HIP runtime double-initialization conflicts.
+_ARCH_HW_DEFAULTS: dict[str, tuple[int, int]] = {
+    "gfx950": (163840, 2400000),  # MI350X / MI355X  — 160 KB LDS, 2.4 GHz
+    "gfx942": (65536, 2100000),  # MI300X / MI300A  —  64 KB LDS, 2.1 GHz
+}
+
+
+@dataclass(frozen=True)
+class _FallbackHardware:
+    N_CU: int
+    lds_capacity: int
+    l2_cache_size: int = 0
+    clock_khz: int = 0
+
+
+@functools.lru_cache(maxsize=8)
+def origama_hardware_info(device_id: int | None = None) -> "_FallbackHardware | Any":
+    """Cached hardware descriptor for Triton GEMM config selection.
+
+    When origami is available, return its hardware_t object and keep the
+    existing analytical selector behavior. Otherwise, fall back to a lightweight
+    descriptor built from torch device properties so offline heuristics still
+    work without the optional origami dependency.
+    """
+    if device_id is None:
+        device_id = torch.cuda.current_device()
+
+    props = torch.cuda.get_device_properties(device_id)
+    arch_full = getattr(props, "gcnArchName", "")  # e.g. "gfx950:sramecc+:xnack-"
+    arch_base = arch_full.split(":")[0]  # e.g. "gfx950"
+    default_lds_capacity, default_clock_khz = _ARCH_HW_DEFAULTS.get(
+        arch_base,
+        (getattr(props, "shared_memory_per_block", 65536), getattr(props, "clock_rate", 0)),
+    )
+
+    if origami is None:
+        return _FallbackHardware(
+            N_CU=props.multi_processor_count,
+            lds_capacity=default_lds_capacity,
+            l2_cache_size=getattr(props, "L2_cache_size", 0),
+            clock_khz=default_clock_khz,
+        )
+
+    arch_enum = getattr(origami.architecture_t, arch_base, None)
+
+    if arch_enum is not None and arch_base in _ARCH_HW_DEFAULTS:
+        return origami.get_hardware_for_arch(
+            arch_enum,
+            props.multi_processor_count,
+            default_lds_capacity,
+            props.L2_cache_size,
+            default_clock_khz,
+        )
+
+    return origami.get_hardware_for_device(device_id)
+
+
+def origami_clear_caches() -> None:
+    """Release cached nanobind-backed origami objects before interpreter shutdown."""
+    origama_hardware_info.cache_clear()
+    origama_select_params.cache_clear()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Stream-K grid heuristic
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_SK_TILE_FRACTIONS = [0.0, 1.0 / 2.0, 1.0 / 8.0, 1.0 / 5.0, 1.0 / 4.0, 1.0 / 3.0]
+_SK_SPLIT_FACTORS = [8, 6, 4, 3, 2, 1]
+_SK_MAX_WORKSPACE = 128 * 1024 * 1024
+
+
+def origama_compute_sk_grid(
+    M: int,
+    N: int,
+    K: int,
+    BLK_M: int,
+    BLK_N: int,
+    BLK_K: int,
+    cu_count: int,
+    elem_bytes_out: int = 2,
+) -> int:
+    tiles = math.ceil(M / BLK_M) * math.ceil(N / BLK_N)
+    sk_grid = tiles
+    iters_per_tile = max(1, math.ceil(K / BLK_K))
+
+    if tiles > cu_count:
+        min_even_tiles = tiles / cu_count
+        for frac in _SK_TILE_FRACTIONS:
+            frac_grid = int((tiles / (min_even_tiles + frac)) + 0.5)
+            partial_size = BLK_M * BLK_N * elem_bytes_out * frac_grid
+            if tiles % frac_grid != 0 and partial_size > _SK_MAX_WORKSPACE:
+                continue
+            if frac_grid <= cu_count:
+                sk_grid = frac_grid
+                break
+    elif tiles < cu_count:
+        for factor in _SK_SPLIT_FACTORS:
+            split_grid = tiles * factor
+            iters_per_cu = iters_per_tile // factor
+            if split_grid <= cu_count and iters_per_cu >= 8:
+                sk_grid = split_grid
+                break
+
+    if tiles % sk_grid != 0:
+        sk_grid = tiles
+
+    if tiles >= cu_count and cu_count in (304, 80, 64):
+        last_wave_remainder = tiles % cu_count
+        if 0 < last_wave_remainder < 128:
+            sk_grid = 256 if cu_count == 304 else 64
+
+    return sk_grid
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LDS usage estimation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _estimate_lds_bytes(
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    elem_bytes_a: int,
+    elem_bytes_b: int,
+    num_stages: int = 2,
+) -> int:
+    """LDS usage for Triton matmul tile without async_copy."""
+    lds_a = block_m * block_k * elem_bytes_a
+    lds_b = block_k * block_n * elem_bytes_b
+    base_buffers = max(1, num_stages - 1)
+    return (lds_a + lds_b) * base_buffers
+
+
+def _padded_size_32_4(unpadded_size: int) -> int:
+    """Triton [[32, 4]] PaddedSharedEncoding — bank-conflict avoidance padding."""
+    block_padding = (unpadded_size >> 5) << 2
+    if (unpadded_size & 31) == 0 and block_padding >= 4:
+        block_padding -= 4
+    return unpadded_size + block_padding
+
+
+def _padded_size_pow2(unpadded_size: int, interval: int, padding: int) -> int:
+    """Triton PaddedSharedEncodingAttr.getPaddedSize for a single (interval, padding) pair."""
+    log2_interval = (interval - 1).bit_length()
+    log2_padding = (padding - 1).bit_length() if padding else 0
+    bp = (unpadded_size >> log2_interval) << log2_padding
+    if unpadded_size % interval == 0 and bp >= padding:
+        bp -= padding
+    return unpadded_size + bp
+
+
+def _estimate_lds_bytes_async_copy(
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    elem_bytes_a: int,
+    elem_bytes_b: int,
+    num_stages: int,
+) -> int:
+    """LDS usage with async_copy (PaddedSharedEncoding + num_stages buffers).
+
+    Matches tritonBLAS origami.estimate_triton_lds_bytes / triton_bench calculate_lds_usage.
+    """
+    elem_a = block_m * block_k
+    elem_b = block_k * block_n
+    padded_a = _padded_size_32_4(elem_a)
+    padded_b = _padded_size_32_4(elem_b)
+    if block_k & (block_k - 1) == 0:
+        pa = _padded_size_pow2(elem_a, block_k, 8)
+        if pa > padded_a:
+            padded_a = pa
+    if block_n & (block_n - 1) == 0:
+        pb = _padded_size_pow2(elem_b, block_n, 8)
+        if pb > padded_b:
+            padded_b = pb
+    return num_stages * (padded_a * elem_bytes_a + padded_b * elem_bytes_b)
+
+
+def origama_calculate_lds_usage(
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    elem_bytes_a: int,
+    elem_bytes_b: int,
+    num_stages: int,
+) -> int:
+    """LDS usage with auto-detection of async_copy mode."""
+    if is_gfx950():
+        return _estimate_lds_bytes_async_copy(
+            block_m, block_n, block_k, elem_bytes_a, elem_bytes_b, num_stages
+        )
+    return _estimate_lds_bytes(block_m, block_n, block_k, elem_bytes_a, elem_bytes_b, num_stages)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Origami analytical config selection (aligned with TensorAtlas / tritonBLAS)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _infer_mi_dim(hardware: Any, element_size_a: int, element_size_b: int) -> list[int]:
+    """Infer matrix instruction dimensions from hardware and dtypes. Align with TensorAtlas."""
+    n_cu = hardware.N_CU
+    max_bits = max(element_size_a, element_size_b)
+    # gfx950
+    if n_cu == 256:
+        if max_bits == 32:
+            return [16, 16, 4]
+        if max_bits == 16:
+            return [16, 16, 32]
+        if max_bits <= 8:
+            return [16, 16, 128]
+    # gfx942 (304, 80, 64 CUs)
+    if n_cu in (304, 80, 64):
+        if max_bits == 32:
+            return [16, 16, 4]
+        if max_bits == 16:
+            return [16, 16, 16]
+        if max_bits == 8:
+            return [16, 16, 32]
+    return [16, 16, 16]
+
+
+def _get_valid_tiles(
+    hardware: Any,
+    block_mn_range: list[int],
+    block_k_range: list[int],
+    mi_dim: list[int],
+    elem_bytes_a: int,
+    elem_bytes_b: int,
+) -> list[tuple[int, int, int, int, int, int, int]]:
+    """Valid (blk_m, blk_n, blk_k, mi_m, mi_n, mi_k, occ) passing LDS check.
+
+    Uses async_copy-aware LDS estimate on gfx950 with num_stages=2.
+    Tiles passing here may still exceed LDS at higher num_stages; callers
+    should verify with origama_calculate_lds_usage for their actual num_stages.
+    """
+    lds_cap = hardware.lds_capacity
+    use_async = is_gfx950()
+    valid = []
+    for bm, bn, bk in (
+        (bm, bn, bk) for bm in block_mn_range for bn in block_mn_range for bk in block_k_range
+    ):
+        if use_async:
+            lds = _estimate_lds_bytes_async_copy(bm, bn, bk, elem_bytes_a, elem_bytes_b, num_stages=2)
+        else:
+            lds = _estimate_lds_bytes(bm, bn, bk, elem_bytes_a, elem_bytes_b, num_stages=2)
+        if lds <= lds_cap:
+            valid.append((bm, bn, bk, mi_dim[0], mi_dim[1], mi_dim[2], 1))
+    return valid
+
+
+def _make_problem(
+    M: int,
+    N: int,
+    K: int,
+    a_dtype: torch.dtype,
+    b_dtype: torch.dtype,
+    c_dtype: torch.dtype,
+    mi_dtype_str: str,
+    trans_a: bool,
+    trans_b: bool,
+    mx_block_size: int = 0,
+) -> Any:
+    """Build origami problem_t for rank_configs / select_workgroup_mapping.
+
+    trans_a, trans_b: logical op(A) @ op(B). NT = (False, True), TN/CRR = (True, False), NN/RRR = (False, False).
+    """
+    problem = origami.problem_t()
+    problem.size = origami.dim3_t(M, N, K)
+    problem.batch = 1
+    # Per your convention: trans_a=True -> origami N, trans_a=False -> origami T
+    problem.a_transpose = origami.transpose_t.N if trans_a else origami.transpose_t.T
+    problem.b_transpose = origami.transpose_t.N if trans_b else origami.transpose_t.T
+    problem.a_dtype = origami.string_to_datatype(_ORIGAMI_DTYPE_TO_STR.get(a_dtype, "bf16"))
+    problem.b_dtype = origami.string_to_datatype(_ORIGAMI_DTYPE_TO_STR.get(b_dtype, "bf16"))
+    problem.c_dtype = origami.string_to_datatype(_ORIGAMI_DTYPE_TO_STR.get(c_dtype, "bf16"))
+    problem.d_dtype = problem.c_dtype
+    problem.mi_dtype = origami.string_to_datatype(mi_dtype_str)
+    problem.a_mx_block_size = mx_block_size
+    problem.b_mx_block_size = mx_block_size
+    return problem
+
+
+def _tiles_to_configs(
+    valid_tiles: list[tuple[int, int, int, int, int, int, int]], streamk: bool = True
+) -> list[Any]:
+    """Convert valid_tiles to origami config_t list."""
+    grid_sel = origami.grid_selection_t.k_split_aware if streamk else origami.grid_selection_t.data_parallel
+    configs = []
+    for blk_m, blk_n, blk_k, mi_m, mi_n, mi_k, occ in valid_tiles:
+        cfg = origami.config_t()
+        cfg.mt = origami.dim3_t(blk_m, blk_n, blk_k)
+        cfg.mi = origami.dim3_t(mi_m, mi_n, mi_k)
+        cfg.occupancy = occ
+        cfg.grid_selection = grid_sel
+        configs.append(cfg)
+    return configs
+
+
+def _safe_rank_configs(problem: Any, hardware: Any, configs: list[Any]) -> list[Any]:
+    """rank_configs that returns [] instead of raising on unsupported problems."""
+    try:
+        return origami.rank_configs(problem, hardware, configs)
+    except Exception as e:
+        from primus_turbo.common.logger import logger
+
+        logger.warning(f"Found Error: {e} in Origama rank_config. Fallback to default config.", once=True)
+
+        return []
+
+
+@functools.lru_cache(maxsize=4096)
+def origama_select_params(
+    M: int,
+    N: int,
+    K: int,
+    out_dtype: torch.dtype,
+    a_dtype: torch.dtype | None = None,
+    b_dtype: torch.dtype | None = None,
+    trans_a: bool = False,
+    trans_b: bool = True,
+) -> tuple[int, int, int, int, str | None, str | None] | None:
+    """Use origami rank_configs + select_workgroup_mapping (align with TensorAtlas selector.py).
+
+    trans_a, trans_b: logical layout (op(A) @ op(B)). Forward NT = (False, True);
+    backward grad_a (NN) = (False, False); backward grad_b (TN) = (True, False).
+    Returns (block_m, block_n, block_k, group_size_m, cache_a, cache_b) or None.
+    """
+    if origami is None:
+        return None
+
+    a_dtype = a_dtype if a_dtype is not None else out_dtype
+    b_dtype = b_dtype if b_dtype is not None else out_dtype
+
+    hardware = origama_hardware_info()
+
+    elem_bits_a = _dtype_bits(a_dtype)
+    elem_bits_b = _dtype_bits(b_dtype)
+    elem_bytes_a = elem_bits_a // 8
+    elem_bytes_b = elem_bits_b // 8
+
+    input_dtype_for_mi = a_dtype if elem_bits_a <= elem_bits_b else b_dtype
+    mi_dtype_str = _ORIGAMI_DTYPE_TO_STR.get(input_dtype_for_mi, _ORIGAMI_DTYPE_TO_STR.get(out_dtype, "bf16"))
+
+    mi_dim = _infer_mi_dim(hardware, elem_bits_a, elem_bits_b)
+    block_mn_range = [64, 128, 256]
+    block_k_range = [64, 128, 256]
+    valid_tiles = _get_valid_tiles(
+        hardware, block_mn_range, block_k_range, mi_dim, elem_bytes_a, elem_bytes_b
+    )
+    if not valid_tiles:
+        return None
+
+    problem = _make_problem(M, N, K, a_dtype, b_dtype, out_dtype, mi_dtype_str, trans_a, trans_b)
+    configs = _tiles_to_configs(valid_tiles, streamk=True)
+
+    ranked = _safe_rank_configs(problem, hardware, configs)
+    if not ranked:
+        return None
+    best_result = ranked[0]
+    best_cfg = best_result.config if hasattr(best_result, "config") else best_result
+    BLK_M = best_cfg.mt.m
+    BLK_N = best_cfg.mt.n
+    BLK_K = best_cfg.mt.k
+
+    elem_bytes_out = _dtype_bits(out_dtype) // 8
+    sk_grid = _compute_sk_grid(M, N, K, BLK_M, BLK_N, BLK_K, hardware.N_CU, elem_bytes_out)
+    wgm_result = origami.select_workgroup_mapping(problem, hardware, best_cfg, sk_grid)
+    gsize_m = abs(wgm_result.wgm)
+
+    _CACHE_HINT_TO_MODIFIER = {0: ".ca", 1: ".cg", 2: ".cv"}
+    cache_a = _CACHE_HINT_TO_MODIFIER.get(getattr(best_cfg, "cache_hints_a", 0), None)
+    cache_b = _CACHE_HINT_TO_MODIFIER.get(getattr(best_cfg, "cache_hints_b", 0), None)
+    # print(
+    #     f"BLK_M: {BLK_M}, BLK_N: {BLK_N}, BLK_K: {BLK_K}, gsize_m: {gsize_m}, cache_a: {cache_a}, cache_b: {cache_b}"
+    # )
+    return BLK_M, BLK_N, BLK_K, gsize_m, cache_a, cache_b
+
+
+atexit.register(origami_clear_caches)

--- a/primus_turbo/triton/utils/origami.py
+++ b/primus_turbo/triton/utils/origami.py
@@ -449,7 +449,7 @@ def origama_select_params(
     BLK_K = best_cfg.mt.k
 
     elem_bytes_out = _dtype_bits(out_dtype) // 8
-    sk_grid = _compute_sk_grid(M, N, K, BLK_M, BLK_N, BLK_K, hardware.N_CU, elem_bytes_out)
+    sk_grid = origama_compute_sk_grid(M, N, K, BLK_M, BLK_N, BLK_K, hardware.N_CU, elem_bytes_out)
     wgm_result = origami.select_workgroup_mapping(problem, hardware, best_cfg, sk_grid)
     gsize_m = abs(wgm_result.wgm)
 

--- a/primus_turbo/triton/utils/triton_knobs_helper.py
+++ b/primus_turbo/triton/utils/triton_knobs_helper.py
@@ -1,0 +1,31 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+AMDGPU Triton compiler knob helpers (shared across GEMM / grouped-GEMM kernels).
+"""
+
+import os
+
+import triton
+
+_KNOBS_SET = False
+
+
+def set_triton_knobs_gfx950() -> None:
+    """Enable AMD compiler knobs for gfx950 (async_copy, block_pingpong, scalarize)."""
+    global _KNOBS_SET
+    if _KNOBS_SET:
+        return
+    _KNOBS_SET = True
+    if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
+        triton.knobs.amd.use_async_copy = True
+        triton.knobs.amd.scalarize_packed_fops = True
+        triton.knobs.amd.use_block_pingpong = True
+    else:
+        os.environ.setdefault("TRITON_HIP_USE_ASYNC_COPY", "1")
+        os.environ.setdefault("AMDGCN_SCALARIZE_PACKED_FOPS", "1")
+        os.environ.setdefault("TRITON_HIP_USE_BLOCK_PINGPONG", "1")


### PR DESCRIPTION
# Description

This PR refactors the Origami analytical GEMM config selection logic and the
AMD Triton compiler knob helpers out of `gemm_kernel.py` into dedicated, shared
utility modules. Previously these helpers lived inside
`primus_turbo/triton/gemm/gemm_kernel.py` and were imported with private
underscore-prefixed names (e.g. `_select_params_origami`, `_get_hardware`,
`_set_knobs_gfx950`) by the GEMM and grouped-GEMM kernels, which created tight
coupling and an awkward dependency graph between kernel files.

The shared logic is now centralized in `primus_turbo/triton/utils/`, the public
helper names are normalized, and architecture / device-capability helpers
(`is_gfx950`, `is_gfx942`, `get_num_cus`) are consolidated in
`primus_turbo/pytorch/core/utils.py`. This is a behavior-preserving refactor
that improves modularity and reuse across the Triton kernel implementations.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `primus_turbo/triton/utils/origami.py`, a new shared module holding the
  Origami analytical config-selection logic previously embedded in
  `gemm_kernel.py`. Public entry points are renamed for clarity:
  `origama_select_params`, `origama_hardware_info`,
  `origama_calculate_lds_usage`, `origama_compute_sk_grid`, and
  `origami_clear_caches`. The module also adds type hints, an `__all__` export
  list, and replaces the bare `RuntimeError` catch in `rank_configs` with a
  broader guarded fallback that logs a warning (once) before returning the
  default config.
- Add `primus_turbo/triton/utils/triton_knobs_helper.py` with
  `set_triton_knobs_gfx950()` (extracted from the old `_set_knobs_gfx950`), so
  the gfx950 AMD compiler knobs can be enabled from a single shared location.
- Add device-capability helpers to `primus_turbo/pytorch/core/utils.py`:
  `is_gfx950()`, `is_gfx942()`, and an `lru_cache`-backed `get_num_cus()`,
  replacing the per-file private `_is_gfx950` / `_get_num_cus` implementations.
- Slim down `primus_turbo/triton/gemm/gemm_kernel.py` (~390 lines removed) by
  deleting the moved Origami/knobs/hardware helpers and importing the new shared
  utilities instead. Add a type-annotated signature to `offline_select_bf16`.
- Update `primus_turbo/triton/gemm/gemm_fp8_kernel.py`,
  `primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py`, and
  `primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py` to import and
  call the renamed shared helpers (`origama_*`, `is_gfx950`, `get_num_cus`,
  `set_triton_knobs_gfx950`).
- Update `primus_turbo/pytorch/core/backend.py` to call the renamed
  `origami_clear_caches` from the new utils module during cache teardown.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
