### PR TITLE
fix: add hybrid format test for float8linear

### DIFF
--- a/tests/pytorch/modules/test_linear_fp8.py
+++ b/tests/pytorch/modules/test_linear_fp8.py
@@ -25,13 +25,16 @@ float8_quant_configs = [
 
 @pytest.mark.parametrize("config", float8_quant_configs)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("format", [Format.E4M3, Format.E5M2])
+@pytest.mark.parametrize("format", [Format.E4M3, Format.E5M2, Format.HYBRID])
 @pytest.mark.parametrize("M", [128, 4096])
 @pytest.mark.parametrize("N", [256, 4096])
 @pytest.mark.parametrize("K", [512, 2048, 8192])
 @pytest.mark.parametrize("bias", [True, False])
 @pytest.mark.parametrize("enable_torch_compile", [True, False])
 def test_float8linear(config, dtype, format, M, N, K, bias, enable_torch_compile):
+    if format == Format.HYBRID and config.granularity != ScalingGranularity.TENSORWISE:
+        pytest.skip("Format.HYBRID is only supported for TENSORWISE granularity")
+
     device = "cuda:0"
 
     config.format = format


### PR DESCRIPTION
# Description

This PR adds test coverage for the `Format.HYBRID` FP8 format in the `Float8Linear` module test. Previously, the parametrized test for `test_float8linear` only covered `Format.E4M3` and `Format.E5M2`. Since `Format.HYBRID` is only supported under `TENSORWISE` scaling granularity, the test is parametrized with `Format.HYBRID` for all configs and skips the unsupported combinations at runtime.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Added `Format.HYBRID` to the `format` parametrization of `test_float8linear` in `tests/pytorch/modules/test_linear_fp8.py`.
- Added a runtime skip so that `Format.HYBRID` is only exercised when `config.granularity == ScalingGranularity.TENSORWISE`, since HYBRID is only supported for tensorwise scaling.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
