### PR TITLE
ci: build release sdist on the ROCm runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,19 +27,24 @@ env:
 
 jobs:
   build-sdist:
+    # Built on the ROCm runner: setup.py imports torch/hipcc while configuring
+    # the extensions even for an sdist, so a ROCm + torch environment is needed.
+    # (--no-isolation reuses the container's torch; sdist only packages source,
+    # it does not compile.)
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: turbo-torch-ut-v2602
     steps:
+      - name: Change owner
+        run: sudo chown -R $(id -u):$(id -g) ${GITHUB_WORKSPACE} || true
       - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0   # setuptools_scm needs full history + tags
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - run: pip install build
       - name: Build sdist
-        run: python -m build --sdist
+        run: |
+          pip3 install -r requirements.txt
+          GPU_ARCHS="gfx942;gfx950" PRIMUS_TURBO_FRAMEWORK="PYTORCH" \
+            python3 -m build --sdist --no-isolation
       - name: Show version baked into sdist
         run: |
           tar -xzf dist/*.tar.gz -O '*/PKG-INFO' | grep -i '^Version:' || true


### PR DESCRIPTION
setup.py imports torch and locates hipcc while configuring the build extensions even for an sdist, so building the sdist needs a ROCm + torch environment. Move build-sdist from ubuntu-latest to the self-hosted ROCm runner and use `python -m build --sdist --no-isolation` so it reuses the container's torch (sdist only packages source; it does not compile).

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
