### PR TITLE
build(release): pin aiter by release tag and slim the sdist

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -7,9 +7,8 @@ on:
 
 env:
   BENCHMARK_ROOT_DIR: /wekafs/primus_turbo/benchmark
-  # Pinned aiter commit for CI. Keep in sync with EXPECTED_AITER_COMMIT in
-  # primus_turbo/common/aiter_utils.py (used for the runtime version check).
-  AITER_COMMIT: b5e03ed191fca11ee423226537ef8d9435e432a6
+  # Required aiter release. Keep in sync with AITER_GIT_TAG in primus_turbo/common/aiter_utils.py.
+  AITER_VERSION: v0.1.14.post1
 
 jobs:
   benchmark-pytorch-gfx942:
@@ -41,8 +40,7 @@ jobs:
           unset AITER_ASM_DIR
           pip3 uninstall -y aiter amd-aiter || true
           pip3 install -r requirements.txt
-          # Install the pinned aiter commit (AITER_COMMIT set at workflow env level).
-          pip3 install "amd-aiter @ git+https://github.com/ROCm/aiter.git@${AITER_COMMIT}"
+          pip3 install "amd-aiter @ git+https://github.com/ROCm/aiter.git@${AITER_VERSION}"
           GPU_ARCHS="gfx942" PRIMUS_TURBO_FRAMEWORK="PYTORCH" pip3 install --no-build-isolation -e ".[pytorch]" -v
       - name: Create benchmark output directory
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,8 @@ on:
 
 env:
   UCCL_WHEEL_DIR: /apps/tas/0_public/primus_turbo_ci/uccl-wheel-v2602
-  # Pinned aiter commit for CI. Keep in sync with EXPECTED_AITER_COMMIT in
-  # primus_turbo/common/aiter_utils.py (used for the runtime version check).
-  AITER_COMMIT: b5e03ed191fca11ee423226537ef8d9435e432a6
+  # Required aiter release. Keep in sync with AITER_GIT_TAG in primus_turbo/common/aiter_utils.py.
+  AITER_VERSION: v0.1.14.post1
 
 jobs:
   code-lint:
@@ -173,8 +172,7 @@ jobs:
           unset AITER_ASM_DIR
           pip3 uninstall -y aiter amd-aiter || true
           pip3 install -r requirements.txt
-          # Install the pinned aiter commit (AITER_COMMIT set at workflow env level).
-          pip3 install "amd-aiter @ git+https://github.com/ROCm/aiter.git@${AITER_COMMIT}"
+          pip3 install "amd-aiter @ git+https://github.com/ROCm/aiter.git@${AITER_VERSION}"
           GPU_ARCHS="gfx942;gfx950" PRIMUS_TURBO_FRAMEWORK="PYTORCH" pip3 install --no-build-isolation -e ".[pytorch]" -v
       - name: Run single-GPU tests (parallel)
         uses: nick-fields/retry@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  # Pinned aiter commit for validate. Keep in sync with ci.yaml / aiter_utils.py.
-  AITER_COMMIT: b5e03ed191fca11ee423226537ef8d9435e432a6
+  # Required aiter release. Keep in sync with AITER_GIT_TAG in primus_turbo/common/aiter_utils.py.
+  AITER_VERSION: v0.1.14.post1
 
 jobs:
   build-sdist:
@@ -76,7 +76,7 @@ jobs:
           unset AITER_ASM_DIR
           pip3 uninstall -y aiter amd-aiter primus-turbo || true
           pip3 install -r requirements.txt
-          pip3 install "amd-aiter @ git+https://github.com/ROCm/aiter.git@${AITER_COMMIT}"
+          pip3 install "amd-aiter @ git+https://github.com/ROCm/aiter.git@${AITER_VERSION}"
           GPU_ARCHS="gfx942;gfx950" PRIMUS_TURBO_FRAMEWORK="PYTORCH" \
             pip3 install --no-build-isolation "$(ls dist/primus_turbo-*.tar.gz)[pytorch]" -v
       - name: Smoke import + version

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,5 +11,12 @@ recursive-include primus_turbo *.py
 recursive-include 3rdparty/composable_kernel/include *
 recursive-include 3rdparty/hipify_torch/hipify_torch *
 
+# setuptools_scm pulls in every git-tracked file by default; drop dev-only
+# scaffolding (CI / editor / benchmarks / AI-agent docs) from the sdist.
+prune agent
+prune benchmark
+prune .github
+prune .cursor
+
 global-exclude *.py[cod]
 global-exclude __pycache__

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Note: JAX support is under active development. Optim support is planned but not 
 - ROCm >= 7.0
 - Python >= 3.10
 - PyTorch >= 2.6.0 (with ROCm support)
