### PR TITLE
ci(release): drop submodule checkout in validate job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,9 @@ jobs:
     steps:
       - name: Change owner
         run: sudo chown -R $(id -u):$(id -g) ${GITHUB_WORKSPACE} || true
+      # No submodules: validate installs the self-contained sdist and only needs
+      # tests/ and requirements.txt from the repo (both live in the main tree).
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive   # provides tests/ and requirements.txt
       - uses: actions/download-artifact@v4
         with:
           name: sdist


### PR DESCRIPTION
The validate job installs the self-contained sdist (which triggers the HIP compile) and only needs tests/ and requirements.txt from the repo, both of which live in the main tree. Recursively checking out submodules on the shallow release clone fails (e.g. 3rdparty/composable_kernel) and is unnecessary, so remove it.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
