### PR TITLE
[Op][Normalization] Add zero_centered_gamma to RMSNorm

### DIFF
--- a/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
+++ b/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
@@ -102,7 +102,7 @@ def _finalize_dgamma(dg_partial: torch.Tensor, gamma_dtype: torch.dtype) -> torc
 
 
 def rmsnorm_fwd_impl(
-    x: torch.Tensor, gamma: torch.Tensor, eps: float
+    x: torch.Tensor, gamma: torch.Tensor, eps: float, zero_centered: bool = False
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, int, int, int]:
     """Forward launcher.
 
@@ -129,6 +129,7 @@ def rmsnorm_fwd_impl(
             H=H,
             eps=eps,
             BLOCK_H=BLOCK_H,
+            ZERO_CENTERED=zero_centered,
             num_warps=num_warps,
             num_stages=num_stages,
         )
@@ -148,6 +149,7 @@ def rmsnorm_fwd_impl(
             eps=eps,
             BLOCK_H=BLOCK_H,
             ROWS_PER_BLOCK=ROWS,
+            ZERO_CENTERED=zero_centered,
             num_warps=num_warps,
             num_stages=num_stages,
         )
@@ -163,6 +165,7 @@ def rmsnorm_bwd_impl(
     ROWS: int,
     num_warps: int,
     num_stages: int,
+    zero_centered: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Backward launcher. Returns (dx [B, H], dgamma [H])."""
     H = gamma.shape[0]
@@ -192,6 +195,7 @@ def rmsnorm_bwd_impl(
             H=H,
             BLOCK_H=BLOCK_H,
             ROWS_PER_BLOCK=ROWS,
+            ZERO_CENTERED=zero_centered,
             num_warps=num_warps,
             num_stages=num_stages,
         )
@@ -216,6 +220,7 @@ def rmsnorm_bwd_impl(
             H=H,
             BLOCK_H=BLOCK_H,
             num_programs=num_programs,
+            ZERO_CENTERED=zero_centered,
         )
     dg = _finalize_dgamma(dg_partial, gamma.dtype)
     return dx, dg

--- a/primus_turbo/pytorch/modules/normalization.py
+++ b/primus_turbo/pytorch/modules/normalization.py
@@ -23,6 +23,7 @@ class RMSNorm(torch.nn.Module):
         normalized_shape: Union[int, list[int], Size],
         eps: Optional[float] = None,
         elementwise_affine: bool = True,
+        zero_centered_gamma: bool = False,
         device=None,
         dtype=None,
     ) -> None:
@@ -38,6 +39,9 @@ class RMSNorm(torch.nn.Module):
             )
         self.eps = eps if eps is not None else 1e-6
         self.elementwise_affine = elementwise_affine
+        # zero_centered_gamma: the effective gain is (1 + weight), so the weight is
+        # initialized to zeros (effective gain == 1).
+        self.zero_centered_gamma = zero_centered_gamma
         if self.elementwise_affine:
             self.weight = Parameter(torch.empty(self.normalized_shape, **factory_kwargs))
         else:
@@ -46,12 +50,16 @@ class RMSNorm(torch.nn.Module):
 
     def reset_parameters(self) -> None:
         if self.elementwise_affine:
-            torch.nn.init.ones_(self.weight)
+            if self.zero_centered_gamma:
+                torch.nn.init.zeros_(self.weight)
+            else:
+                torch.nn.init.ones_(self.weight)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return _rmsnorm(x, self.weight, self.eps)
+        return _rmsnorm(x, self.weight, self.eps, self.zero_centered_gamma)
 
     def extra_repr(self) -> str:
