### PR TITLE
feat(build): add optional ccache/sccache compiler launcher support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ GPU_ARCHS="gfx942;gfx950" pip3 install --no-build-isolation -e ".[pytorch]" -v
 # Supported values: PYTORCH (default), JAX.
 # For example, to compile for JAX:
 PRIMUS_TURBO_FRAMEWORK="JAX" pip3 install --no-build-isolation -e ".[jax]" -v
+
+# (Optional) ccache/sccache are auto-detected on PATH to speed up incremental rebuilds.
+# Just install ccache or sccache and the build will use it automatically.
 ```
 
 ### 3. Testing

--- a/tools/build_ext.py
+++ b/tools/build_ext.py
@@ -54,6 +54,14 @@ def get_cxx_compiler():
     return compiler
 
 
+def _get_compiler_launcher():
+    launcher = os.environ.get("PRIMUS_TURBO_COMPILER_LAUNCHER")
+    if launcher:
+        print(f"[Primus-Turbo] Using compiler cache: {launcher}")
+        return launcher
+    return None
+
+
 class BuildExtension(build_ext):
     @classmethod
     def with_options(cls, **options):
@@ -429,13 +437,20 @@ def _write_ninja_file(
         raise AssertionError("At least one source is required to build a library")
 
     compiler = get_cxx_compiler()
+    launcher = _get_compiler_launcher()
 
     # Version 1.3 is required for the `deps` directive.
     config = ["ninja_required_version = 1.3"]
-    config.append(f"cxx = {compiler}")
+    if launcher:
+        config.append(f"cxx = {launcher} {compiler}")
+    else:
+        config.append(f"cxx = {compiler}")
     if with_cuda or cuda_dlink_post_cflags:
         nvcc = _join_rocm_home("bin", "hipcc")
-        config.append(f"nvcc = {nvcc}")
+        if launcher:
+            config.append(f"nvcc = {launcher} {nvcc}")
+        else:
+            config.append(f"nvcc = {nvcc}")
 
     post_cflags = COMMON_HIP_FLAGS + post_cflags
     flags = [f'cflags = {" ".join(cflags)}']

--- a/tools/build_ext.py
+++ b/tools/build_ext.py
@@ -55,10 +55,10 @@ def get_cxx_compiler():
 
 
 def _get_compiler_launcher():
-    launcher = os.environ.get("PRIMUS_TURBO_COMPILER_LAUNCHER")
-    if launcher:
-        print(f"[Primus-Turbo] Using compiler cache: {launcher}")
-        return launcher
+    for tool in ("sccache", "ccache"):
+        if shutil.which(tool):
+            print(f"[Primus-Turbo] Found {tool}, enabling as compiler launcher")
+            return tool
     return None
 
 


### PR DESCRIPTION
# Description

Add optional ccache/sccache compiler launcher support to speed up incremental Primus-Turbo rebuilds during development. When `PRIMUS_TURBO_COMPILER_LAUNCHER` is set, the specified cache tool is prepended to both `cxx` and `nvcc` compiler commands in the generated Ninja build file. Default behavior is unchanged when the variable is unset.

## Type of change

- [x] Infra/Build change

## Changes

- Add `_get_compiler_launcher()` helper in `tools/build_ext.py` that reads `PRIMUS_TURBO_COMPILER_LAUNCHER` env var
- Modify `_write_ninja_file()` to prepend the launcher to `cxx` and `nvcc` Ninja variables when set
- Document `PRIMUS_TURBO_COMPILER_LAUNCHER` env var in README.md Development section

### Usage

```bash
PRIMUS_TURBO_COMPILER_LAUNCHER=ccache pip install --no-build-isolation -e .
```

### Verification

Tested in `dev_primus_ubuntu_263` container (rocm/primus:v26.3, MI355X):

| Scenario | Result |
|---|---|
| First build with ccache | 55 cacheable calls, 55 misses (expected) |
| Clean rebuild with ccache | 55 cacheable calls, all cache hits |
| Build without env var | `cxx = /opt/rocm-7.2.1/bin/hipcc` (no prefix, default preserved) |

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes