### PR TITLE
opt(grouped_blockwise): MI300/MI355 grouped blockwise FP8 GEMM + HIP fused quant

### DIFF
--- a/csrc/include/primus_turbo/quantization.h
+++ b/csrc/include/primus_turbo/quantization.h
@@ -27,11 +27,13 @@ void compute_padded_group_offs(const IndexType *group_lens_ptr, IndexType *padde
 
 // Fused single-pass row + segment-padded col blockwise FP8 quant (grouped fwd/bwd).
 template <typename FType, typename QType>
-void quantize_blockwise_segment_m_row_col_impl(
-    const FType *x, QType *y_row, QType *y_col_padded, float *scales_row, float *scales_col_padded,
-    const int64_t *group_offs, const int64_t *padded_group_offs, const int64_t M_in,
-    const int64_t N, const int64_t M_padded_max, const int num_groups, const float fp8_max,
-    hipStream_t stream);
+void quantize_blockwise_segment_m_row_col_impl(const FType *x, QType *y_row, QType *y_col_padded,
+                                               float *scales_row, float *scales_col_padded,
+                                               const int64_t *group_offs,
+                                               const int64_t *padded_group_offs, const int64_t M_in,
+                                               const int64_t N, const int64_t M_padded_max,
+                                               const int num_groups, const float fp8_max,
+                                               hipStream_t stream);
 
 // Blockwise FP8 weight quant: [B, M, N] (or [M, N]), one scalar scale per [128,128] tile.
 template <typename FType, typename QType>

--- a/csrc/include/primus_turbo/quantization.h
+++ b/csrc/include/primus_turbo/quantization.h
@@ -33,6 +33,12 @@ void quantize_blockwise_segment_m_row_col_impl(
     const int64_t N, const int64_t M_padded_max, const int num_groups, const float fp8_max,
     hipStream_t stream);
 
+// Blockwise FP8 weight quant: [B, M, N] (or [M, N]), one scalar scale per [128,128] tile.
+template <typename FType, typename QType>
+void quantize_blockwise_for_weight_impl(const FType *w, QType *w_fp8, float *w_scales_inv,
+                                        const int64_t B, const int64_t M, const int64_t N,
+                                        const float fp8_max, hipStream_t stream);
+
 template <typename FType, typename QType, typename ComputeType = float,
           bool PreComputeScale = false>
 void quantize_rowwise_row_major_impl(const FType *x, float *scale, float *scale_inv, QType *y,

--- a/csrc/include/primus_turbo/quantization.h
+++ b/csrc/include/primus_turbo/quantization.h
@@ -19,6 +19,20 @@ template <typename FType, typename QType, typename ComputeType = float>
 void quantize_tensorwise_impl(const FType *x, const float *scale, QType *y, const int64_t n,
                               hipStream_t stream);
 
+// Segment-padded group offsets (each segment rounded up to block_size), on-device.
+template <typename IndexType>
+void compute_padded_group_offs(const IndexType *group_lens_ptr, IndexType *padded_lens_ptr,
+                               IndexType *padded_offs_ptr, const int64_t group_num,
+                               const IndexType block_size, hipStream_t stream);
+
+// Fused single-pass row + segment-padded col blockwise FP8 quant (grouped fwd/bwd).
+template <typename FType, typename QType>
+void quantize_blockwise_segment_m_row_col_impl(
+    const FType *x, QType *y_row, QType *y_col_padded, float *scales_row, float *scales_col_padded,
+    const int64_t *group_offs, const int64_t *padded_group_offs, const int64_t M_in,
+    const int64_t N, const int64_t M_padded_max, const int num_groups, const float fp8_max,
+    hipStream_t stream);
+
 template <typename FType, typename QType, typename ComputeType = float,
           bool PreComputeScale = false>
 void quantize_rowwise_row_major_impl(const FType *x, float *scale, float *scale_inv, QType *y,

--- a/csrc/kernels/grouped_gemm/ck/ck_grouped_gemm_kernel_instance_factory.h
+++ b/csrc/kernels/grouped_gemm/ck/ck_grouped_gemm_kernel_instance_factory.h
@@ -29,10 +29,12 @@ get_ck_grouped_gemm_instance(const ck_tile::index_t group_num,
     MACRO(A, B, C, RowMajor, RowMajor, RowMajor, ck_tile::QuantType::RowColQuant)                  \
     MACRO(A, B, C, RowMajor, RowMajor, RowMajor, ck_tile::QuantType::TensorQuant)                  \
     MACRO(A, B, C, ColMajor, RowMajor, RowMajor, ck_tile::QuantType::RowColQuant)                  \
-    MACRO(A, B, C, ColMajor, RowMajor, RowMajor, ck_tile::QuantType::TensorQuant)                  \
-    MACRO(A, B, C, RowMajor, ColMajor, RowMajor, ck_tile::QuantType::ABQuantGrouped)               \
-    MACRO(A, B, C, RowMajor, RowMajor, RowMajor, ck_tile::QuantType::ABQuantGrouped)               \
-    MACRO(A, B, C, ColMajor, RowMajor, RowMajor, ck_tile::QuantType::ABQuantGrouped)
+    MACRO(A, B, C, ColMajor, RowMajor, RowMajor, ck_tile::QuantType::TensorQuant)
+    // CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+    // Instantiations kept commented (not deleted) to cut CK compile time.
+    // MACRO(A, B, C, RowMajor, ColMajor, RowMajor, ck_tile::QuantType::ABQuantGrouped)
+    // MACRO(A, B, C, RowMajor, RowMajor, RowMajor, ck_tile::QuantType::ABQuantGrouped)
+    // MACRO(A, B, C, ColMajor, RowMajor, RowMajor, ck_tile::QuantType::ABQuantGrouped)
 
 // FP16 * FP16 = FP16
 APPLY_GET_CK_GG_INSTANCE_ALL_LAYOUT(DECL_GET_CK_GG_INSTANCE_EXTERN, ck_tile::half_t, ck_tile::half_t, ck_tile::half_t)

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3_bf16_gfx942.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3_bf16_gfx942.cu
@@ -9,10 +9,16 @@ namespace primus_turbo {
 #ifdef PRIMUS_TURBO_GFX942
 
 // FP8_E4M3 * FP8_E4M3 = BF16
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x32_2x2x1)
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1)
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1_padding)
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_128x128x128_32x32x32_2x2x1)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x32_2x2x1)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x32_2x2x1)
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1)
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1_padding)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1_padding)
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_128x128x128_32x32x32_2x2x1)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_128x128x128_32x32x32_2x2x1)
 
 #endif
 // clang-format on

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3_bf16_gfx950.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3_bf16_gfx950.cu
@@ -14,7 +14,9 @@ APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUA
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_256x256x128_16x16x128_2x2x1_padding)
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_128x128x128_32x32x64_2x2x1)
 // For 1x4x1 config: ABQuantGrouped only
-APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
 #endif
 // clang-format on
 } // namespace primus_turbo

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3_fp16_gfx942.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3_fp16_gfx942.cu
@@ -9,10 +9,16 @@ namespace primus_turbo {
 #ifdef PRIMUS_TURBO_GFX942
 
 // FP8_E4M3 * FP8_E4M3 = FP16
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x32_2x2x1)
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1)
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1_padding)
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_128x128x128_32x32x32_2x2x1)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x32_2x2x1)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x32_2x2x1)
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1)
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1_padding)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1_padding)
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_128x128x128_32x32x32_2x2x1)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_128x128x128_32x32x32_2x2x1)
 
 #endif
 // clang-format on

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3_fp16_gfx950.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3_fp16_gfx950.cu
@@ -14,7 +14,9 @@ APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUA
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_256x256x128_16x16x128_2x2x1_padding)
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_128x128x128_32x32x64_2x2x1)
 // For 1x4x1 config: ABQuantGrouped only
-APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
 #endif
 // clang-format on
 } // namespace primus_turbo

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3xe5m2_bf16_gfx942.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3xe5m2_bf16_gfx942.cu
@@ -9,7 +9,10 @@ namespace primus_turbo {
 #ifdef PRIMUS_TURBO_GFX942
 
 // FP8_E4M3 * FP8_E5M2 = BF16
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x16_2x2x1_padding)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x16_2x2x1_padding)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x16_2x2x1_padding)
 
 #endif
 // clang-format on

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3xe5m2_bf16_gfx950.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3xe5m2_bf16_gfx950.cu
@@ -14,7 +14,9 @@ APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUA
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_256x256x128_16x16x128_2x2x1_padding)
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_128x128x128_32x32x64_2x2x1)
 // For 1x4x1 config: ABQuantGrouped only
-APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
 
 #endif
 // clang-format on

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3xe5m2_fp16_gfx942.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3xe5m2_fp16_gfx942.cu
@@ -9,7 +9,10 @@ namespace primus_turbo {
 #ifdef PRIMUS_TURBO_GFX942
 
 // FP8_E4M3 * FP8_E5M2 = FP16
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x16_2x2x1_padding)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x16_2x2x1_padding)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x16_2x2x1_padding)
 
 #endif
 // clang-format on

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3xe5m2_fp16_gfx950.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e4m3xe5m2_fp16_gfx950.cu
@@ -14,7 +14,9 @@ APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUA
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_256x256x128_16x16x128_2x2x1_padding)
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_128x128x128_32x32x64_2x2x1)
 // For 1x4x1 config: ABQuantGrouped only
-APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::fp8_t, ck_tile::bf8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
 
 #endif
 // clang-format on

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2_bf16_gfx942.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2_bf16_gfx942.cu
@@ -9,10 +9,16 @@ namespace primus_turbo {
 #ifdef PRIMUS_TURBO_GFX942
 
 // FP8_E5M2 * FP8_E5M2 = BF16
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x32_2x2x1)
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1)
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1_padding)
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_128x128x128_32x32x32_2x2x1)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x32_2x2x1)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x32_2x2x1)
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1)
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1_padding)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1_padding)
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_128x128x128_32x32x32_2x2x1)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_128x128x128_32x32x32_2x2x1)
 
 #endif
 // clang-format on

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2_bf16_gfx950.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2_bf16_gfx950.cu
@@ -14,7 +14,9 @@ APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUA
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_256x256x128_16x16x128_2x2x1_padding)
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_128x128x128_32x32x64_2x2x1)
 // For 1x4x1 config: ABQuantGrouped only
-APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
 #endif
 // clang-format on
 } // namespace primus_turbo

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2_fp16_gfx942.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2_fp16_gfx942.cu
@@ -9,10 +9,16 @@ namespace primus_turbo {
 #ifdef PRIMUS_TURBO_GFX942
 
 // FP8_E5M2 * FP8_E5M2 = FP16
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x32_2x2x1)
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1)
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1_padding)
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_128x128x128_32x32x32_2x2x1)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x32_2x2x1)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x32_2x2x1)
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1)
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1_padding)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x128x128_32x32x32_2x2x1_padding)
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_128x128x128_32x32x32_2x2x1)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_128x128x128_32x32x32_2x2x1)
 
 #endif
 // clang-format on

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2_fp16_gfx950.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2_fp16_gfx950.cu
@@ -14,7 +14,9 @@ APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUA
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_256x256x128_16x16x128_2x2x1_padding)
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_128x128x128_32x32x64_2x2x1)
 // For 1x4x1 config: ABQuantGrouped only
-APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::bf8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
 #endif
 // clang-format on
 } // namespace primus_turbo

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2xe4m3_bf16_gfx942.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2xe4m3_bf16_gfx942.cu
@@ -9,7 +9,10 @@ namespace primus_turbo {
 #ifdef PRIMUS_TURBO_GFX942
 
 // FP8_E5M2 * FP8_E4M3 = BF16
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x16_2x2x1_padding)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x16_2x2x1_padding)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x16_2x2x1_padding)
 
 #endif
 // clang-format on

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2xe4m3_bf16_gfx950.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2xe4m3_bf16_gfx950.cu
@@ -14,7 +14,9 @@ APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUA
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_256x256x128_16x16x128_2x2x1_padding)
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_128x128x128_32x32x64_2x2x1)
 // For 1x4x1 config: ABQuantGrouped only
-APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
 
 #endif
 // clang-format on

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2xe4m3_fp16_gfx942.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2xe4m3_fp16_gfx942.cu
@@ -9,7 +9,10 @@ namespace primus_turbo {
 #ifdef PRIMUS_TURBO_GFX942
 
 // FP8_E5M2 * FP8_E4M3 = FP16
-APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x16_2x2x1_padding)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ALL_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x16_2x2x1_padding)
+APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX942, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::half_t, GFX942_CKGroupedGemmTileCfg_256x256x128_32x32x16_2x2x1_padding)
 
 #endif
 // clang-format on

--- a/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2xe4m3_fp16_gfx950.cu
+++ b/csrc/kernels/grouped_gemm/ck/instantiations/ck_grouped_gemm_kernel_fp8_e5m2xe4m3_fp16_gfx950.cu
@@ -14,7 +14,9 @@ APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUA
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_256x256x128_16x16x128_2x2x1_padding)
 APPLY_CK_GG_TENSOR_ROW_QUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_128x128x128_32x32x64_2x2x1)
 // For 1x4x1 config: ABQuantGrouped only
-APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
+// CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise path.
+// Instantiations kept commented (not deleted) to cut CK compile time; see PR discussion.
+// APPLY_CK_GG_ABQUANT_LAYOUT_WITH_ARCH(DECL_CK_QGG_RUNNER_WITH_ARCH, GPUArch::GFX950, ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::half_t, GFX950_CKGroupedGemmTileCfg_128x128x128_16x16x128_1x4x1)
 
 #endif
 // clang-format on

--- a/csrc/kernels/grouped_gemm/ck_grouped_gemm.cu
+++ b/csrc/kernels/grouped_gemm/ck_grouped_gemm.cu
@@ -519,6 +519,8 @@ template void ck_grouped_gemm_fp8<ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::bfloa
                                   ck_tile::QuantType::RowColQuant>(
     const CKGroupedGemmFP8Params<ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, float>
         &params);
