### PR TITLE
fix: bring hipblaslt multi-stream grouped gemm back in autotune

### DIFF
--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -518,7 +518,7 @@ class GroupedGEMMFP8VariableKTritonBackend(KernelBackend):
 class GroupedGEMMFP8VariableKKernelDispatcher(BaseGroupedGEMMVariableKKernelDispatcher):
     _backends = {
         BackendType.CK: BackendEntry(GroupedGEMMFP8VariableKCKBackend),
-        BackendType.HIPBLASLT: BackendEntry(GroupedGEMMFP8VariableKHipblasltBackend, autotune=False),
+        BackendType.HIPBLASLT: BackendEntry(GroupedGEMMFP8VariableKHipblasltBackend),
         BackendType.TRITON: BackendEntry(GroupedGEMMFP8VariableKTritonBackend),
     }
     _cache = TuneCache(1024)


### PR DESCRIPTION
# Description

We already fix the multi-stream bug in this PR(https://github.com/AMD-AGI/Primus-Turbo/pull/319).

This PR re-enables autotuning for the HIPBLASLt backend of the FP8 variable-K grouped GEMM kernel. Previously, the `BackendType.HIPBLASLT` entry in `GroupedGEMMFP8VariableKKernelDispatcher` was registered with `autotune=False`, which excluded the HIPBLASLt multi-stream grouped GEMM implementation from the autotune candidate set. As a result, the dispatcher could not select the HIPBLASLt path even when it was the fastest backend for a given problem shape.

By removing the `autotune=False` override, the HIPBLASLt backend is once again considered during autotuning, allowing the dispatcher to pick the best-performing backend (CK, HIPBLASLt, or Triton) for each grouped GEMM configuration.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Remove the `autotune=False` override from the `BackendType.HIPBLASLT` `BackendEntry` in `GroupedGEMMFP8VariableKKernelDispatcher` (`primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py`), bringing the HIPBLASLt multi-stream grouped GEMM backend back into the autotune candidate set.

# Checklist:

- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
