### PR TITLE
feat: add mxfp8 grouped quantize api

### DIFF
--- a/csrc/include/primus_turbo/quantization.h
+++ b/csrc/include/primus_turbo/quantization.h
@@ -39,10 +39,12 @@ constexpr int MXFP4_BLOCK_SIZE = 32;
 constexpr int MXFP8_BLOCK_SIZE = 32;
 
 // Padding alignment expected for the public ``padding_align_size`` op argument.
-// Must stay in sync with ``MXFP4_PADDING_ALIGN_SIZE`` / ``MXFP8_PADDING_ALIGN_SIZE``
+// Must stay in sync with ``MXFP4_K_DIM_PADDING_ALIGN_SIZE`` / ``MXFP8_K_DIM_PADDING_ALIGN_SIZE``
 // declared in ``primus_turbo/pytorch/core/low_precision.py``.
-constexpr int MXFP4_PADDING_ALIGN_SIZE = 128;
-constexpr int MXFP8_PADDING_ALIGN_SIZE = 128;
+constexpr int MXFP4_K_DIM_PADDING_ALIGN_SIZE = 128;
+constexpr int MXFP8_K_DIM_PADDING_ALIGN_SIZE = 128;
+
+constexpr int MXFP8_GROUP_M_PADDING_ALIGN_SIZE = 32;
 
 struct ScalingRecipe {
     bool use_2d_block = false;
@@ -61,9 +63,10 @@ constexpr int FP4_MANTISSA_BITS   = 1;
 constexpr int FP4_EXPONENT_BITS   = 2;
 constexpr int FP4_TARGET_MAX_POW2 = 2;
 
-constexpr int FP8E5M2_MANTISSA_BITS   = 2;
-constexpr int FP8E5M2_EXPONENT_BITS   = 5;
-constexpr int FP8E5M2_TARGET_MAX_POW2 = 15;
+constexpr int   FP8E5M2_MANTISSA_BITS   = 2;
+constexpr int   FP8E5M2_EXPONENT_BITS   = 5;
+constexpr float FP8E5M2_MAX             = 57344.0;
+constexpr int   FP8E5M2_TARGET_MAX_POW2 = 15;
 
 constexpr int FP8E4M3_MANTISSA_BITS = 3;
 constexpr int FP8E4M3_EXPONENT_BITS = 4;
@@ -96,7 +99,7 @@ void quantize_mxfp4_impl(const DType *input, dtype::float4x2_e2m1 *output, uint8
 
 template <typename IType, typename OType>
 void quantize_mxfp8_dual_impl(const IType *input, OType *rowwise_output, uint8_t *rowwise_scale,
-                              OType *colwise_output, uint8_t *colwise_scale, int M, int N,
+                              OType *colwise_output, uint8_t *colwise_scale, int G, int M, int N,
                               int M_pad, int N_pad, int rowwise_scale_stride,
                               int colwise_scale_stride, int rowwise_scale_N,
                               int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M,
@@ -106,9 +109,36 @@ void quantize_mxfp8_dual_impl(const IType *input, OType *rowwise_output, uint8_t
 
 template <typename IType, typename OType>
 void quantize_mxfp8_impl(const IType *input, OType *output, uint8_t *scale,
-                         detail::QuantizeMode mode, int M, int N, int M_pad, int N_pad,
+                         detail::QuantizeMode mode, int G, int M, int N, int M_pad, int N_pad,
                          int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
                          detail::ScalingRecipe recipe, hipStream_t stream);
+
+template <typename IType, typename OType>
+void quantize_mxfp8_grouped_impl(const IType *input, OType *output, uint8_t *scale,
+                                 const int64_t       *group_offs,
+                                 const int64_t       *group_offs_padded_colwise,
+                                 const int64_t       *group_offs_padded_rowwise,
+                                 detail::QuantizeMode mode, int G, int total_M_padded, int N,
+                                 int N_pad, int scale_stride, int scale_N, int scale_M_pad,
+                                 int scale_N_pad, detail::ScalingRecipe recipe, hipStream_t stream);
+
+template <typename IType, typename OType>
+void grouped_quantize_mxfp8_dual_impl(
+    const IType *input, OType *rowwise_output, uint8_t *rowwise_scale, OType *colwise_output,
+    uint8_t *colwise_scale, const int64_t *group_offs, const int64_t *group_offs_padded_colwise,
+    const int64_t *group_offs_padded_rowwise, int G, int total_M_padded, int N, int N_pad,
+    int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
+    int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
+    int colwise_scale_M_pad, int colwise_scale_N_pad, detail::ScalingRecipe rowwise_recipe,
+    detail::ScalingRecipe colwise_recipe, hipStream_t stream);
+
+// *************** Grouped Padded Layout ***************
+//
+// Computes per-group padded lengths/offsets (rounded up to ``align``) on
+// the GPU; results live in device memory so no D2H sync is required.
+void compute_padded_layout_gpu(const int64_t *group_lens, int64_t *group_lens_padded,
+                               int64_t *group_offs_padded, int G, int64_t align,
+                               hipStream_t stream);
 
 // *************** DeQuantize ***************
 template <typename FType, typename QType, typename ComputeType = float>

--- a/csrc/kernels/quantization/quantization_mxfp8.cu
+++ b/csrc/kernels/quantization/quantization_mxfp8.cu
@@ -151,17 +151,22 @@ __device__ __forceinline__ uint32_t cvt_f32x4_to_fp8x4(float v0, float v1, float
         result = tmp1;
         result = (result << 16) | tmp0;
     } else if constexpr (std::is_same_v<DType, dtype::float8_e5m2>) {
-        uint16_t tmp0 = 0;
+        const float lim  = FP8E5M2_MAX * scale;
+        const float v0c  = fminf(fmaxf(v0, -lim), lim);
+        const float v1c  = fminf(fmaxf(v1, -lim), lim);
+        const float v2c  = fminf(fmaxf(v2, -lim), lim);
+        const float v3c  = fminf(fmaxf(v3, -lim), lim);
+        uint16_t    tmp0 = 0;
         // Convert first pair (v0, v1) to 16-bit packed BF8 (E5M2)
         asm volatile("v_cvt_scalef32_pk_bf8_f32 %0, %1, %2, %3"
                      : "+v"(tmp0)
-                     : "v"(v0), "v"(v1), "v"(scale));
+                     : "v"(v0c), "v"(v1c), "v"(scale));
 
         // Convert second pair (v2, v3) to 16-bit packed BF8 (E5M2)
         uint16_t tmp1 = 0;
         asm volatile("v_cvt_scalef32_pk_bf8_f32 %0, %1, %2, %3"
                      : "+v"(tmp1)
-                     : "v"(v2), "v"(v3), "v"(scale));
+                     : "v"(v2c), "v"(v3c), "v"(scale));
 
         // Combine into 32-bit result: [v0, v1] in low 16 bits, [v2, v3] in high 16 bits
         result = tmp1;
@@ -192,10 +197,18 @@ __device__ __forceinline__ uint32_t cvt_f32x4_to_fp8x4(float v0, float v1, float
  */
 template <typename IType, typename OType, QuantizeMode MODE, bool USE_2D_BLOCK = false>
 __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp8_kernel(
-    const IType *__restrict__ input, OType *__restrict__ out_fp8, uint8_t *__restrict__ out_scale,
-    const int M, const int N, const int M_pad, const int N_pad, const int scale_stride,
-    const int scale_N, const int scale_M_pad, const int scale_N_pad, const bool shuffle_out,
-    const bool shuffle_scale) {
+    const IType *__restrict__ input_base, OType *__restrict__ out_fp8_base,
+    uint8_t *__restrict__ out_scale_base, const int M, const int N, const int M_pad,
+    const int N_pad, const int scale_stride, const int scale_N, const int scale_M_pad,
+    const int scale_N_pad, const bool shuffle_out, const bool shuffle_scale,
+    const int64_t input_per_group_stride = 0, const int64_t out_fp8_per_group_stride = 0,
+    const int64_t out_scale_per_group_stride = 0) {
+    // Per-group (batched) offsets along blockIdx.z; no-op when launched with
+    // grid_z == 1 (single-tensor mode) where the strides are 0.
+    const int    g         = blockIdx.z;
+    const IType *input     = input_base + (int64_t) g * input_per_group_stride;
+    OType       *out_fp8   = out_fp8_base + (int64_t) g * out_fp8_per_group_stride;
+    uint8_t     *out_scale = out_scale_base + (int64_t) g * out_scale_per_group_stride;
     // ========================================================================
     // Thread and Block Identification
     // ========================================================================
@@ -490,17 +503,36 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp8_kernel(
  *   OType:                                       Data type of output
  *   ROWWISE_USE_2D_BLOCK / COLWISE_USE_2D_BLOCK: Use 2D block for r_amax reduction
  */
+// ``per_group_*_stride`` (in *elements*, not bytes) let the same kernel
+// service per-group inputs (``(G, M, N)`` reshape) by offsetting all I/O
+// pointers by ``blockIdx.z * <stride>``.  When the launcher uses
+// ``grid_z == 1`` (default single-tensor mode) ``blockIdx.z == 0`` so the
+// added arithmetic is dead-code-eliminated by the compiler at the call
+// site that passes 0 for the strides.  This avoids duplicating the ~700
+// LOC kernel body for the per-group variant.
 template <typename IType, typename OType, bool ROWWISE_USE_2D_BLOCK = false,
           bool COLWISE_USE_2D_BLOCK = false>
 __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp8_dual_kernel(
-    const IType *__restrict__ input, OType *__restrict__ rowwise_fp8,
-    uint8_t *__restrict__ rowwise_scale, OType *__restrict__ colwise_fp8,
-    uint8_t *__restrict__ colwise_scale, const int M, const int N, const int M_pad, const int N_pad,
-    const int rowwise_scale_stride, const int colwise_scale_stride, const int rowwise_scale_N,
-    const int rowwise_scale_M_pad, const int rowwise_scale_N_pad, const int colwise_scale_M,
-    const int colwise_scale_N, const int colwise_scale_M_pad, const int colwise_scale_N_pad,
-    const bool shuffle_rowwise, const bool shuffle_colwise, const bool shuffle_rowwise_scale,
-    const bool shuffle_colwise_scale) {
+    const IType *__restrict__ input_base, OType *__restrict__ rowwise_fp8_base,
+    uint8_t *__restrict__ rowwise_scale_base, OType *__restrict__ colwise_fp8_base,
+    uint8_t *__restrict__ colwise_scale_base, const int M, const int N, const int M_pad,
+    const int N_pad, const int rowwise_scale_stride, const int colwise_scale_stride,
+    const int rowwise_scale_N, const int rowwise_scale_M_pad, const int rowwise_scale_N_pad,
+    const int colwise_scale_M, const int colwise_scale_N, const int colwise_scale_M_pad,
+    const int colwise_scale_N_pad, const bool shuffle_rowwise, const bool shuffle_colwise,
+    const bool shuffle_rowwise_scale, const bool shuffle_colwise_scale,
+    const int64_t input_per_group_stride = 0, const int64_t rowwise_fp8_per_group_stride = 0,
+    const int64_t rowwise_scale_per_group_stride = 0,
+    const int64_t colwise_fp8_per_group_stride   = 0,
+    const int64_t colwise_scale_per_group_stride = 0) {
+    // Per-group offsets (no-op when launched with grid_z == 1).
+    const int    g             = blockIdx.z;
+    const IType *input         = input_base + (int64_t) g * input_per_group_stride;
+    OType       *rowwise_fp8   = rowwise_fp8_base + (int64_t) g * rowwise_fp8_per_group_stride;
+    uint8_t     *rowwise_scale = rowwise_scale_base + (int64_t) g * rowwise_scale_per_group_stride;
+    OType       *colwise_fp8   = colwise_fp8_base + (int64_t) g * colwise_fp8_per_group_stride;
+    uint8_t     *colwise_scale = colwise_scale_base + (int64_t) g * colwise_scale_per_group_stride;
+
     // ========================================================================
     // Thread and Block Identification
     // ========================================================================
@@ -882,16 +914,869 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp8_dual_kern
     }
 }
 
+/*
+ * MXFP8 Dual Quantization with per-group M-axis zero-padding (fused).
+ * --------------------------------------------------------------------
+ * Same as ``quantize_mxfp8_dual_kernel`` but each per-group region is
+ * zero-padded along M up to a 128 multiple in the OUTPUT tensors, with no
+ * intermediate padded copy of ``input``.  The kernel grid covers the
+ * already-padded M extent (``M_pad = total_M_padded``); within each
+ * 128-row tile (which by construction is fully contained in a single
+ * group thanks to ``group_offs_padded_colwise`` being multiple of BLOCK_M=128):
+ *
+ *   - Real rows (input row index = ``group_offs[g] + (global_row -
+ *     group_offs_padded_colwise[g])``) are loaded from ``input``.
+ *   - Padded rows (``global_row >= group_offs_padded_colwise[g] + M_g``) are
+ *     treated as zero data; their per-row / per-32 amax becomes 0 so we
+ *     force scale = 1.0 (E8M0_EXPONENT_BIAS) to keep output fp8 = 0
+ *     instead of NaN from a 0/0 conversion.
+ */
+template <typename IType, typename OType, bool ROWWISE_USE_2D_BLOCK = false,
+          bool COLWISE_USE_2D_BLOCK = false>
+__global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp8_dual_grouped_kernel(
+    const IType *__restrict__ input, OType *__restrict__ rowwise_fp8,
+    uint8_t *__restrict__ rowwise_scale, OType *__restrict__ colwise_fp8,
+    uint8_t *__restrict__ colwise_scale, const int64_t *__restrict__ group_offs,
+    const int64_t *__restrict__ group_offs_padded_colwise,
+    const int64_t *__restrict__ group_offs_padded_rowwise, const int G, const int N,
+    const int M_pad, const int N_pad, const int rowwise_scale_stride,
+    const int colwise_scale_stride, const int rowwise_scale_N, const int rowwise_scale_M_pad,
+    const int rowwise_scale_N_pad, const int colwise_scale_M, const int colwise_scale_N,
+    const int colwise_scale_M_pad, const int colwise_scale_N_pad, const bool shuffle_rowwise,
+    const bool shuffle_colwise, const bool shuffle_rowwise_scale,
+    const bool shuffle_colwise_scale) {
+    constexpr bool kIshalf = std::is_same_v<IType, dtype::float16>;
+
+    const int tid           = threadIdx.x;
+    const int warp_id       = tid / WARP_SIZE;
+    const int lane_id       = tid % WARP_SIZE;
+    const int row_in_warp   = lane_id / THREADS_PER_ROW;
+    const int thread_in_row = lane_id % THREADS_PER_ROW;
+
+    const int block_m = blockIdx.x;
+    const int block_n = blockIdx.y;
+    const int base_m  = block_m * BLOCK_M;
+    const int base_n  = block_n * BLOCK_N;
+
+    const int K_packed = N_pad;
+    const int M_packed = M_pad;
+
+    constexpr int ROWS_PER_PASS   = WARP_SIZE / THREADS_PER_ROW;
+    constexpr int PASSES_PER_TILE = MXFP8_BLOCK_SIZE / ROWS_PER_PASS;
+    constexpr int TOTAL_CHUNKS    = NUM_CHUNKS_M * NUM_CHUNKS_N;
+
+    // Per-tile group lookup.  base_m and group_offs_padded_colwise are both
+    // multiples of BLOCK_M (=128), so the entire 128-row tile lives in
+    // exactly one group — or *beyond* the last group when the grid is
+    // launched on a host-known upper bound (output tensors are always
+    // sized at the conservative ``M_pad_upper``; only
+    // ``[0, group_offs_padded_colwise[G])`` rows correspond to real groups).
+    //
+    // For an OOB tile we still execute the full kernel but force every
+    // row to take the zero-pad branch (``real_end_in_pad <= base_m``).
+    // Outputs end up as all-zero FP8 with scale = 1.0 (the same
+    // convention the kernel already uses for ``amax == 0`` tiles), so
+    // downstream consumers (preshuffle + GEMM) are race-free even
+    // though they read across the over-allocated region.
+    __shared__ int64_t s_group_offs_orig;
+    __shared__ int64_t s_group_offs_pad;
+    __shared__ int64_t s_group_offs_pad_row;
+    __shared__ int64_t s_real_end_in_pad;
+    if (tid == 0) {
+        int g = -1;
+        for (int i = 0; i < G; ++i) {
+            if (base_m >= group_offs_padded_colwise[i] &&
+                base_m < group_offs_padded_colwise[i + 1]) {
+                g = i;
+                break;
+            }
+        }
+        if (g >= 0) {
+            s_group_offs_orig    = group_offs[g];
+            s_group_offs_pad     = group_offs_padded_colwise[g];
+            s_group_offs_pad_row = group_offs_padded_rowwise[g];
+            s_real_end_in_pad = group_offs_padded_colwise[g] + (group_offs[g + 1] - group_offs[g]);
+        } else {
+            s_group_offs_orig    = 0;
+            s_group_offs_pad     = base_m;
+            s_group_offs_pad_row = base_m;
+            s_real_end_in_pad    = base_m; // every row falls into zero-pad branch
+        }
+    }
+    __syncthreads();
+    const int64_t group_offs_orig    = s_group_offs_orig;
+    const int64_t group_offs_pad     = s_group_offs_pad;
+    const int64_t group_offs_pad_row = s_group_offs_pad_row;
+    const int64_t real_end_in_pad    = s_real_end_in_pad;
+
+    __shared__ uint16_t s_tile[WARPS_PER_BLOCK][MXFP8_BLOCK_SIZE][MXFP8_BLOCK_SIZE + SMEM_PADDING];
+    __shared__ uint32_t
+        s_colwise_fp8[NUM_CHUNKS_N][MXFP8_BLOCK_SIZE][NUM_CHUNKS_M * THREADS_PER_ROW];
+    __shared__ uint8_t s_colwise_scale[NUM_CHUNKS_N][MXFP8_BLOCK_SIZE][NUM_CHUNKS_M];
+
+    for (int round = 0; round < TOTAL_CHUNKS; round += WARPS_PER_BLOCK) {
+        const int chunk_idx = round + warp_id;
+        if (chunk_idx >= TOTAL_CHUNKS)
+            break;
+
+        const int chunk_m = chunk_idx / NUM_CHUNKS_N;
+        const int chunk_n = chunk_idx % NUM_CHUNKS_N;
+        const int tile_m  = base_m + chunk_m * MXFP8_BLOCK_SIZE;
+        const int tile_n  = base_n + chunk_n * MXFP8_BLOCK_SIZE;
+
+        // ---------------- Load tile (input row remap + zero pad) -----------------
+        uint64_t r_tile[PASSES_PER_TILE];
+        {
+            const auto *input_u16  = reinterpret_cast<const uint16_t *>(input);
+            const int   col_base   = thread_in_row * ELEMS_PER_THREAD;
+            const int   global_col = tile_n + col_base;
+
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                const int local_row  = pass * ROWS_PER_PASS + row_in_warp;
+                const int global_row = tile_m + local_row;
+
+                uint64_t packed = 0;
+                if (global_row < real_end_in_pad) {
+                    const int64_t input_row =
+                        group_offs_orig + (static_cast<int64_t>(global_row) - group_offs_pad);
+                    const int64_t row_offset = input_row * N + global_col;
+                    if (global_col + ELEMS_PER_THREAD - 1 < N) {
+                        packed = __ldg(reinterpret_cast<const uint64_t *>(&input_u16[row_offset]));
+                    } else {
+                        uint16_t s0 = (global_col < N) ? __ldg(&input_u16[row_offset]) : 0;
+                        uint16_t s1 = (global_col + 1 < N) ? __ldg(&input_u16[row_offset + 1]) : 0;
+                        uint16_t s2 = (global_col + 2 < N) ? __ldg(&input_u16[row_offset + 2]) : 0;
+                        uint16_t s3 = (global_col + 3 < N) ? __ldg(&input_u16[row_offset + 3]) : 0;
+                        packed = (uint64_t) s0 | ((uint64_t) s1 << 16) | ((uint64_t) s2 << 32) |
+                                 ((uint64_t) s3 << 48);
+                    }
+                }
+
+                *reinterpret_cast<uint32_t *>(&s_tile[warp_id][local_row][col_base]) =
+                    (uint32_t) packed;
+                *reinterpret_cast<uint32_t *>(&s_tile[warp_id][local_row][col_base + 2]) =
+                    (uint32_t) (packed >> 32);
+
+                r_tile[pass] = packed;
+            }
+        }
+
+        // ---------------- Rowwise: amax + scale (with zero-amax safe path) -------
+        float r_rowwise_vals[PASSES_PER_TILE][ELEMS_PER_THREAD];
+        float r_rowwise_amax[PASSES_PER_TILE];
+
+#pragma unroll
+        for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+            r_rowwise_vals[pass][0] = r_rowwise_vals[pass][1] = r_rowwise_vals[pass][2] =
+                r_rowwise_vals[pass][3]                       = 0.f;
+            r_rowwise_amax[pass]                              = 0.f;
+
+            const int global_row = tile_m + pass * ROWS_PER_PASS + row_in_warp;
+            if (global_row < real_end_in_pad) {
+                packed_uint16x4_to_floatx4<kIshalf>(
+                    r_tile[pass], r_rowwise_vals[pass][0], r_rowwise_vals[pass][1],
+                    r_rowwise_vals[pass][2], r_rowwise_vals[pass][3]);
+                float local_amax =
+                    fmaxf(fmaxf(fabsf(r_rowwise_vals[pass][0]), fabsf(r_rowwise_vals[pass][1])),
+                          fmaxf(fabsf(r_rowwise_vals[pass][2]), fabsf(r_rowwise_vals[pass][3])));
+                r_rowwise_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+            }
+        }
+
+        float   r_rowwise_scale_native[PASSES_PER_TILE];
+        uint8_t r_rowwise_scale_e8m0[PASSES_PER_TILE];
+
+        if constexpr (ROWWISE_USE_2D_BLOCK) {
+            float tile_amax = 0.f;
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++)
+                tile_amax = fmaxf(tile_amax, r_rowwise_amax[p]);
+            tile_amax = warp_reduce_max_64_dpp(tile_amax);
+            float   r_scale_native;
+            uint8_t r_scale_e8m0;
+            if (tile_amax == 0.f) {
+                r_scale_native = 1.0f;
+                r_scale_e8m0   = E8M0_EXPONENT_BIAS;
+            } else {
+                compute_tile_scale<OType>(tile_amax, r_scale_native, r_scale_e8m0);
+            }
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++) {
+                r_rowwise_scale_native[p] = r_scale_native;
+                r_rowwise_scale_e8m0[p]   = r_scale_e8m0;
+            }
+        } else {
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++) {
+                if (r_rowwise_amax[p] == 0.f) {
+                    r_rowwise_scale_native[p] = 1.0f;
+                    r_rowwise_scale_e8m0[p]   = E8M0_EXPONENT_BIAS;
+                } else {
+                    compute_tile_scale<OType>(r_rowwise_amax[p], r_rowwise_scale_native[p],
+                                              r_rowwise_scale_e8m0[p]);
+                }
+            }
+        }
+
+        // ---------------- Rowwise: store FP8 + scale (32-padded M layout) -------
+        // Rowwise pads each group's M to MXFP8_GROUP_M_PADDING_ALIGN_SIZE (32): the
+        // real row at padded-128 position ``global_row`` is scattered to its
+        // 32-padded position ``row_out``.  Only real rows (< real_end_in_pad) are
+        // written.  Colwise below keeps the 128-padded layout (wgrad K-reduction).
+        {
+            const int col_base   = thread_in_row * ELEMS_PER_THREAD;
+            const int global_col = tile_n + col_base;
+
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                const int local_row  = pass * ROWS_PER_PASS + row_in_warp;
+                const int global_row = tile_m + local_row;
+
+                if (global_row < real_end_in_pad) {
+                    const int64_t row_out =
+                        group_offs_pad_row + (static_cast<int64_t>(global_row) - group_offs_pad);
+                    uint32_t fp8x4 = cvt_f32x4_to_fp8x4<OType>(
+                        r_rowwise_vals[pass][0], r_rowwise_vals[pass][1], r_rowwise_vals[pass][2],
+                        r_rowwise_vals[pass][3], r_rowwise_scale_native[pass]);
+
+                    if (global_col < N_pad) {
+                        if (shuffle_rowwise) {
+                            int shuffled_idx = compute_shuffled_index<OType>(
+                                static_cast<int>(row_out), global_col, K_packed);
+                            *reinterpret_cast<uint32_t *>(rowwise_fp8 + shuffled_idx) = fp8x4;
+                        } else {
+                            *reinterpret_cast<uint32_t *>(rowwise_fp8 + row_out * K_packed +
+                                                          global_col) = fp8x4;
+                        }
+                    }
+
+                    if (thread_in_row == 0) {
+                        int scale_col = block_n * NUM_CHUNKS_N + chunk_n;
+                        if (shuffle_rowwise_scale) {
+                            if (scale_col < rowwise_scale_N && row_out < rowwise_scale_M_pad &&
+                                scale_col < rowwise_scale_N_pad) {
+                                int idx = compute_shuffle_scale_index(
+                                    static_cast<int>(row_out), scale_col, rowwise_scale_N_pad);
+                                rowwise_scale[idx] = r_rowwise_scale_e8m0[pass];
+                            }
+                        } else {
+                            if (scale_col < rowwise_scale_N) {
+                                rowwise_scale[row_out * rowwise_scale_stride + scale_col] =
+                                    r_rowwise_scale_e8m0[pass];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        __syncthreads();
+
+        // ---------------- Colwise: amax + scale (with zero-amax safe path) -------
+        float r_colwise_vals[PASSES_PER_TILE][ELEMS_PER_THREAD];
+        float r_colwise_amax[PASSES_PER_TILE];
+        {
+            const int row_base = thread_in_row * ELEMS_PER_THREAD;
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                const int local_col  = pass * ROWS_PER_PASS + row_in_warp;
+                const int global_col = tile_n + local_col;
+
+                r_colwise_vals[pass][0] = r_colwise_vals[pass][1] = r_colwise_vals[pass][2] =
+                    r_colwise_vals[pass][3]                       = 0.f;
+                r_colwise_amax[pass]                              = 0.f;
+
+                if (global_col < N) {
+                    r_colwise_vals[pass][0] =
+                        uint16_to_float<kIshalf>(s_tile[warp_id][row_base][local_col]);
+                    r_colwise_vals[pass][1] =
+                        uint16_to_float<kIshalf>(s_tile[warp_id][row_base + 1][local_col]);
+                    r_colwise_vals[pass][2] =
+                        uint16_to_float<kIshalf>(s_tile[warp_id][row_base + 2][local_col]);
+                    r_colwise_vals[pass][3] =
+                        uint16_to_float<kIshalf>(s_tile[warp_id][row_base + 3][local_col]);
+
+                    float local_amax = fmaxf(
+                        fmaxf(fabsf(r_colwise_vals[pass][0]), fabsf(r_colwise_vals[pass][1])),
+                        fmaxf(fabsf(r_colwise_vals[pass][2]), fabsf(r_colwise_vals[pass][3])));
+                    r_colwise_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+                }
+            }
+        }
+
+        float   r_colwise_scale_native[PASSES_PER_TILE];
+        uint8_t r_colwise_scale_e8m0[PASSES_PER_TILE];
+
+        if constexpr (COLWISE_USE_2D_BLOCK) {
+            float tile_amax = 0.f;
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++)
+                tile_amax = fmaxf(tile_amax, r_colwise_amax[p]);
+            tile_amax = warp_reduce_max_64_dpp(tile_amax);
+            float   r_scale_native;
+            uint8_t r_scale_e8m0;
+            if (tile_amax == 0.f) {
+                r_scale_native = 1.0f;
+                r_scale_e8m0   = E8M0_EXPONENT_BIAS;
+            } else {
+                compute_tile_scale<OType>(tile_amax, r_scale_native, r_scale_e8m0);
+            }
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++) {
+                r_colwise_scale_native[p] = r_scale_native;
+                r_colwise_scale_e8m0[p]   = r_scale_e8m0;
+            }
+        } else {
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++) {
+                if (r_colwise_amax[p] == 0.f) {
+                    r_colwise_scale_native[p] = 1.0f;
+                    r_colwise_scale_e8m0[p]   = E8M0_EXPONENT_BIAS;
+                } else {
+                    compute_tile_scale<OType>(r_colwise_amax[p], r_colwise_scale_native[p],
+                                              r_colwise_scale_e8m0[p]);
+                }
+            }
+        }
+
+        // ---------------- Colwise: store FP8 + scale ----------------------------
+        {
+            const int row_base        = thread_in_row * ELEMS_PER_THREAD;
+            const int global_row_base = tile_m + row_base;
+
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                const int local_col  = pass * ROWS_PER_PASS + row_in_warp;
+                const int global_col = tile_n + local_col;
+
+                if (global_col < N) {
+                    uint32_t fp8x4 = cvt_f32x4_to_fp8x4<OType>(
+                        r_colwise_vals[pass][0], r_colwise_vals[pass][1], r_colwise_vals[pass][2],
+                        r_colwise_vals[pass][3], r_colwise_scale_native[pass]);
+
+                    if (global_row_base < M_pad) {
+                        if (shuffle_colwise) {
+                            int shuffled_idx = compute_shuffled_index<OType>(
+                                global_col, global_row_base, M_packed);
+                            *reinterpret_cast<uint32_t *>(colwise_fp8 + shuffled_idx) = fp8x4;
+                        } else {
+                            s_colwise_fp8[chunk_n][pass * ROWS_PER_PASS + row_in_warp]
+                                         [chunk_m * THREADS_PER_ROW + thread_in_row] = fp8x4;
+                        }
+                    }
+
+                    if (thread_in_row == 0) {
+                        int scale_col = block_m * NUM_CHUNKS_M + chunk_m;
+                        if (shuffle_colwise_scale) {
+                            if (scale_col < colwise_scale_N && global_col < colwise_scale_M_pad &&
+                                scale_col < colwise_scale_N_pad) {
+                                int idx = compute_shuffle_scale_index(global_col, scale_col,
+                                                                      colwise_scale_N_pad);
+                                colwise_scale[idx] = r_colwise_scale_e8m0[pass];
+                            }
+                        } else {
+                            s_colwise_scale[chunk_n][pass * ROWS_PER_PASS + row_in_warp][chunk_m] =
+                                (scale_col < colwise_scale_N) ? r_colwise_scale_e8m0[pass]
+                                                              : E8M0_EXPONENT_BIAS;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Coalesced colwise FP8/scale write-out from LDS (non-shuffle path).
+    {
+        if (!shuffle_colwise || !shuffle_colwise_scale) {
+            __syncthreads();
+        }
+
+        if (!shuffle_colwise_scale) {
+            constexpr int SCALE_ITEMS = NUM_CHUNKS_N * MXFP8_BLOCK_SIZE * NUM_CHUNKS_M;
+            static_assert(SCALE_ITEMS <= THREADS_PER_BLOCK,
+                          "Scale write mapping expects <= one item per thread");
+            if (tid < SCALE_ITEMS) {
+                const int n_chunk      = tid / (MXFP8_BLOCK_SIZE * NUM_CHUNKS_M);
+                const int local_tid    = tid % (MXFP8_BLOCK_SIZE * NUM_CHUNKS_M);
+                const int col_in_chunk = local_tid / NUM_CHUNKS_M;
+                const int m_chunk      = local_tid % NUM_CHUNKS_M;
+
+                const int global_col = base_n + n_chunk * MXFP8_BLOCK_SIZE + col_in_chunk;
+                const int scale_col  = block_m * NUM_CHUNKS_M + m_chunk;
+
+                if (scale_col < colwise_scale_N && global_col < N) {
+                    const uint8_t scale_val = s_colwise_scale[n_chunk][col_in_chunk][m_chunk];
+                    colwise_scale[global_col * colwise_scale_stride + scale_col] = scale_val;
+                }
+            }
+        }
+
+        if (!shuffle_colwise) {
+            constexpr int ITEMS_PER_COL = NUM_CHUNKS_M * THREADS_PER_ROW;
+            constexpr int SEGS_PER_COL  = ITEMS_PER_COL / 4;
+            static_assert(ITEMS_PER_COL % 4 == 0, "ITEMS_PER_COL must be divisible by 4");
+            static_assert(THREADS_PER_BLOCK == NUM_CHUNKS_N * MXFP8_BLOCK_SIZE * SEGS_PER_COL,
+                          "Thread count must exactly cover all colwise FP8 segments");
+
+            const int n_chunk      = tid / (MXFP8_BLOCK_SIZE * SEGS_PER_COL);
+            const int local_tid    = tid % (MXFP8_BLOCK_SIZE * SEGS_PER_COL);
+            const int col_in_chunk = local_tid / SEGS_PER_COL;
+            const int seg          = local_tid % SEGS_PER_COL;
+
+            const int global_col = base_n + n_chunk * MXFP8_BLOCK_SIZE + col_in_chunk;
+            if (global_col < N) {
+                const uint4 data = *reinterpret_cast<const uint4 *>(
+                    &s_colwise_fp8[n_chunk][col_in_chunk][seg * 4]);
+                const int row_start = base_m + seg * (4 * ELEMS_PER_THREAD);
+                if (row_start < M_pad) {
+                    *reinterpret_cast<uint4 *>(
+                        colwise_fp8 + static_cast<int64_t>(global_col) * M_packed + row_start) =
+                        data;
+                }
+            }
+        }
+    }
+}
+
+/*
+ * MXFP8 single-direction Quantization with per-group M-axis zero-padding.
+ * ----------------------------------------------------------------------
+ * Single-direction (rowwise OR colwise) counterpart of
+ * ``quantize_mxfp8_dual_grouped_kernel``: quantizes one axis only, fused
+ * with the same per-group M zero-padding scheme.  Modeled on
+ * ``quantize_mxfp8_kernel`` (non-grouped single direction) plus the per-tile
+ * group lookup / input-row remap / zero-pad logic from the dual grouped kernel.
+ *
+ *   - ROWWISE: real rows are scattered to their 32-padded per-group position
+ *     (``group_offs_padded_rowwise``); only real rows are written.
+ *   - COLWISE: output keeps the 128-padded per-group layout
+ *     (``group_offs_padded_colwise``); padding rows are written as zero FP8 with
+ *     scale = 1.0 (E8M0_EXPONENT_BIAS) so the wgrad K-reduction stays correct.
+ *
+ * The grid always covers the 128-padded M extent (``M_pad``) so each 128-row
+ * tile lies fully inside one group; ``group_offs_padded_colwise`` (128-aligned) drives
+ * the tile->group mapping and input-row remap for both directions.
+ */
+template <typename IType, typename OType, QuantizeMode MODE, bool USE_2D_BLOCK = false>
+__global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp8_grouped_kernel(
+    const IType *__restrict__ input, OType *__restrict__ out_fp8, uint8_t *__restrict__ out_scale,
+    const int64_t *__restrict__ group_offs, const int64_t *__restrict__ group_offs_padded_colwise,
+    const int64_t *__restrict__ group_offs_padded_rowwise, const int G, const int N,
+    const int M_pad, const int N_pad, const int scale_stride, const int scale_N,
+    const int scale_M_pad, const int scale_N_pad, const bool shuffle_out,
+    const bool shuffle_scale) {
+    constexpr bool kIsHalf    = std::is_same_v<IType, dtype::float16>;
+    constexpr bool kIsRowwise = (MODE == QuantizeMode::ROWWISE);
+
+    const int tid           = threadIdx.x;
+    const int warp_id       = tid / WARP_SIZE;
+    const int lane_id       = tid % WARP_SIZE;
+    const int row_in_warp   = lane_id / THREADS_PER_ROW;
+    const int thread_in_row = lane_id % THREADS_PER_ROW;
+
+    const int block_m = blockIdx.x;
+    const int block_n = blockIdx.y;
+    const int base_m  = block_m * BLOCK_M;
+    const int base_n  = block_n * BLOCK_N;
+
+    // Rowwise output is [M_pad_row, N_pad] (stride N_pad); colwise is
+    // [N, M_pad] (stride M_pad).
+    const int output_packed_stride = kIsRowwise ? N_pad : M_pad;
+
+    constexpr int ROWS_PER_PASS   = WARP_SIZE / THREADS_PER_ROW;
+    constexpr int PASSES_PER_TILE = MXFP8_BLOCK_SIZE / ROWS_PER_PASS;
+    constexpr int TOTAL_CHUNKS    = NUM_CHUNKS_M * NUM_CHUNKS_N;
+
+    // Per-tile group lookup.  base_m and group_offs_padded_colwise are both multiples
+    // of BLOCK_M (=128), so the 128-row tile lives in exactly one group — or
+    // *beyond* the last group when the grid is launched on a host-known upper
+    // bound, in which case every row takes the zero-pad branch.
+    __shared__ int64_t s_group_offs_orig;
+    __shared__ int64_t s_group_offs_pad;
+    __shared__ int64_t s_group_offs_pad_row;
+    __shared__ int64_t s_real_end_in_pad;
+    if (tid == 0) {
+        int g = -1;
+        for (int i = 0; i < G; ++i) {
+            if (base_m >= group_offs_padded_colwise[i] &&
+                base_m < group_offs_padded_colwise[i + 1]) {
+                g = i;
+                break;
+            }
+        }
+        if (g >= 0) {
+            s_group_offs_orig    = group_offs[g];
+            s_group_offs_pad     = group_offs_padded_colwise[g];
+            s_group_offs_pad_row = group_offs_padded_rowwise[g];
+            s_real_end_in_pad = group_offs_padded_colwise[g] + (group_offs[g + 1] - group_offs[g]);
+        } else {
+            s_group_offs_orig    = 0;
+            s_group_offs_pad     = base_m;
+            s_group_offs_pad_row = base_m;
+            s_real_end_in_pad    = base_m; // every row falls into zero-pad branch
+        }
+    }
+    __syncthreads();
+    const int64_t group_offs_orig    = s_group_offs_orig;
+    const int64_t group_offs_pad     = s_group_offs_pad;
+    const int64_t group_offs_pad_row = s_group_offs_pad_row;
+    const int64_t real_end_in_pad    = s_real_end_in_pad;
+
+    // Shared tile only needed for the colwise transpose (rowwise reads regs).
+    constexpr int       s_tile_DEPTH = kIsRowwise ? 1 : (MXFP8_BLOCK_SIZE + SMEM_PADDING);
+    __shared__ uint16_t s_tile[WARPS_PER_BLOCK][MXFP8_BLOCK_SIZE][s_tile_DEPTH];
+
+    for (int round = 0; round < TOTAL_CHUNKS; round += WARPS_PER_BLOCK) {
+        const int chunk_index = round + warp_id;
+        if (chunk_index >= TOTAL_CHUNKS)
+            break;
+
+        const int chunk_m = chunk_index / NUM_CHUNKS_N;
+        const int chunk_n = chunk_index % NUM_CHUNKS_N;
+        const int tile_m  = base_m + chunk_m * MXFP8_BLOCK_SIZE;
+        const int tile_n  = base_n + chunk_n * MXFP8_BLOCK_SIZE;
+
+        // ---------------- Load tile (input row remap + zero pad) -------------
+        uint64_t r_tile[PASSES_PER_TILE];
+        {
+            const auto *input_u16  = reinterpret_cast<const uint16_t *>(input);
+            const int   col_base   = thread_in_row * ELEMS_PER_THREAD;
+            const int   global_col = tile_n + col_base;
+
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                const int local_row  = pass * ROWS_PER_PASS + row_in_warp;
+                const int global_row = tile_m + local_row;
+
+                uint64_t packed = 0;
+                if (global_row < real_end_in_pad) {
+                    const int64_t input_row =
+                        group_offs_orig + (static_cast<int64_t>(global_row) - group_offs_pad);
+                    const int64_t row_offset = input_row * N + global_col;
+                    if (global_col + ELEMS_PER_THREAD - 1 < N) {
+                        packed = __ldg(reinterpret_cast<const uint64_t *>(&input_u16[row_offset]));
+                    } else {
+                        uint16_t s0 = (global_col < N) ? __ldg(&input_u16[row_offset]) : 0;
+                        uint16_t s1 = (global_col + 1 < N) ? __ldg(&input_u16[row_offset + 1]) : 0;
+                        uint16_t s2 = (global_col + 2 < N) ? __ldg(&input_u16[row_offset + 2]) : 0;
+                        uint16_t s3 = (global_col + 3 < N) ? __ldg(&input_u16[row_offset + 3]) : 0;
+                        packed = (uint64_t) s0 | ((uint64_t) s1 << 16) | ((uint64_t) s2 << 32) |
+                                 ((uint64_t) s3 << 48);
+                    }
+                }
+
+                if constexpr (!kIsRowwise) {
+                    *reinterpret_cast<uint32_t *>(&s_tile[warp_id][local_row][col_base]) =
+                        (uint32_t) packed;
+                    *reinterpret_cast<uint32_t *>(&s_tile[warp_id][local_row][col_base + 2]) =
+                        (uint32_t) (packed >> 32);
+                }
+                r_tile[pass] = packed;
+            }
+        }
+
+        if constexpr (!kIsRowwise) {
+            __syncthreads();
+        }
+
+        // ---------------- amax + scale (zero-amax safe) ----------------------
+        float r_vals[PASSES_PER_TILE][ELEMS_PER_THREAD];
+        float r_amax[PASSES_PER_TILE];
+#pragma unroll
+        for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+            r_vals[pass][0] = r_vals[pass][1] = r_vals[pass][2] = r_vals[pass][3] = 0.f;
+            r_amax[pass]                                                          = 0.f;
+
+            if constexpr (kIsRowwise) {
+                const int global_row = tile_m + pass * ROWS_PER_PASS + row_in_warp;
+                if (global_row < real_end_in_pad) {
+                    packed_uint16x4_to_floatx4<kIsHalf>(r_tile[pass], r_vals[pass][0],
+                                                        r_vals[pass][1], r_vals[pass][2],
+                                                        r_vals[pass][3]);
+                    float local_amax = fmaxf(fmaxf(fabsf(r_vals[pass][0]), fabsf(r_vals[pass][1])),
+                                             fmaxf(fabsf(r_vals[pass][2]), fabsf(r_vals[pass][3])));
+                    r_amax[pass]     = warp_reduce_max_8_dpp(local_amax);
+                }
+            } else {
+                const int row_base   = thread_in_row * ELEMS_PER_THREAD;
+                const int local_col  = pass * ROWS_PER_PASS + row_in_warp;
+                const int global_col = tile_n + local_col;
+                if (global_col < N) {
+                    r_vals[pass][0] =
+                        uint16_to_float<kIsHalf>(s_tile[warp_id][row_base][local_col]);
+                    r_vals[pass][1] =
+                        uint16_to_float<kIsHalf>(s_tile[warp_id][row_base + 1][local_col]);
+                    r_vals[pass][2] =
+                        uint16_to_float<kIsHalf>(s_tile[warp_id][row_base + 2][local_col]);
+                    r_vals[pass][3] =
+                        uint16_to_float<kIsHalf>(s_tile[warp_id][row_base + 3][local_col]);
+                    float local_amax = fmaxf(fmaxf(fabsf(r_vals[pass][0]), fabsf(r_vals[pass][1])),
+                                             fmaxf(fabsf(r_vals[pass][2]), fabsf(r_vals[pass][3])));
+                    r_amax[pass]     = warp_reduce_max_8_dpp(local_amax);
+                }
+            }
+        }
+
+        float   r_scale_native[PASSES_PER_TILE];
+        uint8_t r_scale_e8m0[PASSES_PER_TILE];
+        if constexpr (USE_2D_BLOCK) {
+            float tile_amax = 0.f;
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++)
+                tile_amax = fmaxf(tile_amax, r_amax[p]);
+            tile_amax = warp_reduce_max_64_dpp(tile_amax);
+            float   sn;
+            uint8_t se;
+            if (tile_amax == 0.f) {
+                sn = 1.0f;
+                se = E8M0_EXPONENT_BIAS;
+            } else {
+                compute_tile_scale<OType>(tile_amax, sn, se);
+            }
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++) {
+                r_scale_native[p] = sn;
+                r_scale_e8m0[p]   = se;
+            }
+        } else {
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++) {
+                if (r_amax[p] == 0.f) {
+                    r_scale_native[p] = 1.0f;
+                    r_scale_e8m0[p]   = E8M0_EXPONENT_BIAS;
+                } else {
+                    compute_tile_scale<OType>(r_amax[p], r_scale_native[p], r_scale_e8m0[p]);
+                }
+            }
+        }
+
+        // ---------------- Quantize + store -----------------------------------
+#pragma unroll
+        for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+            uint32_t fp8x4 =
+                cvt_f32x4_to_fp8x4<OType>(r_vals[pass][0], r_vals[pass][1], r_vals[pass][2],
+                                          r_vals[pass][3], r_scale_native[pass]);
+
+            if constexpr (kIsRowwise) {
+                const int col_base   = thread_in_row * ELEMS_PER_THREAD;
+                const int global_col = tile_n + col_base;
+                const int local_row  = pass * ROWS_PER_PASS + row_in_warp;
+                const int global_row = tile_m + local_row;
+
+                if (global_row < real_end_in_pad) {
+                    const int64_t row_out =
+                        group_offs_pad_row + (static_cast<int64_t>(global_row) - group_offs_pad);
+                    if (global_col < N_pad) {
+                        if (shuffle_out) {
+                            int shuffled_index = compute_shuffled_index<OType>(
+                                static_cast<int>(row_out), global_col, output_packed_stride);
+                            *reinterpret_cast<uint32_t *>(out_fp8 + shuffled_index) = fp8x4;
+                        } else {
+                            *reinterpret_cast<uint32_t *>(out_fp8 + row_out * output_packed_stride +
+                                                          global_col) = fp8x4;
+                        }
+                    }
+                    if (thread_in_row == 0) {
+                        int scale_col = block_n * NUM_CHUNKS_N + chunk_n;
+                        if (shuffle_scale) {
+                            if (scale_col < scale_N && row_out < scale_M_pad &&
+                                scale_col < scale_N_pad) {
+                                int scale_index = compute_shuffle_scale_index(
+                                    static_cast<int>(row_out), scale_col, scale_N_pad);
+                                out_scale[scale_index] = r_scale_e8m0[pass];
+                            }
+                        } else {
+                            if (scale_col < scale_N) {
+                                out_scale[row_out * scale_stride + scale_col] = r_scale_e8m0[pass];
+                            }
+                        }
+                    }
+                }
+            } else {
+                const int row_base        = thread_in_row * ELEMS_PER_THREAD;
+                const int global_row_base = tile_m + row_base;
+                const int local_col       = pass * ROWS_PER_PASS + row_in_warp;
+                const int global_col      = tile_n + local_col;
+
+                if (global_col < N) {
+                    if (global_row_base < M_pad) {
+                        if (shuffle_out) {
+                            int shuffled_index = compute_shuffled_index<OType>(
+                                global_col, global_row_base, output_packed_stride);
+                            *reinterpret_cast<uint32_t *>(out_fp8 + shuffled_index) = fp8x4;
+                        } else {
+                            *reinterpret_cast<uint32_t *>(
+                                out_fp8 + static_cast<int64_t>(global_col) * output_packed_stride +
+                                global_row_base) = fp8x4;
+                        }
+                    }
+                    if (thread_in_row == 0) {
+                        int scale_col = block_m * NUM_CHUNKS_M + chunk_m;
+                        if (shuffle_scale) {
+                            if (scale_col < scale_N && global_col < scale_M_pad &&
+                                scale_col < scale_N_pad) {
+                                int scale_index =
+                                    compute_shuffle_scale_index(global_col, scale_col, scale_N_pad);
+                                out_scale[scale_index] = r_scale_e8m0[pass];
+                            }
+                        } else {
+                            if (scale_col < scale_N) {
+                                out_scale[static_cast<int64_t>(global_col) * scale_stride +
+                                          scale_col] = r_scale_e8m0[pass];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+template <typename IType, typename OType>
+void quantize_mxfp8_grouped_impl(const IType *input, OType *output, uint8_t *scale,
+                                 const int64_t *group_offs,
+                                 const int64_t *group_offs_padded_colwise,
+                                 const int64_t *group_offs_padded_rowwise, QuantizeMode mode, int G,
+                                 int total_M_padded, int N, int N_pad, int scale_stride,
+                                 int scale_N, int scale_M_pad, int scale_N_pad,
+                                 ScalingRecipe recipe, hipStream_t stream) {
+    PRIMUS_TURBO_CHECK(recipe.use_rht == false, "MXFP8 not support RHT");
+    PRIMUS_TURBO_CHECK(recipe.use_sr == false, "MXFP8 not support SR");
+
+    dim3 grid((total_M_padded + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
+    dim3 block(THREADS_PER_BLOCK);
+
+#define QUANTIZE_MXFP8_GROUPED_ARGS                                                                \
+    input, output, scale, group_offs, group_offs_padded_colwise, group_offs_padded_rowwise, G, N,  \
+        total_M_padded, N_pad, scale_stride, scale_N, scale_M_pad, scale_N_pad,                    \
+        recipe.shuffle_out, recipe.shuffle_scale
+
+#define QUANTIZE_MXFP8_GROUPED_LAUNCH(USE_2D_BLOCK)                                                \
+    if (mode == QuantizeMode::ROWWISE) {                                                           \
+        quantize_mxfp8_grouped_kernel<IType, OType, QuantizeMode::ROWWISE, USE_2D_BLOCK>           \
+            <<<grid, block, 0, stream>>>(QUANTIZE_MXFP8_GROUPED_ARGS);                             \
+    } else {                                                                                       \
+        quantize_mxfp8_grouped_kernel<IType, OType, QuantizeMode::COLWISE, USE_2D_BLOCK>           \
+            <<<grid, block, 0, stream>>>(QUANTIZE_MXFP8_GROUPED_ARGS);                             \
+    }
+
+    if (recipe.use_2d_block) {
+        QUANTIZE_MXFP8_GROUPED_LAUNCH(true);
+    } else {
+        QUANTIZE_MXFP8_GROUPED_LAUNCH(false);
+    }
+
+#undef QUANTIZE_MXFP8_GROUPED_LAUNCH
+#undef QUANTIZE_MXFP8_GROUPED_ARGS
+}
+
+#define INSTANTIATE_QUANTIZE_MXFP8_GROUPED(IType, OType)                                           \
+    template void quantize_mxfp8_grouped_impl<IType, OType>(                                       \
+        const IType *input, OType *output, uint8_t *scale, const int64_t *group_offs,              \
+        const int64_t *group_offs_padded_colwise, const int64_t *group_offs_padded_rowwise,        \
+        QuantizeMode mode, int G, int total_M_padded, int N, int N_pad, int scale_stride,          \
+        int scale_N, int scale_M_pad, int scale_N_pad, ScalingRecipe recipe, hipStream_t stream)
+
+INSTANTIATE_QUANTIZE_MXFP8_GROUPED(dtype::float16, dtype::float8_e5m2);
+INSTANTIATE_QUANTIZE_MXFP8_GROUPED(dtype::bfloat16, dtype::float8_e5m2);
+INSTANTIATE_QUANTIZE_MXFP8_GROUPED(dtype::float16, dtype::float8_e4m3);
+INSTANTIATE_QUANTIZE_MXFP8_GROUPED(dtype::bfloat16, dtype::float8_e4m3);
+
+#undef INSTANTIATE_QUANTIZE_MXFP8_GROUPED
+
+template <typename IType, typename OType>
+void grouped_quantize_mxfp8_dual_impl(
+    const IType *input, OType *rowwise_output, uint8_t *rowwise_scale, OType *colwise_output,
+    uint8_t *colwise_scale, const int64_t *group_offs, const int64_t *group_offs_padded_colwise,
+    const int64_t *group_offs_padded_rowwise, int G, int total_M_padded, int N, int N_pad,
+    int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
+    int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
+    int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
+    ScalingRecipe colwise_recipe, hipStream_t stream) {
+    PRIMUS_TURBO_CHECK(rowwise_recipe.use_rht == false, "MXFP8 not support RHT");
+    PRIMUS_TURBO_CHECK(colwise_recipe.use_rht == false, "MXFP8 not support RHT");
+    PRIMUS_TURBO_CHECK(rowwise_recipe.use_sr == false, "MXFP8 not support SR");
+    PRIMUS_TURBO_CHECK(colwise_recipe.use_sr == false, "MXFP8 not support SR");
+
+    dim3 grid((total_M_padded + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
+    dim3 block(THREADS_PER_BLOCK);
+
+#define QUANTIZE_MXFP8_DUAL_GROUPED                                                                \
+    input, rowwise_output, rowwise_scale, colwise_output, colwise_scale, group_offs,               \
+        group_offs_padded_colwise, group_offs_padded_rowwise, G, N, total_M_padded, N_pad,         \
+        rowwise_scale_stride, colwise_scale_stride, rowwise_scale_N, rowwise_scale_M_pad,          \
+        rowwise_scale_N_pad, colwise_scale_M, colwise_scale_N, colwise_scale_M_pad,                \
+        colwise_scale_N_pad, rowwise_recipe.shuffle_out, colwise_recipe.shuffle_out,               \
+        rowwise_recipe.shuffle_scale, colwise_recipe.shuffle_scale
+
+#define QUANTIZE_MXFP8_DUAL_GROUPED_LAUNCH(ROWWISE_USE_2D_BLOCK, COLWISE_USE_2D_BLOCK)             \
+    quantize_mxfp8_dual_grouped_kernel<IType, OType, ROWWISE_USE_2D_BLOCK, COLWISE_USE_2D_BLOCK>   \
+        <<<grid, block, 0, stream>>>(QUANTIZE_MXFP8_DUAL_GROUPED)
+
+    if (rowwise_recipe.use_2d_block) {
+        if (colwise_recipe.use_2d_block) {
+            QUANTIZE_MXFP8_DUAL_GROUPED_LAUNCH(true, true);
+        } else {
+            QUANTIZE_MXFP8_DUAL_GROUPED_LAUNCH(true, false);
+        }
+    } else {
+        if (colwise_recipe.use_2d_block) {
+            QUANTIZE_MXFP8_DUAL_GROUPED_LAUNCH(false, true);
+        } else {
+            QUANTIZE_MXFP8_DUAL_GROUPED_LAUNCH(false, false);
+        }
+    }
+
+#undef QUANTIZE_MXFP8_DUAL_GROUPED_LAUNCH
+#undef QUANTIZE_MXFP8_DUAL_GROUPED
+}
+
+template void grouped_quantize_mxfp8_dual_impl<dtype::float16, dtype::float8_e5m2>(
+    const dtype::float16 *x, dtype::float8_e5m2 *rowwise_output, uint8_t *rowwise_scale,
+    dtype::float8_e5m2 *colwise_output, uint8_t *colwise_scale, const int64_t *group_offs,
+    const int64_t *group_offs_padded_colwise, const int64_t *group_offs_padded_rowwise, int G,
+    int total_M_padded, int N, int N_pad, int rowwise_scale_stride, int colwise_scale_stride,
+    int rowwise_scale_N, int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M,
+    int colwise_scale_N, int colwise_scale_M_pad, int colwise_scale_N_pad,
+    ScalingRecipe rowwise_recipe, ScalingRecipe colwise_recipe, hipStream_t stream);
+template void grouped_quantize_mxfp8_dual_impl<dtype::bfloat16, dtype::float8_e5m2>(
+    const dtype::bfloat16 *x, dtype::float8_e5m2 *rowwise_output, uint8_t *rowwise_scale,
+    dtype::float8_e5m2 *colwise_output, uint8_t *colwise_scale, const int64_t *group_offs,
+    const int64_t *group_offs_padded_colwise, const int64_t *group_offs_padded_rowwise, int G,
+    int total_M_padded, int N, int N_pad, int rowwise_scale_stride, int colwise_scale_stride,
+    int rowwise_scale_N, int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M,
+    int colwise_scale_N, int colwise_scale_M_pad, int colwise_scale_N_pad,
+    ScalingRecipe rowwise_recipe, ScalingRecipe colwise_recipe, hipStream_t stream);
+template void grouped_quantize_mxfp8_dual_impl<dtype::float16, dtype::float8_e4m3>(
+    const dtype::float16 *x, dtype::float8_e4m3 *rowwise_output, uint8_t *rowwise_scale,
+    dtype::float8_e4m3 *colwise_output, uint8_t *colwise_scale, const int64_t *group_offs,
+    const int64_t *group_offs_padded_colwise, const int64_t *group_offs_padded_rowwise, int G,
+    int total_M_padded, int N, int N_pad, int rowwise_scale_stride, int colwise_scale_stride,
+    int rowwise_scale_N, int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M,
+    int colwise_scale_N, int colwise_scale_M_pad, int colwise_scale_N_pad,
+    ScalingRecipe rowwise_recipe, ScalingRecipe colwise_recipe, hipStream_t stream);
+template void grouped_quantize_mxfp8_dual_impl<dtype::bfloat16, dtype::float8_e4m3>(
+    const dtype::bfloat16 *x, dtype::float8_e4m3 *rowwise_output, uint8_t *rowwise_scale,
+    dtype::float8_e4m3 *colwise_output, uint8_t *colwise_scale, const int64_t *group_offs,
+    const int64_t *group_offs_padded_colwise, const int64_t *group_offs_padded_rowwise, int G,
+    int total_M_padded, int N, int N_pad, int rowwise_scale_stride, int colwise_scale_stride,
+    int rowwise_scale_N, int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M,
+    int colwise_scale_N, int colwise_scale_M_pad, int colwise_scale_N_pad,
+    ScalingRecipe rowwise_recipe, ScalingRecipe colwise_recipe, hipStream_t stream);
+
 template <typename IType, typename OType>
 void quantize_mxfp8_dual_impl(const IType *input, OType *rowwise_output, uint8_t *rowwise_scale,
-                              OType *colwise_output, uint8_t *colwise_scale, int M, int N,
+                              OType *colwise_output, uint8_t *colwise_scale, int G, int M, int N,
                               int M_pad, int N_pad, int rowwise_scale_stride,
                               int colwise_scale_stride, int rowwise_scale_N,
                               int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M,
                               int colwise_scale_N, int colwise_scale_M_pad, int colwise_scale_N_pad,
                               ScalingRecipe rowwise_recipe, ScalingRecipe colwise_recipe,
                               hipStream_t stream) {
-    dim3 grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
+    // Batched (G > 1) input is handled by replicating the per-matrix grid along
+    // blockIdx.z; each z-slice quantizes one (M, N) group offset by its stride.
+    dim3 grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N, G);
     dim3 block(THREADS_PER_BLOCK);
 
     PRIMUS_TURBO_CHECK(rowwise_recipe.use_rht == false, "MXFP8 not support RHT");
@@ -899,12 +1784,26 @@ void quantize_mxfp8_dual_impl(const IType *input, OType *rowwise_output, uint8_t
     PRIMUS_TURBO_CHECK(rowwise_recipe.use_sr == false, "MXFP8 not support SR");
     PRIMUS_TURBO_CHECK(colwise_recipe.use_sr == false, "MXFP8 not support SR");
 
+    // Per-group strides into the contiguous (G, ...) output/scale buffers. The
+    // scale buffers' leading dim is shuffle-padded (M_pad/N rounded to 256) when
+    // shuffle_scale is set, otherwise tightly M/N rows.
+    const int64_t input_per_group_stride       = (int64_t) M * N;
+    const int64_t rowwise_fp8_per_group_stride = (int64_t) M * N_pad;
+    const int64_t colwise_fp8_per_group_stride = (int64_t) N * M_pad;
+    const int64_t rowwise_scale_per_group_stride =
+        (int64_t) (rowwise_recipe.shuffle_scale ? rowwise_scale_M_pad : M) * rowwise_scale_stride;
+    const int64_t colwise_scale_per_group_stride =
+        (int64_t) (colwise_recipe.shuffle_scale ? colwise_scale_M_pad : colwise_scale_M) *
+        colwise_scale_stride;
+
 #define QUANTIZE_MXFP8_DUAL                                                                        \
     input, rowwise_output, rowwise_scale, colwise_output, colwise_scale, M, N, M_pad, N_pad,       \
         rowwise_scale_stride, colwise_scale_stride, rowwise_scale_N, rowwise_scale_M_pad,          \
         rowwise_scale_N_pad, colwise_scale_M, colwise_scale_N, colwise_scale_M_pad,                \
         colwise_scale_N_pad, rowwise_recipe.shuffle_out, colwise_recipe.shuffle_out,               \
-        rowwise_recipe.shuffle_scale, colwise_recipe.shuffle_scale
+        rowwise_recipe.shuffle_scale, colwise_recipe.shuffle_scale, input_per_group_stride,        \
+        rowwise_fp8_per_group_stride, rowwise_scale_per_group_stride,                              \
+        colwise_fp8_per_group_stride, colwise_scale_per_group_stride
 
 #define QUANTIZE_MXFP8_DUAL_LAUNCH_KERNEL(ROWWISE_USE_2D_BLOCK, COLWISE_USE_2D_BLOCK)              \
     quantize_mxfp8_dual_kernel<IType, OType, ROWWISE_USE_2D_BLOCK, COLWISE_USE_2D_BLOCK>           \
@@ -934,47 +1833,60 @@ void quantize_mxfp8_dual_impl(const IType *input, OType *rowwise_output, uint8_t
 
 template void quantize_mxfp8_dual_impl<dtype::float16, dtype::float8_e5m2>(
     const dtype::float16 *x, dtype::float8_e5m2 *rowwise_output, uint8_t *rowwise_scale,
-    dtype::float8_e5m2 *colwise_output, uint8_t *colwise_scale, int M, int N, int M_pad, int N_pad,
-    int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
+    dtype::float8_e5m2 *colwise_output, uint8_t *colwise_scale, int G, int M, int N, int M_pad,
+    int N_pad, int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
     int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
     ScalingRecipe colwise_recipe, hipStream_t stream);
 template void quantize_mxfp8_dual_impl<dtype::bfloat16, dtype::float8_e5m2>(
     const dtype::bfloat16 *x, dtype::float8_e5m2 *rowwise_output, uint8_t *rowwise_scale,
-    dtype::float8_e5m2 *colwise_output, uint8_t *colwise_scale, int M, int N, int M_pad, int N_pad,
-    int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
+    dtype::float8_e5m2 *colwise_output, uint8_t *colwise_scale, int G, int M, int N, int M_pad,
+    int N_pad, int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
     int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
     ScalingRecipe colwise_recipe, hipStream_t stream);
 template void quantize_mxfp8_dual_impl<dtype::float16, dtype::float8_e4m3>(
     const dtype::float16 *x, dtype::float8_e4m3 *rowwise_output, uint8_t *rowwise_scale,
-    dtype::float8_e4m3 *colwise_output, uint8_t *colwise_scale, int M, int N, int M_pad, int N_pad,
-    int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
+    dtype::float8_e4m3 *colwise_output, uint8_t *colwise_scale, int G, int M, int N, int M_pad,
+    int N_pad, int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
     int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
     ScalingRecipe colwise_recipe, hipStream_t stream);
 template void quantize_mxfp8_dual_impl<dtype::bfloat16, dtype::float8_e4m3>(
     const dtype::bfloat16 *x, dtype::float8_e4m3 *rowwise_output, uint8_t *rowwise_scale,
-    dtype::float8_e4m3 *colwise_output, uint8_t *colwise_scale, int M, int N, int M_pad, int N_pad,
-    int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
+    dtype::float8_e4m3 *colwise_output, uint8_t *colwise_scale, int G, int M, int N, int M_pad,
+    int N_pad, int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
     int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
     ScalingRecipe colwise_recipe, hipStream_t stream);
 
 template <typename IType, typename OType>
 void quantize_mxfp8_impl(const IType *input, OType *output, uint8_t *scale, QuantizeMode mode,
-                         int M, int N, int M_pad, int N_pad, int scale_stride, int scale_N,
+                         int G, int M, int N, int M_pad, int N_pad, int scale_stride, int scale_N,
                          int scale_M_pad, int scale_N_pad, ScalingRecipe recipe,
                          hipStream_t stream) {
-    dim3 grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
+    // Batched (G > 1) input replicates the per-matrix grid along blockIdx.z;
+    // each z-slice quantizes one (M, N) group offset by its per-group stride.
+    dim3 grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N, G);
     dim3 block(THREADS_PER_BLOCK);
 
     PRIMUS_TURBO_CHECK(recipe.use_rht == false, "MXFP8 not support RHT");
     PRIMUS_TURBO_CHECK(recipe.use_sr == false, "MXFP8 not support SR");
 
+    // Per-group strides into the contiguous (G, ...) output / scale buffers.
+    // Output layout depends on mode: rowwise (M, N_pad), colwise (N, M_pad).
+    // Scale leading dim is shuffle-padded to 256 when shuffle_scale is set,
+    // otherwise tightly M (rowwise) / N (colwise) rows.
+    const bool    is_rowwise               = (mode == QuantizeMode::ROWWISE);
+    const int64_t input_per_group_stride   = (int64_t) M * N;
+    const int64_t out_fp8_per_group_stride = is_rowwise ? (int64_t) M * N_pad : (int64_t) N * M_pad;
+    const int64_t out_scale_per_group_stride =
+        (int64_t) (recipe.shuffle_scale ? scale_M_pad : (is_rowwise ? M : N)) * scale_stride;
+
 #define QUANTIZE_MXFP8_KERNEL_ARGS                                                                 \
     input, output, scale, M, N, M_pad, N_pad, scale_stride, scale_N, scale_M_pad, scale_N_pad,     \
-        recipe.shuffle_out, recipe.shuffle_scale
+        recipe.shuffle_out, recipe.shuffle_scale, input_per_group_stride,                          \
+        out_fp8_per_group_stride, out_scale_per_group_stride
 
 #define QUANTIZE_MXFP8_LAUNCH_KERNEL(USE_2D_BLOCK)                                                 \
     if (mode == QuantizeMode::ROWWISE) {                                                           \
@@ -1001,20 +1913,51 @@ void quantize_mxfp8_impl(const IType *input, OType *output, uint8_t *scale, Quan
 }
 
 template void quantize_mxfp8_impl<dtype::float16, dtype::float8_e5m2>(
-    const dtype::float16 *x, dtype::float8_e5m2 *output, uint8_t *scale, QuantizeMode mode, int M,
-    int N, int M_pad, int N_pad, int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
-    ScalingRecipe recipe, hipStream_t stream);
+    const dtype::float16 *x, dtype::float8_e5m2 *output, uint8_t *scale, QuantizeMode mode, int G,
+    int M, int N, int M_pad, int N_pad, int scale_stride, int scale_N, int scale_M_pad,
+    int scale_N_pad, ScalingRecipe recipe, hipStream_t stream);
 template void quantize_mxfp8_impl<dtype::bfloat16, dtype::float8_e5m2>(
-    const dtype::bfloat16 *x, dtype::float8_e5m2 *output, uint8_t *scale, QuantizeMode mode, int M,
-    int N, int M_pad, int N_pad, int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
-    ScalingRecipe recipe, hipStream_t stream);
+    const dtype::bfloat16 *x, dtype::float8_e5m2 *output, uint8_t *scale, QuantizeMode mode, int G,
+    int M, int N, int M_pad, int N_pad, int scale_stride, int scale_N, int scale_M_pad,
+    int scale_N_pad, ScalingRecipe recipe, hipStream_t stream);
 template void quantize_mxfp8_impl<dtype::float16, dtype::float8_e4m3>(
-    const dtype::float16 *x, dtype::float8_e4m3 *output, uint8_t *scale, QuantizeMode mode, int M,
-    int N, int M_pad, int N_pad, int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
-    ScalingRecipe recipe, hipStream_t stream);
+    const dtype::float16 *x, dtype::float8_e4m3 *output, uint8_t *scale, QuantizeMode mode, int G,
+    int M, int N, int M_pad, int N_pad, int scale_stride, int scale_N, int scale_M_pad,
+    int scale_N_pad, ScalingRecipe recipe, hipStream_t stream);
 template void quantize_mxfp8_impl<dtype::bfloat16, dtype::float8_e4m3>(
-    const dtype::bfloat16 *x, dtype::float8_e4m3 *output, uint8_t *scale, QuantizeMode mode, int M,
-    int N, int M_pad, int N_pad, int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
-    ScalingRecipe recipe, hipStream_t stream);
+    const dtype::bfloat16 *x, dtype::float8_e4m3 *output, uint8_t *scale, QuantizeMode mode, int G,
+    int M, int N, int M_pad, int N_pad, int scale_stride, int scale_N, int scale_M_pad,
+    int scale_N_pad, ScalingRecipe recipe, hipStream_t stream);
+
+// ========================================================================
+// Grouped Padded Layout
+// ========================================================================
+//
+// Compute per-group padded lens/offs on the GPU.  Single-thread kernel:
+// G is typically 4–64 so the serial loop is negligible relative to the
+// avoided D2H sync.
+
+__global__ void compute_padded_layout_kernel(const int64_t *__restrict__ group_lens,
+                                             int64_t *__restrict__ group_lens_padded,
+                                             int64_t *__restrict__ group_offs_padded, int G,
+                                             int64_t align) {
+    if (threadIdx.x != 0)
+        return;
+    int64_t offset       = 0;
+    group_offs_padded[0] = 0;
+    for (int i = 0; i < G; ++i) {
+        int64_t m_pad        = (group_lens[i] + align - 1) / align * align;
+        group_lens_padded[i] = m_pad;
+        offset += m_pad;
+        group_offs_padded[i + 1] = offset;
+    }
+}
+
+void compute_padded_layout_gpu(const int64_t *group_lens, int64_t *group_lens_padded,
+                               int64_t *group_offs_padded, int G, int64_t align,
+                               hipStream_t stream) {
+    compute_padded_layout_kernel<<<1, 1, 0, stream>>>(group_lens, group_lens_padded,
+                                                      group_offs_padded, G, align);
+}
 
 } // namespace primus_turbo

--- a/csrc/pytorch/bindings_pytorch.cpp
+++ b/csrc/pytorch/bindings_pytorch.cpp
@@ -56,6 +56,14 @@ TORCH_LIBRARY(primus_turbo_cpp_extension, m) {
           "bool rowwise_use_2d_block, bool colwise_use_2d_block, "
           "bool shuffle_rowwise_scale=False, bool shuffle_rowwise=False, "
           "bool shuffle_colwise_scale=False, bool shuffle_colwise=False) -> Tensor[]");
+    m.def("grouped_quantize_mxfp8_dual(Tensor input, Tensor group_lens, Tensor group_offs, "
+          "ScalarType dest_dtype, "
+          "bool rowwise_use_2d_block, bool colwise_use_2d_block, "
+          "bool shuffle_rowwise_scale=False, bool shuffle_rowwise=False, "
+          "bool shuffle_colwise_scale=False, bool shuffle_colwise=False) -> Tensor[]");
+    m.def("grouped_quantize_mxfp8(Tensor input, Tensor group_lens, Tensor group_offs, "
+          "ScalarType dest_dtype, int axis, "
+          "bool use_2d_block, bool shuffle_scale=False, bool shuffle_out=False) -> Tensor[]");
     m.def("quantize_mxfp8(Tensor input, ScalarType dest_dtype, int axis, "
           "int padding_align_size, "
           "bool use_2d_block, bool shuffle_scale=False, bool shuffle_out=False) -> Tensor[]");
@@ -117,6 +125,8 @@ TORCH_LIBRARY_IMPL(primus_turbo_cpp_extension, CUDA, m) {
 
     // ********* MXFP8 Quantization *********
     m.impl("quantize_mxfp8_dual", quantize_mxfp8_dual);
+    m.impl("grouped_quantize_mxfp8_dual", grouped_quantize_mxfp8_dual);
+    m.impl("grouped_quantize_mxfp8", grouped_quantize_mxfp8);
     m.impl("quantize_mxfp8", quantize_mxfp8);
 
     // ********* Shuffle *********
@@ -157,6 +167,8 @@ TORCH_LIBRARY_IMPL(primus_turbo_cpp_extension, Meta, m) {
 
     // ********* MXFP8 Quantization *********
     m.impl("quantize_mxfp8_dual", quantize_mxfp8_dual_meta);
+    m.impl("grouped_quantize_mxfp8_dual", quantize_mxfp8_dual_grouped_meta);
+    m.impl("grouped_quantize_mxfp8", grouped_quantize_mxfp8_meta);
     m.impl("quantize_mxfp8", quantize_mxfp8_meta);
 
     // ********* Shuffle *********

--- a/csrc/pytorch/extensions.h
+++ b/csrc/pytorch/extensions.h
@@ -93,6 +93,33 @@ std::vector<at::Tensor> quantize_mxfp8_dual_meta(
     const bool shuffle_rowwise_scale = false, const bool shuffle_rowwise = false,
     const bool shuffle_colwise_scale = false, const bool shuffle_colwise = false);
 
+std::vector<at::Tensor> grouped_quantize_mxfp8_dual(
+    const at::Tensor input, const at::Tensor group_lens, const at::Tensor group_offs,
+    const at::ScalarType dest_dtype, const bool rowwise_use_2d_block,
+    const bool colwise_use_2d_block, const bool shuffle_rowwise_scale = false,
+    const bool shuffle_rowwise = false, const bool shuffle_colwise_scale = false,
+    const bool shuffle_colwise = false);
+
+std::vector<at::Tensor> quantize_mxfp8_dual_grouped_meta(
+    const at::Tensor input, const at::Tensor group_lens, const at::Tensor group_offs,
+    const at::ScalarType dest_dtype, const bool rowwise_use_2d_block,
+    const bool colwise_use_2d_block, const bool shuffle_rowwise_scale = false,
+    const bool shuffle_rowwise = false, const bool shuffle_colwise_scale = false,
+    const bool shuffle_colwise = false);
+
+std::vector<at::Tensor> grouped_quantize_mxfp8(const at::Tensor input, const at::Tensor group_lens,
+                                               const at::Tensor     group_offs,
+                                               const at::ScalarType dest_dtype, const int64_t axis,
+                                               const bool use_2d_block,
+                                               const bool shuffle_scale = false,
+                                               const bool shuffle_out   = false);
+
+std::vector<at::Tensor>
+grouped_quantize_mxfp8_meta(const at::Tensor input, const at::Tensor group_lens,
+                            const at::Tensor group_offs, const at::ScalarType dest_dtype,
+                            const int64_t axis, const bool use_2d_block,
+                            const bool shuffle_scale = false, const bool shuffle_out = false);
+
 std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarType dest_dtype,
                                        const int64_t axis, const int64_t padding_align_size,
                                        const bool use_2d_block, const bool shuffle_scale = false,

--- a/csrc/pytorch/quantization/quantization.cpp
+++ b/csrc/pytorch/quantization/quantization.cpp
@@ -12,6 +12,11 @@ namespace primus_turbo::pytorch {
 
 using namespace primus_turbo::dtype;
 
+// Ceil-divide helper shared by the quantization ops below.
+static inline int64_t cdiv(int64_t a, int64_t b) {
+    return (a + b - 1) / b;
+}
+
 // TODO: Check correctness
 float get_float8_max(const at::ScalarType dtype) {
     switch (dtype) {
@@ -283,10 +288,6 @@ std::vector<at::Tensor> quantize_mxfp4_dual(
     const bool shuffle_colwise) {
     using namespace primus_turbo::detail;
 
-    std::function<int64_t(int64_t, int64_t)> cdiv = [](int64_t a, int64_t b) -> int64_t {
-        return (a + b - 1) / b;
-    };
-
     PRIMUS_TURBO_CHECK(input.is_cuda(), "Input must be a CUDA tensor");
     PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
                        "Input must be BFloat16 or Half");
@@ -295,8 +296,8 @@ std::vector<at::Tensor> quantize_mxfp4_dual(
     PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat4_e2m1fn_x2, "Output must be Float4_e2m1fn_x2.");
     // Guard the public op argument against zero/negative values (would otherwise
     // divide-by-zero in cdiv below) and lock it to the expected MXFP4 constant.
-    PRIMUS_TURBO_CHECK(padding_align_size == MXFP4_PADDING_ALIGN_SIZE,
-                       "padding_align_size must be ", MXFP4_PADDING_ALIGN_SIZE,
+    PRIMUS_TURBO_CHECK(padding_align_size == MXFP4_K_DIM_PADDING_ALIGN_SIZE,
+                       "padding_align_size must be ", MXFP4_K_DIM_PADDING_ALIGN_SIZE,
                        " for MXFP4. But got padding_align_size=", padding_align_size);
 
     const int64_t M = input.size(0);
@@ -387,8 +388,6 @@ std::vector<at::Tensor> quantize_mxfp4(const at::Tensor input, const at::ScalarT
                                        const bool shuffle_out) {
     using namespace primus_turbo::detail;
 
-    auto cdiv = [](int64_t a, int64_t b) -> int64_t { return (a + b - 1) / b; };
-
     PRIMUS_TURBO_CHECK(input.is_cuda(), "Input must be a CUDA tensor");
     PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
                        "Input must be BFloat16 or Half");
@@ -398,8 +397,8 @@ std::vector<at::Tensor> quantize_mxfp4(const at::Tensor input, const at::ScalarT
     PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1");
     // Guard the public op argument against zero/negative values (would otherwise
     // divide-by-zero in cdiv below) and lock it to the expected MXFP4 constant.
-    PRIMUS_TURBO_CHECK(padding_align_size == MXFP4_PADDING_ALIGN_SIZE,
-                       "padding_align_size must be ", MXFP4_PADDING_ALIGN_SIZE,
+    PRIMUS_TURBO_CHECK(padding_align_size == MXFP4_K_DIM_PADDING_ALIGN_SIZE,
+                       "padding_align_size must be ", MXFP4_K_DIM_PADDING_ALIGN_SIZE,
                        " for MXFP4. But got padding_align_size=", padding_align_size);
 
     QuantizeMode mode       = (axis == 0) ? QuantizeMode::COLWISE : QuantizeMode::ROWWISE;
@@ -473,25 +472,30 @@ quantize_mxfp8_dual(const at::Tensor input, const at::ScalarType dest_dtype,
                     const bool shuffle_colwise) {
     using namespace primus_turbo::detail;
 
-    std::function<int64_t(int64_t, int64_t)> cdiv = [](int64_t a, int64_t b) -> int64_t {
-        return (a + b - 1) / b;
-    };
-
     PRIMUS_TURBO_CHECK(input.is_cuda(), "Input must be a CUDA tensor");
     PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
                        "Input must be BFloat16 or Half");
-    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
     PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
     PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat8_e4m3fn || dest_dtype == at::kFloat8_e5m2,
                        "Output must be Float8_e4m3fn or Float8_e5m2");
     // Guard the public op argument against zero/negative values (would otherwise
     // divide-by-zero in cdiv below) and lock it to the expected MXFP8 constant.
-    PRIMUS_TURBO_CHECK(padding_align_size == MXFP8_PADDING_ALIGN_SIZE,
-                       "padding_align_size must be ", MXFP8_PADDING_ALIGN_SIZE,
+    PRIMUS_TURBO_CHECK(padding_align_size == MXFP8_K_DIM_PADDING_ALIGN_SIZE,
+                       "padding_align_size must be ", MXFP8_K_DIM_PADDING_ALIGN_SIZE,
                        " for MXFP8. But got padding_align_size=", padding_align_size);
 
-    const int64_t M = input.size(0);
-    const int64_t N = input.size(1);
+    int64_t G, M, N;
+    if (input.dim() == 2) {
+        G = 1;
+        M = input.size(0);
+        N = input.size(1);
+    } else if (input.dim() == 3) {
+        G = input.size(0);
+        M = input.size(1);
+        N = input.size(2);
+    } else {
+        PRIMUS_TURBO_ERROR("Input must be 2D or 3D");
+    }
 
     const int64_t M_pad = cdiv(M, padding_align_size) * padding_align_size;
     const int64_t N_pad = cdiv(N, padding_align_size) * padding_align_size;
@@ -510,6 +514,13 @@ quantize_mxfp8_dual(const at::Tensor input, const at::ScalarType dest_dtype,
     auto device = input.device();
     auto stream = at::cuda::getCurrentCUDAStream();
 
+    // For 3D (batched) input every per-group buffer carries a leading ``G`` dim.
+    // Buffers stay contiguous so the launcher's per-group stride (rows * cols)
+    // lands on each group; ``rowwise_scale_stride`` remains the in-group row
+    // stride. 2D input keeps ``G == 1`` and the original 2D output layout.
+    const bool    is_batched = (input.dim() == 3);
+    const int64_t Gout       = is_batched ? G : 1;
+
     int64_t rowwise_scale_M_pad = cdiv(M, 256) * 256;
     int64_t rowwise_scale_N     = cdiv(N_pad, MXFP8_BLOCK_SIZE);
     int64_t rowwise_scale_N_pad = cdiv(rowwise_scale_N, 8) * 8;
@@ -517,17 +528,18 @@ quantize_mxfp8_dual(const at::Tensor input, const at::ScalarType dest_dtype,
     int64_t    rowwise_scale_stride = 1;
     at::Tensor rowwise_scale;
     if (shuffle_rowwise_scale) {
-        rowwise_scale = at::full({rowwise_scale_M_pad, rowwise_scale_N_pad}, E8M0_EXPONENT_BIAS,
-                                 at::TensorOptions().dtype(at::kByte).device(device));
+        rowwise_scale =
+            at::full({Gout * rowwise_scale_M_pad, rowwise_scale_N_pad}, E8M0_EXPONENT_BIAS,
+                     at::TensorOptions().dtype(at::kByte).device(device));
         rowwise_scale_stride = rowwise_scale.stride(0);
     } else {
-        rowwise_scale =
-            at::empty({M, rowwise_scale_N}, at::TensorOptions().dtype(at::kByte).device(device));
+        rowwise_scale        = at::empty({Gout * M, rowwise_scale_N},
+                                         at::TensorOptions().dtype(at::kByte).device(device));
         rowwise_scale_stride = rowwise_scale_N;
     }
 
     at::Tensor rowwise_output =
-        at::empty({M, N_pad}, at::TensorOptions().dtype(at::kByte).device(device));
+        at::empty({Gout * M, N_pad}, at::TensorOptions().dtype(at::kByte).device(device));
 
     int64_t colwise_scale_M_pad = cdiv(N, 256) * 256;
     int64_t colwise_scale_N     = cdiv(M_pad, MXFP8_BLOCK_SIZE);
@@ -536,17 +548,18 @@ quantize_mxfp8_dual(const at::Tensor input, const at::ScalarType dest_dtype,
     at::Tensor colwise_scale;
     int        colwise_scale_stride = 1;
     if (shuffle_colwise_scale) {
-        colwise_scale = at::full({colwise_scale_M_pad, colwise_scale_N_pad}, E8M0_EXPONENT_BIAS,
-                                 at::TensorOptions().dtype(at::kByte).device(device));
+        colwise_scale =
+            at::full({Gout * colwise_scale_M_pad, colwise_scale_N_pad}, E8M0_EXPONENT_BIAS,
+                     at::TensorOptions().dtype(at::kByte).device(device));
         colwise_scale_stride = colwise_scale.stride(0);
     } else {
-        colwise_scale =
-            at::empty({N, colwise_scale_N}, at::TensorOptions().dtype(at::kByte).device(device));
+        colwise_scale        = at::empty({Gout * N, colwise_scale_N},
+                                         at::TensorOptions().dtype(at::kByte).device(device));
         colwise_scale_stride = colwise_scale_N;
     }
 
     at::Tensor colwise_output =
-        at::empty({N, M_pad}, at::TensorOptions().dtype(at::kByte).device(device));
+        at::empty({Gout * N, M_pad}, at::TensorOptions().dtype(at::kByte).device(device));
 
     TORCH_TYPE_SWITCH_FP16_BF16(
         input.scalar_type(), IType, {TORCH_TYPE_SWITCH_FP8(dest_dtype, OType, {
@@ -555,7 +568,7 @@ quantize_mxfp8_dual(const at::Tensor input, const at::ScalarType dest_dtype,
                 reinterpret_cast<OType *>(rowwise_output.data_ptr()),
                 rowwise_scale.data_ptr<uint8_t>(),
                 reinterpret_cast<OType *>(colwise_output.data_ptr()),
-                colwise_scale.data_ptr<uint8_t>(), M, N, M_pad, N_pad, rowwise_scale_stride,
+                colwise_scale.data_ptr<uint8_t>(), G, M, N, M_pad, N_pad, rowwise_scale_stride,
                 colwise_scale_stride, rowwise_scale_N, rowwise_scale_M_pad, rowwise_scale_N_pad, N,
                 colwise_scale_N, colwise_scale_M_pad, colwise_scale_N_pad,
                 ScalingRecipe(rowwise_use_2d_block, false, false, shuffle_rowwise_scale,
@@ -565,38 +578,57 @@ quantize_mxfp8_dual(const at::Tensor input, const at::ScalarType dest_dtype,
                 stream);
         })});
 
+    if (is_batched) {
+        const int64_t rowwise_scale_rows = shuffle_rowwise_scale ? rowwise_scale_M_pad : M;
+        const int64_t colwise_scale_rows = shuffle_colwise_scale ? colwise_scale_M_pad : N;
+        return {rowwise_output.view({G, M, N_pad}).view(dest_dtype),
+                rowwise_scale.view({G, rowwise_scale_rows, -1}).view(at::kFloat8_e8m0fnu),
+                colwise_output.view({G, N, M_pad}).view(dest_dtype),
+                colwise_scale.view({G, colwise_scale_rows, -1}).view(at::kFloat8_e8m0fnu)};
+    }
+
     return {rowwise_output.view(dest_dtype), rowwise_scale.view(at::kFloat8_e8m0fnu),
             colwise_output.view(dest_dtype), colwise_scale.view(at::kFloat8_e8m0fnu)};
 }
 
-// Quantize MXFP8 with single mode (rowwise or colwise)
 std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarType dest_dtype,
                                        const int64_t axis, const int64_t padding_align_size,
                                        const bool use_2d_block, const bool shuffle_scale,
                                        const bool shuffle_out) {
     using namespace primus_turbo::detail;
 
-    auto cdiv = [](int64_t a, int64_t b) -> int64_t { return (a + b - 1) / b; };
-
     PRIMUS_TURBO_CHECK(input.is_cuda(), "Input must be a CUDA tensor");
     PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
                        "Input must be BFloat16 or Half");
-    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
     PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
     PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat8_e4m3fn || dest_dtype == at::kFloat8_e5m2,
                        "Output must be Float8_e4m3fn or Float8_e5m2");
     PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1");
     // Guard the public op argument against zero/negative values (would otherwise
     // divide-by-zero in cdiv below) and lock it to the expected MXFP8 constant.
-    PRIMUS_TURBO_CHECK(padding_align_size == MXFP8_PADDING_ALIGN_SIZE,
-                       "padding_align_size must be ", MXFP8_PADDING_ALIGN_SIZE,
+    PRIMUS_TURBO_CHECK(padding_align_size == MXFP8_K_DIM_PADDING_ALIGN_SIZE,
+                       "padding_align_size must be ", MXFP8_K_DIM_PADDING_ALIGN_SIZE,
                        " for MXFP8. But got padding_align_size=", padding_align_size);
 
-    QuantizeMode mode       = (axis == 0) ? QuantizeMode::COLWISE : QuantizeMode::ROWWISE;
-    const bool   is_rowwise = (mode == QuantizeMode::ROWWISE);
+    bool         is_rowwise;
+    QuantizeMode mode;
+    int64_t      G, M, N;
+    if (input.dim() == 2) {
+        mode       = (axis == 0) ? QuantizeMode::COLWISE : QuantizeMode::ROWWISE;
+        is_rowwise = (mode == QuantizeMode::ROWWISE);
+        G          = 1;
+        M          = input.size(0);
+        N          = input.size(1);
+    } else if (input.dim() == 3) {
+        mode       = (axis == 1) ? QuantizeMode::COLWISE : QuantizeMode::ROWWISE;
+        is_rowwise = (mode == QuantizeMode::ROWWISE);
+        G          = input.size(0);
+        M          = input.size(1);
+        N          = input.size(2);
+    } else {
+        PRIMUS_TURBO_ERROR("Input must be 2D or 3D");
+    }
 
-    const int64_t M     = input.size(0);
-    const int64_t N     = input.size(1);
     const int64_t M_pad = cdiv(M, padding_align_size) * padding_align_size;
     const int64_t N_pad = cdiv(N, padding_align_size) * padding_align_size;
 
@@ -615,11 +647,263 @@ std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarT
     auto device = input.device();
     auto stream = at::cuda::getCurrentCUDAStream();
 
+    // For 3D (batched) input every per-group buffer carries a leading ``G`` dim.
+    // Buffers stay contiguous so the launcher's per-group stride lands on each
+    // group; ``scale_stride`` remains the in-group row stride. 2D input keeps
+    // ``G == 1`` and the original 2D output layout.
+    const bool    is_batched = (input.dim() == 3);
+    const int64_t Gout       = is_batched ? G : 1;
+
     // Scale dimensions depend on quantization direction:
     //   Rowwise: scale has shape [M, cdiv(N_pad,32)], shuffle-padded to [scale_M_pad, scale_N_pad]
     //   Colwise: scale has shape [N, cdiv(M_pad,32)], shuffle-padded to [scale_M_pad, scale_N_pad]
     int64_t scale_outer = is_rowwise ? M : N;
     int64_t scale_N = is_rowwise ? cdiv(N_pad, MXFP8_BLOCK_SIZE) : cdiv(M_pad, MXFP8_BLOCK_SIZE);
+    int64_t scale_M_pad = cdiv(scale_outer, 256) * 256;
+    int64_t scale_N_pad = cdiv(scale_N, 8) * 8;
+
+    int64_t    scale_stride = 1;
+    at::Tensor scale_tensor;
+    if (shuffle_scale) {
+        scale_tensor = at::full({Gout * scale_M_pad, scale_N_pad}, E8M0_EXPONENT_BIAS,
+                                at::TensorOptions().dtype(at::kByte).device(device));
+        scale_stride = scale_tensor.stride(0);
+    } else {
+        scale_tensor = at::empty({Gout * scale_outer, scale_N},
+                                 at::TensorOptions().dtype(at::kByte).device(device));
+        scale_stride = scale_N;
+    }
+
+    // Output FP8 tensor (1 byte per element):
+    //   Rowwise: [M, N_pad]    Colwise: [N, M_pad]
+    int64_t    output_rows = is_rowwise ? M : N;
+    int64_t    output_cols = is_rowwise ? N_pad : M_pad;
+    at::Tensor output      = at::empty({Gout * output_rows, output_cols},
+                                       at::TensorOptions().dtype(at::kByte).device(device));
+
+    TORCH_TYPE_SWITCH_FP16_BF16(
+        input.scalar_type(), IType, {TORCH_TYPE_SWITCH_FP8(dest_dtype, OType, {
+            quantize_mxfp8_impl<IType, OType>(
+                reinterpret_cast<IType *>(input.data_ptr()),
+                reinterpret_cast<OType *>(output.data_ptr()), scale_tensor.data_ptr<uint8_t>(),
+                mode, G, M, N, M_pad, N_pad, scale_stride, scale_N, scale_M_pad, scale_N_pad,
+                ScalingRecipe(use_2d_block, false, false, shuffle_scale, shuffle_out), stream);
+        })});
+
+    if (is_batched) {
+        const int64_t scale_rows = shuffle_scale ? scale_M_pad : scale_outer;
+        return {output.view({G, output_rows, output_cols}).view(dest_dtype),
+                scale_tensor.view({G, scale_rows, -1}).view(at::kFloat8_e8m0fnu)};
+    }
+
+    return {output.view(dest_dtype), scale_tensor.view(at::kFloat8_e8m0fnu)};
+}
+
+std::vector<at::Tensor>
+grouped_quantize_mxfp8_dual(const at::Tensor input, const at::Tensor group_lens,
+                            const at::Tensor group_offs, const at::ScalarType dest_dtype,
+                            const bool rowwise_use_2d_block, const bool colwise_use_2d_block,
+                            const bool shuffle_rowwise_scale, const bool shuffle_rowwise,
+                            const bool shuffle_colwise_scale, const bool shuffle_colwise) {
+    using namespace primus_turbo::detail;
+
+    PRIMUS_TURBO_CHECK(input.is_cuda(), "Input must be a CUDA tensor");
+    PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
+                       "Input must be BFloat16 or Half");
+    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
+    PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
+    PRIMUS_TURBO_CHECK(group_lens.is_cuda() && group_offs.is_cuda(),
+                       "group_lens / group_offs must be CUDA tensors");
+    PRIMUS_TURBO_CHECK(group_lens.scalar_type() == at::kLong &&
+                           group_offs.scalar_type() == at::kLong,
+                       "group_lens / group_offs must be int64");
+    PRIMUS_TURBO_CHECK(group_lens.dim() == 1 && group_offs.dim() == 1,
+                       "group_lens / group_offs must be 1D");
+    PRIMUS_TURBO_CHECK(group_offs.size(0) == group_lens.size(0) + 1,
+                       "group_offs.size(0) must equal group_lens.size(0) + 1");
+    PRIMUS_TURBO_CHECK(group_lens.size(0) >= 1, "must have at least one group");
+    PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat8_e4m3fn || dest_dtype == at::kFloat8_e5m2,
+                       "Output must be Float8_e4m3fn or Float8_e5m2");
+
+    constexpr int64_t ROW_ALIGN = MXFP8_GROUP_M_PADDING_ALIGN_SIZE; // = 32
+    constexpr int64_t COL_ALIGN = MXFP8_K_DIM_PADDING_ALIGN_SIZE;   // = 128
+
+    const int64_t G         = group_lens.size(0);
+    const int64_t total_M   = input.size(0);
+    const int64_t N         = input.size(1);
+    const int64_t M_pad_col = cdiv(total_M + G * COL_ALIGN, COL_ALIGN) * COL_ALIGN;
+    const int64_t M_pad_row = cdiv(total_M + G * ROW_ALIGN, ROW_ALIGN) * ROW_ALIGN;
+    const int64_t N_pad     = cdiv(N, COL_ALIGN) * COL_ALIGN;
+
+    PRIMUS_TURBO_CHECK(N % MXFP8_BLOCK_SIZE == 0, "N must be divisible by ", MXFP8_BLOCK_SIZE);
+
+    if (shuffle_rowwise) {
+        PRIMUS_TURBO_CHECK(M_pad_col % MXFP8_SHUFFLE_BN == 0, "M_pad_col must be divisible by ",
+                           MXFP8_SHUFFLE_BN,
+                           " for shuffled rowwise FP8. But got M_pad_col=", M_pad_col);
+    }
+    if (shuffle_colwise) {
+        PRIMUS_TURBO_CHECK(N % MXFP8_SHUFFLE_BN == 0, "N must be divisible by ", MXFP8_SHUFFLE_BN,
+                           " for shuffled colwise FP8. But got N=", N);
+    }
+
+    auto device = input.device();
+    auto stream = at::cuda::getCurrentCUDAStream();
+
+    // Fold layout computation into this op (no separate D2H round-trip).
+    // rowwise (fwd/dgrad A): 32-padded per-group M layout.
+    auto group_lens_padded_rowwise = at::empty_like(group_lens);
+    auto group_offs_padded_rowwise = at::empty({G + 1}, group_offs.options());
+    primus_turbo::compute_padded_layout_gpu(
+        group_lens.data_ptr<int64_t>(), group_lens_padded_rowwise.data_ptr<int64_t>(),
+        group_offs_padded_rowwise.data_ptr<int64_t>(), static_cast<int>(G), ROW_ALIGN, stream);
+    // colwise (wgrad A): 128-padded per-group M layout; also drives the kernel
+    // grid + tile->group mapping (BLOCK_M = 128).
+    auto group_lens_padded_colwise = at::empty_like(group_lens);
+    auto group_offs_padded_colwise = at::empty({G + 1}, group_offs.options());
+    primus_turbo::compute_padded_layout_gpu(
+        group_lens.data_ptr<int64_t>(), group_lens_padded_colwise.data_ptr<int64_t>(),
+        group_offs_padded_colwise.data_ptr<int64_t>(), static_cast<int>(G), COL_ALIGN, stream);
+
+    // Rowwise (fwd/dgrad A): 32-padded per-group M layout (M_pad_row rows).
+    int64_t rowwise_scale_M_pad = cdiv(M_pad_row, 256) * 256;
+    int64_t rowwise_scale_N     = cdiv(N_pad, MXFP8_BLOCK_SIZE);
+    int64_t rowwise_scale_N_pad = cdiv(rowwise_scale_N, 8) * 8;
+
+    int64_t    rowwise_scale_stride = 1;
+    at::Tensor rowwise_scale;
+    if (shuffle_rowwise_scale) {
+        rowwise_scale = at::full({rowwise_scale_M_pad, rowwise_scale_N_pad}, E8M0_EXPONENT_BIAS,
+                                 at::TensorOptions().dtype(at::kByte).device(device));
+        rowwise_scale_stride = rowwise_scale.stride(0);
+    } else {
+        rowwise_scale        = at::empty({M_pad_row, rowwise_scale_N},
+                                         at::TensorOptions().dtype(at::kByte).device(device));
+        rowwise_scale_stride = rowwise_scale_N;
+    }
+
+    at::Tensor rowwise_output =
+        at::empty({M_pad_row, N_pad}, at::TensorOptions().dtype(at::kByte).device(device));
+
+    int64_t colwise_scale_M_pad = cdiv(N, 256) * 256;
+    int64_t colwise_scale_N     = cdiv(M_pad_col, MXFP8_BLOCK_SIZE);
+    int64_t colwise_scale_N_pad = cdiv(colwise_scale_N, 8) * 8;
+
+    at::Tensor colwise_scale;
+    int        colwise_scale_stride = 1;
+    if (shuffle_colwise_scale) {
+        colwise_scale = at::full({colwise_scale_M_pad, colwise_scale_N_pad}, E8M0_EXPONENT_BIAS,
+                                 at::TensorOptions().dtype(at::kByte).device(device));
+        colwise_scale_stride = colwise_scale.stride(0);
+    } else {
+        colwise_scale =
+            at::empty({N, colwise_scale_N}, at::TensorOptions().dtype(at::kByte).device(device));
+        colwise_scale_stride = colwise_scale_N;
+    }
+
+    at::Tensor colwise_output =
+        at::empty({N, M_pad_col}, at::TensorOptions().dtype(at::kByte).device(device));
+
+    TORCH_TYPE_SWITCH_FP16_BF16(
+        input.scalar_type(), IType, {TORCH_TYPE_SWITCH_FP8(dest_dtype, OType, {
+            grouped_quantize_mxfp8_dual_impl<IType, OType>(
+                reinterpret_cast<IType *>(input.data_ptr()),
+                reinterpret_cast<OType *>(rowwise_output.data_ptr()),
+                rowwise_scale.data_ptr<uint8_t>(),
+                reinterpret_cast<OType *>(colwise_output.data_ptr()),
+                colwise_scale.data_ptr<uint8_t>(), group_offs.data_ptr<int64_t>(),
+                group_offs_padded_colwise.data_ptr<int64_t>(),
+                group_offs_padded_rowwise.data_ptr<int64_t>(), static_cast<int>(G),
+                static_cast<int>(M_pad_col), static_cast<int>(N), static_cast<int>(N_pad),
+                rowwise_scale_stride, colwise_scale_stride, rowwise_scale_N, rowwise_scale_M_pad,
+                rowwise_scale_N_pad, N, colwise_scale_N, colwise_scale_M_pad, colwise_scale_N_pad,
+                ScalingRecipe(rowwise_use_2d_block, false, false, shuffle_rowwise_scale,
+                              shuffle_rowwise),
+                ScalingRecipe(colwise_use_2d_block, false, false, shuffle_colwise_scale,
+                              shuffle_colwise),
+                stream);
+        })});
+
+    return {rowwise_output.view(dest_dtype), rowwise_scale.view(at::kFloat8_e8m0fnu),
+            colwise_output.view(dest_dtype), colwise_scale.view(at::kFloat8_e8m0fnu),
+            group_lens_padded_rowwise,       group_offs_padded_rowwise,
+            group_lens_padded_colwise,       group_offs_padded_colwise};
+}
+
+// Quantize MXFP8 with single mode (rowwise or colwise)
+std::vector<at::Tensor> grouped_quantize_mxfp8(const at::Tensor input, const at::Tensor group_lens,
+                                               const at::Tensor     group_offs,
+                                               const at::ScalarType dest_dtype, const int64_t axis,
+                                               const bool use_2d_block, const bool shuffle_scale,
+                                               const bool shuffle_out) {
+    using namespace primus_turbo::detail;
+
+    PRIMUS_TURBO_CHECK(input.is_cuda(), "Input must be a CUDA tensor");
+    PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
+                       "Input must be BFloat16 or Half");
+    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
+    PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
+    PRIMUS_TURBO_CHECK(group_lens.is_cuda() && group_offs.is_cuda(),
+                       "group_lens / group_offs must be CUDA tensors");
+    PRIMUS_TURBO_CHECK(group_lens.scalar_type() == at::kLong &&
+                           group_offs.scalar_type() == at::kLong,
+                       "group_lens / group_offs must be int64");
+    PRIMUS_TURBO_CHECK(group_lens.dim() == 1 && group_offs.dim() == 1,
+                       "group_lens / group_offs must be 1D");
+    PRIMUS_TURBO_CHECK(group_offs.size(0) == group_lens.size(0) + 1,
+                       "group_offs.size(0) must equal group_lens.size(0) + 1");
+    PRIMUS_TURBO_CHECK(group_lens.size(0) >= 1, "must have at least one group");
+    PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat8_e4m3fn || dest_dtype == at::kFloat8_e5m2,
+                       "Output must be Float8_e4m3fn or Float8_e5m2");
+    PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1");
+
+    constexpr int64_t ROW_ALIGN = MXFP8_GROUP_M_PADDING_ALIGN_SIZE; // = 32
+    constexpr int64_t COL_ALIGN = MXFP8_K_DIM_PADDING_ALIGN_SIZE;   // = 128
+
+    const bool         is_rowwise = (axis == 1);
+    const QuantizeMode mode       = is_rowwise ? QuantizeMode::ROWWISE : QuantizeMode::COLWISE;
+
+    const int64_t G       = group_lens.size(0);
+    const int64_t total_M = input.size(0);
+    const int64_t N       = input.size(1);
+    // Grid covers the 128-padded M extent so each 128-row tile is in one group.
+    const int64_t M_pad_col = cdiv(total_M + G * COL_ALIGN, COL_ALIGN) * COL_ALIGN;
+    const int64_t M_pad_row = cdiv(total_M + G * ROW_ALIGN, ROW_ALIGN) * ROW_ALIGN;
+    const int64_t N_pad     = cdiv(N, COL_ALIGN) * COL_ALIGN;
+
+    PRIMUS_TURBO_CHECK(N % MXFP8_BLOCK_SIZE == 0, "N must be divisible by ", MXFP8_BLOCK_SIZE);
+
+    if (shuffle_out) {
+        if (is_rowwise) {
+            PRIMUS_TURBO_CHECK(M_pad_row % MXFP8_SHUFFLE_BN == 0, "M_pad_row must be divisible by ",
+                               MXFP8_SHUFFLE_BN,
+                               " for shuffled rowwise FP8. But got M_pad_row=", M_pad_row);
+        } else {
+            PRIMUS_TURBO_CHECK(N % MXFP8_SHUFFLE_BN == 0, "N must be divisible by ",
+                               MXFP8_SHUFFLE_BN, " for shuffled colwise FP8. But got N=", N);
+        }
+    }
+
+    auto device = input.device();
+    auto stream = at::cuda::getCurrentCUDAStream();
+
+    // colwise (128) drives the grid + tile->group mapping; rowwise (16) gives
+    // rowwise output row positions.  Both computed on GPU (async).
+    auto group_lens_padded_colwise = at::empty_like(group_lens);
+    auto group_offs_padded_colwise = at::empty({G + 1}, group_offs.options());
+    primus_turbo::compute_padded_layout_gpu(
+        group_lens.data_ptr<int64_t>(), group_lens_padded_colwise.data_ptr<int64_t>(),
+        group_offs_padded_colwise.data_ptr<int64_t>(), static_cast<int>(G), COL_ALIGN, stream);
+    auto group_lens_padded_rowwise = at::empty_like(group_lens);
+    auto group_offs_padded_rowwise = at::empty({G + 1}, group_offs.options());
+    primus_turbo::compute_padded_layout_gpu(
+        group_lens.data_ptr<int64_t>(), group_lens_padded_rowwise.data_ptr<int64_t>(),
+        group_offs_padded_rowwise.data_ptr<int64_t>(), static_cast<int>(G), ROW_ALIGN, stream);
+
+    // Scale dimensions (mirror ``quantize_mxfp8``, using the grouped M_pad_col / M_pad_row).
+    int64_t scale_outer = is_rowwise ? M_pad_row : N;
+    int64_t scale_N =
+        is_rowwise ? cdiv(N_pad, MXFP8_BLOCK_SIZE) : cdiv(M_pad_col, MXFP8_BLOCK_SIZE);
     int64_t scale_M_pad = cdiv(scale_outer, 256) * 256;
     int64_t scale_N_pad = cdiv(scale_N, 8) * 8;
 
@@ -635,23 +919,30 @@ std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarT
         scale_stride = scale_N;
     }
 
-    // Output FP8 tensor (1 byte per element):
-    //   Rowwise: [M, N_pad]    Colwise: [N, M_pad]
-    int64_t    output_rows = is_rowwise ? M : N;
-    int64_t    output_cols = is_rowwise ? N_pad : M_pad;
+    int64_t    output_rows = is_rowwise ? M_pad_row : N;
+    int64_t    output_cols = is_rowwise ? N_pad : M_pad_col;
     at::Tensor output =
         at::empty({output_rows, output_cols}, at::TensorOptions().dtype(at::kByte).device(device));
 
     TORCH_TYPE_SWITCH_FP16_BF16(
         input.scalar_type(), IType, {TORCH_TYPE_SWITCH_FP8(dest_dtype, OType, {
-            quantize_mxfp8_impl<IType, OType>(
+            quantize_mxfp8_grouped_impl<IType, OType>(
                 reinterpret_cast<IType *>(input.data_ptr()),
                 reinterpret_cast<OType *>(output.data_ptr()), scale_tensor.data_ptr<uint8_t>(),
-                mode, M, N, M_pad, N_pad, scale_stride, scale_N, scale_M_pad, scale_N_pad,
+                group_offs.data_ptr<int64_t>(), group_offs_padded_colwise.data_ptr<int64_t>(),
+                group_offs_padded_rowwise.data_ptr<int64_t>(), mode, static_cast<int>(G),
+                static_cast<int>(M_pad_col), static_cast<int>(N), static_cast<int>(N_pad),
+                static_cast<int>(scale_stride), static_cast<int>(scale_N),
+                static_cast<int>(scale_M_pad), static_cast<int>(scale_N_pad),
                 ScalingRecipe(use_2d_block, false, false, shuffle_scale, shuffle_out), stream);
         })});
 
-    return {output.view(dest_dtype), scale_tensor.view(at::kFloat8_e8m0fnu)};
+    if (is_rowwise) {
+        return {output.view(dest_dtype), scale_tensor.view(at::kFloat8_e8m0fnu),
+                group_lens_padded_rowwise, group_offs_padded_rowwise};
+    }
+    return {output.view(dest_dtype), scale_tensor.view(at::kFloat8_e8m0fnu),
+            group_lens_padded_colwise, group_offs_padded_colwise};
 }
 
 } // namespace primus_turbo::pytorch

--- a/csrc/pytorch/quantization/quantization_meta.cpp
+++ b/csrc/pytorch/quantization/quantization_meta.cpp
@@ -64,8 +64,8 @@ std::vector<at::Tensor> quantize_mxfp4_dual_meta(
     PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat4_e2m1fn_x2, "Output must be Float4_e2m1fn_x2");
     // Guard the public op argument against zero/negative values (would otherwise
     // divide-by-zero in cdiv below) and lock it to the expected MXFP4 constant.
-    PRIMUS_TURBO_CHECK(padding_align_size == MXFP4_PADDING_ALIGN_SIZE,
-                       "padding_align_size must be ", MXFP4_PADDING_ALIGN_SIZE,
+    PRIMUS_TURBO_CHECK(padding_align_size == MXFP4_K_DIM_PADDING_ALIGN_SIZE,
+                       "padding_align_size must be ", MXFP4_K_DIM_PADDING_ALIGN_SIZE,
                        " for MXFP4. But got padding_align_size=", padding_align_size);
 
     const int64_t M = input.size(0);
@@ -143,8 +143,8 @@ std::vector<at::Tensor> quantize_mxfp4_meta(const at::Tensor input, const at::Sc
     PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1");
     // Guard the public op argument against zero/negative values (would otherwise
     // divide-by-zero in cdiv below) and lock it to the expected MXFP4 constant.
-    PRIMUS_TURBO_CHECK(padding_align_size == MXFP4_PADDING_ALIGN_SIZE,
-                       "padding_align_size must be ", MXFP4_PADDING_ALIGN_SIZE,
+    PRIMUS_TURBO_CHECK(padding_align_size == MXFP4_K_DIM_PADDING_ALIGN_SIZE,
+                       "padding_align_size must be ", MXFP4_K_DIM_PADDING_ALIGN_SIZE,
                        " for MXFP4. But got padding_align_size=", padding_align_size);
 
     const bool    is_rowwise = (axis == 1);
@@ -189,18 +189,25 @@ quantize_mxfp8_dual_meta(const at::Tensor input, const at::ScalarType dest_dtype
 
     PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
                        "Input must be BFloat16 or Half");
-    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
     PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
     PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat8_e4m3fn || dest_dtype == at::kFloat8_e5m2,
                        "Output must be Float8_e4m3fn or Float8_e5m2");
     // Guard the public op argument against zero/negative values (would otherwise
     // divide-by-zero in cdiv below) and lock it to the expected MXFP8 constant.
-    PRIMUS_TURBO_CHECK(padding_align_size == MXFP8_PADDING_ALIGN_SIZE,
-                       "padding_align_size must be ", MXFP8_PADDING_ALIGN_SIZE,
+    PRIMUS_TURBO_CHECK(padding_align_size == MXFP8_K_DIM_PADDING_ALIGN_SIZE,
+                       "padding_align_size must be ", MXFP8_K_DIM_PADDING_ALIGN_SIZE,
                        " for MXFP8. But got padding_align_size=", padding_align_size);
 
-    const int64_t M = input.size(0);
-    const int64_t N = input.size(1);
+    int64_t M, N;
+    if (input.dim() == 2) {
+        M = input.size(0);
+        N = input.size(1);
+    } else if (input.dim() == 3) {
+        M = input.size(1);
+        N = input.size(2);
+    } else {
+        PRIMUS_TURBO_ERROR("Input must be 2D or 3D");
+    }
 
     const int64_t M_pad = cdiv(M, padding_align_size) * padding_align_size;
     const int64_t N_pad = cdiv(N, padding_align_size) * padding_align_size;
@@ -252,6 +259,127 @@ quantize_mxfp8_dual_meta(const at::Tensor input, const at::ScalarType dest_dtype
             colwise_output.view(dest_dtype), colwise_scale.view(at::kFloat8_e8m0fnu)};
 }
 
+std::vector<at::Tensor>
+quantize_mxfp8_dual_grouped_meta(const at::Tensor input, const at::Tensor group_lens,
+                                 const at::Tensor group_offs, const at::ScalarType dest_dtype,
+                                 const bool rowwise_use_2d_block, const bool colwise_use_2d_block,
+                                 const bool shuffle_rowwise_scale, const bool shuffle_rowwise,
+                                 const bool shuffle_colwise_scale, const bool shuffle_colwise) {
+    using namespace primus_turbo::detail;
+    auto cdiv = [](int64_t a, int64_t b) -> int64_t { return (a + b - 1) / b; };
+
+    PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
+                       "Input must be BFloat16 or Half");
+    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
+    PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat8_e4m3fn || dest_dtype == at::kFloat8_e5m2,
+                       "Output must be Float8_e4m3fn or Float8_e5m2");
+
+    constexpr int64_t ALIGN = MXFP8_K_DIM_PADDING_ALIGN_SIZE;
+
+    const int64_t     G         = group_lens.size(0);
+    const int64_t     total_M   = input.size(0);
+    const int64_t     N         = input.size(1);
+    constexpr int64_t ROW_ALIGN = MXFP8_GROUP_M_PADDING_ALIGN_SIZE; // = 32
+    const int64_t     M_pad_col = cdiv(total_M + G * ALIGN, ALIGN) * ALIGN;
+    const int64_t     M_pad_row = cdiv(total_M + G * ROW_ALIGN, ROW_ALIGN) * ROW_ALIGN;
+    const int64_t     N_pad     = cdiv(N, ALIGN) * ALIGN;
+
+    int64_t rowwise_scale_M_pad = cdiv(M_pad_row, 256) * 256;
+    int64_t rowwise_scale_N     = cdiv(N_pad, MXFP8_BLOCK_SIZE);
+    int64_t rowwise_scale_N_pad = cdiv(rowwise_scale_N, 8) * 8;
+
+    at::Tensor rowwise_scale;
+    if (shuffle_rowwise_scale) {
+        rowwise_scale = at::empty({rowwise_scale_M_pad, rowwise_scale_N_pad},
+                                  at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+    } else {
+        rowwise_scale = at::empty({M_pad_row, rowwise_scale_N},
+                                  at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+    }
+
+    at::Tensor rowwise_output =
+        at::empty({M_pad_row, N_pad}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+
+    int64_t colwise_scale_M_pad = cdiv(N, 256) * 256;
+    int64_t colwise_scale_N     = cdiv(M_pad_col, MXFP8_BLOCK_SIZE);
+    int64_t colwise_scale_N_pad = cdiv(colwise_scale_N, 8) * 8;
+
+    at::Tensor colwise_scale;
+    if (shuffle_colwise_scale) {
+        colwise_scale = at::empty({colwise_scale_M_pad, colwise_scale_N_pad},
+                                  at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+    } else {
+        colwise_scale =
+            at::empty({N, colwise_scale_N}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+    }
+
+    at::Tensor colwise_output =
+        at::empty({N, M_pad_col}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+
+    auto group_lens_padded_colwise = at::empty_like(group_lens);
+    auto group_offs_padded_colwise = at::empty({G + 1}, group_offs.options());
+    auto group_lens_padded_rowwise = at::empty_like(group_lens);
+    auto group_offs_padded_rowwise = at::empty({G + 1}, group_offs.options());
+
+    return {rowwise_output.view(dest_dtype), rowwise_scale.view(at::kFloat8_e8m0fnu),
+            colwise_output.view(dest_dtype), colwise_scale.view(at::kFloat8_e8m0fnu),
+            group_lens_padded_rowwise,       group_offs_padded_rowwise,
+            group_lens_padded_colwise,       group_offs_padded_colwise};
+}
+
+std::vector<at::Tensor>
+grouped_quantize_mxfp8_meta(const at::Tensor input, const at::Tensor group_lens,
+                            const at::Tensor group_offs, const at::ScalarType dest_dtype,
+                            const int64_t axis, const bool use_2d_block, const bool shuffle_scale,
+                            const bool shuffle_out) {
+    using namespace primus_turbo::detail;
+    auto cdiv = [](int64_t a, int64_t b) -> int64_t { return (a + b - 1) / b; };
+
+    PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
+                       "Input must be BFloat16 or Half");
+    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
+    PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat8_e4m3fn || dest_dtype == at::kFloat8_e5m2,
+                       "Output must be Float8_e4m3fn or Float8_e5m2");
+    PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1");
+
+    constexpr int64_t ROW_ALIGN = MXFP8_GROUP_M_PADDING_ALIGN_SIZE; // = 32
+    constexpr int64_t COL_ALIGN = MXFP8_K_DIM_PADDING_ALIGN_SIZE;   // = 128
+
+    const bool    is_rowwise = (axis == 1);
+    const int64_t G          = group_lens.size(0);
+    const int64_t total_M    = input.size(0);
+    const int64_t N          = input.size(1);
+    const int64_t M_pad_col  = cdiv(total_M + G * COL_ALIGN, COL_ALIGN) * COL_ALIGN;
+    const int64_t M_pad_row  = cdiv(total_M + G * ROW_ALIGN, ROW_ALIGN) * ROW_ALIGN;
+    const int64_t N_pad      = cdiv(N, COL_ALIGN) * COL_ALIGN;
+
+    int64_t scale_outer = is_rowwise ? M_pad_row : N;
+    int64_t scale_N =
+        is_rowwise ? cdiv(N_pad, MXFP8_BLOCK_SIZE) : cdiv(M_pad_col, MXFP8_BLOCK_SIZE);
+    int64_t scale_M_pad = cdiv(scale_outer, 256) * 256;
+    int64_t scale_N_pad = cdiv(scale_N, 8) * 8;
+
+    at::Tensor scale_tensor;
+    if (shuffle_scale) {
+        scale_tensor = at::empty({scale_M_pad, scale_N_pad},
+                                 at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+    } else {
+        scale_tensor = at::empty({scale_outer, scale_N},
+                                 at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+    }
+
+    int64_t    output_rows = is_rowwise ? M_pad_row : N;
+    int64_t    output_cols = is_rowwise ? N_pad : M_pad_col;
+    at::Tensor output      = at::empty({output_rows, output_cols},
+                                       at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+
+    auto group_lens_padded = at::empty_like(group_lens);
+    auto group_offs_padded = at::empty({G + 1}, group_offs.options());
+
+    return {output.view(dest_dtype), scale_tensor.view(at::kFloat8_e8m0fnu), group_lens_padded,
+            group_offs_padded};
+}
+
 std::vector<at::Tensor> quantize_mxfp8_meta(const at::Tensor input, const at::ScalarType dest_dtype,
                                             const int64_t axis, const int64_t padding_align_size,
                                             const bool use_2d_block, const bool shuffle_scale,
@@ -262,22 +390,32 @@ std::vector<at::Tensor> quantize_mxfp8_meta(const at::Tensor input, const at::Sc
 
     PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
                        "Input must be BFloat16 or Half");
-    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
     PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat8_e4m3fn || dest_dtype == at::kFloat8_e5m2,
                        "Output must be Float8_e4m3fn or Float8_e5m2");
     PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1");
     PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
     // Guard the public op argument against zero/negative values (would otherwise
     // divide-by-zero in cdiv below) and lock it to the expected MXFP8 constant.
-    PRIMUS_TURBO_CHECK(padding_align_size == MXFP8_PADDING_ALIGN_SIZE,
-                       "padding_align_size must be ", MXFP8_PADDING_ALIGN_SIZE,
+    PRIMUS_TURBO_CHECK(padding_align_size == MXFP8_K_DIM_PADDING_ALIGN_SIZE,
+                       "padding_align_size must be ", MXFP8_K_DIM_PADDING_ALIGN_SIZE,
                        " for MXFP8. But got padding_align_size=", padding_align_size);
 
-    const bool    is_rowwise = (axis == 1);
-    const int64_t M          = input.size(0);
-    const int64_t N          = input.size(1);
-    const int64_t M_pad      = cdiv(M, padding_align_size) * padding_align_size;
-    const int64_t N_pad      = cdiv(N, padding_align_size) * padding_align_size;
+    bool    is_rowwise;
+    int64_t M, N;
+    if (input.dim() == 2) {
+        is_rowwise = (axis == 1);
+        M          = input.size(0);
+        N          = input.size(1);
+    } else if (input.dim() == 3) {
+        is_rowwise = (axis == 2);
+        M          = input.size(1);
+        N          = input.size(2);
+    } else {
+        PRIMUS_TURBO_ERROR("Input must be 2D or 3D");
+    }
+
+    const int64_t M_pad = cdiv(M, padding_align_size) * padding_align_size;
+    const int64_t N_pad = cdiv(N, padding_align_size) * padding_align_size;
 
     PRIMUS_TURBO_CHECK(N % MXFP8_BLOCK_SIZE == 0, "N must be divisible by ", MXFP8_BLOCK_SIZE);
 

--- a/primus_turbo/pytorch/core/low_precision.py
+++ b/primus_turbo/pytorch/core/low_precision.py
@@ -93,11 +93,11 @@ except AttributeError:
 # Block size for MXFP4
 MXFP4_BLOCK_SIZE = 32
 # Padding align size for MXFP4
-MXFP4_PADDING_ALIGN_SIZE = 128
+MXFP4_K_DIM_PADDING_ALIGN_SIZE = 128
 # Block size for MXFP8
 MXFP8_BLOCK_SIZE = 32
 # Padding align size for MXFP8
-MXFP8_PADDING_ALIGN_SIZE = 128
+MXFP8_K_DIM_PADDING_ALIGN_SIZE = 128
 # Block size for BLOCKWISE scaling
 BLOCKWISE_BLOCK_SIZE = 128
 

--- a/primus_turbo/pytorch/core/quantized_tensor.py
+++ b/primus_turbo/pytorch/core/quantized_tensor.py
@@ -12,9 +12,9 @@ import torch
 
 from primus_turbo.pytorch.core.low_precision import (
     MXFP4_BLOCK_SIZE,
-    MXFP4_PADDING_ALIGN_SIZE,
+    MXFP4_K_DIM_PADDING_ALIGN_SIZE,
     MXFP8_BLOCK_SIZE,
-    MXFP8_PADDING_ALIGN_SIZE,
+    MXFP8_K_DIM_PADDING_ALIGN_SIZE,
     ScalingGranularity,
     ScalingRecipe,
     check_mxfp4_support,
@@ -60,10 +60,10 @@ def _get_padding_align_size(tensor: QuantizedTensor):
         return 0
     else:
         if tensor._dest_dtype == float4_e2m1fn_x2:
-            return MXFP4_PADDING_ALIGN_SIZE
+            return MXFP4_K_DIM_PADDING_ALIGN_SIZE
         else:
             assert tensor._dest_dtype == float8_e4m3 or tensor._dest_dtype == float8_e5m2
-            return MXFP8_PADDING_ALIGN_SIZE
+            return MXFP8_K_DIM_PADDING_ALIGN_SIZE
 
 
 def _get_packing_factor(tensor: QuantizedTensor):

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -12,9 +12,9 @@ from torch.library import triton_op, wrap_triton
 
 from primus_turbo.pytorch.core.low_precision import (
     MXFP4_BLOCK_SIZE,
-    MXFP4_PADDING_ALIGN_SIZE,
+    MXFP4_K_DIM_PADDING_ALIGN_SIZE,
     MXFP8_BLOCK_SIZE,
-    MXFP8_PADDING_ALIGN_SIZE,
+    MXFP8_K_DIM_PADDING_ALIGN_SIZE,
     ScalingRecipe,
     check_mxfp4_support,
     check_mxfp8_support,
@@ -391,7 +391,7 @@ def quantize_mxfp8_impl(
         return torch.ops.primus_turbo_cpp_extension.quantize_mxfp8_dual(
             x,
             out_dtype,
-            MXFP8_PADDING_ALIGN_SIZE,
+            MXFP8_K_DIM_PADDING_ALIGN_SIZE,
             scaling_recipe.use_2d_block,
             scaling_recipe_for_trans.use_2d_block,
             scaling_recipe.shuffle_scale,
@@ -404,7 +404,80 @@ def quantize_mxfp8_impl(
             x,
             out_dtype,
             axis,
-            MXFP8_PADDING_ALIGN_SIZE,
+            MXFP8_K_DIM_PADDING_ALIGN_SIZE,
+            scaling_recipe.use_2d_block,
+            scaling_recipe.shuffle_scale,
+            scaling_recipe.shuffle_out,
+        )
+
+
+def grouped_quantize_mxfp8_impl(
+    x: torch.Tensor,
+    out_dtype: torch.dtype,
+    axis: Union[int, None],
+    block_size: int,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    with_trans: bool = False,
+    scaling_recipe: Optional[ScalingRecipe] = None,
+    scaling_recipe_for_trans: Optional[ScalingRecipe] = None,
+) -> Union[
+    Tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ],
+    Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+]:
+    """MXFP8 quantization fused with per-group M-axis zero-padding.
+
+    Each per-group region of ``x`` (defined by ``group_lens`` / ``group_offs``)
+    is virtually zero-padded along M: rowwise to 32 and colwise to 128.  The
+    padded per-group layouts are computed on GPU (no D2H sync).
+    """
+    mxfp8_support, reason = check_mxfp8_support()
+    assert mxfp8_support, reason
+
+    assert block_size == MXFP8_BLOCK_SIZE, f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
+
+    scaling_recipe = ScalingRecipe() if scaling_recipe is None else scaling_recipe
+    if with_trans:
+        scaling_recipe_for_trans = (
+            ScalingRecipe() if scaling_recipe_for_trans is None else scaling_recipe_for_trans
+        )
+    else:
+        scaling_recipe_for_trans = scaling_recipe
+
+    if not with_trans:
+        assert axis in (0, 1), "The axis must be 0 or 1 when with_trans is False."
+    else:
+        assert axis is None, "The axis must be None when with_trans is True."
+
+    if with_trans:
+        return torch.ops.primus_turbo_cpp_extension.grouped_quantize_mxfp8_dual(
+            x,
+            group_lens,
+            group_offs,
+            out_dtype,
+            scaling_recipe.use_2d_block,
+            scaling_recipe_for_trans.use_2d_block,
+            scaling_recipe.shuffle_scale,
+            scaling_recipe.shuffle_out,
+            scaling_recipe_for_trans.shuffle_scale,
+            scaling_recipe_for_trans.shuffle_out,
+        )
+    else:
+        return torch.ops.primus_turbo_cpp_extension.grouped_quantize_mxfp8(
+            x,
+            group_lens,
+            group_offs,
+            out_dtype,
+            axis,
             scaling_recipe.use_2d_block,
             scaling_recipe.shuffle_scale,
             scaling_recipe.shuffle_out,
@@ -500,7 +573,7 @@ def quantize_mxfp4_impl(
         return torch.ops.primus_turbo_cpp_extension.quantize_mxfp4_dual(
             x,
             out_dtype,
-            MXFP4_PADDING_ALIGN_SIZE,
+            MXFP4_K_DIM_PADDING_ALIGN_SIZE,
             scaling_recipe.use_2d_block,
             scaling_recipe.use_sr,
             scaling_recipe.use_rht,
@@ -517,7 +590,7 @@ def quantize_mxfp4_impl(
             x,
             out_dtype,
             axis,
-            MXFP4_PADDING_ALIGN_SIZE,
+            MXFP4_K_DIM_PADDING_ALIGN_SIZE,
             scaling_recipe.use_2d_block,
             scaling_recipe.use_sr,
             scaling_recipe.use_rht,

--- a/primus_turbo/pytorch/ops/quantization.py
+++ b/primus_turbo/pytorch/ops/quantization.py
@@ -19,6 +19,7 @@ from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
     dequantize_fp8_tensorwise_impl,
     dequantize_mxfp4_impl,
     dequantize_mxfp8_impl,
+    grouped_quantize_mxfp8_impl,
     quant_fp8_blockwise_for_weight_impl,
     quant_fp8_blockwise_impl,
     quantize_fp8_rowwise_impl,
@@ -88,7 +89,6 @@ def quantize_fp8_with_trans(
     granularity: ScalingGranularity,
     *,
     block_size: Optional[int] = None,
-    axis: Optional[int] = None,
     scaling_recipe: Optional[ScalingRecipe] = None,
     scaling_recipe_for_trans: Optional[ScalingRecipe] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -109,8 +109,85 @@ def quantize_fp8_with_trans(
         return quantize_mxfp8_impl(
             x,
             out_dtype,
+            None,
+            block_size,
+            True,
+            scaling_recipe,
+            scaling_recipe_for_trans,
+        )
+    else:
+        raise NotImplementedError(f"Unknown granularity {granularity}")
+
+
+def grouped_quantize_fp8(
+    x: torch.Tensor,
+    out_dtype: torch.dtype,
+    granularity: ScalingGranularity,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    *,
+    block_size: Optional[int] = None,
+    axis: Optional[int] = None,
+    scaling_recipe: Optional[ScalingRecipe] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    FP8 Grouped Quantize
+    """
+    if granularity == ScalingGranularity.MX_BLOCKWISE:
+        assert (
+            block_size == MXFP8_BLOCK_SIZE
+        ), f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
+
+        return grouped_quantize_mxfp8_impl(
+            x,
+            out_dtype,
             axis,
             block_size,
+            group_lens,
+            group_offs,
+            False,
+            scaling_recipe,
+            None,
+        )
+    else:
+        raise NotImplementedError(f"Unknown granularity {granularity}")
+
+
+def grouped_quantize_fp8_with_trans(
+    x: torch.Tensor,
+    out_dtype: torch.dtype,
+    granularity: ScalingGranularity,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    *,
+    block_size: Optional[int] = None,
+    scaling_recipe: Optional[ScalingRecipe] = None,
+    scaling_recipe_for_trans: Optional[ScalingRecipe] = None,
+) -> Tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """
+    FP8 Grouped Quantize with trans
+    """
+    if granularity == ScalingGranularity.MX_BLOCKWISE:
+        assert (
+            block_size == MXFP8_BLOCK_SIZE
+        ), f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
+
+        return grouped_quantize_mxfp8_impl(
+            x,
+            out_dtype,
+            None,
+            block_size,
+            group_lens,
+            group_offs,
             True,
             scaling_recipe,
             scaling_recipe_for_trans,

--- a/tests/pytorch/ops/test_quantization.py
+++ b/tests/pytorch/ops/test_quantization.py
@@ -136,6 +136,50 @@ def padding_size(n: int, padding_align_size: int) -> int:
     return (n + padding_align_size - 1) // padding_align_size * padding_align_size - n
 
 
+# MXFP8 quantization-mode convention by input rank (matches the C++ op):
+#   2D input: axis==0 -> colwise, axis==1 -> rowwise
+#   3D input: axis==1 -> colwise, axis==0 -> rowwise  (the M axis index shifts by 1)
+def _mxfp8_is_rowwise(is_batch: bool, axis: int) -> bool:
+    return (axis == 0) if is_batch else (axis == 1)
+
+
+def _mxfp8_pad_to_align(x_mat, is_rowwise, orig_dtype):
+    # MXFP8 padding alignment for the FP8 output / scale layout.
+    MXFP8_PAD_ALIGN = 128
+
+    """Zero-pad a 2D matrix along the quantized axis (rowwise -> N, colwise -> M)."""
+    if is_rowwise:
+        pad = torch.zeros(
+            x_mat.size(0), padding_size(x_mat.size(1), MXFP8_PAD_ALIGN), device=x_mat.device, dtype=orig_dtype
+        )
+        return torch.cat([x_mat, pad], dim=1)
+    pad = torch.zeros(
+        padding_size(x_mat.size(0), MXFP8_PAD_ALIGN), x_mat.size(1), device=x_mat.device, dtype=orig_dtype
+    )
+    return torch.cat([x_mat, pad], dim=0)
+
+
+def _assert_mxfp8_roundtrip(
+    x_mat, fp8_mat, scale_mat, *, is_rowwise, granularity, scaling_recipe, orig_dtype, dest_dtype
+):
+    """Dequantize one MXFP8 direction and compare against the zero-padded input.
+
+    ``is_rowwise`` picks the dequant axis (rowwise -> 1, colwise -> 0) and the
+    padded reference axis (rowwise pads N, colwise pads M).
+    """
+    ref = _mxfp8_pad_to_align(x_mat, is_rowwise, orig_dtype)
+    out = dequantize_fp8(
+        fp8_mat.contiguous(),
+        orig_dtype,
+        granularity=granularity,
+        block_size=MXFP8_BLOCK_SIZE,
+        axis=1 if is_rowwise else 0,
+        scale_inv=scale_mat.contiguous(),
+        scaling_recipe=scaling_recipe,
+    )
+    torch.testing.assert_close(ref, out, **get_tolerances(dest_dtype))
+
+
 @pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("dest_dtype", [turbo.float8_e4m3, turbo.float8_e5m2])
 @pytest.mark.parametrize("B", [1, 4])
@@ -145,75 +189,80 @@ def padding_size(n: int, padding_align_size: int) -> int:
 @pytest.mark.parametrize("granularity", [ScalingGranularity.MX_BLOCKWISE])
 @pytest.mark.parametrize("use_2d_block", [True, False])
 def test_quantize_mxfp8(orig_dtype, dest_dtype, B, M, N, axis, granularity, use_2d_block):
-    padding_align_size = 128
-
+    """Single-direction MXFP8 quantization on a 2D ``(G*M, N)`` input."""
     # Skip unit test on gfx942.
     mxfp8_supported, reason = check_mxfp8_support()
     if not mxfp8_supported:
         pytest.skip(reason)
 
-    MX_BLOCK_SIZE = 32
     torch.manual_seed(42)
-
-    x = torch.randn((B, M, N), device="cuda", dtype=orig_dtype)
-
-    row_length = x.size(-1)
-    x_2d = x.view(-1, row_length)
-    if padding_align_size is not None:
-        if axis == 0:
-            x_2d_ref = torch.cat(
-                [
-                    x_2d,
-                    torch.zeros(
-                        padding_size(x_2d.size(0), padding_align_size),
-                        x_2d.size(1),
-                        device=x.device,
-                        dtype=orig_dtype,
-                    ),
-                ],
-                dim=axis,
-            )
-        else:
-            x_2d_ref = torch.cat(
-                [
-                    x_2d,
-                    torch.zeros(
-                        x_2d.size(0),
-                        padding_size(x_2d.size(1), padding_align_size),
-                        device=x.device,
-                        dtype=orig_dtype,
-                    ),
-                ],
-                dim=axis,
-            )
-    else:
-        x_2d_ref = x_2d
-
-    scaling_recipe = ScalingRecipe(
-        use_2d_block=use_2d_block,
-    )
+    x_2d = torch.randn((B * M, N), device="cuda", dtype=orig_dtype)
+    scaling_recipe = ScalingRecipe(use_2d_block=use_2d_block)
 
     x_fp8, x_scale_inv = quantize_fp8(
         x_2d,
         dest_dtype,
         granularity=granularity,
         axis=axis,
-        block_size=MX_BLOCK_SIZE,
+        block_size=MXFP8_BLOCK_SIZE,
         scaling_recipe=scaling_recipe,
     )
 
-    # check quantize and dequantize precision
-    out = dequantize_fp8(
+    _assert_mxfp8_roundtrip(
+        x_2d,
         x_fp8,
-        orig_dtype,
+        x_scale_inv,
+        is_rowwise=_mxfp8_is_rowwise(False, axis),
         granularity=granularity,
-        block_size=MX_BLOCK_SIZE,
+        scaling_recipe=scaling_recipe,
+        orig_dtype=orig_dtype,
+        dest_dtype=dest_dtype,
+    )
+
+
+@pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dest_dtype", [turbo.float8_e4m3, turbo.float8_e5m2])
+@pytest.mark.parametrize("G", [1, 4])
+@pytest.mark.parametrize("M", [32, 64, 256, 1024])
+@pytest.mark.parametrize("N", [32, 64, 256, 1024])
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("granularity", [ScalingGranularity.MX_BLOCKWISE])
+@pytest.mark.parametrize("use_2d_block", [True, False])
+def test_quantize_mxfp8_batched(orig_dtype, dest_dtype, G, M, N, axis, granularity, use_2d_block):
+    """Single-direction MXFP8 quantization on a batched 3D ``(G, M, N)`` input.
+
+    Each group is quantized independently (blockIdx.z); validated per group.
+    """
+    mxfp8_supported, reason = check_mxfp8_support()
+    if not mxfp8_supported:
+        pytest.skip(reason)
+
+    torch.manual_seed(42)
+    x = torch.randn((G, M, N), device="cuda", dtype=orig_dtype)
+    scaling_recipe = ScalingRecipe(use_2d_block=use_2d_block)
+
+    x_fp8, x_scale_inv = quantize_fp8(
+        x,
+        dest_dtype,
+        granularity=granularity,
         axis=axis,
-        scale_inv=x_scale_inv,
+        block_size=MXFP8_BLOCK_SIZE,
         scaling_recipe=scaling_recipe,
     )
 
-    torch.testing.assert_close(x_2d_ref, out, **get_tolerances(dest_dtype))
+    assert x_fp8.dim() == 3 and x_fp8.size(0) == G
+    is_rowwise = _mxfp8_is_rowwise(True, axis)
+    for g in range(G):
+        _assert_mxfp8_roundtrip(
+            x[g],
+            x_fp8[g],
+            x_scale_inv[g],
+            is_rowwise=is_rowwise,
+            granularity=granularity,
+            scaling_recipe=scaling_recipe,
+            orig_dtype=orig_dtype,
+            dest_dtype=dest_dtype,
+        )
 
 
 @pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16])
@@ -224,85 +273,85 @@ def test_quantize_mxfp8(orig_dtype, dest_dtype, B, M, N, axis, granularity, use_
 @pytest.mark.parametrize("granularity", [ScalingGranularity.MX_BLOCKWISE])
 @pytest.mark.parametrize("use_2d_block", [True, False])
 def test_quantize_mxfp8_with_trans(orig_dtype, dest_dtype, B, M, N, granularity, use_2d_block):
-    padding_align_size = 128
-
+    """Dual (rowwise + colwise) MXFP8 quantization on a 2D ``(G*M, N)`` input."""
     mxfp8_supported, reason = check_mxfp8_support()
     if not mxfp8_supported:
         pytest.skip(reason)
 
-    scaling_recipe = ScalingRecipe(
-        use_2d_block=use_2d_block,
-    )
-
-    MX_BLOCK_SIZE = 32
+    scaling_recipe = ScalingRecipe(use_2d_block=use_2d_block)
     torch.manual_seed(42)
+    x_2d = torch.randn((B * M, N), device="cuda", dtype=orig_dtype)
 
-    x = torch.ones((B, M, N), device="cuda", dtype=orig_dtype) * 6
-
-    row_length = x.size(-1)
-    x_2d = x.view(-1, row_length)
-    M_actual = x_2d.size(0)
-    N_actual = x_2d.size(1)
-
-    x_fp8_rowwise, x_scale_inv_rowwise, x_fp8_colwise, x_scale_inv_colwise = quantize_fp8_with_trans(
+    row_fp8, row_scale, col_fp8, col_scale = quantize_fp8_with_trans(
         x_2d,
         dest_dtype,
         granularity=granularity,
-        block_size=MX_BLOCK_SIZE,
+        block_size=MXFP8_BLOCK_SIZE,
         scaling_recipe=scaling_recipe,
         scaling_recipe_for_trans=scaling_recipe,
     )
 
-    # Test 2: Dequantize and compare with zero-padded reference.
-    # Rowwise dequantize: output shape [M, N_pad]
-    x_2d_ref_rowwise = torch.cat(
-        [
+    for is_rowwise, fp8_mat, scale_mat in (
+        (True, row_fp8, row_scale),
+        (False, col_fp8, col_scale),
+    ):
+        _assert_mxfp8_roundtrip(
             x_2d,
-            torch.zeros(
-                M_actual,
-                padding_size(N_actual, padding_align_size),
-                device=x_2d.device,
-                dtype=orig_dtype,
-            ),
-        ],
-        dim=1,
-    )
+            fp8_mat,
+            scale_mat,
+            is_rowwise=is_rowwise,
+            granularity=granularity,
+            scaling_recipe=scaling_recipe,
+            orig_dtype=orig_dtype,
+            dest_dtype=dest_dtype,
+        )
 
-    out_rowwise = dequantize_fp8(
-        x_fp8_rowwise,
-        orig_dtype,
+
+@pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dest_dtype", [turbo.float8_e4m3, turbo.float8_e5m2])
+@pytest.mark.parametrize("G", [1, 4])
+@pytest.mark.parametrize("M", [32, 64, 256, 1024])
+@pytest.mark.parametrize("N", [32, 64, 256, 1024])
+@pytest.mark.parametrize("granularity", [ScalingGranularity.MX_BLOCKWISE])
+@pytest.mark.parametrize("use_2d_block", [True, False])
+def test_quantize_mxfp8_with_trans_batched(orig_dtype, dest_dtype, G, M, N, granularity, use_2d_block):
+    """Dual MXFP8 quantization on a batched 3D ``(G, M, N)`` input.
+
+    Validates each group's rowwise + colwise outputs independently.
+    """
+    mxfp8_supported, reason = check_mxfp8_support()
+    if not mxfp8_supported:
+        pytest.skip(reason)
+
+    scaling_recipe = ScalingRecipe(use_2d_block=use_2d_block)
+    torch.manual_seed(42)
+    x = torch.randn((G, M, N), device="cuda", dtype=orig_dtype)
+
+    row_fp8, row_scale, col_fp8, col_scale = quantize_fp8_with_trans(
+        x,
+        dest_dtype,
         granularity=granularity,
-        block_size=MX_BLOCK_SIZE,
-        axis=1,
-        scale_inv=x_scale_inv_rowwise,
+        block_size=MXFP8_BLOCK_SIZE,
         scaling_recipe=scaling_recipe,
-    )
-    torch.testing.assert_close(x_2d_ref_rowwise, out_rowwise, **get_tolerances(dest_dtype))
-
-    # Colwise dequantize: output shape [M_pad, N]
-    x_2d_ref_colwise = torch.cat(
-        [
-            x_2d,
-            torch.zeros(
-                padding_size(M_actual, padding_align_size),
-                N_actual,
-                device=x_2d.device,
-                dtype=orig_dtype,
-            ),
-        ],
-        dim=0,
+        scaling_recipe_for_trans=scaling_recipe,
     )
 
-    out_colwise = dequantize_fp8(
-        x_fp8_colwise,
-        orig_dtype,
-        granularity=granularity,
-        block_size=MX_BLOCK_SIZE,
-        axis=0,
-        scale_inv=x_scale_inv_colwise,
-        scaling_recipe=scaling_recipe,
-    )
-    torch.testing.assert_close(x_2d_ref_colwise, out_colwise, **get_tolerances(dest_dtype))
+    assert row_fp8.dim() == 3 and row_fp8.size(0) == G
+    for g in range(G):
+        for is_rowwise, fp8_mat, scale_mat in (
+            (True, row_fp8[g], row_scale[g]),
+            (False, col_fp8[g], col_scale[g]),
+        ):
+            _assert_mxfp8_roundtrip(
+                x[g],
+                fp8_mat,
+                scale_mat,
+                is_rowwise=is_rowwise,
+                granularity=granularity,
+                scaling_recipe=scaling_recipe,
+                orig_dtype=orig_dtype,
+                dest_dtype=dest_dtype,
+            )
 
 
 @pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16])


### PR DESCRIPTION
# Description

This PR adds a new **MXFP8 grouped quantize** API to Primus-Turbo. It enables quantizing a stacked/grouped activation tensor to MXFP8 where each per-group region (defined by `group_lens` / `group_offs`) is virtually zero-padded along the M axis before scale computation. The per-group padded lengths and offsets are computed entirely on the GPU, so no device-to-host synchronization is required on the hot path. This is the quantization building block needed by grouped/MoE FP8 pipelines.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- **Python public API** (`primus_turbo/pytorch/ops/quantization.py`): add `grouped_quantize_fp8` and `grouped_quantize_fp8_with_trans` for MXFP8 blockwise grouped quantization (with optional fused transpose output).
- **Python kernel impl** (`primus_turbo/pytorch/kernels/quantization/quantization_impl.py`): add `grouped_quantize_mxfp8_impl`, dispatching to the new C++/CUDA ops and fusing per-group M-axis zero-padding (rowwise to 32, colwise to 128).
- **C++ ops & bindings** (`csrc/pytorch/quantization/quantization.cpp`, `quantization_meta.cpp`, `bindings_pytorch.cpp`, `extensions.h`): register `grouped_quantize_mxfp8` and `grouped_quantize_mxfp8_dual` ops with their CUDA and Meta implementations.
- **CUDA kernels** (`csrc/kernels/quantization/quantization_mxfp8.cu`, `csrc/include/primus_turbo/quantization.h`): add `quantize_mxfp8_grouped_impl`, `grouped_quantize_mxfp8_dual_impl`, and `compute_padded_layout_gpu` which computes per-group padded lengths/offsets on the GPU (no D2H sync).
- **Constants** (`primus_turbo/pytorch/core/low_precision.py`, `quantized_tensor.py`, `quantization.h`): rename `MXFP4/8_PADDING_ALIGN_SIZE` → `MXFP4/8_K_DIM_PADDING_ALIGN_SIZE`, add `MXFP8_GROUP_M_PADDING_ALIGN_SIZE = 32`, and add `FP8E5M2_MAX`.
- **Tests** (`tests/pytorch/ops/test_quantization.py`): add coverage for the grouped MXFP8 quantize paths (with and without transpose).

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