+#if 0  // CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise
+       // path. Explicit instantiations kept (not deleted) to cut CK compile time.
 // fp8 * fp8 -> fp16 (ABQuantGrouped/blockwise)
 template void ck_grouped_gemm_fp8<ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, float,
                                   ck_tile::QuantType::ABQuantGrouped>(
@@ -555,6 +557,7 @@ template void ck_grouped_gemm_fp8<ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::bfloa
                                   ck_tile::QuantType::ABQuantGrouped>(
     const CKGroupedGemmFP8Params<ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, float>
         &params);
+#endif // ABQuantGrouped grouped-gemm instantiations disabled
 // ck_grouped_gemm_variable_k explicit instantiation.
 // fp16 * fp16 -> fp16
 template void ck_grouped_gemm_variable_k<ck_tile::half_t, ck_tile::half_t, ck_tile::half_t>(
@@ -629,6 +632,8 @@ template void ck_grouped_gemm_fp8_variable_k<ck_tile::bf8_t, ck_tile::fp8_t, ck_
                                              float, ck_tile::QuantType::RowColQuant>(
     const CKGroupedGemmFP8Params<ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, float>
         &params);
+#if 0 // CK grouped BLOCKWISE (ABQuantGrouped) dropped: Triton is the production blockwise
+      // path. Explicit instantiations kept (not deleted) to cut CK compile time.
 // fp8 * fp8 -> fp16 (ABQuantGrouped/blockwise)
 template void ck_grouped_gemm_fp8_variable_k<ck_tile::fp8_t, ck_tile::fp8_t, ck_tile::half_t, float,
                                              ck_tile::QuantType::ABQuantGrouped>(
@@ -666,6 +671,7 @@ template void ck_grouped_gemm_fp8_variable_k<ck_tile::bf8_t, ck_tile::fp8_t, ck_
     const CKGroupedGemmFP8Params<ck_tile::bf8_t, ck_tile::fp8_t, ck_tile::bfloat16_t, float>
         &params);
 
+#endif // ABQuantGrouped grouped-gemm instantiations disabled
 template void compute_group_offs<int64_t>(const int64_t *group_lens_ptr, int64_t *group_offs_ptr,
                                           const int64_t group_num, hipStream_t stream);
 } // namespace primus_turbo

--- a/csrc/kernels/quantization/quantization_blockwise.cu
+++ b/csrc/kernels/quantization/quantization_blockwise.cu
@@ -16,11 +16,11 @@ using namespace primus_turbo::dtype;
 template <typename IndexType>
 __global__ void compute_padded_group_offs_device(const IndexType *group_lens_ptr,
                                                  IndexType       *padded_lens_ptr,
-                                                 IndexType       *padded_offs_ptr,
-                                                 const int        group_num,
-                                                 const IndexType  block_size) {
+                                                 IndexType *padded_offs_ptr, const int group_num,
+                                                 const IndexType block_size) {
     const int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx == 0) padded_offs_ptr[0] = 0;
+    if (idx == 0)
+        padded_offs_ptr[0] = 0;
     if (idx < group_num) {
         IndexType cumsum = 0;
         for (int i = 0; i < idx; ++i) {
@@ -39,8 +39,10 @@ void compute_padded_group_offs(const IndexType *group_lens_ptr, IndexType *padde
                                const IndexType block_size, hipStream_t stream) {
     const int threads_per_block = 256;
     const int blocks = static_cast<int>((group_num + threads_per_block - 1) / threads_per_block);
-    compute_padded_group_offs_device<IndexType><<<dim3(blocks), dim3(threads_per_block), 0, stream>>>(
-        group_lens_ptr, padded_lens_ptr, padded_offs_ptr, static_cast<int>(group_num), block_size);
+    compute_padded_group_offs_device<IndexType>
+        <<<dim3(blocks), dim3(threads_per_block), 0, stream>>>(
+            group_lens_ptr, padded_lens_ptr, padded_offs_ptr, static_cast<int>(group_num),
+            block_size);
 }
 
 template void compute_padded_group_offs<int64_t>(const int64_t *group_lens_ptr,
@@ -48,75 +50,73 @@ template void compute_padded_group_offs<int64_t>(const int64_t *group_lens_ptr,
                                                  const int64_t group_num, const int64_t block_size,
                                                  hipStream_t stream);
 
-
 // Single-pass fused row + segment-padded col blockwise FP8 quant.
 // One bf16 read of x [M_in, N]; vals cached in vregs (64 fp32/thread).
 // Row amax: 16-thread sub-warp xor reduce → write row FP8 + scale per round.
 // Col amax: per-thread col_amax[8] over 8 rounds → LDS reduce across 16 row-slots
 // → broadcast scale; col-padded FP8 written from regs. ~9KB LDS, 3-4 blocks/CU.
 template <typename FType, typename QType>
-__launch_bounds__(256) __global__
-void quant_fp8_blockwise_segment_m_row_col_kernel(
-    const FType *__restrict__ x_ptr,
-    QType *__restrict__ x_fp8_row_ptr,
-    QType *__restrict__ x_fp8_col_padded_ptr,
-    float *__restrict__ x_scales_row_ptr,
-    float *__restrict__ x_scales_col_padded_ptr,
-    const int64_t *__restrict__ group_offs_ptr,
-    const int64_t *__restrict__ padded_group_offs_ptr,
-    const int64_t M_in, const int64_t N, const int num_groups,
-    const float fp8_max) {
-    constexpr int BLOCK_SIZE = 128;
-    constexpr int PACK       = 8;
-    constexpr int THREADS_PER_ROW = BLOCK_SIZE / PACK;            // 16
-    constexpr int ROWS_PER_ROUND  = 256 / THREADS_PER_ROW;        // 16
-    constexpr int ROUNDS          = BLOCK_SIZE / ROWS_PER_ROUND;  // 8
+__launch_bounds__(256) __global__ void quant_fp8_blockwise_segment_m_row_col_kernel(
+    const FType *__restrict__ x_ptr, QType *__restrict__ x_fp8_row_ptr,
+    QType *__restrict__ x_fp8_col_padded_ptr, float *__restrict__ x_scales_row_ptr,
+    float *__restrict__ x_scales_col_padded_ptr, const int64_t *__restrict__ group_offs_ptr,
+    const int64_t *__restrict__ padded_group_offs_ptr, const int64_t M_in, const int64_t N,
+    const int num_groups, const float fp8_max) {
+    constexpr int BLOCK_SIZE      = 128;
+    constexpr int PACK            = 8;
+    constexpr int THREADS_PER_ROW = BLOCK_SIZE / PACK;           // 16
+    constexpr int ROWS_PER_ROUND  = 256 / THREADS_PER_ROW;       // 16
+    constexpr int ROUNDS          = BLOCK_SIZE / ROWS_PER_ROUND; // 8
 
-    const int64_t pid_m   = blockIdx.x;
-    const int64_t col_blk = blockIdx.y;
-    const int     tid     = threadIdx.x;
+    const int64_t pid_m         = blockIdx.x;
+    const int64_t col_blk       = blockIdx.y;
+    const int     tid           = threadIdx.x;
     const int     pack_idx      = tid % THREADS_PER_ROW;
     const int     load_row_base = tid / THREADS_PER_ROW;
 
-    const int64_t M_padded = padded_group_offs_ptr[num_groups];
+    const int64_t M_padded        = padded_group_offs_ptr[num_groups];
     const int64_t pad_block_start = pid_m * BLOCK_SIZE;
-    if (pad_block_start >= M_padded) return;
+    if (pad_block_start >= M_padded)
+        return;
 
     int group_id = 0;
-    #pragma unroll 1
+#pragma unroll 1
     for (int g = 0; g < num_groups; ++g) {
         if (pad_block_start >= padded_group_offs_ptr[g] &&
-            pad_block_start <  padded_group_offs_ptr[g + 1]) group_id = g;
+            pad_block_start < padded_group_offs_ptr[g + 1])
+            group_id = g;
     }
     const int64_t orig_start = group_offs_ptr[group_id];
     const int64_t orig_end   = group_offs_ptr[group_id + 1];
     const int64_t pad_start  = padded_group_offs_ptr[group_id];
 
-    const int64_t col_start      = col_blk * BLOCK_SIZE;
-    const float   clip_lo = -static_cast<float>(fp8_max);
-    const float   clip_hi =  static_cast<float>(fp8_max);
+    const int64_t col_start = col_blk * BLOCK_SIZE;
+    const float   clip_lo   = -static_cast<float>(fp8_max);
+    const float   clip_hi   = static_cast<float>(fp8_max);
 
     float vals[ROUNDS][PACK];
     float col_amax_local[PACK];
-    #pragma unroll
-    for (int i = 0; i < PACK; ++i) col_amax_local[i] = 0.f;
+#pragma unroll
+    for (int i = 0; i < PACK; ++i)
+        col_amax_local[i] = 0.f;
 
     __shared__ bool s_valid_row[BLOCK_SIZE];
 
-    #pragma unroll
+#pragma unroll
     for (int r = 0; r < ROUNDS; ++r) {
-        const int local_m = load_row_base + r * ROWS_PER_ROUND;
-        const int local_n = pack_idx * PACK;
-        const int64_t in_m    = orig_start + (pad_block_start + local_m - pad_start);
+        const int     local_m  = load_row_base + r * ROWS_PER_ROUND;
+        const int     local_n  = pack_idx * PACK;
+        const int64_t in_m     = orig_start + (pad_block_start + local_m - pad_start);
         const bool    valid_in = (in_m >= orig_start) && (in_m < orig_end) && (in_m < M_in);
-        if (pack_idx == 0) s_valid_row[local_m] = valid_in;
+        if (pack_idx == 0)
+            s_valid_row[local_m] = valid_in;
 
         const int64_t gn = col_start + local_n;
-        FType buf[PACK];
+        FType         buf[PACK];
         if (valid_in && gn + PACK <= N) {
             load_data<FType, PACK>(x_ptr + in_m * N + gn, buf);
         } else {
-            #pragma unroll
+#pragma unroll
             for (int i = 0; i < PACK; ++i) {
                 const int64_t cn = gn + i;
                 buf[i] = (valid_in && cn < N) ? x_ptr[in_m * N + cn] : static_cast<FType>(0.f);
@@ -124,15 +124,16 @@ void quant_fp8_blockwise_segment_m_row_col_kernel(
         }
 
         float row_amax = 0.f;
-        #pragma unroll
+#pragma unroll
         for (int i = 0; i < PACK; ++i) {
             const float v  = static_cast<float>(buf[i]);
             const float av = fabsf(v);
-            vals[r][i] = v;
-            row_amax = fmaxf(row_amax, av);
-            if (valid_in) col_amax_local[i] = fmaxf(col_amax_local[i], av);
+            vals[r][i]     = v;
+            row_amax       = fmaxf(row_amax, av);
+            if (valid_in)
+                col_amax_local[i] = fmaxf(col_amax_local[i], av);
         }
-        #pragma unroll
+#pragma unroll
         for (int offset = THREADS_PER_ROW >> 1; offset > 0; offset >>= 1) {
             row_amax = fmaxf(row_amax, __shfl_xor(row_amax, offset, THREADS_PER_ROW));
         }
@@ -140,17 +141,18 @@ void quant_fp8_blockwise_segment_m_row_col_kernel(
 
         if (valid_in) {
             QType out[PACK];
-            #pragma unroll
+#pragma unroll
             for (int i = 0; i < PACK; ++i) {
                 out[i] = static_cast<QType>(fmaxf(fminf(vals[r][i] * row_scale, clip_hi), clip_lo));
             }
             if (gn + PACK <= N) {
                 store_data<QType, PACK>(x_fp8_row_ptr + in_m * N + gn, out);
             } else {
-                #pragma unroll
+#pragma unroll
                 for (int i = 0; i < PACK; ++i) {
                     const int64_t cn = gn + i;
-                    if (cn < N) x_fp8_row_ptr[in_m * N + cn] = out[i];
+                    if (cn < N)
+                        x_fp8_row_ptr[in_m * N + cn] = out[i];
                 }
             }
             if (pack_idx == 0) {
@@ -160,8 +162,8 @@ void quant_fp8_blockwise_segment_m_row_col_kernel(
         }
     }
 
-    __shared__ float s_col_partial[ROWS_PER_ROUND][BLOCK_SIZE];   // 8KB
-    #pragma unroll
+    __shared__ float s_col_partial[ROWS_PER_ROUND][BLOCK_SIZE]; // 8KB
+#pragma unroll
     for (int i = 0; i < PACK; ++i) {
         s_col_partial[load_row_base][pack_idx * PACK + i] = col_amax_local[i];
     }
@@ -170,68 +172,69 @@ void quant_fp8_blockwise_segment_m_row_col_kernel(
     __shared__ float s_col_scale[BLOCK_SIZE];
     if (tid < BLOCK_SIZE) {
         float col_amax = 0.f;
-        #pragma unroll
+#pragma unroll
         for (int rs = 0; rs < ROWS_PER_ROUND; ++rs) {
             col_amax = fmaxf(col_amax, s_col_partial[rs][tid]);
         }
         const float col_scale = static_cast<float>(fp8_max) / fmaxf(col_amax, 1e-4f);
-        s_col_scale[tid] = col_scale;
-        const int64_t gn = col_start + tid;
-        if (gn < N) x_scales_col_padded_ptr[pid_m * N + gn] = 1.0f / col_scale;
+        s_col_scale[tid]      = col_scale;
+        const int64_t gn      = col_start + tid;
+        if (gn < N)
+            x_scales_col_padded_ptr[pid_m * N + gn] = 1.0f / col_scale;
     }
     __syncthreads();
 
-    #pragma unroll
+#pragma unroll
     for (int r = 0; r < ROUNDS; ++r) {
-        const int local_m = load_row_base + r * ROWS_PER_ROUND;
-        const int local_n = pack_idx * PACK;
-        const int64_t out_m = pad_block_start + local_m;
-        const int64_t gn    = col_start + local_n;
-        const bool    valid = s_valid_row[local_m];
+        const int     local_m = load_row_base + r * ROWS_PER_ROUND;
+        const int     local_n = pack_idx * PACK;
+        const int64_t out_m   = pad_block_start + local_m;
+        const int64_t gn      = col_start + local_n;
+        const bool    valid   = s_valid_row[local_m];
 
         QType out[PACK];
-        #pragma unroll
+#pragma unroll
         for (int i = 0; i < PACK; ++i) {
             const float v = valid ? vals[r][i] : 0.f;
-            out[i] = static_cast<QType>(
-                fmaxf(fminf(v * s_col_scale[local_n + i], clip_hi), clip_lo));
+            out[i] =
+                static_cast<QType>(fmaxf(fminf(v * s_col_scale[local_n + i], clip_hi), clip_lo));
         }
         if (out_m < M_padded && gn + PACK <= N) {
             store_data<QType, PACK>(x_fp8_col_padded_ptr + out_m * N + gn, out);
         } else if (out_m < M_padded) {
-            #pragma unroll
+#pragma unroll
             for (int i = 0; i < PACK; ++i) {
                 const int64_t cn = gn + i;
-                if (cn < N) x_fp8_col_padded_ptr[out_m * N + cn] = out[i];
+                if (cn < N)
+                    x_fp8_col_padded_ptr[out_m * N + cn] = out[i];
             }
         }
     }
 }
 
 template <typename FType, typename QType>
-void quantize_blockwise_segment_m_row_col_impl(
-    const FType *x, QType *y_row, QType *y_col_padded,
-    float *scales_row, float *scales_col_padded,
-    const int64_t *group_offs, const int64_t *padded_group_offs,
-    const int64_t M_in, const int64_t N, const int64_t M_padded_max,
-    const int num_groups, const float fp8_max, hipStream_t stream) {
+void quantize_blockwise_segment_m_row_col_impl(const FType *x, QType *y_row, QType *y_col_padded,
+                                               float *scales_row, float *scales_col_padded,
+                                               const int64_t *group_offs,
+                                               const int64_t *padded_group_offs, const int64_t M_in,
+                                               const int64_t N, const int64_t M_padded_max,
+                                               const int num_groups, const float fp8_max,
+                                               hipStream_t stream) {
     constexpr int BLOCK_SIZE = 128;
-    const int64_t m_blocks = (M_padded_max + BLOCK_SIZE - 1) / BLOCK_SIZE;
-    const int64_t n_blocks = (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
-    dim3 grid(m_blocks, n_blocks);
-    quant_fp8_blockwise_segment_m_row_col_kernel<FType, QType>
-        <<<grid, dim3(256), 0, stream>>>(
-            x, y_row, y_col_padded, scales_row, scales_col_padded,
-            group_offs, padded_group_offs, M_in, N, num_groups, fp8_max);
+    const int64_t m_blocks   = (M_padded_max + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    const int64_t n_blocks   = (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    dim3          grid(m_blocks, n_blocks);
+    quant_fp8_blockwise_segment_m_row_col_kernel<FType, QType><<<grid, dim3(256), 0, stream>>>(
+        x, y_row, y_col_padded, scales_row, scales_col_padded, group_offs, padded_group_offs, M_in,
+        N, num_groups, fp8_max);
 }
 
-#define DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(FType, QType)                          \
-    template void quantize_blockwise_segment_m_row_col_impl<FType, QType>(        \
-        const FType *x, QType *y_row, QType *y_col_padded, float *scales_row,           \
-        float *scales_col_padded, const int64_t *group_offs,                            \
-        const int64_t *padded_group_offs, const int64_t M_in, const int64_t N,          \
-        const int64_t M_padded_max, const int num_groups, const float fp8_max,          \
-        hipStream_t stream);
+#define DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(FType, QType)                                           \
+    template void quantize_blockwise_segment_m_row_col_impl<FType, QType>(                         \
+        const FType *x, QType *y_row, QType *y_col_padded, float *scales_row,                      \
+        float *scales_col_padded, const int64_t *group_offs, const int64_t *padded_group_offs,     \
+        const int64_t M_in, const int64_t N, const int64_t M_padded_max, const int num_groups,     \
+        const float fp8_max, hipStream_t stream);
 DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(dtype::bfloat16, dtype::float8_e4m3)
 DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(dtype::bfloat16, dtype::float8_e5m2)
 DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(dtype::float16, dtype::float8_e4m3)
@@ -242,21 +245,21 @@ DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(dtype::float16, dtype::float8_e5m2)
 // tile. 256 threads/block; vec-8 packed loads; BlockReduce<AbsMax>.
 template <typename FType, typename QType>
 __launch_bounds__(256) __global__
-void quant_fp8_blockwise_for_weight_kernel(const FType *__restrict__ w_ptr,
-                                           QType *__restrict__ w_fp8_ptr,
-                                           float *__restrict__ w_scales_inv_ptr,
-                                           const int64_t M, const int64_t N,
-                                           const float fp8_max) {
-    constexpr int BLOCK_SIZE = 128;
-    constexpr int PACK       = 8;
-    constexpr int THREADS_PER_ROW = BLOCK_SIZE / PACK;            // 16
-    constexpr int ROWS_PER_ROUND  = 256 / THREADS_PER_ROW;        // 16
-    constexpr int ROUNDS          = BLOCK_SIZE / ROWS_PER_ROUND;  // 8
+    void quant_fp8_blockwise_for_weight_kernel(const FType *__restrict__ w_ptr,
+                                               QType *__restrict__ w_fp8_ptr,
+                                               float *__restrict__ w_scales_inv_ptr,
+                                               const int64_t M, const int64_t N,
+                                               const float fp8_max) {
+    constexpr int BLOCK_SIZE      = 128;
+    constexpr int PACK            = 8;
+    constexpr int THREADS_PER_ROW = BLOCK_SIZE / PACK;           // 16
+    constexpr int ROWS_PER_ROUND  = 256 / THREADS_PER_ROW;       // 16
+    constexpr int ROUNDS          = BLOCK_SIZE / ROWS_PER_ROUND; // 8
 
-    const int64_t bid     = blockIdx.x;
-    const int64_t row_blk = blockIdx.y;
-    const int64_t col_blk = blockIdx.z;
-    const int     tid     = threadIdx.x;
+    const int64_t bid           = blockIdx.x;
+    const int64_t row_blk       = blockIdx.y;
+    const int64_t col_blk       = blockIdx.z;
+    const int     tid           = threadIdx.x;
     const int     pack_idx      = tid % THREADS_PER_ROW;
     const int     load_row_base = tid / THREADS_PER_ROW;
 
@@ -267,28 +270,28 @@ void quant_fp8_blockwise_for_weight_kernel(const FType *__restrict__ w_ptr,
     float vals[ROUNDS][PACK];
     float amax = 0.f;
 
-    #pragma unroll
+#pragma unroll
     for (int r = 0; r < ROUNDS; ++r) {
-        const int local_m = load_row_base + r * ROWS_PER_ROUND;
-        const int local_n = pack_idx * PACK;
-        const int64_t gm  = row_start + local_m;
-        const int64_t gn  = col_start + local_n;
-        FType buf[PACK];
+        const int     local_m = load_row_base + r * ROWS_PER_ROUND;
+        const int     local_n = pack_idx * PACK;
+        const int64_t gm      = row_start + local_m;
+        const int64_t gn      = col_start + local_n;
+        FType         buf[PACK];
         if (gm < M && gn + PACK <= N) {
             load_data<FType, PACK>(w_ptr + batch_off + gm * N + gn, buf);
         } else {
-            #pragma unroll
+#pragma unroll
             for (int i = 0; i < PACK; ++i) {
                 const int64_t cn = gn + i;
-                buf[i] = (gm < M && cn < N) ? w_ptr[batch_off + gm * N + cn]
-                                            : static_cast<FType>(0.f);
+                buf[i] =
+                    (gm < M && cn < N) ? w_ptr[batch_off + gm * N + cn] : static_cast<FType>(0.f);
             }
         }
-        #pragma unroll
+#pragma unroll
         for (int i = 0; i < PACK; ++i) {
             const float v = static_cast<float>(buf[i]);
-            vals[r][i] = v;
-            amax = fmaxf(amax, fabsf(v));
+            vals[r][i]    = v;
+            amax          = fmaxf(amax, fabsf(v));
         }
     }
 
@@ -296,7 +299,7 @@ void quant_fp8_blockwise_for_weight_kernel(const FType *__restrict__ w_ptr,
     // Clamp eps matches Triton reference (tl.maximum(w_tile_max, 1e-4)).
     const float scale   = static_cast<float>(fp8_max) / fmaxf(amax, 1e-4f);
     const float clip_lo = -static_cast<float>(fp8_max);
-    const float clip_hi =  static_cast<float>(fp8_max);
+    const float clip_hi = static_cast<float>(fp8_max);
 
     if (tid == 0) {
         const int64_t sn = (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
@@ -304,24 +307,25 @@ void quant_fp8_blockwise_for_weight_kernel(const FType *__restrict__ w_ptr,
         w_scales_inv_ptr[bid * sm * sn + row_blk * sn + col_blk] = 1.0f / scale;
     }
 
-    #pragma unroll
+#pragma unroll
     for (int r = 0; r < ROUNDS; ++r) {
-        const int local_m = load_row_base + r * ROWS_PER_ROUND;
-        const int local_n = pack_idx * PACK;
-        const int64_t gm  = row_start + local_m;
-        const int64_t gn  = col_start + local_n;
-        QType out[PACK];
-        #pragma unroll
+        const int     local_m = load_row_base + r * ROWS_PER_ROUND;
+        const int     local_n = pack_idx * PACK;
+        const int64_t gm      = row_start + local_m;
+        const int64_t gn      = col_start + local_n;
+        QType         out[PACK];
+#pragma unroll
         for (int i = 0; i < PACK; ++i) {
             out[i] = static_cast<QType>(fmaxf(fminf(vals[r][i] * scale, clip_hi), clip_lo));
         }
         if (gm < M && gn + PACK <= N) {
             store_data<QType, PACK>(w_fp8_ptr + batch_off + gm * N + gn, out);
         } else if (gm < M) {
-            #pragma unroll
+#pragma unroll
             for (int i = 0; i < PACK; ++i) {
                 const int64_t cn = gn + i;
-                if (cn < N) w_fp8_ptr[batch_off + gm * N + cn] = out[i];
+                if (cn < N)
+                    w_fp8_ptr[batch_off + gm * N + cn] = out[i];
             }
         }
     }
@@ -329,21 +333,20 @@ void quant_fp8_blockwise_for_weight_kernel(const FType *__restrict__ w_ptr,
 
 template <typename FType, typename QType>
 void quantize_blockwise_for_weight_impl(const FType *w, QType *w_fp8, float *w_scales_inv,
-                                         const int64_t B, const int64_t M, const int64_t N,
-                                         const float fp8_max, hipStream_t stream) {
+                                        const int64_t B, const int64_t M, const int64_t N,
+                                        const float fp8_max, hipStream_t stream) {
     constexpr int BLOCK_SIZE = 128;
-    const int64_t m_blocks = (M + BLOCK_SIZE - 1) / BLOCK_SIZE;
-    const int64_t n_blocks = (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
-    dim3 grid(B, m_blocks, n_blocks);
+    const int64_t m_blocks   = (M + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    const int64_t n_blocks   = (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    dim3          grid(B, m_blocks, n_blocks);
     quant_fp8_blockwise_for_weight_kernel<FType, QType>
         <<<grid, dim3(256), 0, stream>>>(w, w_fp8, w_scales_inv, M, N, fp8_max);
 }
 
-#define DECL_QUANT_BLOCKWISE_FOR_WEIGHT_INSTANCE(FType, QType)                          \
-    template void quantize_blockwise_for_weight_impl<FType, QType>(                     \
-        const FType *w, QType *w_fp8, float *w_scales_inv,                              \
-        const int64_t B, const int64_t M, const int64_t N,                              \
-        const float fp8_max, hipStream_t stream);
+#define DECL_QUANT_BLOCKWISE_FOR_WEIGHT_INSTANCE(FType, QType)                                     \
+    template void quantize_blockwise_for_weight_impl<FType, QType>(                                \
+        const FType *w, QType *w_fp8, float *w_scales_inv, const int64_t B, const int64_t M,       \
+        const int64_t N, const float fp8_max, hipStream_t stream);
 DECL_QUANT_BLOCKWISE_FOR_WEIGHT_INSTANCE(dtype::bfloat16, dtype::float8_e4m3)
 DECL_QUANT_BLOCKWISE_FOR_WEIGHT_INSTANCE(dtype::bfloat16, dtype::float8_e5m2)
 DECL_QUANT_BLOCKWISE_FOR_WEIGHT_INSTANCE(dtype::float16, dtype::float8_e4m3)

--- a/csrc/kernels/quantization/quantization_blockwise.cu
+++ b/csrc/kernels/quantization/quantization_blockwise.cu
@@ -1,0 +1,240 @@
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+//
+// See LICENSE for license information.
+
+#include "primus_turbo/common.h"
+#include "primus_turbo/device/utils.cuh"
+#include "primus_turbo/quantization.h"
+
+namespace primus_turbo {
+
+using namespace primus_turbo::dtype;
+
+// Segment-padded group offsets (each segment rounded up to block_size). Used by the
+// fused segment-m row+col quant below; computed on-device to avoid host sync.
+template <typename IndexType>
+__global__ void compute_padded_group_offs_device(const IndexType *group_lens_ptr,
+                                                 IndexType       *padded_lens_ptr,
+                                                 IndexType       *padded_offs_ptr,
+                                                 const int        group_num,
+                                                 const IndexType  block_size) {
+    const int64_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx == 0) padded_offs_ptr[0] = 0;
+    if (idx < group_num) {
+        IndexType cumsum = 0;
+        for (int i = 0; i < idx; ++i) {
+            cumsum += ((group_lens_ptr[i] + block_size - 1) / block_size) * block_size;
+        }
+        const IndexType padded_self =
+            ((group_lens_ptr[idx] + block_size - 1) / block_size) * block_size;
+        padded_lens_ptr[idx]     = padded_self;
+        padded_offs_ptr[idx + 1] = cumsum + padded_self;
+    }
+}
+
+template <typename IndexType>
+void compute_padded_group_offs(const IndexType *group_lens_ptr, IndexType *padded_lens_ptr,
+                               IndexType *padded_offs_ptr, const int64_t group_num,
+                               const IndexType block_size, hipStream_t stream) {
+    const int threads_per_block = 256;
+    const int blocks = static_cast<int>((group_num + threads_per_block - 1) / threads_per_block);
+    compute_padded_group_offs_device<IndexType><<<dim3(blocks), dim3(threads_per_block), 0, stream>>>(
+        group_lens_ptr, padded_lens_ptr, padded_offs_ptr, static_cast<int>(group_num), block_size);
+}
+
+template void compute_padded_group_offs<int64_t>(const int64_t *group_lens_ptr,
+                                                 int64_t *padded_lens_ptr, int64_t *padded_offs_ptr,
+                                                 const int64_t group_num, const int64_t block_size,
+                                                 hipStream_t stream);
+
+
+// Single-pass fused row + segment-padded col blockwise FP8 quant.
+// One bf16 read of x [M_in, N]; vals cached in vregs (64 fp32/thread).
+// Row amax: 16-thread sub-warp xor reduce → write row FP8 + scale per round.
+// Col amax: per-thread col_amax[8] over 8 rounds → LDS reduce across 16 row-slots
+// → broadcast scale; col-padded FP8 written from regs. ~9KB LDS, 3-4 blocks/CU.
+template <typename FType, typename QType>
+__launch_bounds__(256) __global__
+void quant_fp8_blockwise_segment_m_row_col_kernel(
+    const FType *__restrict__ x_ptr,
+    QType *__restrict__ x_fp8_row_ptr,
+    QType *__restrict__ x_fp8_col_padded_ptr,
+    float *__restrict__ x_scales_row_ptr,
+    float *__restrict__ x_scales_col_padded_ptr,
+    const int64_t *__restrict__ group_offs_ptr,
+    const int64_t *__restrict__ padded_group_offs_ptr,
+    const int64_t M_in, const int64_t N, const int num_groups,
+    const float fp8_max) {
+    constexpr int BLOCK_SIZE = 128;
+    constexpr int PACK       = 8;
+    constexpr int THREADS_PER_ROW = BLOCK_SIZE / PACK;            // 16
+    constexpr int ROWS_PER_ROUND  = 256 / THREADS_PER_ROW;        // 16
+    constexpr int ROUNDS          = BLOCK_SIZE / ROWS_PER_ROUND;  // 8
+
+    const int64_t pid_m   = blockIdx.x;
+    const int64_t col_blk = blockIdx.y;
+    const int     tid     = threadIdx.x;
+    const int     pack_idx      = tid % THREADS_PER_ROW;
+    const int     load_row_base = tid / THREADS_PER_ROW;
+
+    const int64_t M_padded = padded_group_offs_ptr[num_groups];
+    const int64_t pad_block_start = pid_m * BLOCK_SIZE;
+    if (pad_block_start >= M_padded) return;
+
+    int group_id = 0;
+    #pragma unroll 1
+    for (int g = 0; g < num_groups; ++g) {
+        if (pad_block_start >= padded_group_offs_ptr[g] &&
+            pad_block_start <  padded_group_offs_ptr[g + 1]) group_id = g;
+    }
+    const int64_t orig_start = group_offs_ptr[group_id];
+    const int64_t orig_end   = group_offs_ptr[group_id + 1];
+    const int64_t pad_start  = padded_group_offs_ptr[group_id];
+
+    const int64_t col_start      = col_blk * BLOCK_SIZE;
+    const float   clip_lo = -static_cast<float>(fp8_max);
+    const float   clip_hi =  static_cast<float>(fp8_max);
+
+    float vals[ROUNDS][PACK];
+    float col_amax_local[PACK];
+    #pragma unroll
+    for (int i = 0; i < PACK; ++i) col_amax_local[i] = 0.f;
+
+    __shared__ bool s_valid_row[BLOCK_SIZE];
+
+    #pragma unroll
+    for (int r = 0; r < ROUNDS; ++r) {
+        const int local_m = load_row_base + r * ROWS_PER_ROUND;
+        const int local_n = pack_idx * PACK;
+        const int64_t in_m    = orig_start + (pad_block_start + local_m - pad_start);
+        const bool    valid_in = (in_m >= orig_start) && (in_m < orig_end) && (in_m < M_in);
+        if (pack_idx == 0) s_valid_row[local_m] = valid_in;
+
+        const int64_t gn = col_start + local_n;
+        FType buf[PACK];
+        if (valid_in && gn + PACK <= N) {
+            load_data<FType, PACK>(x_ptr + in_m * N + gn, buf);
+        } else {
+            #pragma unroll
+            for (int i = 0; i < PACK; ++i) {
+                const int64_t cn = gn + i;
+                buf[i] = (valid_in && cn < N) ? x_ptr[in_m * N + cn] : static_cast<FType>(0.f);
+            }
+        }
+
+        float row_amax = 0.f;
+        #pragma unroll
+        for (int i = 0; i < PACK; ++i) {
+            const float v  = static_cast<float>(buf[i]);
+            const float av = fabsf(v);
+            vals[r][i] = v;
+            row_amax = fmaxf(row_amax, av);
+            if (valid_in) col_amax_local[i] = fmaxf(col_amax_local[i], av);
+        }
+        #pragma unroll
+        for (int offset = THREADS_PER_ROW >> 1; offset > 0; offset >>= 1) {
+            row_amax = fmaxf(row_amax, __shfl_xor(row_amax, offset, THREADS_PER_ROW));
+        }
+        const float row_scale = static_cast<float>(fp8_max) / fmaxf(row_amax, 1e-4f);
+
+        if (valid_in) {
+            QType out[PACK];
+            #pragma unroll
+            for (int i = 0; i < PACK; ++i) {
+                out[i] = static_cast<QType>(fmaxf(fminf(vals[r][i] * row_scale, clip_hi), clip_lo));
+            }
+            if (gn + PACK <= N) {
+                store_data<QType, PACK>(x_fp8_row_ptr + in_m * N + gn, out);
+            } else {
+                #pragma unroll
+                for (int i = 0; i < PACK; ++i) {
+                    const int64_t cn = gn + i;
+                    if (cn < N) x_fp8_row_ptr[in_m * N + cn] = out[i];
+                }
+            }
+            if (pack_idx == 0) {
+                // Pshuffled [N_blocks, M_in]: matches the persistent fwd GEMM scale order.
+                x_scales_row_ptr[col_blk * M_in + in_m] = 1.0f / row_scale;
+            }
+        }
+    }
+
+    __shared__ float s_col_partial[ROWS_PER_ROUND][BLOCK_SIZE];   // 8KB
+    #pragma unroll
+    for (int i = 0; i < PACK; ++i) {
+        s_col_partial[load_row_base][pack_idx * PACK + i] = col_amax_local[i];
+    }
+    __syncthreads();
+
+    __shared__ float s_col_scale[BLOCK_SIZE];
+    if (tid < BLOCK_SIZE) {
+        float col_amax = 0.f;
+        #pragma unroll
+        for (int rs = 0; rs < ROWS_PER_ROUND; ++rs) {
+            col_amax = fmaxf(col_amax, s_col_partial[rs][tid]);
+        }
+        const float col_scale = static_cast<float>(fp8_max) / fmaxf(col_amax, 1e-4f);
+        s_col_scale[tid] = col_scale;
+        const int64_t gn = col_start + tid;
+        if (gn < N) x_scales_col_padded_ptr[pid_m * N + gn] = 1.0f / col_scale;
+    }
+    __syncthreads();
+
+    #pragma unroll
+    for (int r = 0; r < ROUNDS; ++r) {
+        const int local_m = load_row_base + r * ROWS_PER_ROUND;
+        const int local_n = pack_idx * PACK;
+        const int64_t out_m = pad_block_start + local_m;
+        const int64_t gn    = col_start + local_n;
+        const bool    valid = s_valid_row[local_m];
+
+        QType out[PACK];
+        #pragma unroll
+        for (int i = 0; i < PACK; ++i) {
+            const float v = valid ? vals[r][i] : 0.f;
+            out[i] = static_cast<QType>(
+                fmaxf(fminf(v * s_col_scale[local_n + i], clip_hi), clip_lo));
+        }
+        if (out_m < M_padded && gn + PACK <= N) {
+            store_data<QType, PACK>(x_fp8_col_padded_ptr + out_m * N + gn, out);
+        } else if (out_m < M_padded) {
+            #pragma unroll
+            for (int i = 0; i < PACK; ++i) {
+                const int64_t cn = gn + i;
+                if (cn < N) x_fp8_col_padded_ptr[out_m * N + cn] = out[i];
+            }
+        }
+    }
+}
+
+template <typename FType, typename QType>
+void quantize_blockwise_segment_m_row_col_impl(
+    const FType *x, QType *y_row, QType *y_col_padded,
+    float *scales_row, float *scales_col_padded,
+    const int64_t *group_offs, const int64_t *padded_group_offs,
+    const int64_t M_in, const int64_t N, const int64_t M_padded_max,
+    const int num_groups, const float fp8_max, hipStream_t stream) {
+    constexpr int BLOCK_SIZE = 128;
+    const int64_t m_blocks = (M_padded_max + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    const int64_t n_blocks = (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    dim3 grid(m_blocks, n_blocks);
+    quant_fp8_blockwise_segment_m_row_col_kernel<FType, QType>
+        <<<grid, dim3(256), 0, stream>>>(
+            x, y_row, y_col_padded, scales_row, scales_col_padded,
+            group_offs, padded_group_offs, M_in, N, num_groups, fp8_max);
+}
+
+#define DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(FType, QType)                          \
+    template void quantize_blockwise_segment_m_row_col_impl<FType, QType>(        \
+        const FType *x, QType *y_row, QType *y_col_padded, float *scales_row,           \
+        float *scales_col_padded, const int64_t *group_offs,                            \
+        const int64_t *padded_group_offs, const int64_t M_in, const int64_t N,          \
+        const int64_t M_padded_max, const int num_groups, const float fp8_max,          \
+        hipStream_t stream);
+DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(dtype::bfloat16, dtype::float8_e4m3)
+DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(dtype::bfloat16, dtype::float8_e5m2)
+DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(dtype::float16, dtype::float8_e4m3)
+DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(dtype::float16, dtype::float8_e5m2)
+#undef DECL_QUANT_BLOCKWISE_SEGM_INSTANCE
+
+} // namespace primus_turbo

--- a/csrc/kernels/quantization/quantization_blockwise.cu
+++ b/csrc/kernels/quantization/quantization_blockwise.cu
@@ -3,6 +3,7 @@
 // See LICENSE for license information.
 
 #include "primus_turbo/common.h"
+#include "primus_turbo/device/reduce.cuh"
 #include "primus_turbo/device/utils.cuh"
 #include "primus_turbo/quantization.h"
 
@@ -236,5 +237,117 @@ DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(dtype::bfloat16, dtype::float8_e5m2)
 DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(dtype::float16, dtype::float8_e4m3)
 DECL_QUANT_BLOCKWISE_SEGM_INSTANCE(dtype::float16, dtype::float8_e5m2)
 #undef DECL_QUANT_BLOCKWISE_SEGM_INSTANCE
+
+// Weight blockwise FP8 quant: 3D weight [B, M, N], one scalar scale per [128,128]
+// tile. 256 threads/block; vec-8 packed loads; BlockReduce<AbsMax>.
+template <typename FType, typename QType>
+__launch_bounds__(256) __global__
+void quant_fp8_blockwise_for_weight_kernel(const FType *__restrict__ w_ptr,
+                                           QType *__restrict__ w_fp8_ptr,
+                                           float *__restrict__ w_scales_inv_ptr,
+                                           const int64_t M, const int64_t N,
+                                           const float fp8_max) {
+    constexpr int BLOCK_SIZE = 128;
+    constexpr int PACK       = 8;
+    constexpr int THREADS_PER_ROW = BLOCK_SIZE / PACK;            // 16
+    constexpr int ROWS_PER_ROUND  = 256 / THREADS_PER_ROW;        // 16
+    constexpr int ROUNDS          = BLOCK_SIZE / ROWS_PER_ROUND;  // 8
+
+    const int64_t bid     = blockIdx.x;
+    const int64_t row_blk = blockIdx.y;
+    const int64_t col_blk = blockIdx.z;
+    const int     tid     = threadIdx.x;
+    const int     pack_idx      = tid % THREADS_PER_ROW;
+    const int     load_row_base = tid / THREADS_PER_ROW;
+
+    const int64_t row_start = row_blk * BLOCK_SIZE;
+    const int64_t col_start = col_blk * BLOCK_SIZE;
+    const int64_t batch_off = bid * M * N;
+
+    float vals[ROUNDS][PACK];
+    float amax = 0.f;
+
+    #pragma unroll
+    for (int r = 0; r < ROUNDS; ++r) {
+        const int local_m = load_row_base + r * ROWS_PER_ROUND;
+        const int local_n = pack_idx * PACK;
+        const int64_t gm  = row_start + local_m;
+        const int64_t gn  = col_start + local_n;
+        FType buf[PACK];
+        if (gm < M && gn + PACK <= N) {
+            load_data<FType, PACK>(w_ptr + batch_off + gm * N + gn, buf);
+        } else {
+            #pragma unroll
+            for (int i = 0; i < PACK; ++i) {
+                const int64_t cn = gn + i;
+                buf[i] = (gm < M && cn < N) ? w_ptr[batch_off + gm * N + cn]
+                                            : static_cast<FType>(0.f);
+            }
+        }
+        #pragma unroll
+        for (int i = 0; i < PACK; ++i) {
+            const float v = static_cast<float>(buf[i]);
+            vals[r][i] = v;
+            amax = fmaxf(amax, fabsf(v));
+        }
+    }
+
+    amax = BlockReduce<AbsMaxOp, float>(amax);
+    // Clamp eps matches Triton reference (tl.maximum(w_tile_max, 1e-4)).
+    const float scale   = static_cast<float>(fp8_max) / fmaxf(amax, 1e-4f);
+    const float clip_lo = -static_cast<float>(fp8_max);
+    const float clip_hi =  static_cast<float>(fp8_max);
+
+    if (tid == 0) {
+        const int64_t sn = (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
+        const int64_t sm = (M + BLOCK_SIZE - 1) / BLOCK_SIZE;
+        w_scales_inv_ptr[bid * sm * sn + row_blk * sn + col_blk] = 1.0f / scale;
+    }
+
+    #pragma unroll
+    for (int r = 0; r < ROUNDS; ++r) {
+        const int local_m = load_row_base + r * ROWS_PER_ROUND;
+        const int local_n = pack_idx * PACK;
+        const int64_t gm  = row_start + local_m;
+        const int64_t gn  = col_start + local_n;
+        QType out[PACK];
+        #pragma unroll
+        for (int i = 0; i < PACK; ++i) {
+            out[i] = static_cast<QType>(fmaxf(fminf(vals[r][i] * scale, clip_hi), clip_lo));
+        }
+        if (gm < M && gn + PACK <= N) {
+            store_data<QType, PACK>(w_fp8_ptr + batch_off + gm * N + gn, out);
+        } else if (gm < M) {
+            #pragma unroll
+            for (int i = 0; i < PACK; ++i) {
+                const int64_t cn = gn + i;
+                if (cn < N) w_fp8_ptr[batch_off + gm * N + cn] = out[i];
+            }
+        }
+    }
+}
+
+template <typename FType, typename QType>
+void quantize_blockwise_for_weight_impl(const FType *w, QType *w_fp8, float *w_scales_inv,
+                                         const int64_t B, const int64_t M, const int64_t N,
+                                         const float fp8_max, hipStream_t stream) {
+    constexpr int BLOCK_SIZE = 128;
+    const int64_t m_blocks = (M + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    const int64_t n_blocks = (N + BLOCK_SIZE - 1) / BLOCK_SIZE;
+    dim3 grid(B, m_blocks, n_blocks);
+    quant_fp8_blockwise_for_weight_kernel<FType, QType>
+        <<<grid, dim3(256), 0, stream>>>(w, w_fp8, w_scales_inv, M, N, fp8_max);
+}
+
+#define DECL_QUANT_BLOCKWISE_FOR_WEIGHT_INSTANCE(FType, QType)                          \
+    template void quantize_blockwise_for_weight_impl<FType, QType>(                     \
+        const FType *w, QType *w_fp8, float *w_scales_inv,                              \
+        const int64_t B, const int64_t M, const int64_t N,                              \
+        const float fp8_max, hipStream_t stream);
+DECL_QUANT_BLOCKWISE_FOR_WEIGHT_INSTANCE(dtype::bfloat16, dtype::float8_e4m3)
+DECL_QUANT_BLOCKWISE_FOR_WEIGHT_INSTANCE(dtype::bfloat16, dtype::float8_e5m2)
+DECL_QUANT_BLOCKWISE_FOR_WEIGHT_INSTANCE(dtype::float16, dtype::float8_e4m3)
+DECL_QUANT_BLOCKWISE_FOR_WEIGHT_INSTANCE(dtype::float16, dtype::float8_e5m2)
+#undef DECL_QUANT_BLOCKWISE_FOR_WEIGHT_INSTANCE
 
 } // namespace primus_turbo

--- a/csrc/pytorch/bindings_pytorch.cpp
+++ b/csrc/pytorch/bindings_pytorch.cpp
@@ -34,6 +34,8 @@ TORCH_LIBRARY(primus_turbo_cpp_extension, m) {
           "scale_opt=None) -> Tensor[]");
     m.def("quantize_fp8_blockwise_segment_m_row_col(Tensor input, ScalarType dest_dtype, "
           "int block_size, Tensor group_lens, Tensor group_offs) -> Tensor[]");
+    m.def("quantize_fp8_blockwise_for_weight(Tensor input, ScalarType dest_dtype, int block_size) "
+          "-> Tensor[]");
 
     m.def("dequantize_fp8_tensorwise(Tensor input, Tensor scale_inv, ScalarType dest_dtype) -> "
           "Tensor");
@@ -113,6 +115,7 @@ TORCH_LIBRARY_IMPL(primus_turbo_cpp_extension, CUDA, m) {
     m.impl("quantize_fp8_rowwise", quantize_fp8_rowwise);
     m.impl("dequantize_fp8_rowwise", dequantize_fp8_rowwise);
     m.impl("quantize_fp8_blockwise_segment_m_row_col", quantize_fp8_blockwise_segment_m_row_col);
+    m.impl("quantize_fp8_blockwise_for_weight", quantize_fp8_blockwise_for_weight);
 
     // ********* MXFP4 Quantization *********
     m.impl("quantize_mxfp4_dual", quantize_mxfp4_dual);
@@ -155,6 +158,7 @@ TORCH_LIBRARY_IMPL(primus_turbo_cpp_extension, Meta, m) {
     m.impl("dequantize_fp8_rowwise", dequantize_fp8_rowwise_meta);
     m.impl("quantize_fp8_blockwise_segment_m_row_col",
            quantize_fp8_blockwise_segment_m_row_col_meta);
+    m.impl("quantize_fp8_blockwise_for_weight", quantize_fp8_blockwise_for_weight_meta);
 
     // ********* MXFP4 Quantization *********
     m.impl("quantize_mxfp4_dual", quantize_mxfp4_dual_meta);

--- a/csrc/pytorch/bindings_pytorch.cpp
+++ b/csrc/pytorch/bindings_pytorch.cpp
@@ -32,6 +32,8 @@ TORCH_LIBRARY(primus_turbo_cpp_extension, m) {
           "Tensor[]");
     m.def("quantize_fp8_rowwise(Tensor input, ScalarType dest_dtype, int axis, Tensor? "
           "scale_opt=None) -> Tensor[]");
+    m.def("quantize_fp8_blockwise_segment_m_row_col(Tensor input, ScalarType dest_dtype, "
+          "int block_size, Tensor group_lens, Tensor group_offs) -> Tensor[]");
 
     m.def("dequantize_fp8_tensorwise(Tensor input, Tensor scale_inv, ScalarType dest_dtype) -> "
           "Tensor");
@@ -110,6 +112,7 @@ TORCH_LIBRARY_IMPL(primus_turbo_cpp_extension, CUDA, m) {
     m.impl("dequantize_fp8_tensorwise", dequantize_fp8_tensorwise);
     m.impl("quantize_fp8_rowwise", quantize_fp8_rowwise);
     m.impl("dequantize_fp8_rowwise", dequantize_fp8_rowwise);
+    m.impl("quantize_fp8_blockwise_segment_m_row_col", quantize_fp8_blockwise_segment_m_row_col);
 
     // ********* MXFP4 Quantization *********
     m.impl("quantize_mxfp4_dual", quantize_mxfp4_dual);
@@ -150,6 +153,8 @@ TORCH_LIBRARY_IMPL(primus_turbo_cpp_extension, Meta, m) {
     m.impl("dequantize_fp8_tensorwise", dequantize_fp8_tensorwise_meta);
     m.impl("quantize_fp8_rowwise", quantize_fp8_rowwise_meta);
     m.impl("dequantize_fp8_rowwise", dequantize_fp8_rowwise_meta);
+    m.impl("quantize_fp8_blockwise_segment_m_row_col",
+           quantize_fp8_blockwise_segment_m_row_col_meta);
 
     // ********* MXFP4 Quantization *********
     m.impl("quantize_mxfp4_dual", quantize_mxfp4_dual_meta);

--- a/csrc/pytorch/extensions.h
+++ b/csrc/pytorch/extensions.h
@@ -33,9 +33,11 @@ std::vector<at::Tensor> quantize_fp8_tensorwise_meta(const at::Tensor          i
                                                      const at::ScalarType      dest_dtype,
                                                      c10::optional<at::Tensor> scale_opt);
 
-std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col(
-    const at::Tensor input, const at::ScalarType dest_dtype, const int64_t block_size,
-    const at::Tensor group_lens, const at::Tensor group_offs);
+std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col(const at::Tensor     input,
+                                                                 const at::ScalarType dest_dtype,
+                                                                 const int64_t        block_size,
+                                                                 const at::Tensor     group_lens,
+                                                                 const at::Tensor     group_offs);
 
 std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col_meta(
     const at::Tensor input, const at::ScalarType dest_dtype, const int64_t block_size,

--- a/csrc/pytorch/extensions.h
+++ b/csrc/pytorch/extensions.h
@@ -41,6 +41,14 @@ std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col_meta(
     const at::Tensor input, const at::ScalarType dest_dtype, const int64_t block_size,
     const at::Tensor group_lens, const at::Tensor group_offs);
 
+std::vector<at::Tensor> quantize_fp8_blockwise_for_weight(const at::Tensor     input,
+                                                          const at::ScalarType dest_dtype,
+                                                          const int64_t        block_size);
+
+std::vector<at::Tensor> quantize_fp8_blockwise_for_weight_meta(const at::Tensor     input,
+                                                               const at::ScalarType dest_dtype,
+                                                               const int64_t        block_size);
+
 std::vector<at::Tensor> quantize_fp8_rowwise(const at::Tensor     input,
                                              const at::ScalarType dest_dtype, const int64_t axis,
                                              c10::optional<at::Tensor> scale_opt);

--- a/csrc/pytorch/extensions.h
+++ b/csrc/pytorch/extensions.h
@@ -33,6 +33,14 @@ std::vector<at::Tensor> quantize_fp8_tensorwise_meta(const at::Tensor          i
                                                      const at::ScalarType      dest_dtype,
                                                      c10::optional<at::Tensor> scale_opt);
 
+std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col(
+    const at::Tensor input, const at::ScalarType dest_dtype, const int64_t block_size,
+    const at::Tensor group_lens, const at::Tensor group_offs);
+
+std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col_meta(
+    const at::Tensor input, const at::ScalarType dest_dtype, const int64_t block_size,
+    const at::Tensor group_lens, const at::Tensor group_offs);
+
 std::vector<at::Tensor> quantize_fp8_rowwise(const at::Tensor     input,
                                              const at::ScalarType dest_dtype, const int64_t axis,
                                              c10::optional<at::Tensor> scale_opt);

--- a/csrc/pytorch/grouped_gemm/ck_grouped_gemm.cpp
+++ b/csrc/pytorch/grouped_gemm/ck_grouped_gemm.cpp
@@ -195,9 +195,12 @@ at::Tensor ck_grouped_gemm_fp8(at::Tensor &a, at::Tensor &b, at::Tensor &a_scale
                 else if (granularity == "ROWWISE")
                     primus_turbo::ck_grouped_gemm_fp8<AType, BType, CType, float,
                                                       ck_tile::QuantType::RowColQuant>(params);
-                else // BLOCKWISE
-                primus_turbo::ck_grouped_gemm_fp8<AType, BType, CType, float,
-                                                  ck_tile::QuantType::ABQuantGrouped>(params);)))
+                else // BLOCKWISE: CK support dropped; Triton is the production blockwise path.
+                     // primus_turbo::ck_grouped_gemm_fp8<AType, BType, CType, float,
+                     //                                   ck_tile::QuantType::ABQuantGrouped>(params);
+                PRIMUS_TURBO_CHECK(
+                    false,
+                    "CK grouped GEMM FP8 does not support BLOCKWISE; use the Triton backend.");)))
 
     return c;
 }
@@ -315,9 +318,12 @@ at::Tensor ck_grouped_gemm_fp8_variable_k(at::Tensor &a, at::Tensor &b, at::Tens
                     primus_turbo::ck_grouped_gemm_fp8_variable_k<AType, BType, CType, float,
                                                                  ck_tile::QuantType::RowColQuant>(
                         params);
-                else // BLOCKWISE
-                primus_turbo::ck_grouped_gemm_fp8_variable_k<
-                    AType, BType, CType, float, ck_tile::QuantType::ABQuantGrouped>(params);)))
+                else // BLOCKWISE: CK support dropped; Triton is the production blockwise path.
+                     // primus_turbo::ck_grouped_gemm_fp8_variable_k<
+                     //     AType, BType, CType, float, ck_tile::QuantType::ABQuantGrouped>(params);
+                PRIMUS_TURBO_CHECK(false,
+                                   "CK grouped GEMM FP8 variable-K does not support BLOCKWISE; "
+                                   "use the Triton backend.");)))
 
     return c;
 }

--- a/csrc/pytorch/quantization/quantization.cpp
+++ b/csrc/pytorch/quantization/quantization.cpp
@@ -658,9 +658,11 @@ std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarT
 // One bf16/fp16 read of `input` [M, N] emits the row-wise scaled tensor (fwd/dgrad)
 // and the segment-padded col-wise scaled tensor (variable-K wgrad). Row scales are
 // pshuffled [N_blocks, M] to match the persistent GEMM's coalesced scale reads.
-std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col(
-    const at::Tensor input, const at::ScalarType dest_dtype, const int64_t block_size,
-    const at::Tensor group_lens, const at::Tensor group_offs) {
+std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col(const at::Tensor     input,
+                                                                 const at::ScalarType dest_dtype,
+                                                                 const int64_t        block_size,
+                                                                 const at::Tensor     group_lens,
+                                                                 const at::Tensor     group_offs) {
     PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf);
     PRIMUS_TURBO_CHECK(is_torch_fp8(dest_dtype));
     PRIMUS_TURBO_CHECK(input.dim() == 2);
@@ -675,19 +677,19 @@ std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col(
     // Segment-padded group offsets on-device (avoids div + zeros + cumsum host ops).
     auto var_k_group_lens = at::empty({num_groups}, group_lens.options());
     auto var_k_group_offs = at::empty({num_groups + 1}, group_lens.options());
-    compute_padded_group_offs<int64_t>(
-        reinterpret_cast<const int64_t *>(group_lens.data_ptr()),
-        reinterpret_cast<int64_t *>(var_k_group_lens.data_ptr()),
-        reinterpret_cast<int64_t *>(var_k_group_offs.data_ptr()), num_groups, block_size, stream);
+    compute_padded_group_offs<int64_t>(reinterpret_cast<const int64_t *>(group_lens.data_ptr()),
+                                       reinterpret_cast<int64_t *>(var_k_group_lens.data_ptr()),
+                                       reinterpret_cast<int64_t *>(var_k_group_offs.data_ptr()),
+                                       num_groups, block_size, stream);
 
     const int64_t M_padded_max = M + num_groups * block_size;
 
     // Kernel mask-writes cover every position read downstream, so skip zero-init.
     // Row scales emitted pshuffled [N_blocks, M] to match the fwd GEMM layout.
-    auto x_fp8_row           = at::empty({M, N}, input.options().dtype(dest_dtype));
-    auto x_fp8_col_padded    = at::empty({M_padded_max, N}, input.options().dtype(dest_dtype));
-    auto x_scales_row        = at::empty({(N + block_size - 1) / block_size, M},
-                                         input.options().dtype(at::kFloat));
+    auto x_fp8_row        = at::empty({M, N}, input.options().dtype(dest_dtype));
+    auto x_fp8_col_padded = at::empty({M_padded_max, N}, input.options().dtype(dest_dtype));
+    auto x_scales_row =
+        at::empty({(N + block_size - 1) / block_size, M}, input.options().dtype(at::kFloat));
     auto x_scales_col_padded = at::empty({(M_padded_max + block_size - 1) / block_size, N},
                                          input.options().dtype(at::kFloat));
 
@@ -706,8 +708,8 @@ std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col(
         });
     });
 
-    return {x_fp8_row, x_fp8_col_padded, x_scales_row, x_scales_col_padded, var_k_group_lens,
-            var_k_group_offs};
+    return {x_fp8_row,           x_fp8_col_padded, x_scales_row,
+            x_scales_col_padded, var_k_group_lens, var_k_group_offs};
 }
 
 // Blockwise FP8 weight quant: 2D [M, N] or 3D [B, M, N], one scalar scale per [128,128] tile.
@@ -716,7 +718,8 @@ std::vector<at::Tensor> quantize_fp8_blockwise_for_weight(const at::Tensor     i
                                                           const int64_t        block_size) {
     PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf);
     PRIMUS_TURBO_CHECK(is_torch_fp8(dest_dtype));
-    PRIMUS_TURBO_CHECK(input.dim() == 2 || input.dim() == 3, "weight quant requires 2D or 3D input");
+    PRIMUS_TURBO_CHECK(input.dim() == 2 || input.dim() == 3,
+                       "weight quant requires 2D or 3D input");
     PRIMUS_TURBO_CHECK(block_size == 128, "only block_size=128 currently supported");
 
     const bool    is_2d    = (input.dim() == 2);
@@ -728,10 +731,10 @@ std::vector<at::Tensor> quantize_fp8_blockwise_for_weight(const at::Tensor     i
 
     std::vector<int64_t> out_shape =
         is_2d ? std::vector<int64_t>{M, N} : std::vector<int64_t>{B, M, N};
-    std::vector<int64_t> scale_shape =
-        is_2d ? std::vector<int64_t>{m_blocks, n_blocks} : std::vector<int64_t>{B, m_blocks, n_blocks};
-    auto output    = at::empty(out_shape, input.options().dtype(dest_dtype));
-    auto scale_inv = at::empty(scale_shape, input.options().dtype(at::kFloat));
+    std::vector<int64_t> scale_shape = is_2d ? std::vector<int64_t>{m_blocks, n_blocks}
+                                             : std::vector<int64_t>{B, m_blocks, n_blocks};
+    auto                 output      = at::empty(out_shape, input.options().dtype(dest_dtype));
+    auto                 scale_inv   = at::empty(scale_shape, input.options().dtype(at::kFloat));
 
     auto        stream  = at::cuda::getCurrentCUDAStream();
     const float fp8_max = get_float8_max(dest_dtype);

--- a/csrc/pytorch/quantization/quantization.cpp
+++ b/csrc/pytorch/quantization/quantization.cpp
@@ -710,4 +710,40 @@ std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col(
             var_k_group_offs};
 }
 
+// Blockwise FP8 weight quant: 2D [M, N] or 3D [B, M, N], one scalar scale per [128,128] tile.
+std::vector<at::Tensor> quantize_fp8_blockwise_for_weight(const at::Tensor     input,
+                                                          const at::ScalarType dest_dtype,
+                                                          const int64_t        block_size) {
+    PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf);
+    PRIMUS_TURBO_CHECK(is_torch_fp8(dest_dtype));
+    PRIMUS_TURBO_CHECK(input.dim() == 2 || input.dim() == 3, "weight quant requires 2D or 3D input");
+    PRIMUS_TURBO_CHECK(block_size == 128, "only block_size=128 currently supported");
+
+    const bool    is_2d    = (input.dim() == 2);
+    const int64_t B        = is_2d ? 1 : input.size(0);
+    const int64_t M        = is_2d ? input.size(0) : input.size(1);
+    const int64_t N        = is_2d ? input.size(1) : input.size(2);
+    const int64_t m_blocks = (M + block_size - 1) / block_size;
+    const int64_t n_blocks = (N + block_size - 1) / block_size;
+
+    std::vector<int64_t> out_shape =
+        is_2d ? std::vector<int64_t>{M, N} : std::vector<int64_t>{B, M, N};
+    std::vector<int64_t> scale_shape =
+        is_2d ? std::vector<int64_t>{m_blocks, n_blocks} : std::vector<int64_t>{B, m_blocks, n_blocks};
+    auto output    = at::empty(out_shape, input.options().dtype(dest_dtype));
+    auto scale_inv = at::empty(scale_shape, input.options().dtype(at::kFloat));
+
+    auto        stream  = at::cuda::getCurrentCUDAStream();
+    const float fp8_max = get_float8_max(dest_dtype);
+    TORCH_TYPE_SWITCH_FP16_BF16(input.scalar_type(), FType, {
+        TORCH_TYPE_SWITCH_FP8(output.scalar_type(), QType, {
+            quantize_blockwise_for_weight_impl<FType, QType>(
+                reinterpret_cast<const FType *>(input.data_ptr()),
+                reinterpret_cast<QType *>(output.data_ptr()),
+                reinterpret_cast<float *>(scale_inv.data_ptr()), B, M, N, fp8_max, stream);
+        });
+    });
+    return {output, scale_inv};
+}
+
 } // namespace primus_turbo::pytorch

--- a/csrc/pytorch/quantization/quantization.cpp
+++ b/csrc/pytorch/quantization/quantization.cpp
@@ -654,4 +654,60 @@ std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarT
     return {output.view(dest_dtype), scale_tensor.view(at::kFloat8_e8m0fnu)};
 }
 
+// Fused single-pass row + segment-padded col blockwise FP8 quant for grouped GEMM.
+// One bf16/fp16 read of `input` [M, N] emits the row-wise scaled tensor (fwd/dgrad)
+// and the segment-padded col-wise scaled tensor (variable-K wgrad). Row scales are
+// pshuffled [N_blocks, M] to match the persistent GEMM's coalesced scale reads.
+std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col(
+    const at::Tensor input, const at::ScalarType dest_dtype, const int64_t block_size,
+    const at::Tensor group_lens, const at::Tensor group_offs) {
+    PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf);
+    PRIMUS_TURBO_CHECK(is_torch_fp8(dest_dtype));
+    PRIMUS_TURBO_CHECK(input.dim() == 2);
+    PRIMUS_TURBO_CHECK(block_size == 128);
+
+    const int64_t M          = input.size(0);
+    const int64_t N          = input.size(1);
+    const int     num_groups = static_cast<int>(group_lens.size(0));
+
+    auto stream = at::cuda::getCurrentCUDAStream();
+
+    // Segment-padded group offsets on-device (avoids div + zeros + cumsum host ops).
+    auto var_k_group_lens = at::empty({num_groups}, group_lens.options());
+    auto var_k_group_offs = at::empty({num_groups + 1}, group_lens.options());
+    compute_padded_group_offs<int64_t>(
+        reinterpret_cast<const int64_t *>(group_lens.data_ptr()),
+        reinterpret_cast<int64_t *>(var_k_group_lens.data_ptr()),
+        reinterpret_cast<int64_t *>(var_k_group_offs.data_ptr()), num_groups, block_size, stream);
+
+    const int64_t M_padded_max = M + num_groups * block_size;
+
+    // Kernel mask-writes cover every position read downstream, so skip zero-init.
+    // Row scales emitted pshuffled [N_blocks, M] to match the fwd GEMM layout.
+    auto x_fp8_row           = at::empty({M, N}, input.options().dtype(dest_dtype));
+    auto x_fp8_col_padded    = at::empty({M_padded_max, N}, input.options().dtype(dest_dtype));
+    auto x_scales_row        = at::empty({(N + block_size - 1) / block_size, M},
+                                         input.options().dtype(at::kFloat));
+    auto x_scales_col_padded = at::empty({(M_padded_max + block_size - 1) / block_size, N},
+                                         input.options().dtype(at::kFloat));
+
+    const float fp8_max = get_float8_max(dest_dtype);
+    TORCH_TYPE_SWITCH_FP16_BF16(input.scalar_type(), FType, {
+        TORCH_TYPE_SWITCH_FP8(x_fp8_row.scalar_type(), QType, {
+            quantize_blockwise_segment_m_row_col_impl<FType, QType>(
+                reinterpret_cast<const FType *>(input.data_ptr()),
+                reinterpret_cast<QType *>(x_fp8_row.data_ptr()),
+                reinterpret_cast<QType *>(x_fp8_col_padded.data_ptr()),
+                reinterpret_cast<float *>(x_scales_row.data_ptr()),
+                reinterpret_cast<float *>(x_scales_col_padded.data_ptr()),
+                reinterpret_cast<const int64_t *>(group_offs.data_ptr()),
+                reinterpret_cast<const int64_t *>(var_k_group_offs.data_ptr()), M, N, M_padded_max,
+                num_groups, fp8_max, stream);
+        });
+    });
+
+    return {x_fp8_row, x_fp8_col_padded, x_scales_row, x_scales_col_padded, var_k_group_lens,
+            var_k_group_offs};
+}
+
 } // namespace primus_turbo::pytorch

--- a/csrc/pytorch/quantization/quantization.cpp
+++ b/csrc/pytorch/quantization/quantization.cpp
@@ -667,6 +667,11 @@ std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col(const at::Tenso
     PRIMUS_TURBO_CHECK(is_torch_fp8(dest_dtype));
     PRIMUS_TURBO_CHECK(input.dim() == 2);
     PRIMUS_TURBO_CHECK(block_size == 128);
+    for (const auto &t : {group_lens, group_offs}) {
+        PRIMUS_TURBO_CHECK(t.is_cuda(), "group_lens / group_offs must be CUDA tensors");
+        PRIMUS_TURBO_CHECK(t.scalar_type() == at::kLong, "group_lens / group_offs must be int64");
+        PRIMUS_TURBO_CHECK(t.is_contiguous(), "group_lens / group_offs must be contiguous");
+    }
 
     const int64_t M          = input.size(0);
     const int64_t N          = input.size(1);

--- a/csrc/pytorch/quantization/quantization_meta.cpp
+++ b/csrc/pytorch/quantization/quantization_meta.cpp
@@ -333,4 +333,22 @@ std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col_meta(
     };
 }
 
+std::vector<at::Tensor> quantize_fp8_blockwise_for_weight_meta(const at::Tensor     input,
+                                                              const at::ScalarType dest_dtype,
+                                                              const int64_t        block_size) {
+    PRIMUS_TURBO_CHECK(input.dim() == 2 || input.dim() == 3);
+    const bool    is_2d    = (input.dim() == 2);
+    const int64_t B        = is_2d ? 1 : input.size(0);
+    const int64_t M        = is_2d ? input.size(0) : input.size(1);
+    const int64_t N        = is_2d ? input.size(1) : input.size(2);
+    const int64_t m_blocks = (M + block_size - 1) / block_size;
+    const int64_t n_blocks = (N + block_size - 1) / block_size;
+    auto          fp8_meta  = at::dtype(dest_dtype).device(at::kMeta);
+    auto          fp32_meta = at::dtype(at::kFloat).device(at::kMeta);
+    if (is_2d) {
+        return {at::empty({M, N}, fp8_meta), at::empty({m_blocks, n_blocks}, fp32_meta)};
+    }
+    return {at::empty({B, M, N}, fp8_meta), at::empty({B, m_blocks, n_blocks}, fp32_meta)};
+}
+
 } // namespace primus_turbo::pytorch

--- a/csrc/pytorch/quantization/quantization_meta.cpp
+++ b/csrc/pytorch/quantization/quantization_meta.cpp
@@ -326,7 +326,7 @@ std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col_meta(
     return {
         at::empty({M, N}, fp8_meta),
         at::empty({M_padded_max, N}, fp8_meta),
-        at::empty({(N + block_size - 1) / block_size, M}, fp32_meta),  // pshuffled
+        at::empty({(N + block_size - 1) / block_size, M}, fp32_meta), // pshuffled
         at::empty({(M_padded_max + block_size - 1) / block_size, N}, fp32_meta),
         at::empty({num_groups}, i64_meta),
         at::empty({num_groups + 1}, i64_meta),
@@ -334,15 +334,15 @@ std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col_meta(
 }
 
 std::vector<at::Tensor> quantize_fp8_blockwise_for_weight_meta(const at::Tensor     input,
-                                                              const at::ScalarType dest_dtype,
-                                                              const int64_t        block_size) {
+                                                               const at::ScalarType dest_dtype,
+                                                               const int64_t        block_size) {
     PRIMUS_TURBO_CHECK(input.dim() == 2 || input.dim() == 3);
-    const bool    is_2d    = (input.dim() == 2);
-    const int64_t B        = is_2d ? 1 : input.size(0);
-    const int64_t M        = is_2d ? input.size(0) : input.size(1);
-    const int64_t N        = is_2d ? input.size(1) : input.size(2);
-    const int64_t m_blocks = (M + block_size - 1) / block_size;
-    const int64_t n_blocks = (N + block_size - 1) / block_size;
+    const bool    is_2d     = (input.dim() == 2);
+    const int64_t B         = is_2d ? 1 : input.size(0);
+    const int64_t M         = is_2d ? input.size(0) : input.size(1);
+    const int64_t N         = is_2d ? input.size(1) : input.size(2);
+    const int64_t m_blocks  = (M + block_size - 1) / block_size;
+    const int64_t n_blocks  = (N + block_size - 1) / block_size;
     auto          fp8_meta  = at::dtype(dest_dtype).device(at::kMeta);
     auto          fp32_meta = at::dtype(at::kFloat).device(at::kMeta);
     if (is_2d) {

--- a/csrc/pytorch/quantization/quantization_meta.cpp
+++ b/csrc/pytorch/quantization/quantization_meta.cpp
@@ -313,4 +313,24 @@ std::vector<at::Tensor> quantize_mxfp8_meta(const at::Tensor input, const at::Sc
     return {output.view(dest_dtype), scale_tensor.view(at::kFloat8_e8m0fnu)};
 }
 
+std::vector<at::Tensor> quantize_fp8_blockwise_segment_m_row_col_meta(
+    const at::Tensor input, const at::ScalarType dest_dtype, const int64_t block_size,
+    const at::Tensor group_lens, const at::Tensor group_offs) {
+    const int64_t M            = input.size(0);
+    const int64_t N            = input.size(1);
+    const int64_t num_groups   = group_lens.size(0);
+    const int64_t M_padded_max = M + num_groups * block_size;
+    auto          fp8_meta     = at::dtype(dest_dtype).device(at::kMeta);
+    auto          fp32_meta    = at::dtype(at::kFloat).device(at::kMeta);
+    auto          i64_meta     = at::dtype(at::kLong).device(at::kMeta);
+    return {
+        at::empty({M, N}, fp8_meta),
+        at::empty({M_padded_max, N}, fp8_meta),
+        at::empty({(N + block_size - 1) / block_size, M}, fp32_meta),  // pshuffled
+        at::empty({(M_padded_max + block_size - 1) / block_size, N}, fp32_meta),
+        at::empty({num_groups}, i64_meta),
+        at::empty({num_groups + 1}, i64_meta),
+    };
+}
+
 } // namespace primus_turbo::pytorch

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -48,10 +48,11 @@ _HYBRID_SUPPORTED_DTYPES = (
 
 
 class GroupedGEMMFP8CKBackend(KernelBackend):
+    # BLOCKWISE intentionally excluded: the Triton path (with pshuffled scales +
+    # HIP fused quant) is the production blockwise backend; CK adds no value here.
     SUPPORTED_GRANULARITIES = {
         ScalingGranularity.TENSORWISE,
         ScalingGranularity.ROWWISE,
-        ScalingGranularity.BLOCKWISE,
     }
 
     SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES + _HYBRID_SUPPORTED_DTYPES)
@@ -109,10 +110,10 @@ class GroupedGEMMFP8CKBackend(KernelBackend):
 
 
 class GroupedGEMMFP8VariableKCKBackend(KernelBackend):
+    # BLOCKWISE intentionally excluded: variable-K BLOCKWISE wgrad runs on Triton.
     SUPPORTED_GRANULARITIES = {
         ScalingGranularity.TENSORWISE,
         ScalingGranularity.ROWWISE,
-        ScalingGranularity.BLOCKWISE,
     }
 
     SUPPORTED_DTYPES = set(_COMMON_SUPPORTED_DTYPES + _HYBRID_SUPPORTED_DTYPES)

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -285,13 +285,6 @@ def quant_fp8_blockwise_for_weight_impl_meta(
     return w_fp8, w_scales
 
 
-# HIP wins on small surrounding GEMMs (single C++ call → low host overhead) but
-# loses on big ones (vreg pressure → 1 block/CU bottlenecks the next GEMM); pick
-# HIP only below this M_total*N*K threshold. Calibrated across LFM2 / Qwen3 /
-# DeepSeek-V3 / GPT-OSS BLOCKWISE shapes.
-_HIP_SEGMENT_GEMM_FLOPS_THRESHOLD = 70_000_000_000
-
-
 @torch.library.custom_op("primus_turbo::quant_fp8_blockwise_segment_m_row_col_impl", mutates_args=())
 def quant_fp8_blockwise_segment_m_row_col_impl(
     x: torch.Tensor,
@@ -322,13 +315,19 @@ def quant_fp8_blockwise_segment_m_row_col_impl(
     assert x.is_contiguous() and x.dim() == 2
     # HIP fast path: only when the C++ op is built and block_size == 128 (its
     # only supported size); otherwise fall through to the Triton kernel below.
+    # HIP wins on small surrounding GEMMs (single C++ call → low host overhead) but
+    # loses on big ones (vreg pressure → 1 block/CU bottlenecks the next GEMM), so it
+    # is gated by a GEMM-FLOPs threshold. TODO: this empirical threshold (calibrated
+    # across LFM2 / Qwen3 / DeepSeek-V3 / GPT-OSS BLOCKWISE shapes) is a heuristic —
+    # replace with a principled cost model / autotune signal when available.
+    hip_gemm_flops_threshold = 70_000_000_000
     if (
         gemm_other_dim is not None
         and block_size == 128
         and hasattr(torch.ops.primus_turbo_cpp_extension, "quantize_fp8_blockwise_segment_m_row_col")
     ):
         gemm_flops = x.size(0) * x.size(1) * gemm_other_dim
-        if gemm_flops <= _HIP_SEGMENT_GEMM_FLOPS_THRESHOLD:
+        if gemm_flops <= hip_gemm_flops_threshold:
             return torch.ops.primus_turbo_cpp_extension.quantize_fp8_blockwise_segment_m_row_col(
                 x, dtype, block_size, group_lens, group_offs
             )

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -8,7 +8,6 @@ from typing import Optional, Tuple, Union
 
 import torch
 import triton
-from torch.library import triton_op, wrap_triton
 
 from primus_turbo.pytorch.core.low_precision import (
     MXFP4_BLOCK_SIZE,
@@ -227,9 +226,7 @@ def quant_fp8_blockwise_for_weight_impl(
     # Triton kernel fallback when the C++ extension lacks the op. Benefits both the
     # grouped and non-grouped blockwise paths that quantize weights through here.
     if hasattr(torch.ops.primus_turbo_cpp_extension, "quantize_fp8_blockwise_for_weight"):
-        return torch.ops.primus_turbo_cpp_extension.quantize_fp8_blockwise_for_weight(
-            w, dtype, block_size
-        )
+        return torch.ops.primus_turbo_cpp_extension.quantize_fp8_blockwise_for_weight(w, dtype, block_size)
 
     ori_dims = w.dim()
     if ori_dims == 2:
@@ -346,11 +343,27 @@ def quant_fp8_blockwise_segment_m_row_col_impl(
     )
     grid = (triton.cdiv(M_padded_max, block_size), triton.cdiv(N, block_size))
     quant_fp8_blockwise_segment_m_row_col_kernel[grid](
-        x, x_fp8_row, x_fp8_col_padded, x_scales_row, x_scales_col_padded,
-        group_offs, var_k_group_offs, M, N, num_groups, block_size, torch.finfo(dtype).max,
+        x,
+        x_fp8_row,
+        x_fp8_col_padded,
+        x_scales_row,
+        x_scales_col_padded,
+        group_offs,
+        var_k_group_offs,
+        M,
+        N,
+        num_groups,
+        block_size,
+        torch.finfo(dtype).max,
     )
-    return (x_fp8_row, x_fp8_col_padded, x_scales_row, x_scales_col_padded,
-            var_k_group_lens, var_k_group_offs)
+    return (
+        x_fp8_row,
+        x_fp8_col_padded,
+        x_scales_row,
+        x_scales_col_padded,
+        var_k_group_lens,
+        var_k_group_offs,
+    )
 
 
 @quant_fp8_blockwise_segment_m_row_col_impl.register_fake

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -223,6 +223,14 @@ def quant_fp8_blockwise_for_weight_impl(
     if not w.is_contiguous():
         w = w.contiguous()
 
+    # HIP fast path (single C++ call → lower host overhead, identical output layout);
+    # Triton kernel fallback when the C++ extension lacks the op. Benefits both the
+    # grouped and non-grouped blockwise paths that quantize weights through here.
+    if hasattr(torch.ops.primus_turbo_cpp_extension, "quantize_fp8_blockwise_for_weight"):
+        return torch.ops.primus_turbo_cpp_extension.quantize_fp8_blockwise_for_weight(
+            w, dtype, block_size
+        )
+
     ori_dims = w.dim()
     if ori_dims == 2:
         B, M, N = 1, *w.shape

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -223,9 +223,12 @@ def quant_fp8_blockwise_for_weight_impl(
         w = w.contiguous()
 
     # HIP fast path (single C++ call → lower host overhead, identical output layout);
-    # Triton kernel fallback when the C++ extension lacks the op. Benefits both the
-    # grouped and non-grouped blockwise paths that quantize weights through here.
-    if hasattr(torch.ops.primus_turbo_cpp_extension, "quantize_fp8_blockwise_for_weight"):
+    # only when the C++ op is built and block_size == 128 (its only supported size),
+    # else fall through to the Triton kernel. Benefits both the grouped and
+    # non-grouped blockwise paths that quantize weights through here.
+    if block_size == 128 and hasattr(
+        torch.ops.primus_turbo_cpp_extension, "quantize_fp8_blockwise_for_weight"
+    ):
         return torch.ops.primus_turbo_cpp_extension.quantize_fp8_blockwise_for_weight(w, dtype, block_size)
 
     ori_dims = w.dim()
@@ -317,7 +320,13 @@ def quant_fp8_blockwise_segment_m_row_col_impl(
               var_k_group_lens [B], var_k_group_offs [B+1]).
     """
     assert x.is_contiguous() and x.dim() == 2
-    if gemm_other_dim is not None:
+    # HIP fast path: only when the C++ op is built and block_size == 128 (its
+    # only supported size); otherwise fall through to the Triton kernel below.
+    if (
+        gemm_other_dim is not None
+        and block_size == 128
+        and hasattr(torch.ops.primus_turbo_cpp_extension, "quantize_fp8_blockwise_segment_m_row_col")
+    ):
         gemm_flops = x.size(0) * x.size(1) * gemm_other_dim
         if gemm_flops <= _HIP_SEGMENT_GEMM_FLOPS_THRESHOLD:
             return torch.ops.primus_turbo_cpp_extension.quantize_fp8_blockwise_segment_m_row_col(

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -23,7 +23,7 @@ from primus_turbo.triton.quantization.quant_blockwise import (
     quant_fp8_blockwise_dual_kernel,
     quant_fp8_blockwise_for_weight_kernel,
     quant_fp8_blockwise_kernel,
-    quant_fp8_blockwise_segment_m_kernel,
+    quant_fp8_blockwise_segment_m_row_col_kernel,
 )
 from primus_turbo.triton.quantization.quantization_mxfp4 import dequantize_mxfp4_kernel
 from primus_turbo.triton.quantization.quantization_mxfp8 import dequantize_mxfp8_kernel
@@ -202,88 +202,6 @@ def quant_fp8_blockwise_dual_impl_meta(
     return x_fp8_row, x_scales_row, x_fp8_col, x_scales_col
 
 
-@triton_op("primus_turbo::quant_fp8_blockwise_segment_m_impl", mutates_args=())
-def quant_fp8_blockwise_segment_m_impl(
-    x: torch.Tensor,
-    dtype: torch.dtype,
-    block_size: int,
-    group_lens: torch.Tensor,
-    group_offs: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """
-    Quantization for fp8 blockwise with segment-aware padding (axis=0 only).
-
-    Reads from original tensor, writes to padded tensor with segment alignment.
-
-    Args:
-        x: Input tensor to quantize [M, N].
-        dtype: FP8 dtype for output.
-        block_size: Block size for quantization.
-        group_lens: Segment lengths [B].
-        group_offs: Segment offsets [B+1].
-
-    Returns:
-        x_fp8: FP8-quantized tensor [M_padded, N].
-        x_scales: Per-block scale tensor in float32.
-        var_k_group_lens: Padded segment lengths [B].
-        var_k_group_offs: Padded segment offsets [B+1].
-    """
-    assert x.is_contiguous() and x.dim() == 2, "Input must be 2D and contiguous"
-
-    M, N = x.shape
-    num_groups = group_lens.size(0)
-
-    var_k_group_lens = ((group_lens + block_size - 1) // block_size) * block_size
-    var_k_group_offs = torch.zeros(num_groups + 1, dtype=torch.int64, device=x.device)
-    var_k_group_offs[1:] = torch.cumsum(var_k_group_lens, dim=0)
-
-    # Use upper bound for allocation to avoid .item() sync (required for graph capture)
-    # Each segment can have at most block_size padding, so M_padded <= M + num_groups * block_size
-    M_padded_max = M + num_groups * block_size
-
-    # Allocate output tensors with upper bound size
-    x_fp8 = torch.zeros((M_padded_max, N), dtype=dtype, device=x.device)
-    x_scales = torch.zeros((triton.cdiv(M_padded_max, block_size), N), dtype=torch.float32, device=x.device)
-
-    # Launch kernel - out-of-bounds blocks are handled by the kernel's mask logic
-    grid = (triton.cdiv(M_padded_max, block_size), triton.cdiv(N, block_size))
-    wrap_triton(quant_fp8_blockwise_segment_m_kernel)[grid](
-        x,
-        x_fp8,
-        x_scales,
-        group_offs,
-        var_k_group_offs,
-        N,
-        num_groups,
-        block_size,
-        torch.finfo(dtype).max,
-    )
-    return x_fp8, x_scales, var_k_group_lens, var_k_group_offs
-
-
-@quant_fp8_blockwise_segment_m_impl.register_fake
-def quant_fp8_blockwise_segment_m_impl_meta(
-    x: torch.Tensor,
-    dtype: torch.dtype,
-    block_size: int,
-    group_lens: torch.Tensor,
-    group_offs: torch.Tensor,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    assert x.dim() == 2, "Input must be 2D"
-
-    M, N = x.shape
-    num_groups = group_lens.size(0)
-
-    # Use upper bound for allocation
-    M_padded_max = M + num_groups * block_size
-
-    x_fp8 = torch.empty((M_padded_max, N), dtype=dtype, device=x.device)
-    x_scales = torch.empty((triton.cdiv(M_padded_max, block_size), N), dtype=torch.float32, device=x.device)
-    var_k_group_lens = torch.empty(num_groups, dtype=torch.int64, device=x.device)
-    var_k_group_offs = torch.empty(num_groups + 1, dtype=torch.int64, device=x.device)
-    return x_fp8, x_scales, var_k_group_lens, var_k_group_offs
-
-
 @torch.library.custom_op("primus_turbo::quant_fp8_blockwise_for_weight_impl", mutates_args=())
 def quant_fp8_blockwise_for_weight_impl(
     w: torch.Tensor,
@@ -357,6 +275,96 @@ def quant_fp8_blockwise_for_weight_impl_meta(
         w_fp8 = w_fp8.squeeze(0)
         w_scales = w_scales.squeeze(0)
     return w_fp8, w_scales
+
+
+# HIP wins on small surrounding GEMMs (single C++ call → low host overhead) but
+# loses on big ones (vreg pressure → 1 block/CU bottlenecks the next GEMM); pick
+# HIP only below this M_total*N*K threshold. Calibrated across LFM2 / Qwen3 /
+# DeepSeek-V3 / GPT-OSS BLOCKWISE shapes.
+_HIP_SEGMENT_GEMM_FLOPS_THRESHOLD = 70_000_000_000
+
+
+@torch.library.custom_op("primus_turbo::quant_fp8_blockwise_segment_m_row_col_impl", mutates_args=())
+def quant_fp8_blockwise_segment_m_row_col_impl(
+    x: torch.Tensor,
+    dtype: torch.dtype,
+    block_size: int,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    gemm_other_dim: Optional[int] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused row + segment-padded col quant of a grouped tensor in one pass.
+
+    A single bf16 read of `x` produces the row-wise scaled tensor (fwd/dgrad GEMM)
+    and the segment-padded col-wise scaled tensor (variable-K wgrad). Row scales are
+    pshuffled [N_blocks, M] to match the persistent GEMM's coalesced scale reads.
+
+    Dispatches to the HIP fast path when the surrounding GEMM is small enough that its
+    lower host overhead wins; otherwise launches the Triton kernel. Pass `gemm_other_dim`
+    (the GEMM dim not visible from x.shape) to enable the dispatch; default = Triton.
+
+    Registered as ``torch.library.custom_op`` (opaque to inductor) to sidestep the AMD
+    MI300 / Triton 3.7 ``identify_mutated_tensors`` DCE bug, matching the other blockwise
+    quant impls.
+
+    Returns: (x_fp8_row [M,N], x_fp8_col_padded [M_padded_max,N],
+              x_scales_row [N_blocks,M], x_scales_col_padded [M_padded_blocks,N],
+              var_k_group_lens [B], var_k_group_offs [B+1]).
+    """
+    assert x.is_contiguous() and x.dim() == 2
+    if gemm_other_dim is not None:
+        gemm_flops = x.size(0) * x.size(1) * gemm_other_dim
+        if gemm_flops <= _HIP_SEGMENT_GEMM_FLOPS_THRESHOLD:
+            return torch.ops.primus_turbo_cpp_extension.quantize_fp8_blockwise_segment_m_row_col(
+                x, dtype, block_size, group_lens, group_offs
+            )
+
+    M, N = x.shape
+    num_groups = group_lens.size(0)
+    # Segment-padded group offsets (each segment rounded up to block_size). Only the
+    # Triton fallback (large GEMMs) reaches here, where this host cost is negligible;
+    # the HIP fast path computes them in-kernel.
+    var_k_group_lens = ((group_lens + block_size - 1) // block_size) * block_size
+    var_k_group_offs = torch.zeros(num_groups + 1, dtype=torch.int64, device=x.device)
+    var_k_group_offs[1:] = torch.cumsum(var_k_group_lens, dim=0)
+    M_padded_max = M + num_groups * block_size
+    # Kernel mask-writes cover all positions read downstream; skip zero-init.
+    # x_scales_row in pshuffled [N_blocks, M] matches the fwd GEMM scale order.
+    x_fp8_row = torch.empty((M, N), dtype=dtype, device=x.device)
+    x_fp8_col_padded = torch.empty((M_padded_max, N), dtype=dtype, device=x.device)
+    x_scales_row = torch.empty((triton.cdiv(N, block_size), M), dtype=torch.float32, device=x.device)
+    x_scales_col_padded = torch.empty(
+        (triton.cdiv(M_padded_max, block_size), N), dtype=torch.float32, device=x.device
+    )
+    grid = (triton.cdiv(M_padded_max, block_size), triton.cdiv(N, block_size))
+    quant_fp8_blockwise_segment_m_row_col_kernel[grid](
+        x, x_fp8_row, x_fp8_col_padded, x_scales_row, x_scales_col_padded,
+        group_offs, var_k_group_offs, M, N, num_groups, block_size, torch.finfo(dtype).max,
+    )
+    return (x_fp8_row, x_fp8_col_padded, x_scales_row, x_scales_col_padded,
+            var_k_group_lens, var_k_group_offs)
+
+
+@quant_fp8_blockwise_segment_m_row_col_impl.register_fake
+def quant_fp8_blockwise_segment_m_row_col_impl_meta(
+    x: torch.Tensor,
+    dtype: torch.dtype,
+    block_size: int,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    gemm_other_dim: Optional[int] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    M, N = x.shape
+    num_groups = group_lens.size(0)
+    M_padded_max = M + num_groups * block_size
+    return (
+        torch.empty((M, N), dtype=dtype, device=x.device),
+        torch.empty((M_padded_max, N), dtype=dtype, device=x.device),
+        torch.empty((triton.cdiv(N, block_size), M), dtype=torch.float32, device=x.device),
+        torch.empty((triton.cdiv(M_padded_max, block_size), N), dtype=torch.float32, device=x.device),
+        torch.empty(num_groups, dtype=torch.int64, device=x.device),
+        torch.empty(num_groups + 1, dtype=torch.int64, device=x.device),
+    )
 
 
 def quantize_mxfp8_impl(

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -29,8 +29,7 @@ from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
 )
 from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
     quant_fp8_blockwise_for_weight_impl,
-    quant_fp8_blockwise_impl,
-    quant_fp8_blockwise_segment_m_impl,
+    quant_fp8_blockwise_segment_m_row_col_impl,
 )
 
 __all__ = [
@@ -79,8 +78,14 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
         a_dtype = _get_fp8_dtype(config.format, True)
         b_dtype = _get_fp8_dtype(config.format, True)
 
-        a_fp8_row, a_scale_inv_row = quant_fp8_blockwise_impl(
-            a, a_dtype, axis=1, block_size=config.block_size
+        # One bf16 read of `a` → row-wise (fwd) + segment-padded col-wise (bwd wgrad).
+        # Row scales are pre-shuffled to the persistent GEMM's scale order. gemm_other_dim
+        # = fwd-GEMM N lets the quant pick the HIP fast path on small GEMMs.
+        gemm_n = b.size(-2) if trans_b else b.size(-1)
+        a_fp8_row, a_fp8_col, a_scale_inv_row, a_scale_inv_col, _, _ = (
+            quant_fp8_blockwise_segment_m_row_col_impl(
+                a, a_dtype, config.block_size, group_lens, group_offs, gemm_other_dim=gemm_n
+            )
         )
 
         b_fp8, b_scale_inv = quant_fp8_blockwise_for_weight_impl(b, b_dtype, block_size=config.block_size)
@@ -98,10 +103,6 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
             granularity=config.granularity.value,
             num_cu=num_cu,
             default_backend=BackendType.TRITON.value,
-        )
-
-        a_fp8_col, a_scale_inv_col, _, _ = quant_fp8_blockwise_segment_m_impl(
-            a, a_dtype, config.block_size, group_lens, group_offs
         )
 
         ctx.save_for_backward(
@@ -135,9 +136,18 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
         block_size = ctx.config.block_size
         grad_out_dtype = _get_fp8_dtype(ctx.config.format, False)
 
-        # Quantize grad_out in row-wise for dgrad
-        grad_out_fp8_row, grad_out_scale_inv_row = quant_fp8_blockwise_impl(
-            grad_out, grad_out_dtype, axis=1, block_size=block_size
+        # One bf16 read of grad_out → row-wise (dgrad) + segment-padded col-wise (wgrad).
+        # gemm_other_dim = bwd-GEMM K lets the quant pick the HIP fast path on small GEMMs.
+        gemm_k = b_fp8.size(-1) if ctx.trans_b else b_fp8.size(-2)
+        (
+            grad_out_fp8_row,
+            grad_out_fp8_col,
+            grad_out_scale_inv_row,
+            grad_out_scale_inv_col,
+            var_k_group_lens,
+            var_k_group_offs,
+        ) = quant_fp8_blockwise_segment_m_row_col_impl(
+            grad_out, grad_out_dtype, block_size, group_lens, group_offs, gemm_other_dim=gemm_k
         )
 
         # grad_a: grad_out @ b^T
@@ -154,17 +164,6 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
             granularity=ctx.config.granularity.value,
             num_cu=ctx.num_cu,
             default_backend=BackendType.TRITON.value,
-        )
-
-        # Quantize grad_out with segment padding for wgrad (colwise quantization)
-        grad_out_fp8_col, grad_out_scale_inv_col, var_k_group_lens, var_k_group_offs = (
-            quant_fp8_blockwise_segment_m_impl(
-                grad_out,
-                grad_out_dtype,
-                block_size,
-                group_lens,
-                group_offs,
-            )
         )
 
         grad_b = grouped_gemm_fp8_variable_k_impl(

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -20,7 +20,7 @@ Contains:
     - grouped_gemm_fp8_rowwise_variable_k_triton_kernel: Backward public API
 
   Blockwise scaling:
-    - _grouped_blockwise_fp8_persistent_gemm_kernel: Forward
+    - _grouped_blockwise_fp8_persistent_gemm_kernel_unaligned: Forward
     - _grouped_blockwise_fp8_variable_k_gemm_kernel: Backward variable-K
     - grouped_gemm_fp8_blockwise_triton_kernel: Forward public API
     - grouped_gemm_fp8_blockwise_variable_k_triton_kernel: Backward public API
@@ -43,6 +43,9 @@ from primus_turbo.triton.gemm.gemm_kernel import (
     _select_params_origami,
     _set_knobs_gfx950,
 )
+_grouped_blockwise_warmed: set = set()
+_grouped_blockwise_vk_warmed: set = set()
+
 from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
     NUM_XCDS,
     _chiplet_transform_chunked,
@@ -1196,8 +1199,44 @@ def grouped_gemm_fp8_rowwise_variable_k_triton_kernel(
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
+# 8-config curated set covering small/medium/large M and N-major/M-major reductions.
+# All BK=128 (winners). Trimmed from a 32-config sweep that always picked one of these.
+def _get_grouped_blockwise_autotune_configs():
+    # BLOCK_SIZE_N pinned to 128: the persistent kernel loads ONE b_scale per
+    # tile (assumes BN == SCALE_BLOCK_N == 128). With BN=256 the kernel applies
+    # the wrong scale to half the output cols → ~10dB SNR drop. There's also a
+    # known MI300X MFMA layout bug on FP8 e4m3fnuz with BN=64/256.
+    return [
+        # small/medium fallback
+        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 64}, num_warps=4, num_stages=2),
+        # large-M, M-major
+        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 64}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 64}, num_warps=8, num_stages=1),
+    ]
+
+
+# Used for K % 128 != 0 (masked-tail path); shares the same config sweep as the aligned
+# kernel so unaligned shapes (e.g. GPT-OSS K=2880) are not artificially restricted.
+def _get_grouped_blockwise_autotune_configs_unaligned():
+    return _get_grouped_blockwise_autotune_configs()
+
+
+@triton.autotune(configs=_get_grouped_blockwise_autotune_configs_unaligned(), key=["G", "N", "K"])
 @triton.jit()
-def _grouped_blockwise_fp8_persistent_gemm_kernel(
+def _grouped_blockwise_fp8_persistent_gemm_kernel_unaligned(
     # Pointers
     A,  # [M_total, K] FP8
     B,  # [G, ?, ?] FP8
@@ -1216,8 +1255,8 @@ def _grouped_blockwise_fp8_persistent_gemm_kernel(
     stride_cm,  # C row stride
     stride_cn,  # C col stride
     # A_scales strides (pre-transposed: [K//128, M_total])
-    stride_as_k,  # A_scales_t.stride(0)
-    stride_as_m,  # A_scales_t.stride(1)
+    stride_as_k,  # a_scales.stride(0)
+    stride_as_m,  # a_scales.stride(1)
     # B_scales strides
     stride_bs_g,  # B_scales.stride(0) — group stride
     stride_bs_n,  # stride along N-block dimension
@@ -1362,41 +1401,193 @@ def _grouped_blockwise_fp8_persistent_gemm_kernel(
         tl.store(C_, c, c_mask)
 
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# Blockwise FP8 Variable-K Backward Kernel (persistent, CPU-sync-free)
-#
-# Computes: C[g] = LHS[g]^T @ RHS[g] with 1D+1D block-wise scales
-# ═══════════════════════════════════════════════════════════════════════════════
+# Blockwise FP8 forward v2: K-loop split into outer (scale block, SCALE_BLOCK_K=128)
+# × inner (compute block, BLOCK_SIZE_K). Requires K % SCALE_BLOCK_K == 0.
+# BLOCK_N pinned to 128 (BN=64/256 have an MFMA layout bug on MI300X FP8 e4m3fnuz).
+# BLOCK_M=256 must use BLOCK_K=128 (same bug otherwise).
+@triton.autotune(configs=_get_grouped_blockwise_autotune_configs(), key=["G", "N", "K"])
+@triton.jit()
+def _grouped_blockwise_fp8_persistent_gemm_kernel(
+    A,
+    B,
+    C,
+    A_scales_ptr,
+    B_scales_ptr,
+    group_offs_ptr,
+    G: tl.constexpr,
+    N,
+    K,
+    stride_am,
+    stride_bg,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_as_k,
+    stride_as_m,
+    stride_bs_g,
+    stride_bs_n,
+    stride_bs_k,
+    stride_ak: tl.constexpr,
+    stride_bk: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    SCALE_BLOCK_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+    CACHE_MODIFIER: tl.constexpr,
+    G_POW2: tl.constexpr,
+):
+    """Grouped blockwise FP8 v2; needs K % SCALE_BLOCK_K == 0."""
+    pid = tl.program_id(0)
+    if NUM_XCDS != 1:
+        pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
+
+    SUB_K_ITERS: tl.constexpr = SCALE_BLOCK_K // BLOCK_SIZE_K
+
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+
+    # Vectorise the per-group cumsum so the per-tile group lookup is a single
+    # masked compare+reduce instead of an O(G) carry-dependent scan. tl.arange
+    # needs a power-of-2 bound, so pad to G_POW2 and mask the tail to 0 tiles
+    # (padded groups contribute nothing to cumsum / group_idx selection).
+    g_arange = tl.arange(0, G_POW2)
+    g_valid = g_arange < G
+    g_starts  = tl.load(group_offs_ptr + g_arange, mask=g_valid, other=0)
+    g_ends    = tl.load(group_offs_ptr + g_arange + 1, mask=g_valid, other=0)
+    m_per_g_v = (g_ends - g_starts).to(tl.int32)
+    tiles_per_g_v = tl.cdiv(m_per_g_v, BLOCK_SIZE_M) * num_pid_n
+    cum_incl_v = tl.cumsum(tiles_per_g_v, axis=0)
+    total_tiles = tl.sum(tiles_per_g_v, axis=0)
+
+    tl.assume(stride_am > 0)
+    tl.assume(stride_ak > 0)
+    tl.assume(stride_bn > 0)
+    tl.assume(stride_bk > 0)
+    tl.assume(stride_cm > 0)
+    tl.assume(stride_cn > 0)
+
+    acc_dtype = tl.float32
+
+    for global_tile_id in range(pid, total_tiles, NUM_SMS):
+        # group_idx via vector compare; gather (m_start, M_g, tile_start) via mask+sum.
+        group_idx = tl.sum((cum_incl_v <= global_tile_id).to(tl.int32), axis=0)
+        is_cur = (g_arange == group_idx).to(tl.int32)
+        m_start_g = tl.sum(g_starts.to(tl.int32) * is_cur, axis=0)
+        M_g = tl.sum(m_per_g_v * is_cur, axis=0)
+        tiles_m_g = tl.cdiv(M_g, BLOCK_SIZE_M)
+        tile_start = tl.sum(tl.where(g_arange < group_idx, tiles_per_g_v, 0), axis=0)
+        local_tile = global_tile_id - tile_start
+
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        swizzle_group = local_tile // num_pid_in_group
+        first_pid_m = swizzle_group * GROUP_SIZE_M
+        group_size_m = min(tiles_m_g - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + ((local_tile % num_pid_in_group) % group_size_m)
+        pid_n = (local_tile % num_pid_in_group) // group_size_m
+        tl.assume(pid_m >= 0)
+        tl.assume(pid_n >= 0)
+
+        rm = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M_g
+        rn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+        rk = tl.arange(0, BLOCK_SIZE_K)
+        rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
+
+        group_offset_b = group_idx.to(tl.int64) * stride_bg
+        A_BASE = A + m_start_g * stride_am + rm[:, None] * stride_am + rk[None, :] * stride_ak
+        B_BASE = B + group_offset_b + rk[:, None] * stride_bk + rn[None, :] * stride_bn
+
+        as_ptrs_base = A_scales_ptr + (m_start_g + rm.to(tl.int64)) * stride_as_m
+        bs_ptr_base = B_scales_ptr + group_idx.to(tl.int64) * stride_bs_g + pid_n * stride_bs_n
+
+        # Outer = scale blocks; inner = SUB_K_ITERS dots sharing one (a_s, b_s).
+        loop_kb = K // SCALE_BLOCK_K
+        tl.assume(loop_kb > 1)
+        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
+
+        for kb in range(0, loop_kb):
+            partial = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
+            for sub in tl.static_range(SUB_K_ITERS):
+                if stride_ak == 1:
+                    a = tl.load(tl.multiple_of(A_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)
+                else:
+                    a = tl.load(tl.multiple_of(A_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER)
+                if stride_bk == 1:
+                    b = tl.load(tl.multiple_of(B_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER)
+                else:
+                    b = tl.load(tl.multiple_of(B_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)
+                partial += tl.dot(a, b)
+                A_BASE += BLOCK_SIZE_K * stride_ak
+                B_BASE += BLOCK_SIZE_K * stride_bk
+
+            a_s = tl.load(as_ptrs_base + kb * stride_as_k)
+            b_s = tl.load(bs_ptr_base + kb * stride_bs_k)
+            acc += partial * (a_s * b_s)[:, None]
+
+        c = acc.to(C.type.element_ty)
+        rm_s = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M_g
+        rn_s = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+        rn_s = tl.max_contiguous(tl.multiple_of(rn_s, BLOCK_SIZE_N), BLOCK_SIZE_N)
+        c_mask = (rm_s[:, None] < M_g) & (rn_s[None, :] < N)
+        C_ = C + m_start_g * stride_cm + rm_s[:, None] * stride_cm + rn_s[None, :] * stride_cn
+        tl.store(C_, c, c_mask)
 
 
+# Blockwise FP8 variable-K backward (persistent, CPU-sync-free):
+#   C[g] = LHS[g]^T @ RHS[g] with 1D+1D blockwise scales.
+# Autotune is keyed on shape-stable (G, OUT_M, OUT_N) only — per-group M varies.
+def _bwd_autotune_configs():
+    # 8-config curated set for variable-K wgrad. BK=128 always wins; covers M-major and N-major.
+    return [
+        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
+                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 32}, num_warps=4, num_stages=2),
+    ]
+
+
+@triton.autotune(
+    configs=_bwd_autotune_configs(),
+    key=["G", "OUT_M", "OUT_N", "A_K_CONTIGUOUS", "B_K_CONTIGUOUS"],
+)
 @triton.jit()
 def _grouped_blockwise_fp8_variable_k_gemm_kernel(
-    # C[g] = LHS_g^T @ RHS_g * block_scales
-    LHS,  # [M_padded_total, OUT_M] FP8
-    RHS,  # [M_padded_total, OUT_N] FP8
-    C,  # [G, OUT_M, OUT_N]
-    LHS_scales_ptr,  # [ceil(M_padded/128), OUT_M] float32
-    RHS_scales_ptr,  # [ceil(M_padded/128), OUT_N] float32
-    group_offs_ptr,  # [G+1] int64 (padded segment offsets, each aligned to 128)
-    G,  # number of groups
+    LHS,
+    RHS,
+    C,
+    LHS_scales_ptr,
+    RHS_scales_ptr,
+    group_offs_ptr,
+    G,
     OUT_M,
     OUT_N,
-    # Strides
     stride_lhs_m,
     stride_rhs_m,
     stride_cg,
     stride_cm,
     stride_cn,
-    # LHS_scales strides
     stride_ls_0,
     stride_ls_1,
-    # RHS_scales strides
     stride_rs_0,
     stride_rs_1,
-    # Constexpr strides
     stride_lhs_n: tl.constexpr,
     stride_rhs_n: tl.constexpr,
-    # Tile config
+    A_K_CONTIGUOUS: tl.constexpr,
+    B_K_CONTIGUOUS: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
@@ -1406,15 +1597,8 @@ def _grouped_blockwise_fp8_variable_k_gemm_kernel(
     CHUNK_SIZE: tl.constexpr,
     CACHE_MODIFIER: tl.constexpr,
 ):
-    """Persistent grouped block-wise FP8 variable-K GEMM kernel (backward, CPU-sync-free).
-
-    All groups share the same output dims (OUT_M × OUT_N), only the inner product
-    dimension M_g varies per group. 1D+1D scale pattern for TN/CRR layout.
-
-    NOTE: Data is segment-padded to BLOCK_SIZE_K (128) boundaries by
-    quant_fp8_blockwise_segment_m_impl, so M_g is always a multiple of
-    BLOCK_SIZE_K. No masking is needed in the K-loop.
-    """
+    """Variable-K BWD: C[g] = LHS_g^T @ RHS_g. M_g is segment-padded to BLOCK_SIZE_K
+    by quant_fp8_blockwise_segment_m_row_col_impl, so no K-loop masking is needed."""
     pid = tl.program_id(0)
     if NUM_XCDS != 1:
         pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
@@ -1459,8 +1643,16 @@ def _grouped_blockwise_fp8_variable_k_gemm_kernel(
         rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
 
         # ── Base pointers ──
-        LHS_BASE = LHS + m_start * stride_lhs_m + rm[:, None] * stride_lhs_n + rk[None, :] * stride_lhs_m
-        RHS_BASE = RHS + m_start * stride_rhs_m + rk[:, None] * stride_rhs_m + rn[None, :] * stride_rhs_n
+        # K-contig path: LHS layout is [OUT_M, M_padded_max], rk dim has stride 1.
+        # Strided path: LHS layout is [M_padded_total, OUT_M], rk dim has stride OUT_M.
+        if A_K_CONTIGUOUS:
+            LHS_BASE = LHS + m_start + rm[:, None] * stride_lhs_n + rk[None, :]
+        else:
+            LHS_BASE = LHS + m_start * stride_lhs_m + rm[:, None] * stride_lhs_n + rk[None, :] * stride_lhs_m
+        if B_K_CONTIGUOUS:
+            RHS_BASE = RHS + m_start + rk[:, None] + rn[None, :] * stride_rhs_n
+        else:
+            RHS_BASE = RHS + m_start * stride_rhs_m + rk[:, None] * stride_rhs_m + rn[None, :] * stride_rhs_n
 
         scale_row_start = m_start // BLOCK_SIZE_K
 
@@ -1470,27 +1662,19 @@ def _grouped_blockwise_fp8_variable_k_gemm_kernel(
         acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
 
         for k in range(loop_k):
-            if stride_lhs_n == 1:
-                a = tl.load(
-                    tl.multiple_of(LHS_BASE, (16, 1)),
-                    cache_modifier=CACHE_MODIFIER,
-                )
+            if A_K_CONTIGUOUS:
+                a = tl.load(tl.multiple_of(LHS_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)
+            elif stride_lhs_n == 1:
+                a = tl.load(tl.multiple_of(LHS_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER)
             else:
-                a = tl.load(
-                    tl.multiple_of(LHS_BASE, (1, 16)),
-                    cache_modifier=CACHE_MODIFIER,
-                )
+                a = tl.load(tl.multiple_of(LHS_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)
 
-            if stride_rhs_n == 1:
-                b = tl.load(
-                    tl.multiple_of(RHS_BASE, (1, 16)),
-                    cache_modifier=CACHE_MODIFIER,
-                )
+            if B_K_CONTIGUOUS:
+                b = tl.load(tl.multiple_of(RHS_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER)
+            elif stride_rhs_n == 1:
+                b = tl.load(tl.multiple_of(RHS_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)
             else:
-                b = tl.load(
-                    tl.multiple_of(RHS_BASE, (16, 1)),
-                    cache_modifier=CACHE_MODIFIER,
-                )
+                b = tl.load(tl.multiple_of(RHS_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER)
 
             partial = tl.dot(a, b)
 
@@ -1500,8 +1684,14 @@ def _grouped_blockwise_fp8_variable_k_gemm_kernel(
             b_s = tl.load(RHS_scales_ptr + scale_row * stride_rs_0 + rn * stride_rs_1)
             acc += partial * a_s[:, None] * b_s[None, :]
 
-            LHS_BASE += BLOCK_SIZE_K * stride_lhs_m
-            RHS_BASE += BLOCK_SIZE_K * stride_rhs_m
+            if A_K_CONTIGUOUS:
+                LHS_BASE += BLOCK_SIZE_K
+            else:
+                LHS_BASE += BLOCK_SIZE_K * stride_lhs_m
+            if B_K_CONTIGUOUS:
+                RHS_BASE += BLOCK_SIZE_K
+            else:
+                RHS_BASE += BLOCK_SIZE_K * stride_rhs_m
 
         # ── Store output ──
         c = acc.to(C.type.element_ty)
@@ -1533,7 +1723,7 @@ def grouped_gemm_fp8_blockwise_triton_kernel(
     Args:
         a: [M_total, K] FP8 input (trans_a=False always).
         b: [G, N, K] (if trans_b=True) or [G, K, N] FP8 weights.
-        a_scales: [M_total, K//128] float32, block-wise scale for A.
+        a_scales: [K//128, M_total] float32, block-wise scale for A (pre-shuffled).
         b_scales: [G, ceil(N/128), ceil(K/128)] or [G, ceil(K/128), ceil(N/128)] float32.
         group_offs: [G+1] int64 prefix sum of group lengths.
         trans_b: If True, b[g] is [N, K] (transposed).
@@ -1571,56 +1761,85 @@ def grouped_gemm_fp8_blockwise_triton_kernel(
     stride_ak = a.stride(1)
 
     out = torch.empty((M_total, N), device=a.device, dtype=out_dtype)
-    A_scales_t = a_scales.T.contiguous()
+    # a_scales arrives pre-shuffled as [K_blocks, M_total] (quant op + CK both emit
+    # this layout); kernel reads it coalesced with no runtime .T.contiguous().
     num_sms = _get_num_cus()
 
-    blk_m = 256
-    blk_n = 128  # Keep 128 to match B_scale block alignment
-    blk_k = 128
-    even_k = K % blk_k == 0
+    aligned = K % 128 == 0
+    # First call for this (G, N, K, aligned) shape: prime autotune with a balanced
+    # group_offs distribution. Triton's autotune key is (G, N, K) only — group_lens
+    # is not part of the key, so whichever distribution happens to drive the first
+    # call gets baked into the cached config. In MoE training, per-step routing is
+    # uneven and varies, so without this warm-up we'd cache a config tuned to one
+    # accidental imbalance. Run a synthetic balanced-offs trial into a scratch out
+    # so the chosen config generalizes across the lifetime of the process.
+    if (G, N, K, aligned) not in _grouped_blockwise_warmed:
+        _grouped_blockwise_warmed.add((G, N, K, aligned))
+        per = M_total // G
+        bal_offs = torch.arange(G + 1, device=group_offs.device, dtype=group_offs.dtype) * per
+        bal_offs[-1] = M_total
+        out_warm = torch.empty_like(out)
+        if aligned:
+            if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
+                triton.knobs.amd.use_async_copy = False
+            _grouped_blockwise_fp8_persistent_gemm_kernel[(num_sms,)](
+                a, b, out_warm, a_scales, b_scales, bal_offs,
+                G, N, K,
+                a.stride(0), stride_bg, stride_bn,
+                out_warm.stride(0), out_warm.stride(1),
+                a_scales.stride(0), a_scales.stride(1),
+                b_scales.stride(0), stride_bs_n, stride_bs_k,
+                stride_ak=stride_ak, stride_bk=stride_bk,
+                SCALE_BLOCK_K=128,
+                NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
+                CACHE_MODIFIER=".ca",
+                G_POW2=triton.next_power_of_2(G),
+                waves_per_eu=0, matrix_instr_nonkdim=16, kpack=2,
+            )
+        else:
+            _grouped_blockwise_fp8_persistent_gemm_kernel_unaligned[(num_sms,)](
+                a, b, out_warm, a_scales, b_scales, bal_offs,
+                G, N, K,
+                a.stride(0), stride_bg, stride_bn,
+                out_warm.stride(0), out_warm.stride(1),
+                a_scales.stride(0), a_scales.stride(1),
+                b_scales.stride(0), stride_bs_n, stride_bs_k,
+                stride_ak=stride_ak, stride_bk=stride_bk,
+                NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
+                EVEN_K=False, CACHE_MODIFIER=".ca",
+                waves_per_eu=0, matrix_instr_nonkdim=16, kpack=1,
+            )
 
-    # GROUP_SIZE_M heuristic (match tensorwise)
-    tiles_m_per_group = (M_total + G * blk_m - 1) // (G * blk_m)
-    tiles_n = (N + blk_n - 1) // blk_n
-    group_m = 8 if min(tiles_m_per_group, tiles_n) < 16 else 4
-
-    _grouped_blockwise_fp8_persistent_gemm_kernel[(num_sms,)](
-        a,
-        b,
-        out,
-        A_scales_t,
-        b_scales,
-        group_offs,
-        G,
-        N,
-        K,
-        a.stride(0),
-        stride_bg,
-        stride_bn,
-        out.stride(0),
-        out.stride(1),
-        A_scales_t.stride(0),
-        A_scales_t.stride(1),
-        b_scales.stride(0),
-        stride_bs_n,
-        stride_bs_k,
-        stride_ak=stride_ak,
-        stride_bk=stride_bk,
-        BLOCK_SIZE_M=blk_m,
-        BLOCK_SIZE_N=blk_n,
-        BLOCK_SIZE_K=blk_k,
-        GROUP_SIZE_M=group_m,
-        NUM_SMS=num_sms,
-        NUM_XCDS=NUM_XCDS,
-        CHUNK_SIZE=32,
-        EVEN_K=even_k,
-        CACHE_MODIFIER=".ca",
-        num_warps=8,
-        num_stages=1,  # 256×128×128 needs 48KB/stage; 2 stages=96KB > 64KB LDS
-        waves_per_eu=0,
-        matrix_instr_nonkdim=16,
-        kpack=1,
-    )
+    if aligned:
+        if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
+            triton.knobs.amd.use_async_copy = False
+        _grouped_blockwise_fp8_persistent_gemm_kernel[(num_sms,)](
+            a, b, out, a_scales, b_scales, group_offs,
+            G, N, K,
+            a.stride(0), stride_bg, stride_bn,
+            out.stride(0), out.stride(1),
+            a_scales.stride(0), a_scales.stride(1),
+            b_scales.stride(0), stride_bs_n, stride_bs_k,
+            stride_ak=stride_ak, stride_bk=stride_bk,
+            SCALE_BLOCK_K=128,
+            NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
+            CACHE_MODIFIER=".ca",
+            G_POW2=triton.next_power_of_2(G),
+            waves_per_eu=0, matrix_instr_nonkdim=16, kpack=2,
+        )
+    else:
+        _grouped_blockwise_fp8_persistent_gemm_kernel_unaligned[(num_sms,)](
+            a, b, out, a_scales, b_scales, group_offs,
+            G, N, K,
+            a.stride(0), stride_bg, stride_bn,
+            out.stride(0), out.stride(1),
+            a_scales.stride(0), a_scales.stride(1),
+            b_scales.stride(0), stride_bs_n, stride_bs_k,
+            stride_ak=stride_ak, stride_bk=stride_bk,
+            NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
+            EVEN_K=False, CACHE_MODIFIER=".ca",
+            waves_per_eu=0, matrix_instr_nonkdim=16, kpack=1,
+        )
     return out
 
 
@@ -1634,6 +1853,10 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
     rhs_scales: torch.Tensor,
     group_offs: torch.Tensor,
     out_dtype: torch.dtype = torch.bfloat16,
+    a_k_contig: bool = False,
+    b_k_contig: bool = False,
+    out_M: int = -1,
+    out_N: int = -1,
 ) -> torch.Tensor:
     """Variable-K grouped block-wise FP8 GEMM (backward, 1D+1D scaling) using Triton.
 
@@ -1643,12 +1866,20 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
     Output: [G, OUT_M, OUT_N].
 
     Args:
-        lhs: [M_padded_total, OUT_M] FP8 (segment-padded, each segment aligned to 128).
-        rhs: [M_padded_total, OUT_N] FP8.
+        lhs: [M_padded_total, OUT_M] FP8 if a_k_contig=False (default).
+             [OUT_M, M_padded_max] FP8 if a_k_contig=True (K-axis contig).
+        rhs: [M_padded_total, OUT_N] or [OUT_N, M_padded_max] (mirror of lhs).
         lhs_scales: [ceil(M_padded/128), OUT_M] float32.
         rhs_scales: [ceil(M_padded/128), OUT_N] float32.
         group_offs: [G+1] int64 padded segment offsets.
         out_dtype: Output dtype (default bfloat16).
+        a_k_contig: If True, lhs is the transposed layout [OUT_M, M_padded_max]
+                    so the K-axis is contiguous → kernel uses vectorized K-contig
+                    loads. Combined with the fused-quant-with-xpose op, replaces
+                    the strided-A pattern at no extra cost.
+        b_k_contig: Same for rhs.
+        out_M, out_N: Required when *_k_contig=True (cannot infer from transposed
+                      shape because it equals OUT_M/N).
 
     Returns:
         [G, OUT_M, OUT_N] output.
@@ -1659,52 +1890,67 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
         _set_amd_knobs(enable=False)
 
     assert lhs.ndim == 2 and rhs.ndim == 2
-    assert lhs.shape[0] == rhs.shape[0]
-    OUT_M = lhs.shape[1]
-    OUT_N = rhs.shape[1]
     G = group_offs.shape[0] - 1
+
+    if a_k_contig:
+        OUT_M = out_M if out_M > 0 else lhs.shape[0]
+    else:
+        OUT_M = lhs.shape[1]
+    if b_k_contig:
+        OUT_N = out_N if out_N > 0 else rhs.shape[0]
+    else:
+        OUT_N = rhs.shape[1]
 
     out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)
     num_sms = _get_num_cus()
 
-    # Use 128x128 tiles to reduce register pressure from double-accumulator
-    # (partial + acc both need full tile VGPRs for blockwise scale application).
-    # With 256x256 tiles + 8 warps, 2 accumulator sets need ~290 VGPRs/wave
-    # which exceeds the 256 limit at 2 waves/SIMD, causing spilling.
-    # 128x128 with 4 warps keeps VGPRs at ~170/wave, fitting 2 waves/SIMD.
+    # K-axis stride: for K-contig, dim 1 of [OUT_M, M_padded_max] = 1.
+    # For strided, dim 0 of [M_padded_total, OUT_M] = OUT_M.
+    stride_lhs_m = lhs.stride(1) if a_k_contig else lhs.stride(0)
+    stride_rhs_m = rhs.stride(1) if b_k_contig else rhs.stride(0)
+    # Output-row stride: for K-contig, dim 0 = M_padded_max. For strided, dim 1 = 1.
+    stride_lhs_n = lhs.stride(0) if a_k_contig else lhs.stride(1)
+    stride_rhs_n = rhs.stride(0) if b_k_contig else rhs.stride(1)
+
+    # Same balanced-warmup logic as the fwd kernel: autotune key is
+    # (G, OUT_M, OUT_N, A_K_CONTIGUOUS, B_K_CONTIGUOUS) — group_offs is not part
+    # of the key, so prime the cache once with a balanced distribution so the
+    # chosen config generalizes across MoE per-step routing variation.
+    warm_key = (G, OUT_M, OUT_N, a_k_contig, b_k_contig)
+    if warm_key not in _grouped_blockwise_vk_warmed:
+        _grouped_blockwise_vk_warmed.add(warm_key)
+        # Padded segment lens for variable-K need to respect BLOCK_K alignment;
+        # use M_padded // G rounded down to BLOCK_K (=128) granularity.
+        M_padded = lhs.shape[1] if a_k_contig else lhs.shape[0]
+        per = max((M_padded // G) // 128 * 128, 128)
+        bal_offs = torch.arange(G + 1, device=group_offs.device, dtype=group_offs.dtype) * per
+        bal_offs[-1] = M_padded
+        out_warm = torch.empty_like(out)
+        _grouped_blockwise_fp8_variable_k_gemm_kernel[(num_sms,)](
+            lhs, rhs, out_warm, lhs_scales, rhs_scales, bal_offs,
+            G, OUT_M, OUT_N,
+            stride_lhs_m, stride_rhs_m,
+            out_warm.stride(0), out_warm.stride(1), out_warm.stride(2),
+            lhs_scales.stride(0), lhs_scales.stride(1),
+            rhs_scales.stride(0), rhs_scales.stride(1),
+            stride_lhs_n=stride_lhs_n, stride_rhs_n=stride_rhs_n,
+            A_K_CONTIGUOUS=a_k_contig, B_K_CONTIGUOUS=b_k_contig,
+            NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
+            CACHE_MODIFIER=".ca",
+            waves_per_eu=2, matrix_instr_nonkdim=16, kpack=2,
+        )
+
     _grouped_blockwise_fp8_variable_k_gemm_kernel[(num_sms,)](
-        lhs,
-        rhs,
-        out,
-        lhs_scales,
-        rhs_scales,
-        group_offs,
-        G,
-        OUT_M,
-        OUT_N,
-        lhs.stride(0),
-        rhs.stride(0),
-        out.stride(0),
-        out.stride(1),
-        out.stride(2),
-        lhs_scales.stride(0),
-        lhs_scales.stride(1),
-        rhs_scales.stride(0),
-        rhs_scales.stride(1),
-        stride_lhs_n=lhs.stride(1),
-        stride_rhs_n=rhs.stride(1),
-        BLOCK_SIZE_M=128,
-        BLOCK_SIZE_N=128,
-        BLOCK_SIZE_K=128,
-        GROUP_SIZE_M=4,
-        NUM_SMS=num_sms,
-        NUM_XCDS=NUM_XCDS,
-        CHUNK_SIZE=32,
+        lhs, rhs, out, lhs_scales, rhs_scales, group_offs,
+        G, OUT_M, OUT_N,
+        stride_lhs_m, stride_rhs_m,
+        out.stride(0), out.stride(1), out.stride(2),
+        lhs_scales.stride(0), lhs_scales.stride(1),
+        rhs_scales.stride(0), rhs_scales.stride(1),
+        stride_lhs_n=stride_lhs_n, stride_rhs_n=stride_rhs_n,
+        A_K_CONTIGUOUS=a_k_contig, B_K_CONTIGUOUS=b_k_contig,
+        NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
         CACHE_MODIFIER=".ca",
-        num_warps=4,
-        num_stages=2,
-        waves_per_eu=0,
-        matrix_instr_nonkdim=16,
-        kpack=1,
+        waves_per_eu=2, matrix_instr_nonkdim=16, kpack=2,
     )
     return out

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -44,6 +44,7 @@ from primus_turbo.triton.gemm.gemm_kernel import (
     _select_params_origami,
     _set_knobs_gfx950,
 )
+
 _grouped_blockwise_warmed: set = set()
 _grouped_blockwise_vk_warmed: set = set()
 
@@ -1209,23 +1210,95 @@ def _get_grouped_blockwise_autotune_configs():
     # known MI300X MFMA layout bug on FP8 e4m3fnuz with BN=64/256.
     return [
         # small/medium fallback
-        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 32}, num_warps=4, num_stages=2),
-        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=4, num_stages=2),
-        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 64}, num_warps=4, num_stages=2),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 8,
+                "CHUNK_SIZE": 32,
+            },
+            num_warps=4,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 4,
+                "CHUNK_SIZE": 32,
+            },
+            num_warps=4,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 8,
+                "CHUNK_SIZE": 64,
+            },
+            num_warps=4,
+            num_stages=2,
+        ),
         # large-M, M-major
-        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 64}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 64}, num_warps=8, num_stages=1),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 256,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 4,
+                "CHUNK_SIZE": 32,
+            },
+            num_warps=8,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 256,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 8,
+                "CHUNK_SIZE": 32,
+            },
+            num_warps=8,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 256,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 4,
+                "CHUNK_SIZE": 32,
+            },
+            num_warps=8,
+            num_stages=1,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 256,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 8,
+                "CHUNK_SIZE": 64,
+            },
+            num_warps=8,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 256,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 4,
+                "CHUNK_SIZE": 64,
+            },
+            num_warps=8,
+            num_stages=1,
+        ),
     ]
 
 
@@ -1285,8 +1358,8 @@ def _grouped_blockwise_fp8_persistent_gemm_kernel(
     # (padded groups contribute nothing to cumsum / group_idx selection).
     g_arange = tl.arange(0, G_POW2)
     g_valid = g_arange < G
-    g_starts  = tl.load(group_offs_ptr + g_arange, mask=g_valid, other=0)
-    g_ends    = tl.load(group_offs_ptr + g_arange + 1, mask=g_valid, other=0)
+    g_starts = tl.load(group_offs_ptr + g_arange, mask=g_valid, other=0)
+    g_ends = tl.load(group_offs_ptr + g_arange + 1, mask=g_valid, other=0)
     m_per_g_v = (g_ends - g_starts).to(tl.int32)
     tiles_per_g_v = tl.cdiv(m_per_g_v, BLOCK_SIZE_M) * num_pid_n
     cum_incl_v = tl.cumsum(tiles_per_g_v, axis=0)
@@ -1390,22 +1463,94 @@ def _grouped_blockwise_fp8_persistent_gemm_kernel(
 def _bwd_autotune_configs():
     # 8-config curated set for variable-K wgrad. BK=128 always wins; covers M-major and N-major.
     return [
-        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 32}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE_M": 256, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 256, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 4, "CHUNK_SIZE": 32}, num_warps=8, num_stages=1),
-        triton.Config({"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 128,
-                       "GROUP_SIZE_M": 8, "CHUNK_SIZE": 32}, num_warps=4, num_stages=2),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 4,
+                "CHUNK_SIZE": 32,
+            },
+            num_warps=8,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 256,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 4,
+                "CHUNK_SIZE": 32,
+            },
+            num_warps=8,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 256,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 8,
+                "CHUNK_SIZE": 32,
+            },
+            num_warps=8,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 256,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 4,
+                "CHUNK_SIZE": 32,
+            },
+            num_warps=8,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 256,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 8,
+                "CHUNK_SIZE": 32,
+            },
+            num_warps=8,
+            num_stages=2,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 256,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 4,
+                "CHUNK_SIZE": 32,
+            },
+            num_warps=8,
+            num_stages=1,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 256,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 4,
+                "CHUNK_SIZE": 32,
+            },
+            num_warps=8,
+            num_stages=1,
+        ),
+        triton.Config(
+            {
+                "BLOCK_SIZE_M": 128,
+                "BLOCK_SIZE_N": 128,
+                "BLOCK_SIZE_K": 128,
+                "GROUP_SIZE_M": 8,
+                "CHUNK_SIZE": 32,
+            },
+            num_warps=4,
+            num_stages=2,
+        ),
     ]
 
 
@@ -1631,33 +1776,69 @@ def grouped_gemm_fp8_blockwise_triton_kernel(
         if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
             triton.knobs.amd.use_async_copy = False
         _grouped_blockwise_fp8_persistent_gemm_kernel[(num_sms,)](
-            a, b, out_warm, a_scales, b_scales, bal_offs,
-            G, N, K,
-            a.stride(0), stride_bg, stride_bn,
-            out_warm.stride(0), out_warm.stride(1),
-            a_scales.stride(0), a_scales.stride(1),
-            b_scales.stride(0), stride_bs_n, stride_bs_k,
-            stride_ak=stride_ak, stride_bk=stride_bk,
-            NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
-            EVEN_K=aligned, CACHE_MODIFIER=".ca",
+            a,
+            b,
+            out_warm,
+            a_scales,
+            b_scales,
+            bal_offs,
+            G,
+            N,
+            K,
+            a.stride(0),
+            stride_bg,
+            stride_bn,
+            out_warm.stride(0),
+            out_warm.stride(1),
+            a_scales.stride(0),
+            a_scales.stride(1),
+            b_scales.stride(0),
+            stride_bs_n,
+            stride_bs_k,
+            stride_ak=stride_ak,
+            stride_bk=stride_bk,
+            NUM_SMS=num_sms,
+            NUM_XCDS=NUM_XCDS,
+            EVEN_K=aligned,
+            CACHE_MODIFIER=".ca",
             G_POW2=triton.next_power_of_2(G),
-            waves_per_eu=0, matrix_instr_nonkdim=16, kpack=2,
+            waves_per_eu=0,
+            matrix_instr_nonkdim=16,
+            kpack=2,
         )
 
     if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
         triton.knobs.amd.use_async_copy = False
     _grouped_blockwise_fp8_persistent_gemm_kernel[(num_sms,)](
-        a, b, out, a_scales, b_scales, group_offs,
-        G, N, K,
-        a.stride(0), stride_bg, stride_bn,
-        out.stride(0), out.stride(1),
-        a_scales.stride(0), a_scales.stride(1),
-        b_scales.stride(0), stride_bs_n, stride_bs_k,
-        stride_ak=stride_ak, stride_bk=stride_bk,
-        NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
-        EVEN_K=aligned, CACHE_MODIFIER=".ca",
+        a,
+        b,
+        out,
+        a_scales,
+        b_scales,
+        group_offs,
+        G,
+        N,
+        K,
+        a.stride(0),
+        stride_bg,
+        stride_bn,
+        out.stride(0),
+        out.stride(1),
+        a_scales.stride(0),
+        a_scales.stride(1),
+        b_scales.stride(0),
+        stride_bs_n,
+        stride_bs_k,
+        stride_ak=stride_ak,
+        stride_bk=stride_bk,
+        NUM_SMS=num_sms,
+        NUM_XCDS=NUM_XCDS,
+        EVEN_K=aligned,
+        CACHE_MODIFIER=".ca",
         G_POW2=triton.next_power_of_2(G),
-        waves_per_eu=0, matrix_instr_nonkdim=16, kpack=2,
+        waves_per_eu=0,
+        matrix_instr_nonkdim=16,
+        kpack=2,
     )
     return out
 
@@ -1746,30 +1927,64 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
         bal_offs[-1] = M_padded
         out_warm = torch.empty_like(out)
         _grouped_blockwise_fp8_variable_k_gemm_kernel[(num_sms,)](
-            lhs, rhs, out_warm, lhs_scales, rhs_scales, bal_offs,
-            G, OUT_M, OUT_N,
-            stride_lhs_m, stride_rhs_m,
-            out_warm.stride(0), out_warm.stride(1), out_warm.stride(2),
-            lhs_scales.stride(0), lhs_scales.stride(1),
-            rhs_scales.stride(0), rhs_scales.stride(1),
-            stride_lhs_n=stride_lhs_n, stride_rhs_n=stride_rhs_n,
-            A_K_CONTIGUOUS=a_k_contig, B_K_CONTIGUOUS=b_k_contig,
-            NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
+            lhs,
+            rhs,
+            out_warm,
+            lhs_scales,
+            rhs_scales,
+            bal_offs,
+            G,
+            OUT_M,
+            OUT_N,
+            stride_lhs_m,
+            stride_rhs_m,
+            out_warm.stride(0),
+            out_warm.stride(1),
+            out_warm.stride(2),
+            lhs_scales.stride(0),
+            lhs_scales.stride(1),
+            rhs_scales.stride(0),
+            rhs_scales.stride(1),
+            stride_lhs_n=stride_lhs_n,
+            stride_rhs_n=stride_rhs_n,
+            A_K_CONTIGUOUS=a_k_contig,
+            B_K_CONTIGUOUS=b_k_contig,
+            NUM_SMS=num_sms,
+            NUM_XCDS=NUM_XCDS,
             CACHE_MODIFIER=".ca",
-            waves_per_eu=2, matrix_instr_nonkdim=16, kpack=2,
+            waves_per_eu=2,
+            matrix_instr_nonkdim=16,
+            kpack=2,
         )
 
     _grouped_blockwise_fp8_variable_k_gemm_kernel[(num_sms,)](
-        lhs, rhs, out, lhs_scales, rhs_scales, group_offs,
-        G, OUT_M, OUT_N,
-        stride_lhs_m, stride_rhs_m,
-        out.stride(0), out.stride(1), out.stride(2),
-        lhs_scales.stride(0), lhs_scales.stride(1),
-        rhs_scales.stride(0), rhs_scales.stride(1),
-        stride_lhs_n=stride_lhs_n, stride_rhs_n=stride_rhs_n,
-        A_K_CONTIGUOUS=a_k_contig, B_K_CONTIGUOUS=b_k_contig,
-        NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
+        lhs,
+        rhs,
+        out,
+        lhs_scales,
+        rhs_scales,
+        group_offs,
+        G,
+        OUT_M,
+        OUT_N,
+        stride_lhs_m,
+        stride_rhs_m,
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        lhs_scales.stride(0),
+        lhs_scales.stride(1),
+        rhs_scales.stride(0),
+        rhs_scales.stride(1),
+        stride_lhs_n=stride_lhs_n,
+        stride_rhs_n=stride_rhs_n,
+        A_K_CONTIGUOUS=a_k_contig,
+        B_K_CONTIGUOUS=b_k_contig,
+        NUM_SMS=num_sms,
+        NUM_XCDS=NUM_XCDS,
         CACHE_MODIFIER=".ca",
-        waves_per_eu=2, matrix_instr_nonkdim=16, kpack=2,
+        waves_per_eu=2,
+        matrix_instr_nonkdim=16,
+        kpack=2,
     )
     return out

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -1378,7 +1378,10 @@ def _grouped_blockwise_fp8_persistent_gemm_kernel(
         # group_idx via vector compare; gather (m_start, M_g, tile_start) via mask+sum.
         group_idx = tl.sum((cum_incl_v <= global_tile_id).to(tl.int32), axis=0)
         is_cur = (g_arange == group_idx).to(tl.int32)
-        m_start_g = tl.sum(g_starts.to(tl.int32) * is_cur, axis=0)
+        # Keep m_start_g int64: it is a row offset into A/C and feeds pointer
+        # arithmetic (m_start_g * stride), which overflows int32 once M_total*K
+        # exceeds 2^31. M_g (per-group rows) stays int32 (bounded).
+        m_start_g = tl.sum(g_starts * is_cur.to(tl.int64), axis=0)
         M_g = tl.sum(m_per_g_v * is_cur, axis=0)
         tiles_m_g = tl.cdiv(M_g, BLOCK_SIZE_M)
         tile_start = tl.sum(tl.where(g_arange < group_idx, tiles_per_g_v, 0), axis=0)

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -20,7 +20,8 @@ Contains:
     - grouped_gemm_fp8_rowwise_variable_k_triton_kernel: Backward public API
 
   Blockwise scaling:
-    - _grouped_blockwise_fp8_persistent_gemm_kernel_unaligned: Forward
+    - _grouped_blockwise_fp8_persistent_gemm_kernel: Forward (EVEN_K handles
+      both K-aligned and K-unaligned shapes)
     - _grouped_blockwise_fp8_variable_k_gemm_kernel: Backward variable-K
     - grouped_gemm_fp8_blockwise_triton_kernel: Forward public API
     - grouped_gemm_fp8_blockwise_variable_k_triton_kernel: Backward public API
@@ -1228,182 +1229,9 @@ def _get_grouped_blockwise_autotune_configs():
     ]
 
 
-# Used for K % 128 != 0 (masked-tail path); shares the same config sweep as the aligned
-# kernel so unaligned shapes (e.g. GPT-OSS K=2880) are not artificially restricted.
-def _get_grouped_blockwise_autotune_configs_unaligned():
-    return _get_grouped_blockwise_autotune_configs()
-
-
-@triton.autotune(configs=_get_grouped_blockwise_autotune_configs_unaligned(), key=["G", "N", "K"])
-@triton.jit()
-def _grouped_blockwise_fp8_persistent_gemm_kernel_unaligned(
-    # Pointers
-    A,  # [M_total, K] FP8
-    B,  # [G, ?, ?] FP8
-    C,  # [M_total, N]
-    A_scales_ptr,  # [K//128, M_total] float32 (pre-transposed for coalesced access)
-    B_scales_ptr,  # [G, ?, ?] float32 (block-wise, layout depends on trans_b)
-    group_offs_ptr,  # [G+1] int64
-    # Dimensions
-    G,  # number of groups (runtime)
-    N,
-    K,
-    # Strides
-    stride_am,  # A row stride
-    stride_bg,  # B group stride: b.stride(0)
-    stride_bn,  # B N-stride (within a group)
-    stride_cm,  # C row stride
-    stride_cn,  # C col stride
-    # A_scales strides (pre-transposed: [K//128, M_total])
-    stride_as_k,  # a_scales.stride(0)
-    stride_as_m,  # a_scales.stride(1)
-    # B_scales strides
-    stride_bs_g,  # B_scales.stride(0) — group stride
-    stride_bs_n,  # stride along N-block dimension
-    stride_bs_k,  # stride along K-block dimension
-    # Constexpr strides
-    stride_ak: tl.constexpr,
-    stride_bk: tl.constexpr,
-    # Tile config
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_K: tl.constexpr,
-    GROUP_SIZE_M: tl.constexpr,
-    NUM_SMS: tl.constexpr,
-    NUM_XCDS: tl.constexpr,
-    CHUNK_SIZE: tl.constexpr,
-    EVEN_K: tl.constexpr,
-    CACHE_MODIFIER: tl.constexpr,
-):
-    """Persistent grouped block-wise FP8 GEMM kernel (CPU-sync-free)."""
-    pid = tl.program_id(0)
-    if NUM_XCDS != 1:
-        pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
-
-    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
-
-    # ── Compute total tiles across all groups ──
-    total_tiles: tl.int32 = 0
-    for _g in range(G):
-        m_g = (tl.load(group_offs_ptr + _g + 1) - tl.load(group_offs_ptr + _g)).to(tl.int32)
-        total_tiles += tl.cdiv(m_g, BLOCK_SIZE_M) * num_pid_n
-
-    tl.assume(stride_am > 0)
-    tl.assume(stride_ak > 0)
-    tl.assume(stride_bn > 0)
-    tl.assume(stride_bk > 0)
-    tl.assume(stride_cm > 0)
-    tl.assume(stride_cn > 0)
-
-    acc_dtype = tl.float32
-
-    for global_tile_id in range(pid, total_tiles, NUM_SMS):
-        # ── Find group via linear scan (O(G)) ──
-        group_idx: tl.int32 = 0
-        tile_start: tl.int32 = 0
-        cumsum: tl.int32 = 0
-        for _g in range(G):
-            m_g_i = (tl.load(group_offs_ptr + _g + 1) - tl.load(group_offs_ptr + _g)).to(tl.int32)
-            tiles_g = tl.cdiv(m_g_i, BLOCK_SIZE_M) * num_pid_n
-            new_cumsum = cumsum + tiles_g
-            if global_tile_id >= new_cumsum:
-                group_idx = _g + 1
-                tile_start = new_cumsum
-            cumsum = new_cumsum
-
-        # ── Group-local tile → (pid_m, pid_n) ──
-        local_tile = global_tile_id - tile_start
-        m_start_g = tl.load(group_offs_ptr + group_idx)  # int64
-        M_g = (tl.load(group_offs_ptr + group_idx + 1) - m_start_g).to(tl.int32)
-        tiles_m_g = tl.cdiv(M_g, BLOCK_SIZE_M)
-
-        num_pid_in_group = GROUP_SIZE_M * num_pid_n
-        swizzle_group = local_tile // num_pid_in_group
-        first_pid_m = swizzle_group * GROUP_SIZE_M
-        group_size_m = min(tiles_m_g - first_pid_m, GROUP_SIZE_M)
-        pid_m = first_pid_m + ((local_tile % num_pid_in_group) % group_size_m)
-        pid_n = (local_tile % num_pid_in_group) // group_size_m
-        tl.assume(pid_m >= 0)
-        tl.assume(pid_n >= 0)
-
-        # ── Address computation ──
-        rm = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M_g
-        rn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
-        rk = tl.arange(0, BLOCK_SIZE_K)
-        rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
-
-        group_offset_b = group_idx.to(tl.int64) * stride_bg
-        A_BASE = A + m_start_g * stride_am + rm[:, None] * stride_am + rk[None, :] * stride_ak
-        B_BASE = B + group_offset_b + rk[:, None] * stride_bk + rn[None, :] * stride_bn
-
-        # A_scales pointer: pre-transposed [K//128, M_total]
-        as_ptrs_base = A_scales_ptr + (m_start_g + rm.to(tl.int64)) * stride_as_m
-
-        # B_scales pointer: B_scales[g, pn, ki] (2D block scaling)
-        bs_ptr_base = B_scales_ptr + group_idx.to(tl.int64) * stride_bs_g + pid_n * stride_bs_n
-
-        # ── K-loop with block-wise scaling (EVEN_K pattern) ──
-        loop_k = tl.cdiv(K, BLOCK_SIZE_K)
-        if not EVEN_K:
-            loop_k -= 1
-        tl.assume(loop_k > 1)
-
-        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
-
-        for ki in range(0, loop_k):
-            if stride_ak == 1:
-                a = tl.load(tl.multiple_of(A_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)
-            else:
-                a = tl.load(tl.multiple_of(A_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER)
-
-            if stride_bk == 1:
-                b = tl.load(tl.multiple_of(B_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER)
-            else:
-                b = tl.load(tl.multiple_of(B_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)
-
-            partial = tl.dot(a, b)
-
-            # Block-wise scales: a_s is [BLOCK_M] vector, b_s is scalar
-            a_s = tl.load(as_ptrs_base + ki * stride_as_k)
-            b_s = tl.load(bs_ptr_base + ki * stride_bs_k)
-            acc += partial * (a_s * b_s)[:, None]
-
-            A_BASE += BLOCK_SIZE_K * stride_ak
-            B_BASE += BLOCK_SIZE_K * stride_bk
-
-        if not EVEN_K:
-            # ── Last partial K-block (masked) ──
-            rk_last = loop_k * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
-            A_LAST = A + m_start_g * stride_am + rm[:, None] * stride_am + rk_last[None, :] * stride_ak
-            B_LAST = B + group_offset_b + rk_last[:, None] * stride_bk + rn[None, :] * stride_bn
-            if stride_ak == 1:
-                A_LAST = tl.multiple_of(A_LAST, (1, 16))
-            else:
-                A_LAST = tl.multiple_of(A_LAST, (16, 1))
-            if stride_bk == 1:
-                B_LAST = tl.multiple_of(B_LAST, (16, 1))
-            else:
-                B_LAST = tl.multiple_of(B_LAST, (1, 16))
-            a = tl.load(A_LAST, mask=rk_last[None, :] < K, other=0.0, cache_modifier=CACHE_MODIFIER)
-            b = tl.load(B_LAST, mask=rk_last[:, None] < K, other=0.0, cache_modifier=CACHE_MODIFIER)
-            partial = tl.dot(a, b)
-            a_s = tl.load(as_ptrs_base + loop_k * stride_as_k)
-            b_s = tl.load(bs_ptr_base + loop_k * stride_bs_k)
-            acc += partial * (a_s * b_s)[:, None]
-
-        # ── Store output ──
-        c = acc.to(C.type.element_ty)
-        rm_s = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M_g
-        rn_s = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
-        rn_s = tl.max_contiguous(tl.multiple_of(rn_s, BLOCK_SIZE_N), BLOCK_SIZE_N)
-        c_mask = (rm_s[:, None] < M_g) & (rn_s[None, :] < N)
-        C_ = C + m_start_g * stride_cm + rm_s[:, None] * stride_cm + rn_s[None, :] * stride_cn
-        tl.store(C_, c, c_mask)
-
-
-# Blockwise FP8 forward v2: K-loop split into outer (scale block, SCALE_BLOCK_K=128)
-# × inner (compute block, BLOCK_SIZE_K). Requires K % SCALE_BLOCK_K == 0.
-# BLOCK_N pinned to 128 (BN=64/256 have an MFMA layout bug on MI300X FP8 e4m3fnuz).
+# Single persistent kernel for both K-aligned (EVEN_K) and K-unaligned (masked
+# tail) blockwise FP8. BLOCK_N pinned to 128 (BN=64/256 hit an MFMA layout bug on
+# MI300X FP8 e4m3fnuz); BLOCK_M=256 must use BLOCK_K=128 (same bug).
 # BLOCK_M=256 must use BLOCK_K=128 (same bug otherwise).
 @triton.autotune(configs=_get_grouped_blockwise_autotune_configs(), key=["G", "N", "K"])
 @triton.jit()
@@ -1432,20 +1260,22 @@ def _grouped_blockwise_fp8_persistent_gemm_kernel(
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
-    SCALE_BLOCK_K: tl.constexpr,
     GROUP_SIZE_M: tl.constexpr,
     NUM_SMS: tl.constexpr,
     NUM_XCDS: tl.constexpr,
     CHUNK_SIZE: tl.constexpr,
+    EVEN_K: tl.constexpr,
     CACHE_MODIFIER: tl.constexpr,
     G_POW2: tl.constexpr,
 ):
-    """Grouped blockwise FP8 v2; needs K % SCALE_BLOCK_K == 0."""
+    """Persistent grouped block-wise FP8 GEMM (fwd/dgrad), CPU-sync-free.
+
+    Handles K % BLOCK_SIZE_K == 0 (EVEN_K=True, no tail) and the masked K-tail
+    (EVEN_K=False) in one body. BLOCK_SIZE_K == SCALE_BLOCK_K == 128: one block
+    scale per K-block. A scales are pre-shuffled [K//128, M] for coalesced reads."""
     pid = tl.program_id(0)
     if NUM_XCDS != 1:
         pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
-
-    SUB_K_ITERS: tl.constexpr = SCALE_BLOCK_K // BLOCK_SIZE_K
 
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
 
@@ -1502,28 +1332,47 @@ def _grouped_blockwise_fp8_persistent_gemm_kernel(
         as_ptrs_base = A_scales_ptr + (m_start_g + rm.to(tl.int64)) * stride_as_m
         bs_ptr_base = B_scales_ptr + group_idx.to(tl.int64) * stride_bs_g + pid_n * stride_bs_n
 
-        # Outer = scale blocks; inner = SUB_K_ITERS dots sharing one (a_s, b_s).
-        loop_kb = K // SCALE_BLOCK_K
-        tl.assume(loop_kb > 1)
+        # ── K-loop with per-block scaling (one block scale per BLOCK_SIZE_K) ──
+        loop_k = tl.cdiv(K, BLOCK_SIZE_K)
+        if not EVEN_K:
+            loop_k -= 1
+        tl.assume(loop_k > 1)
         acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
 
-        for kb in range(0, loop_kb):
-            partial = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
-            for sub in tl.static_range(SUB_K_ITERS):
-                if stride_ak == 1:
-                    a = tl.load(tl.multiple_of(A_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)
-                else:
-                    a = tl.load(tl.multiple_of(A_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER)
-                if stride_bk == 1:
-                    b = tl.load(tl.multiple_of(B_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER)
-                else:
-                    b = tl.load(tl.multiple_of(B_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)
-                partial += tl.dot(a, b)
-                A_BASE += BLOCK_SIZE_K * stride_ak
-                B_BASE += BLOCK_SIZE_K * stride_bk
+        for ki in range(0, loop_k):
+            if stride_ak == 1:
+                a = tl.load(tl.multiple_of(A_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)
+            else:
+                a = tl.load(tl.multiple_of(A_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER)
+            if stride_bk == 1:
+                b = tl.load(tl.multiple_of(B_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER)
+            else:
+                b = tl.load(tl.multiple_of(B_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)
+            partial = tl.dot(a, b)
+            a_s = tl.load(as_ptrs_base + ki * stride_as_k)
+            b_s = tl.load(bs_ptr_base + ki * stride_bs_k)
+            acc += partial * (a_s * b_s)[:, None]
+            A_BASE += BLOCK_SIZE_K * stride_ak
+            B_BASE += BLOCK_SIZE_K * stride_bk
 
-            a_s = tl.load(as_ptrs_base + kb * stride_as_k)
-            b_s = tl.load(bs_ptr_base + kb * stride_bs_k)
+        if not EVEN_K:
+            # ── Last partial K-block (masked) ──
+            rk_last = loop_k * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+            A_LAST = A + m_start_g * stride_am + rm[:, None] * stride_am + rk_last[None, :] * stride_ak
+            B_LAST = B + group_offset_b + rk_last[:, None] * stride_bk + rn[None, :] * stride_bn
+            if stride_ak == 1:
+                A_LAST = tl.multiple_of(A_LAST, (1, 16))
+            else:
+                A_LAST = tl.multiple_of(A_LAST, (16, 1))
+            if stride_bk == 1:
+                B_LAST = tl.multiple_of(B_LAST, (16, 1))
+            else:
+                B_LAST = tl.multiple_of(B_LAST, (1, 16))
+            a = tl.load(A_LAST, mask=rk_last[None, :] < K, other=0.0, cache_modifier=CACHE_MODIFIER)
+            b = tl.load(B_LAST, mask=rk_last[:, None] < K, other=0.0, cache_modifier=CACHE_MODIFIER)
+            partial = tl.dot(a, b)
+            a_s = tl.load(as_ptrs_base + loop_k * stride_as_k)
+            b_s = tl.load(bs_ptr_base + loop_k * stride_bs_k)
             acc += partial * (a_s * b_s)[:, None]
 
         c = acc.to(C.type.element_ty)
@@ -1779,67 +1628,37 @@ def grouped_gemm_fp8_blockwise_triton_kernel(
         bal_offs = torch.arange(G + 1, device=group_offs.device, dtype=group_offs.dtype) * per
         bal_offs[-1] = M_total
         out_warm = torch.empty_like(out)
-        if aligned:
-            if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
-                triton.knobs.amd.use_async_copy = False
-            _grouped_blockwise_fp8_persistent_gemm_kernel[(num_sms,)](
-                a, b, out_warm, a_scales, b_scales, bal_offs,
-                G, N, K,
-                a.stride(0), stride_bg, stride_bn,
-                out_warm.stride(0), out_warm.stride(1),
-                a_scales.stride(0), a_scales.stride(1),
-                b_scales.stride(0), stride_bs_n, stride_bs_k,
-                stride_ak=stride_ak, stride_bk=stride_bk,
-                SCALE_BLOCK_K=128,
-                NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
-                CACHE_MODIFIER=".ca",
-                G_POW2=triton.next_power_of_2(G),
-                waves_per_eu=0, matrix_instr_nonkdim=16, kpack=2,
-            )
-        else:
-            _grouped_blockwise_fp8_persistent_gemm_kernel_unaligned[(num_sms,)](
-                a, b, out_warm, a_scales, b_scales, bal_offs,
-                G, N, K,
-                a.stride(0), stride_bg, stride_bn,
-                out_warm.stride(0), out_warm.stride(1),
-                a_scales.stride(0), a_scales.stride(1),
-                b_scales.stride(0), stride_bs_n, stride_bs_k,
-                stride_ak=stride_ak, stride_bk=stride_bk,
-                NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
-                EVEN_K=False, CACHE_MODIFIER=".ca",
-                waves_per_eu=0, matrix_instr_nonkdim=16, kpack=1,
-            )
-
-    if aligned:
         if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
             triton.knobs.amd.use_async_copy = False
         _grouped_blockwise_fp8_persistent_gemm_kernel[(num_sms,)](
-            a, b, out, a_scales, b_scales, group_offs,
+            a, b, out_warm, a_scales, b_scales, bal_offs,
             G, N, K,
             a.stride(0), stride_bg, stride_bn,
-            out.stride(0), out.stride(1),
+            out_warm.stride(0), out_warm.stride(1),
             a_scales.stride(0), a_scales.stride(1),
             b_scales.stride(0), stride_bs_n, stride_bs_k,
             stride_ak=stride_ak, stride_bk=stride_bk,
-            SCALE_BLOCK_K=128,
             NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
-            CACHE_MODIFIER=".ca",
+            EVEN_K=aligned, CACHE_MODIFIER=".ca",
             G_POW2=triton.next_power_of_2(G),
             waves_per_eu=0, matrix_instr_nonkdim=16, kpack=2,
         )
-    else:
-        _grouped_blockwise_fp8_persistent_gemm_kernel_unaligned[(num_sms,)](
-            a, b, out, a_scales, b_scales, group_offs,
-            G, N, K,
-            a.stride(0), stride_bg, stride_bn,
-            out.stride(0), out.stride(1),
-            a_scales.stride(0), a_scales.stride(1),
-            b_scales.stride(0), stride_bs_n, stride_bs_k,
-            stride_ak=stride_ak, stride_bk=stride_bk,
-            NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
-            EVEN_K=False, CACHE_MODIFIER=".ca",
-            waves_per_eu=0, matrix_instr_nonkdim=16, kpack=1,
-        )
+
+    if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
+        triton.knobs.amd.use_async_copy = False
+    _grouped_blockwise_fp8_persistent_gemm_kernel[(num_sms,)](
+        a, b, out, a_scales, b_scales, group_offs,
+        G, N, K,
+        a.stride(0), stride_bg, stride_bn,
+        out.stride(0), out.stride(1),
+        a_scales.stride(0), a_scales.stride(1),
+        b_scales.stride(0), stride_bs_n, stride_bs_k,
+        stride_ak=stride_ak, stride_bk=stride_bk,
+        NUM_SMS=num_sms, NUM_XCDS=NUM_XCDS,
+        EVEN_K=aligned, CACHE_MODIFIER=".ca",
+        G_POW2=triton.next_power_of_2(G),
+        waves_per_eu=0, matrix_instr_nonkdim=16, kpack=2,
+    )
     return out
 
 

--- a/primus_turbo/triton/quantization/quant_blockwise.py
+++ b/primus_turbo/triton/quantization/quant_blockwise.py
@@ -179,7 +179,7 @@ def quant_fp8_blockwise_segment_m_row_col_kernel(
     for valid input rows. Row scales are written pre-shuffled as [N_blocks, M_in] so the
     persistent fwd GEMM reads them by stride with no runtime .T.contiguous().
     """
-    pid_m = tl.program_id(axis=0)   # padded M index
+    pid_m = tl.program_id(axis=0)  # padded M index
     pid_n = tl.program_id(axis=1)
 
     M_padded = tl.load(padded_group_offs_ptr + num_groups)
@@ -203,28 +203,18 @@ def quant_fp8_blockwise_segment_m_row_col_kernel(
     offs_n = tl.cast(pid_n * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE), tl.int64)
     offs_m_in = orig_start + (offs_m_out - pad_start)
 
-    mask_in = (
-        (offs_m_in[:, None] >= orig_start)
-        & (offs_m_in[:, None] < orig_end)
-        & (offs_n[None, :] < N)
-    )
+    mask_in = (offs_m_in[:, None] >= orig_start) & (offs_m_in[:, None] < orig_end) & (offs_n[None, :] < N)
 
-    x = tl.load(
-        x_ptr + offs_m_in[:, None] * N + offs_n[None, :], mask=mask_in, other=0.0
-    ).to(tl.float32)
+    x = tl.load(x_ptr + offs_m_in[:, None] * N + offs_n[None, :], mask=mask_in, other=0.0).to(tl.float32)
     x_abs = tl.abs(x)
 
     col_max = tl.maximum(tl.max(x_abs, axis=0, keep_dims=True), 1e-4)
     col_scale = FP8_MAX / col_max
-    x_fp8_col = tl.clamp(x * col_scale, min=-FP8_MAX, max=FP8_MAX).to(
-        x_fp8_col_padded_ptr.dtype.element_ty
-    )
+    x_fp8_col = tl.clamp(x * col_scale, min=-FP8_MAX, max=FP8_MAX).to(x_fp8_col_padded_ptr.dtype.element_ty)
 
     row_max = tl.maximum(tl.max(x_abs, axis=1, keep_dims=True), 1e-4)
     row_scale = FP8_MAX / row_max
-    x_fp8_row = tl.clamp(x * row_scale, min=-FP8_MAX, max=FP8_MAX).to(
-        x_fp8_row_ptr.dtype.element_ty
-    )
+    x_fp8_row = tl.clamp(x * row_scale, min=-FP8_MAX, max=FP8_MAX).to(x_fp8_row_ptr.dtype.element_ty)
 
     out_mask_pad = (offs_m_out[:, None] < M_padded) & (offs_n[None, :] < N)
     tl.store(

--- a/primus_turbo/triton/quantization/quant_blockwise.py
+++ b/primus_turbo/triton/quantization/quant_blockwise.py
@@ -112,87 +112,6 @@ def quant_fp8_blockwise_dual_kernel(
     )
 
 
-# Blockwise quantize with segment padding
-# Reads from original tensor, writes to padded tensor with segment alignment
-@triton.jit
-def quant_fp8_blockwise_segment_m_kernel(
-    x_ptr,  # Input tensor [M_in, N]
-    x_fp8_ptr,  # Output tensor [M_out, N] (padded)
-    x_scales_ptr,  # Output scales [M_out // BLOCK_SIZE, N]
-    group_offs_ptr,  # Original group offsets [B+1]
-    padded_group_offs_ptr,  # Padded group offsets [B+1]
-    N,
-    num_groups,
-    BLOCK_SIZE: tl.constexpr,
-    FP8_MAX: tl.constexpr,
-):
-    """
-    Each program handles one BLOCK_SIZE x BLOCK_SIZE tile in the output (padded) space.
-    Maps back to input space using group offsets.
-    """
-    pid_m = tl.program_id(axis=0)  # Block index in M dimension (padded)
-    pid_n = tl.program_id(axis=1)  # Block index in N dimension
-
-    # Get actual M_padded for bounds checking (last element of padded_group_offs)
-    M_padded = tl.load(padded_group_offs_ptr + num_groups)
-
-    # Early exit for out-of-bounds blocks (when using upper bound allocation)
-    block_start = pid_m * BLOCK_SIZE
-    if block_start >= M_padded:
-        return
-
-    # Find which group this block belongs to by searching padded_group_offs
-    group_id = 0
-    for g in range(num_groups):
-        padded_start = tl.load(padded_group_offs_ptr + g)
-        padded_end = tl.load(padded_group_offs_ptr + g + 1)
-        if block_start >= padded_start and block_start < padded_end:
-            group_id = g
-
-    # Get group boundaries
-    orig_group_start = tl.load(group_offs_ptr + group_id)
-    orig_group_end = tl.load(group_offs_ptr + group_id + 1)
-    padded_group_start = tl.load(padded_group_offs_ptr + group_id)
-
-    # Calculate offsets in padded output space
-    offs_m_out = tl.cast(pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE), tl.int64)
-    offs_n = tl.cast(pid_n * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE), tl.int64)
-
-    # Map output offset to input offset
-    offs_m_in = orig_group_start + (offs_m_out - padded_group_start)
-
-    # Mask: valid if within original group and within N
-    mask = (
-        (offs_m_in[:, None] >= orig_group_start)
-        & (offs_m_in[:, None] < orig_group_end)
-        & (offs_n[None, :] < N)
-    )
-
-    # Load from input (using input offsets)
-    x_ptrs = x_ptr + offs_m_in[:, None] * N + offs_n[None, :]
-    x_tile = tl.load(x_ptrs, mask=mask, other=0.0).to(tl.float32)
-    x_tile_abs = tl.abs(x_tile)
-
-    # Compute scale and quantize
-    x_fp8_tile, x_scales_tile = compute_scale_and_quant(x_tile, x_tile_abs, 0, FP8_MAX)
-
-    # Store to padded output (using output offsets)
-    x_fp8_ptrs = x_fp8_ptr + offs_m_out[:, None] * N + offs_n[None, :]
-    # Output mask: check both M and N bounds
-    out_mask = (offs_m_out[:, None] < M_padded) & (offs_n[None, :] < N)
-    tl.store(x_fp8_ptrs, x_fp8_tile.to(x_fp8_ptr.dtype.element_ty), mask=out_mask)
-
-    # Store scale
-    scale_offs = pid_m * N + offs_n
-    scale_mask = (pid_m < tl.cdiv(M_padded, BLOCK_SIZE)) & (offs_n < N)
-    x_scales_tile_inv = tl.reshape(1.0 / x_scales_tile, BLOCK_SIZE)
-    tl.store(
-        x_scales_ptr + scale_offs,
-        x_scales_tile_inv,
-        mask=scale_mask,
-    )
-
-
 # w_ptr         [B, M, N]
 # w_fp8_ptr     [B, M, N] FP8
 # w_scales_ptr  [B, M // BLOCK_SIZE, N // BLOCK_SIZE] FP32
@@ -235,3 +154,106 @@ def quant_fp8_blockwise_for_weight_kernel(
     scale_offs = batch_offset_scales + pid_m * tl.cdiv(N, BLOCK_SIZE) + pid_n
     w_scales_inv = 1.0 / w_scales
     tl.store(w_scales_ptr + scale_offs, w_scales_inv)
+
+
+@triton.jit
+def quant_fp8_blockwise_segment_m_row_col_kernel(
+    x_ptr,
+    x_fp8_row_ptr,
+    x_fp8_col_padded_ptr,
+    x_scales_row_ptr,
+    x_scales_col_padded_ptr,
+    group_offs_ptr,
+    padded_group_offs_ptr,
+    M_in,
+    N,
+    num_groups,
+    BLOCK_SIZE: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+):
+    """Fused row + segment-padded col quant for grouped GEMM (dgrad + variable-K wgrad).
+
+    One bf16 read of x produces: row-wise scaled output (for the fwd/dgrad GEMM) and
+    segment-padded col-wise scaled output (for the variable-K wgrad GEMM). Each program
+    handles one [BLOCK, BLOCK] tile in padded output space; row outputs are emitted only
+    for valid input rows. Row scales are written pre-shuffled as [N_blocks, M_in] so the
+    persistent fwd GEMM reads them by stride with no runtime .T.contiguous().
+    """
+    pid_m = tl.program_id(axis=0)   # padded M index
+    pid_n = tl.program_id(axis=1)
+
+    M_padded = tl.load(padded_group_offs_ptr + num_groups)
+    block_start = pid_m * BLOCK_SIZE
+    if block_start >= M_padded:
+        return
+
+    # Find group containing this padded tile
+    group_id = 0
+    for g in range(num_groups):
+        ps = tl.load(padded_group_offs_ptr + g)
+        pe = tl.load(padded_group_offs_ptr + g + 1)
+        if block_start >= ps and block_start < pe:
+            group_id = g
+
+    orig_start = tl.load(group_offs_ptr + group_id)
+    orig_end = tl.load(group_offs_ptr + group_id + 1)
+    pad_start = tl.load(padded_group_offs_ptr + group_id)
+
+    offs_m_out = tl.cast(pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE), tl.int64)
+    offs_n = tl.cast(pid_n * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE), tl.int64)
+    offs_m_in = orig_start + (offs_m_out - pad_start)
+
+    mask_in = (
+        (offs_m_in[:, None] >= orig_start)
+        & (offs_m_in[:, None] < orig_end)
+        & (offs_n[None, :] < N)
+    )
+
+    x = tl.load(
+        x_ptr + offs_m_in[:, None] * N + offs_n[None, :], mask=mask_in, other=0.0
+    ).to(tl.float32)
+    x_abs = tl.abs(x)
+
+    col_max = tl.maximum(tl.max(x_abs, axis=0, keep_dims=True), 1e-4)
+    col_scale = FP8_MAX / col_max
+    x_fp8_col = tl.clamp(x * col_scale, min=-FP8_MAX, max=FP8_MAX).to(
+        x_fp8_col_padded_ptr.dtype.element_ty
+    )
+
+    row_max = tl.maximum(tl.max(x_abs, axis=1, keep_dims=True), 1e-4)
+    row_scale = FP8_MAX / row_max
+    x_fp8_row = tl.clamp(x * row_scale, min=-FP8_MAX, max=FP8_MAX).to(
+        x_fp8_row_ptr.dtype.element_ty
+    )
+
+    out_mask_pad = (offs_m_out[:, None] < M_padded) & (offs_n[None, :] < N)
+    tl.store(
+        x_fp8_col_padded_ptr + offs_m_out[:, None] * N + offs_n[None, :],
+        x_fp8_col,
+        mask=out_mask_pad,
+    )
+
+    tl.store(
+        x_fp8_row_ptr + offs_m_in[:, None] * N + offs_n[None, :],
+        x_fp8_row,
+        mask=mask_in,
+    )
+
+    col_scale_inv = tl.reshape(1.0 / col_scale, BLOCK_SIZE)
+    col_scale_mask = (pid_m < tl.cdiv(M_padded, BLOCK_SIZE)) & (offs_n < N)
+    tl.store(
+        x_scales_col_padded_ptr + pid_m * N + offs_n,
+        col_scale_inv,
+        mask=col_scale_mask,
+    )
+
+    row_scale_inv = tl.reshape(1.0 / row_scale, BLOCK_SIZE)
+    row_scale_mask = (offs_m_in >= orig_start) & (offs_m_in < orig_end) & (offs_m_in < M_in)
+    # Pshuffled [N_blocks, M_in]: matches the persistent fwd GEMM's scale order, so the
+    # GEMM reads scales coalesced with no runtime .T.contiguous(). The HIP fast path
+    # (quantize_fp8_blockwise_segment_m_row_col) emits the same layout.
+    tl.store(
+        x_scales_row_ptr + pid_n * M_in + offs_m_in,
+        row_scale_inv,
+        mask=row_scale_mask,
+    )

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -334,11 +334,11 @@ def test_grouped_gemm_fp8_rowwise_deterministic(B, M, NK, ori_dtype, format, tra
 @pytest.mark.parametrize("ori_dtype", ORI_DTYPE_VALUES)
 @pytest.mark.parametrize("format", FORMAT_VALUES)
 @pytest.mark.parametrize("block_size", [128])
-@pytest.mark.parametrize("trans_b", [True])
-@pytest.mark.parametrize("balance", [False])
+@pytest.mark.parametrize("trans_b", TRANS_B_VALUES)
+@pytest.mark.parametrize("balance", BALANCE_VALUES)
 @pytest.mark.parametrize("backend", [BackendType.TRITON])
 @pytest.mark.deterministic
-def test_grouped_gemm_fp8_blockwise_triton_deterministic(
+def test_grouped_gemm_fp8_blockwise_deterministic(
     B, M, NK, ori_dtype, format, block_size, trans_b, balance, backend
 ):
     N, K = NK

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -334,36 +334,6 @@ def test_grouped_gemm_fp8_rowwise_deterministic(B, M, NK, ori_dtype, format, tra
 @pytest.mark.parametrize("ori_dtype", ORI_DTYPE_VALUES)
 @pytest.mark.parametrize("format", FORMAT_VALUES)
 @pytest.mark.parametrize("block_size", [128])
-@pytest.mark.parametrize("trans_b", TRANS_B_VALUES)
-@pytest.mark.parametrize("balance", BALANCE_VALUES)
-@pytest.mark.parametrize("backend", [BackendType.CK])
-@pytest.mark.deterministic
-def test_grouped_gemm_fp8_blockwise_deterministic(
-    B, M, NK, ori_dtype, format, block_size, trans_b, balance, backend
-):
-    N, K = NK
-    _run_grouped_gemm_fp8_deterministic_test(
-        B=B,
-        M=M,
-        N=N,
-        K=K,
-        ori_dtype=ori_dtype,
-        format=format,
-        granularity=ScalingGranularity.BLOCKWISE,
-        trans_b=trans_b,
-        balance=balance,
-        backend=backend,
-        block_size=block_size,
-        repeats=10,
-    )
-
-
-@pytest.mark.parametrize("B", _DET_B_VALUES)
-@pytest.mark.parametrize("M", _DET_M_VALUES)
-@pytest.mark.parametrize("NK", _DET_NK_VALUES)
-@pytest.mark.parametrize("ori_dtype", ORI_DTYPE_VALUES)
-@pytest.mark.parametrize("format", FORMAT_VALUES)
-@pytest.mark.parametrize("block_size", [128])
 @pytest.mark.parametrize("trans_b", [True])
 @pytest.mark.parametrize("balance", [False])
 @pytest.mark.parametrize("backend", [BackendType.TRITON])
@@ -459,7 +429,7 @@ def test_grouped_gemm_fp8_rowwise(B, M, NK, ori_dtype, format, trans_b, balance,
 @pytest.mark.parametrize("block_size", [128])
 @pytest.mark.parametrize("trans_b", TRANS_B_VALUES)
 @pytest.mark.parametrize("balance", BALANCE_VALUES)
-@pytest.mark.parametrize("backend", [None, BackendType.CK, BackendType.TRITON])
+@pytest.mark.parametrize("backend", [None, BackendType.TRITON])
 @pytest.mark.parametrize("auto_tune", [False, True])
 def test_grouped_gemm_fp8_blockwise(
     B, M, NK, ori_dtype, format, block_size, trans_b, balance, backend, auto_tune


### PR DESCRIPTION
# Description

Optimizes the grouped **BLOCKWISE** FP8 GEMM path (fwd + dgrad + variable-K wgrad)
on MI300X (gfx942) and MI355X (gfx950), layered on `main` and the db7882d (#339)
non-grouped blockwise rework. Triton is the production backend; a HIP fused-quant
fast path cuts host-dispatch overhead on small grouped GEMMs.

Fixes # (n/a)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

- **Grouped GEMM kernels**: persistent fwd/dgrad kernel with hoisted scale loads and
  a vectorised per-tile group lookup; unify the K-aligned and K-unaligned kernels
  into a single `EVEN_K` kernel (tail elided when aligned); curated variable-K wgrad
  autotune set; pshuffled `[K_blocks, M]` A-scale layout (coalesced reads, no runtime
  `.T.contiguous()`).
- **Fused quant**: `quant_fp8_blockwise_segment_m_row_col` — one bf16 read emits
  row-wise (fwd/dgrad) + segment-padded col-wise (wgrad) outputs; `custom_op`
  registration (sidesteps the Triton 3.7 inductor DCE bug); HIP fast path below a
  GEMM-FLOPs threshold, Triton otherwise.
- **HIP weight quant** fast path (`quantize_fp8_blockwise_for_weight`), shared by the
  grouped and non-grouped blockwise paths (layout-identical to the Triton kernel).
- New csrc: `csrc/kernels/quantization/quantization_blockwise.cu` + bindings/meta.
- Drop CK for grouped BLOCKWISE (Triton is the production backend; CK asserts on
  unaligned shapes). Non-grouped GEMM CK is untouched.

Perf (grouped blockwise fwd+bwd, Triton vs `main` Triton): MI355X +28–50% full-pass
across LFM2 / Qwen3 / DeepSeek-V3; MI300X matches/beats `main` (+16–20% on large B=16).

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
