### PR TITLE
ci(ut): temporary skip jax test_dispatch_combine ut

### DIFF
--- a/tests/jax/lax/test_dispatch_combine.py
+++ b/tests/jax/lax/test_dispatch_combine.py
@@ -16,6 +16,15 @@ from tests.jax.test_utils import skip_if_lt_x_gpu
 key = jax.random.PRNGKey(123)
 num_ranks = jax.local_device_count()
 
+# ---------------------------------------------------------------------------
+# NOTE: Temporarily disabled: INPROC (single-process pmap) DeepEP dispatch/combine
+# intermittently deadlocks on this XLA/ROCm stack.
+pytestmark = pytest.mark.skip(
+    reason="INPROC (single-process pmap) DeepEP dispatch/combine intermittently "
+    "deadlocks; covered by per_process tests in test_mp_dispatch_combine.py. "
+    "See module docstring/comment for the cross-device circular-wait root cause."
+)
+
 
 # ============================================================================
 # Fixtures


### PR DESCRIPTION
# Description

This PR temporarily disables the in-process (single-process `pmap`) DeepEP dispatch/combine unit test in the JAX test suite.

The `tests/jax/lax/test_dispatch_combine.py` test exercises the INPROC (single-process `pmap`) DeepEP dispatch/combine path, which intermittently deadlocks on the current XLA/ROCm stack due to a cross-device circular-wait condition.
Because the failure is non-deterministic, it makes CI flaky and blocks otherwise-healthy pipelines.

The same dispatch/combine functionality remains covered by the per-process tests in `test_mp_dispatch_combine.py`, so disabling the INPROC variant does not reduce effective test coverage.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add a module-level `pytestmark = pytest.mark.skip(...)` to `tests/jax/lax/test_dispatch_combine.py` so the entire module is skipped in CI.
- Document the reason for skipping: the INPROC (single-process `pmap`) DeepEP dispatch/combine path intermittently deadlocks on the XLA/ROCm stack because of a cross-device circular-wait condition.
- Note that equivalent coverage is provided by the per-process tests in `test_mp_dispatch_combine.py`.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