-        return "{normalized_shape}, eps={eps}, elementwise_affine={elementwise_affine}".format(
-            **self.__dict__
+        return (
+            "{normalized_shape}, eps={eps}, elementwise_affine={elementwise_affine}, "
+            "zero_centered_gamma={zero_centered_gamma}".format(**self.__dict__)
         )

--- a/primus_turbo/pytorch/ops/normalization.py
+++ b/primus_turbo/pytorch/ops/normalization.py
@@ -6,7 +6,7 @@
 """Triton-backed RMSNorm ops (standard + fused residual variant).
 
 Public API:
-    - ``rmsnorm(x, gamma, eps=1e-6) -> y``
+    - ``rmsnorm(x, gamma, eps=1e-6, zero_centered=False) -> y``
     - ``rmsnorm_residual(x, residual, gamma, eps=1e-6) -> (y, x_plus_r)``
 """
 from __future__ import annotations
@@ -27,7 +27,7 @@ __all__ = ["rmsnorm", "rmsnorm_residual"]
 
 class _RMSNormFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x: torch.Tensor, gamma: torch.Tensor, eps: float = 1e-6):
+    def forward(ctx, x: torch.Tensor, gamma: torch.Tensor, eps: float = 1e-6, zero_centered: bool = False):
         assert x.is_cuda and gamma.is_cuda, "rmsnorm: x and gamma must be CUDA tensors"
         orig_shape = x.shape
         H = gamma.shape[0]
@@ -35,10 +35,11 @@ class _RMSNormFunction(torch.autograd.Function):
             orig_shape[-1] == H
         ), f"rmsnorm: last dim of x ({orig_shape[-1]}) must equal gamma.shape[0] ({H})"
 
-        y, x2, rstd, BLOCK_H, ROWS, num_warps, num_stages = rmsnorm_fwd_impl(x, gamma, eps)
+        y, x2, rstd, BLOCK_H, ROWS, num_warps, num_stages = rmsnorm_fwd_impl(x, gamma, eps, zero_centered)
 
         ctx.save_for_backward(x2, gamma, rstd)
         ctx.eps = eps
+        ctx.zero_centered = zero_centered
         ctx.orig_shape = orig_shape
         ctx.BLOCK_H = BLOCK_H
         ctx.ROWS = ROWS
@@ -58,8 +59,9 @@ class _RMSNormFunction(torch.autograd.Function):
             ctx.ROWS,
             ctx.num_warps,
             ctx.num_stages,
+            ctx.zero_centered,
         )
-        return dx.reshape(ctx.orig_shape), dg, None
+        return dx.reshape(ctx.orig_shape), dg, None, None
 
 
 class _RMSNormResidualFunction(torch.autograd.Function):
@@ -108,8 +110,19 @@ class _RMSNormResidualFunction(torch.autograd.Function):
         return dx_out, dx_out, dg, None
 
 
