### PR TITLE
fix(attention): match qkv_format strides in forward fake kernel

### DIFF
--- a/primus_turbo/pytorch/kernels/attention/attention_aiter_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_aiter_impl.py
@@ -373,7 +373,16 @@ def _attention_aiter_forward_impl_fake(
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     batch_size, seq_len_q, num_heads_q, _ = q.shape
     _, _, _, head_dim_v = v.shape
-    out = torch.empty((batch_size, seq_len_q, num_heads_q, head_dim_v), dtype=q.dtype, device=q.device)
+    if qkv_format == "sbhd":
+        out = torch.empty(
+            (seq_len_q, batch_size, num_heads_q, head_dim_v), dtype=q.dtype, device=q.device
+        ).permute(1, 0, 2, 3)
+    elif qkv_format == "bhsd":
+        out = torch.empty(
+            (batch_size, num_heads_q, seq_len_q, head_dim_v), dtype=q.dtype, device=q.device
+        ).permute(0, 2, 1, 3)
+    else:
+        out = torch.empty((batch_size, seq_len_q, num_heads_q, head_dim_v), dtype=q.dtype, device=q.device)
     softmax_lse = torch.empty((batch_size, num_heads_q, seq_len_q), dtype=torch.float32, device=q.device)
     S_dmask = torch.empty((0,), dtype=q.dtype, device=q.device)
     rng_state = torch.empty((2,), dtype=torch.int64, device=q.device)

--- a/tests/pytorch/ops/test_attention.py
+++ b/tests/pytorch/ops/test_attention.py
@@ -484,3 +484,45 @@ def test_attention_fp8_with_sparse_do(batch, config, causal):
     assert dq_snr > 15, "query_grad_snr too low"
     assert dk_snr > 15, "key_grad_snr too low"
     assert dv_snr > 15, "value_grad_snr too low"
+
+
+@pytest.mark.parametrize("qkv_format", ["bshd", "sbhd", "bhsd"])
+def test_attention_fake_kernel_strides(qkv_format):
+    """Verify that torch.compile sees correct output strides for every qkv_format.
+
+    The fake (meta) kernel must produce output tensors whose strides match the
+    eager kernel so that torch.compile's shape/stride propagation is correct.
+    """
+    device = "cuda"
+    dtype = torch.bfloat16
+    batch, seq_q, seq_kv, num_heads, head_dim = 2, 32, 32, 4, 64
+
+    if qkv_format == "sbhd":
+        q = torch.randn(seq_q, batch, num_heads, head_dim, device=device, dtype=dtype).permute(1, 0, 2, 3)
+        k = torch.randn(seq_kv, batch, num_heads, head_dim, device=device, dtype=dtype).permute(1, 0, 2, 3)
+        v = torch.randn(seq_kv, batch, num_heads, head_dim, device=device, dtype=dtype).permute(1, 0, 2, 3)
+    elif qkv_format == "bhsd":
+        q = torch.randn(batch, num_heads, seq_q, head_dim, device=device, dtype=dtype).transpose(1, 2)
+        k = torch.randn(batch, num_heads, seq_kv, head_dim, device=device, dtype=dtype).transpose(1, 2)
+        v = torch.randn(batch, num_heads, seq_kv, head_dim, device=device, dtype=dtype).transpose(1, 2)
+    else:
+        q = torch.randn(batch, seq_q, num_heads, head_dim, device=device, dtype=dtype)
+        k = torch.randn(batch, seq_kv, num_heads, head_dim, device=device, dtype=dtype)
+        v = torch.randn(batch, seq_kv, num_heads, head_dim, device=device, dtype=dtype)
+
+    out_eager = flash_attn_func(q, k, v, causal=True)
+    eager_strides = out_eager.stride()
+
+    torch._dynamo.reset()
+
+    @torch.compile(fullgraph=True)
+    def fn(q, k, v):
+        return flash_attn_func(q, k, v, causal=True)
+
+    out_compiled = fn(q, k, v)
+
+    assert out_compiled.stride() == eager_strides, (
+        f"Stride mismatch for qkv_format={qkv_format}: "
+        f"compiled={out_compiled.stride()}, eager={eager_strides}"
+    )
+    assert out_compiled.shape == out_eager.shape


### PR DESCRIPTION
Correct the output tensor strides in `_attention_aiter_forward_impl_fake` for `sbhd` and `bhsd` `qkv_format` so that `torch.compile` shape/stride propagation matches eager execution.

- Adds per-format stride derivation in the forward fake kernel
- Adds `torch.compile` stride tests for all three `qkv_format` variants (`sbhd`, `bhsd`, `bshd`)
- Required for correct compiled diffusion attention on `sbhd`-format inputs (Flux 12B MXFP4 path)

# Description

The forward fake kernel previously returned output tensors with strides matching `bshd` layout regardless of the input `qkv_format`. Under `torch.compile`, this mismatch caused downstream ops to be lowered against the wrong stride pattern, producing incorrect numerics for `sbhd` and `bhsd` formats. The fix derives the correct output strides from `qkv_format` in the fake kernel, matching the strides produced by the real kernel in eager mode.

Verified end-to-end as part of `dev/mxfp4-aiter-preshuffle-min` @ 026e136 (Flux 12B uses `sbhd` qkv_format under `torch.compile`; MXFP4 1000-step exit 0, FP8 delayed 1000-step exit 0).

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- `primus_turbo/pytorch/kernels/attention/attention_aiter_impl.py`: in `_attention_aiter_forward_impl_fake`, derive output strides from `qkv_format` so `sbhd`/`bhsd`/`bshd` all match eager-mode strides
- `tests/pytorch/ops/test_attention.py`: add `torch.compile` stride-parity tests across all three `qkv_format` variants

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A - internal fake-kernel correctness fix; no user-facing API change)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
