### PR TITLE
feat: refine quant config arguments

### DIFF
--- a/primus_turbo/pytorch/core/low_precision.py
+++ b/primus_turbo/pytorch/core/low_precision.py
@@ -169,6 +169,7 @@ class Float8QuantConfig:
     strategy: ScalingStrategy = ScalingStrategy.DYNAMIC
     scale_dtype: ScaleDtype = ScaleDtype.FP32
     block_size: Optional[int] = None  # Default: not used for tensorwise/rowwise
+    use_weight_block_scaling: Optional[bool] = None
 
     def __post_init__(self):
         if self.granularity == ScalingGranularity.BLOCKWISE:
@@ -193,6 +194,8 @@ class Float4QuantConfig:
     strategy: ScalingStrategy = ScalingStrategy.DYNAMIC
     scale_dtype: ScaleDtype = ScaleDtype.E8M0
     block_size: int = 32
+    use_2d_block_weight_scaling: bool = False
+    use_gradient_rht: bool = False
     use_gradient_sr: bool = False
 
     def __post_init__(self):

--- a/primus_turbo/pytorch/core/low_precision.py
+++ b/primus_turbo/pytorch/core/low_precision.py
@@ -169,7 +169,7 @@ class Float8QuantConfig:
     strategy: ScalingStrategy = ScalingStrategy.DYNAMIC
     scale_dtype: ScaleDtype = ScaleDtype.FP32
     block_size: Optional[int] = None  # Default: not used for tensorwise/rowwise
-    use_weight_block_scaling: Optional[bool] = None
+    use_2d_block_weight_scaling: Optional[bool] = None
 
     def __post_init__(self):
         if self.granularity == ScalingGranularity.BLOCKWISE:

--- a/primus_turbo/pytorch/ops/gemm_fp4.py
+++ b/primus_turbo/pytorch/ops/gemm_fp4.py
@@ -73,7 +73,7 @@ class FP4GemmMXFunction(torch.autograd.Function):
             )
 
         b_scaling_recipe = ScalingRecipe(
-            use_2d_block=True,
+            use_2d_block=config.use_2d_block_weight_scaling,
             use_sr=False,
             use_rht=False,
         )