-def rmsnorm(x: torch.Tensor, gamma: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
-    return _RMSNormFunction.apply(x, gamma, eps)
+def rmsnorm(
+    x: torch.Tensor, gamma: torch.Tensor, eps: float = 1e-6, zero_centered: bool = False
+) -> torch.Tensor:
+    """RMSNorm.
+
+    Args:
+        x: input tensor; normalization is over the last dim.
+        gamma: learnable gain of shape ``[x.shape[-1]]``.
+        eps: variance epsilon.
+        zero_centered: if True, the effective gain is ``(1 + gamma)`` (computed in
+            fp32). Initialize ``gamma`` to zeros in this mode.
+    """
+    return _RMSNormFunction.apply(x, gamma, eps, zero_centered)
 
 
 def rmsnorm_residual(

--- a/primus_turbo/triton/normalization/rmsnorm_kernel.py
+++ b/primus_turbo/triton/normalization/rmsnorm_kernel.py
@@ -54,6 +54,7 @@ def rmsnorm_fwd_kernel(
     H: tl.constexpr,
     eps,
     BLOCK_H: tl.constexpr,
+    ZERO_CENTERED: tl.constexpr = False,
 ):
     row = tl.program_id(0)
     offs = tl.arange(0, BLOCK_H)
@@ -66,6 +67,9 @@ def rmsnorm_fwd_kernel(
     var = tl.sum(x * x, axis=0) / H
     rstd = tl.rsqrt(var + eps)
     g = tl.load(g_ptrs, mask=mask, other=0.0).to(tl.float32)
+    if ZERO_CENTERED:
+        # zero-centered gamma: effective gain is (1 + g), computed in fp32.
+        g = g + 1.0
     y = (x * rstd * g).to(Y_ptr.dtype.element_ty)
     tl.store(y_ptrs, y, mask=mask)
     tl.store(RSTD_ptr + row, rstd)
@@ -89,6 +93,7 @@ def rmsnorm_fwd_kernel_multi_row(
     eps,
     BLOCK_H: tl.constexpr,
     ROWS_PER_BLOCK: tl.constexpr,
+    ZERO_CENTERED: tl.constexpr = False,
 ):
     pid = tl.program_id(0)
     row_start = pid * ROWS_PER_BLOCK
@@ -105,6 +110,9 @@ def rmsnorm_fwd_kernel_multi_row(
     full_mask = row_mask[:, None] & h_mask[None, :]
     x = tl.load(x_ptrs, mask=full_mask, other=0.0).to(tl.float32)
     g = tl.load(g_ptrs, mask=h_mask, other=0.0).to(tl.float32)
+    if ZERO_CENTERED:
+        # zero-centered gamma: effective gain is (1 + g), computed in fp32.
+        g = g + 1.0
 
     var = tl.sum(x * x, axis=1) / H
     rstd = tl.rsqrt(var + eps)
@@ -235,6 +243,7 @@ def rmsnorm_bwd_kernel_multi_row(
     H: tl.constexpr,
     BLOCK_H: tl.constexpr,
     ROWS_PER_BLOCK: tl.constexpr,
+    ZERO_CENTERED: tl.constexpr = False,
 ):
     pid = tl.program_id(0)
     row_start = pid * ROWS_PER_BLOCK
@@ -253,6 +262,10 @@ def rmsnorm_bwd_kernel_multi_row(
     x = tl.load(x_ptrs, mask=full_mask, other=0.0).to(tl.float32)
     dy = tl.load(dy_ptrs, mask=full_mask, other=0.0).to(tl.float32)
     g = tl.load(g_ptrs, mask=h_mask, other=0.0).to(tl.float32)
+    if ZERO_CENTERED:
+        # zero-centered gamma: dx flows through the effective gain (1 + g).
+        # dgamma is unchanged: d(1 + g)/dg = 1, so it still accumulates dy * x_hat.
+        g = g + 1.0
     rstd = tl.load(RSTD_ptr + row_offs, mask=row_mask, other=0.0).to(tl.float32)
 
     x_hat = x * rstd[:, None]
@@ -294,12 +307,17 @@ def rmsnorm_bwd_kernel_grid_stride(
     H: tl.constexpr,
     BLOCK_H: tl.constexpr,
     num_programs: tl.constexpr,
+    ZERO_CENTERED: tl.constexpr = False,
 ):
     pid = tl.program_id(0)
     h_offs = tl.arange(0, BLOCK_H)
     h_mask = h_offs < H
 
     g = tl.load(G_ptr + h_offs, mask=h_mask, other=0.0).to(tl.float32)
+    if ZERO_CENTERED:
+        # zero-centered gamma: dx flows through the effective gain (1 + g).
+        # dgamma is unchanged: d(1 + g)/dg = 1, so it still accumulates dy * x_hat.
+        g = g + 1.0
     dg_acc = tl.zeros((BLOCK_H,), dtype=tl.float32)
 
     for row in range(pid, B, num_programs):

--- a/tests/pytorch/modules/test_normalization.py
+++ b/tests/pytorch/modules/test_normalization.py
@@ -6,6 +6,7 @@
 
 import pytest
 import torch
+import torch.nn.functional as F
 
 import primus_turbo.pytorch as turbo
 from tests.pytorch.test_utils import get_tolerances
@@ -41,3 +42,39 @@ def test_rmsnorm(dtype):
 
     torch.testing.assert_close(x_torch.grad, x_turbo.grad, **get_tolerances(dtype))
     torch.testing.assert_close(turbo_rmsnorm.weight.grad, torch_rmsnorm.weight.grad, **get_tolerances(dtype))
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_rmsnorm_zero_centered(dtype):
+    torch.manual_seed(42)
+    device = "cuda"
+    eps = 1e-6
+    seq = 128
+    hidden = 512
+
+    turbo_rmsnorm = turbo.modules.RMSNorm(
+        normalized_shape=hidden, eps=eps, zero_centered_gamma=True, device=device, dtype=dtype
+    )
+    # zero_centered_gamma initializes the weight to zeros (effective gain == 1).
+    assert torch.count_nonzero(turbo_rmsnorm.weight) == 0
+
+    # Non-trivial weight so the (1 + gamma) gain actually exercises the kernel.
+    turbo_rmsnorm.weight.data.copy_(torch.randn(hidden, device=device, dtype=dtype) * 0.1)
+
+    x_turbo = torch.randn(seq, hidden, device=device, dtype=dtype, requires_grad=True)
+    x_ref = x_turbo.clone().detach().requires_grad_()
+    weight_ref = turbo_rmsnorm.weight.detach().clone().requires_grad_()
+
+    # FWD — reference folds the +1 into the gain.
+    out_turbo = turbo_rmsnorm(x_turbo)
+    out_ref = F.rms_norm(x_ref, [hidden], 1.0 + weight_ref, eps)
+
+    torch.testing.assert_close(out_ref, out_turbo, **get_tolerances(dtype))
+
+    # BWD
+    grad_out = torch.randn_like(out_turbo)
+    out_turbo.backward(grad_out)
+    out_ref.backward(grad_out)
+
+    torch.testing.assert_close(x_turbo.grad, x_ref.grad, **get_tolerances(dtype))
+    torch.testing.assert_close(turbo_rmsnorm.weight.grad, weight_ref.grad, **get_tolerances(dtype))

--- a/tests/pytorch/ops/test_normalization.py
+++ b/tests/pytorch/ops/test_normalization.py
@@ -44,6 +44,37 @@ def test_rmsnorm_ops(dtype, outer_shape, inner_shape):
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("outer_shape", [(1,), (511,), (4096,)])
 @pytest.mark.parametrize("inner_shape", [128, 4096, 8192])
+def test_rmsnorm_zero_centered_ops(dtype, outer_shape, inner_shape):
+    # zero_centered=True applies a (1 + gamma) gain. Reference folds the +1 into the weight.
+    torch.manual_seed(3)
+    device = "cuda:0"
+    eps = 1e-6
+
+    shape = outer_shape + (inner_shape,)
+    x = torch.randn(shape, dtype=dtype, device=device, requires_grad=True)
+    gamma = torch.randn(inner_shape, dtype=dtype, device=device, requires_grad=True)
+    x_ref = x.detach().clone().requires_grad_()
+    gamma_ref = gamma.detach().clone().requires_grad_()
+
+    # FWD — reference uses (1 + gamma) as the gain.
+    y_ref = F.rms_norm(x_ref, [inner_shape], 1.0 + gamma_ref, eps)
+    y = rmsnorm(x, gamma, eps, zero_centered=True)
+
+    torch.testing.assert_close(y_ref, y, **get_tolerances(dtype))
+
+    # BWD — d(1 + gamma)/d(gamma) = 1, so the gamma grad is unchanged and
+    # flows through (1 + gamma_ref) to the gamma_ref leaf.
+    grad_out = torch.randn_like(y)
+    y.backward(grad_out)
+    y_ref.backward(grad_out)
+
+    torch.testing.assert_close(x.grad, x_ref.grad, **get_tolerances(dtype))
+    torch.testing.assert_close(gamma.grad, gamma_ref.grad, **get_tolerances(dtype))
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("outer_shape", [(1,), (511,), (4096,)])
+@pytest.mark.parametrize("inner_shape", [128, 4096, 8192])
 def test_rmsnorm_residual_ops(dtype, outer_shape, inner_shape):
     torch.manual_seed(2)
     device = "cuda:0"


### PR DESCRIPTION
# Description

Implements zero-centered gamma in the RMSNorm triton kernel, canonical to the way we see in TransformerEngine and Gemma.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Zero-centered gamma flag in RMSNorm kernel
- Tests in `test_normalization` files.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
