### PR TITLE
ci: gate GPU jobs behind ci:gpu label and add concurrency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,15 @@ on:
     tags:
       - 'v*'
   pull_request:
+    # 'labeled' lets maintainers trigger the GPU jobs by adding the 'ci:gpu'
+    # label after a quick review, instead of every PR push burning GPU runners.
+    types: [opened, synchronize, reopened, labeled]
+
+# Cancel an in-progress run when the same PR (or branch) gets a new push,
+# so repeated pushes don't stack up on the scarce self-hosted GPU runners.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   UCCL_WHEEL_DIR: /apps/tas/0_public/primus_turbo_ci/uccl-wheel-v2602
@@ -57,6 +66,11 @@ jobs:
           options: "--check --diff --color --verbose --line-length=110"
 
   install-dependencies:
+    # GPU runner job: for PRs, only run when a maintainer adds the 'ci:gpu'
+    # label. Non-PR events (push to main, tags, manual dispatch) always run.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:gpu')
     runs-on: turbo-torch-ut-v2602
     env:
         UCCL_COMMIT: 69a21407d261a8ff0f01f83bb0f5b35da059876d #  [rdma] Make CQ Ex flags configurable for NIC compatibility. (#689)
@@ -118,6 +132,10 @@ jobs:
 
   unittest-pytorch-gfx942:
     needs: [code-lint, install-dependencies]
+    # GPU runner job: gated on the 'ci:gpu' label for PRs (see install-dependencies).
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:gpu')
     runs-on: turbo-torch-ut-v2602 # launch in the container turbo_torch_github_runner_v2602 based on the image rocm/primus:v26.2
     env:
       PRIMUS_TURBO_WORKDIR: /apps/tas/0_public/primus_turbo_ci/actions-runner-torch
@@ -209,6 +227,10 @@ jobs:
 
   unittest-jax-gfx942:
     needs: code-lint
+    # GPU runner job: gated on the 'ci:gpu' label for PRs (see install-dependencies).
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:gpu')
     runs-on: turbo-jax-ut-v2602 # launch in the container turbo_jax_github_runner_v2602 based on the image rocm/jax-training:maxtext-v26.2
     env:
       PRIMUS_TURBO_WORKDIR: /apps/tas/0_public/primus_turbo_ci/actions-runner-jax


### PR DESCRIPTION
Conserve scarce self-hosted GPU runners on pull requests:
- Add a concurrency group so new pushes cancel the in-progress run for the same PR/branch instead of stacking up.
- Require the 'ci:gpu' label on PRs before the GPU runner jobs (install-dependencies, unittest-pytorch-gfx942, unittest-jax-gfx942) run; non-PR events still run unconditionally.
- Trigger on the 'labeled' event so adding the label starts the run.

code-lint stays automatic on every PR as a cheap first filter.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