@@ -114,7 +114,7 @@ class FP4GemmMXFunction(torch.autograd.Function):
             a_t_scaling_recipe = ScalingRecipe(
                 use_2d_block=False,
                 use_sr=False,
-                use_rht=True,
+                use_rht=config.use_gradient_rht,
             )
             quantized_a_t = QuantizedTensor.quantize(
                 a_fp4.dequantize(),
@@ -129,9 +129,9 @@ class FP4GemmMXFunction(torch.autograd.Function):
             quantized_b_t = b_t
         else:
             b_t_scaling_recipe = ScalingRecipe(
-                use_2d_block=True,
+                use_2d_block=config.use_2d_block_weight_scaling,
                 use_sr=False,
-                use_rht=True,
+                use_rht=config.use_gradient_rht,
             )
             quantized_b_t = QuantizedTensor.quantize(
                 b_fp4.dequantize(),
@@ -166,7 +166,7 @@ class FP4GemmMXFunction(torch.autograd.Function):
         grad_out_scaling_recipe = ScalingRecipe(
             use_2d_block=False,
             use_sr=ctx.config.use_gradient_sr,
-            use_rht=True,
+            use_rht=ctx.config.use_gradient_rht,
         )
 
         quantized_grad_out = QuantizedTensor.quantize(
@@ -195,7 +195,7 @@ class FP4GemmMXFunction(torch.autograd.Function):
         grad_out_t_scaling_recipe = ScalingRecipe(
             use_2d_block=False,
             use_sr=ctx.config.use_gradient_sr,
-            use_rht=True,
+            use_rht=ctx.config.use_gradient_rht,
         )
         quantized_grad_out_t = QuantizedTensor.quantize(
             grad_out,

--- a/primus_turbo/pytorch/ops/gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/gemm_fp8.py
@@ -468,7 +468,7 @@ class FP8GemmMXFunction(torch.autograd.Function):
             assert isinstance(a_t, QuantizedTensor)
             quantized_a_t = a_t
 
-        b_scaling_recipe = ScalingRecipe(use_2d_block=True)
+        b_scaling_recipe = ScalingRecipe(use_2d_block=config.use_2d_block_weight_scaling)
         if isinstance(b, QuantizedTensor):
             quantized_b = b
             check_quantized_tensor(quantized_b, config, axis=-1, scaling_recipe=b_scaling_recipe)

--- a/tests/pytorch/ops/test_gemm_fp4.py
+++ b/tests/pytorch/ops/test_gemm_fp4.py
@@ -103,7 +103,12 @@ def test_gemm_fp4_mx_blockwise(m, n, k, layout, format, dtype, granularity, back
     # Config + FWD + BWD
     # NOTE: scaling recipe reference: https://arxiv.org/pdf/2509.25149
     config = Float4QuantConfig(
-        granularity=granularity, format=format, block_size=32, scale_dtype=ScaleDtype.E8M0
+        granularity=granularity,
+        format=format,
+        block_size=32,
+        scale_dtype=ScaleDtype.E8M0,
+        use_2d_block_weight_scaling=True,
+        use_gradient_rht=True,
     )
     print(config)
     c = gemm_fp4(a, b, trans_a, trans_b, dtype, config)
@@ -179,11 +184,16 @@ def _run_gemm_fp4_mx_quantized_tensor_test(
     c_ref.backward(grad_c)
     torch.cuda.synchronize()
 
+    use_2d_block_weight_scaling = True
+    use_gradient_rht = True
+
     config = Float4QuantConfig(
         granularity=ScalingGranularity.MX_BLOCKWISE,
         format=format,
         block_size=32,
         scale_dtype=ScaleDtype.E8M0,
+        use_2d_block_weight_scaling=use_2d_block_weight_scaling,
+        use_gradient_rht=use_gradient_rht,
     )
 
     fp4_dtype = FP4GemmMXFunction.get_fp4_dtype(format)
@@ -211,7 +221,7 @@ def _run_gemm_fp4_mx_quantized_tensor_test(
         block_size=config.block_size,
         axis=1,
         scaling_recipe=ScalingRecipe(
-            use_2d_block=True,
+            use_2d_block=use_2d_block_weight_scaling,
             use_sr=False,
             use_rht=False,
         ),


### PR DESCRIPTION
# Description

This PR exposes the low-precision (FP8/FP4) scaling strategy to users through the quantization config objects. Previously, key scaling behaviors in the MX GEMM forward and backward passes (such as 2D block weight scaling and randomized Hadamard transform on gradients) were hardcoded inside the operators, which prevented users from tuning the numerical recipe for their own training setups. By surfacing these knobs in `Float8QuantConfig` and `Float4QuantConfig`, users can now control the scaling recipe without modifying internal kernel code.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Added `use_2d_block_weight_scaling` field to `Float8QuantConfig` in `primus_turbo/pytorch/core/low_precision.py`.
- Added `use_2d_block_weight_scaling` and `use_gradient_rht` fields to `Float4QuantConfig` in `primus_turbo/pytorch/core/low_precision.py`.
- Updated `FP4GemmMXFunction` in `primus_turbo/pytorch/ops/gemm_fp4.py` to drive the weight 2D-block scaling recipe from `config.use_2d_block_weight_scaling` and the gradient/weight RHT recipe from `config.use_gradient_rht` instead of hardcoded values, in both the forward and backward passes.
- Updated `FP8GemmMXFunction` in `primus_turbo/pytorch/ops/gemm_fp8.py` to derive the weight scaling recipe's `use_2d_block` from the config instead of a hardcoded `True`.

# Checklist:

- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