+- [AITER](https://github.com/ROCm/aiter) (required for some operators, e.g. FlashAttention / FP8): `pip3 install "amd-aiter @ git+https://github.com/ROCm/aiter.git@v0.1.14.post1"`
 - rocSHMEM (optional, required for **experimental DeepEP**). Please refer to our [DeepEP Installation Guide](primus_turbo/pytorch/deep_ep/README.md) for instructions.
 
 #### Hardware

--- a/primus_turbo/common/aiter_utils.py
+++ b/primus_turbo/common/aiter_utils.py
@@ -6,53 +6,67 @@
 
 """Helpers for the optional ``aiter`` dependency.
 
-aiter is imported lazily (only when an AITER-backed op runs), so it stays out of
-the package metadata while users still get a clear error when it is needed. The
-pinned commit is usually newer than PyPI's, so it is installed from git.
+aiter is imported lazily (only when an AITER-backed op runs). Primus-Turbo
+requires the amd-aiter release below; it is not on PyPI, so install from git tag.
 """
 
 import importlib.metadata
-import re
 from typing import NoReturn
 
 from primus_turbo.common.logger import logger
 
-# Single source of truth for the aiter commit; CI installs this exact commit.
-EXPECTED_AITER_COMMIT = "b5e03ed191fca11ee423226537ef8d9435e432a6"
-_AITER_DIST_NAME = "amd-aiter"  # pip dist name; importable module is ``aiter``
+# Required aiter release. Keep in sync with AITER_VERSION in the ci / benchmark
+# / release workflows.
+AITER_VERSION = "0.1.14.post1"
+AITER_GIT_TAG = "v0.1.14.post1"
+_AITER_DIST_NAME = "amd-aiter"
+_AITER_GIT_URL = "https://github.com/ROCm/aiter.git"
+
+_AITER_PIP_INSTALL = f'pip install "amd-aiter @ git+{_AITER_GIT_URL}@{AITER_GIT_TAG}"'
 
 AITER_INSTALL_HINT = (
-    "Primus-Turbo requires 'aiter' for this operator, but it is not installed. "
-    "Install the pinned commit (not available on PyPI):\n"
-    f'  pip install "amd-aiter @ git+https://github.com/ROCm/aiter.git@{EXPECTED_AITER_COMMIT}"'
+    f"Primus-Turbo requires amd-aiter=={AITER_VERSION} for this operator. Install it with:\n"
+    f"  {_AITER_PIP_INSTALL}"
 )
 
 _version_checked = False
 
 
-def _installed_aiter_commit():
-    # aiter's setuptools_scm version embeds the commit, e.g. "0.1.1.dev1611+gf299f579a".
+def _installed_aiter_version():
     try:
-        version = importlib.metadata.version(_AITER_DIST_NAME)
+        return importlib.metadata.version(_AITER_DIST_NAME)
     except importlib.metadata.PackageNotFoundError:
         return None
-    match = re.search(r"\+g([0-9a-fA-F]+)", version)
-    return match.group(1) if match else None
+
+
+def _versions_match(installed: str, expected: str) -> bool:
+    # Ignore any local/dev suffix (e.g. an editable checkout's "+g1234567").
+    try:
+        from packaging.version import InvalidVersion, Version
+
+        try:
+            return Version(installed).public == Version(expected).public
+        except InvalidVersion:
+            return False
+    except ImportError:
+        return installed.split("+")[0] == expected
 
 
 def check_aiter_version_once():
-    """Warn once if the installed aiter commit differs from the pin."""
+    """Warn once if the installed aiter version differs from the pin."""
     global _version_checked
     if _version_checked:
         return
     _version_checked = True
 
-    installed = _installed_aiter_commit()
-    if installed and not EXPECTED_AITER_COMMIT.lower().startswith(installed.lower()):
+    installed = _installed_aiter_version()
+    if installed and not _versions_match(installed, AITER_VERSION):
         logger.warning(
-            "aiter commit mismatch: installed=%s, expected=%s; behavior/perf may differ.",
+            "aiter version mismatch: installed=%s, expected=%s; behavior/perf may differ. "
+            "To match, run:\n  %s",
             installed,
-            EXPECTED_AITER_COMMIT,
+            AITER_VERSION,
+            _AITER_PIP_INSTALL,
             once=True,
         )
 


### PR DESCRIPTION
Pin the aiter dependency to a tagged release (v0.1.14.post1) instead of a floating git commit, so users/CI install a named version rather than a raw SHA. amd-aiter is not on PyPI, so it is still installed from its git tag.

- aiter_utils: EXPECTED_AITER_COMMIT -> AITER_VERSION / AITER_GIT_TAG; version check compares the release segment (tolerates editable +g suffix) and the mismatch warning now prints the exact install command.
- ci / benchmark / release workflows: AITER_COMMIT -> AITER_VERSION.
- README: document the required aiter release.
- MANIFEST.in: prune dev-only dirs (agent / benchmark / .github / .cursor) from the sdist; setuptools_scm otherwise packs every git-tracked file.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
