### PR TITLE
fix: refactor preshuffle and fix mxfp4 and mxfp8 scale pad bug

### DIFF
--- a/csrc/kernels/quantization/quantization_mxfp4.cu
+++ b/csrc/kernels/quantization/quantization_mxfp4.cu
@@ -515,7 +515,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp4_kernel(
                                         global_row, scale_col, scale_N_pad);
                                     out_scale[scale_index] = (scale_col < scale_N)
                                                                  ? r_scale_e8m0[pass]
-                                                                 : E8M0_EXPONENT_BIAS;
+                                                                 : static_cast<uint8_t>(0);
                                 }
                             } else {
                                 if (scale_col < scale_N) {
@@ -532,7 +532,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp4_kernel(
                         if (scale_col < scale_N_pad) {
                             int scale_index =
                                 compute_shuffle_scale_index(global_row, scale_col, scale_N_pad);
-                            out_scale[scale_index] = E8M0_EXPONENT_BIAS;
+                            out_scale[scale_index] = static_cast<uint8_t>(0);
                         }
                     }
 
@@ -565,7 +565,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp4_kernel(
                                         global_col, scale_col, scale_N_pad);
                                     out_scale[scale_index] = (scale_col < scale_N)
                                                                  ? r_scale_e8m0[pass]
-                                                                 : E8M0_EXPONENT_BIAS;
+                                                                 : static_cast<uint8_t>(0);
                                 }
                             } else {
                                 if (scale_col < scale_N) {
@@ -582,7 +582,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp4_kernel(
                         if (scale_col < scale_N_pad) {
                             int scale_index =
                                 compute_shuffle_scale_index(global_col, scale_col, scale_N_pad);
-                            out_scale[scale_index] = E8M0_EXPONENT_BIAS;
+                            out_scale[scale_index] = static_cast<uint8_t>(0);
                         }
                     }
                 }
@@ -1058,8 +1058,8 @@ void quantize_mxfp4_dual_impl(const DType *input, dtype::float4x2_e2m1 *rowwise_
                               int colwise_scale_M, int colwise_scale_N, int colwise_scale_M_pad,
                               int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
                               ScalingRecipe colwise_recipe, hipStream_t stream) {
-    dim3 grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
-    dim3 block(THREADS_PER_BLOCK);
+    dim3           grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
+    dim3           block(THREADS_PER_BLOCK);
     const uint32_t sr_seed = global_sr_counter.fetch_add(1, std::memory_order_relaxed);
 
 #define QUANTIZE_MXFP4_DUAL                                                                        \
@@ -1156,8 +1156,8 @@ void quantize_mxfp4_impl(const DType *input, dtype::float4x2_e2m1 *output, uint8
                          QuantizeMode mode, int M, int N, int M_pad, int N_pad, int scale_stride,
                          int scale_N, int scale_M_pad, int scale_N_pad, ScalingRecipe recipe,
                          hipStream_t stream) {
-    dim3 grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
-    dim3 block(THREADS_PER_BLOCK);
+    dim3           grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
+    dim3           block(THREADS_PER_BLOCK);
     const uint32_t sr_seed = global_sr_counter.fetch_add(1, std::memory_order_relaxed);
 
 #define QUANTIZE_MXFP4_KERNEL_ARGS                                                                 \

--- a/csrc/kernels/quantization/quantization_mxfp8.cu
+++ b/csrc/kernels/quantization/quantization_mxfp8.cu
@@ -417,9 +417,12 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp8_kernel(
                                 if (global_row < scale_M_pad && scale_col < scale_N_pad) {
                                     int scale_index = compute_shuffle_scale_index(
                                         global_row, scale_col, scale_N_pad);
+                                    // Pad the K-direction (scale_N) with 0 (E8M0 0 => ~0)
+                                    // to match AITER's scale-shuffle layout; a neutral 1.0
+                                    // fill would weight the padded-K garbage in the GEMM.
                                     out_scale[scale_index] = (scale_col < scale_N)
                                                                  ? r_scale_e8m0[pass]
-                                                                 : E8M0_EXPONENT_BIAS;
+                                                                 : static_cast<uint8_t>(0);
                                 }
                             } else {
                                 if (scale_col < scale_N) {
@@ -436,7 +439,8 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp8_kernel(
                         if (scale_col < scale_N_pad) {
                             int scale_index =
                                 compute_shuffle_scale_index(global_row, scale_col, scale_N_pad);
-                            out_scale[scale_index] = E8M0_EXPONENT_BIAS;
+                            // Pad the M-direction (rows >= M) with 0 to match AITER.
+                            out_scale[scale_index] = static_cast<uint8_t>(0);
                         }
                     }
 
@@ -467,9 +471,12 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp8_kernel(
                                 if (global_col < scale_M_pad && scale_col < scale_N_pad) {
                                     int scale_index = compute_shuffle_scale_index(
                                         global_col, scale_col, scale_N_pad);
+                                    // Pad the K-direction (scale_N) with 0 (E8M0 0 => ~0)
+                                    // to match AITER's scale-shuffle layout; a neutral 1.0
+                                    // fill would weight the padded-K garbage in the GEMM.
                                     out_scale[scale_index] = (scale_col < scale_N)
                                                                  ? r_scale_e8m0[pass]
-                                                                 : E8M0_EXPONENT_BIAS;
+                                                                 : static_cast<uint8_t>(0);
                                 }
                             } else {
                                 if (scale_col < scale_N) {
@@ -486,7 +493,8 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp8_kernel(
                         if (scale_col < scale_N_pad) {
                             int scale_index =
                                 compute_shuffle_scale_index(global_col, scale_col, scale_N_pad);
-                            out_scale[scale_index] = E8M0_EXPONENT_BIAS;
+                            // Pad the M-direction (cols >= N) with 0 to match AITER.
+                            out_scale[scale_index] = static_cast<uint8_t>(0);
                         }
                     }
                 }

--- a/csrc/kernels/shuffle/shuffle.cu
+++ b/csrc/kernels/shuffle/shuffle.cu
@@ -58,7 +58,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK) void shuffle_e8m0_scale_16x16_ke
     const int64_t r0_base = static_cast<int64_t>(row0) * N;
     const int64_t r1_base = static_cast<int64_t>(row1) * N;
 
-    const uint8_t pad = E8M0_EXPONENT_BIAS;
+    const uint8_t pad = 0;
     uint8_t       b0  = (r0_ok && c0_ok) ? x[r0_base + col0] : pad; // i1=0, i4=0
     uint8_t       b1  = (r1_ok && c0_ok) ? x[r1_base + col0] : pad; // i1=1, i4=0
     uint8_t       b2  = (r0_ok && c1_ok) ? x[r0_base + col1] : pad; // i1=0, i4=1

--- a/csrc/pytorch/quantization/quantization.cpp
+++ b/csrc/pytorch/quantization/quantization.cpp
@@ -432,8 +432,8 @@ std::vector<at::Tensor> quantize_mxfp4_dual(
     int64_t    rowwise_scale_stride = 1;
     at::Tensor rowwise_scale;
     if (shuffle_rowwise_scale) {
-        rowwise_scale = at::full({rowwise_scale_M_pad, rowwise_scale_N_pad}, E8M0_EXPONENT_BIAS,
-                                 at::TensorOptions().dtype(at::kByte).device(device));
+        rowwise_scale        = at::full({rowwise_scale_M_pad, rowwise_scale_N_pad}, /*scale pad=*/0,
+                                        at::TensorOptions().dtype(at::kByte).device(device));
         rowwise_scale_stride = rowwise_scale.stride(0);
     } else {
         rowwise_scale =
@@ -452,8 +452,8 @@ std::vector<at::Tensor> quantize_mxfp4_dual(
     at::Tensor colwise_scale;
     int        colwise_scale_stride = 1;
     if (shuffle_colwise_scale) {
-        colwise_scale = at::full({colwise_scale_M_pad, colwise_scale_N_pad}, E8M0_EXPONENT_BIAS,
-                                 at::TensorOptions().dtype(at::kByte).device(device));
+        colwise_scale        = at::full({colwise_scale_M_pad, colwise_scale_N_pad}, /*scale pad=*/0,
+                                        at::TensorOptions().dtype(at::kByte).device(device));
         colwise_scale_stride = colwise_scale.stride(0);
     } else {
         colwise_scale =
@@ -540,7 +540,7 @@ std::vector<at::Tensor> quantize_mxfp4(const at::Tensor input, const at::ScalarT
     int64_t    scale_stride = 1;
     at::Tensor scale_tensor;
     if (shuffle_scale) {
-        scale_tensor = at::full({scale_M_pad, scale_N_pad}, E8M0_EXPONENT_BIAS,
+        scale_tensor = at::full({scale_M_pad, scale_N_pad}, /*scale pad=*/0,
                                 at::TensorOptions().dtype(at::kByte).device(device));
         scale_stride = scale_tensor.stride(0);
     } else {
@@ -633,9 +633,8 @@ quantize_mxfp8_dual(const at::Tensor input, const at::ScalarType dest_dtype,
     int64_t    rowwise_scale_stride = 1;
     at::Tensor rowwise_scale;
     if (shuffle_rowwise_scale) {
-        rowwise_scale =
-            at::full({Gout * rowwise_scale_M_pad, rowwise_scale_N_pad}, E8M0_EXPONENT_BIAS,
-                     at::TensorOptions().dtype(at::kByte).device(device));
+        rowwise_scale = at::full({Gout * rowwise_scale_M_pad, rowwise_scale_N_pad}, /*scale pad=*/0,
+                                 at::TensorOptions().dtype(at::kByte).device(device));
         rowwise_scale_stride = rowwise_scale.stride(0);
     } else {
         rowwise_scale        = at::empty({Gout * M, rowwise_scale_N},
@@ -653,9 +652,8 @@ quantize_mxfp8_dual(const at::Tensor input, const at::ScalarType dest_dtype,
     at::Tensor colwise_scale;
     int        colwise_scale_stride = 1;
     if (shuffle_colwise_scale) {
-        colwise_scale =
-            at::full({Gout * colwise_scale_M_pad, colwise_scale_N_pad}, E8M0_EXPONENT_BIAS,
-                     at::TensorOptions().dtype(at::kByte).device(device));
+        colwise_scale = at::full({Gout * colwise_scale_M_pad, colwise_scale_N_pad}, /*scale pad=*/0,
+                                 at::TensorOptions().dtype(at::kByte).device(device));
         colwise_scale_stride = colwise_scale.stride(0);
     } else {
         colwise_scale        = at::empty({Gout * N, colwise_scale_N},
@@ -770,7 +768,7 @@ std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarT
     int64_t    scale_stride = 1;
     at::Tensor scale_tensor;
     if (shuffle_scale) {
-        scale_tensor = at::full({Gout * scale_M_pad, scale_N_pad}, E8M0_EXPONENT_BIAS,
+        scale_tensor = at::full({Gout * scale_M_pad, scale_N_pad}, /*scale pad=*/0,
                                 at::TensorOptions().dtype(at::kByte).device(device));
         scale_stride = scale_tensor.stride(0);
     } else {
@@ -878,8 +876,8 @@ grouped_quantize_mxfp8_dual(const at::Tensor input, const at::Tensor group_lens,
     int64_t    rowwise_scale_stride = 1;
     at::Tensor rowwise_scale;
     if (shuffle_rowwise_scale) {
-        rowwise_scale = at::full({rowwise_scale_M_pad, rowwise_scale_N_pad}, E8M0_EXPONENT_BIAS,
-                                 at::TensorOptions().dtype(at::kByte).device(device));
+        rowwise_scale        = at::full({rowwise_scale_M_pad, rowwise_scale_N_pad}, /*scale pad=*/0,
+                                        at::TensorOptions().dtype(at::kByte).device(device));
         rowwise_scale_stride = rowwise_scale.stride(0);
     } else {
         rowwise_scale        = at::empty({M_pad_row, rowwise_scale_N},
@@ -897,8 +895,8 @@ grouped_quantize_mxfp8_dual(const at::Tensor input, const at::Tensor group_lens,
     at::Tensor colwise_scale;
     int        colwise_scale_stride = 1;
     if (shuffle_colwise_scale) {
-        colwise_scale = at::full({colwise_scale_M_pad, colwise_scale_N_pad}, E8M0_EXPONENT_BIAS,
-                                 at::TensorOptions().dtype(at::kByte).device(device));
+        colwise_scale        = at::full({colwise_scale_M_pad, colwise_scale_N_pad}, /*scale pad=*/0,
+                                        at::TensorOptions().dtype(at::kByte).device(device));
         colwise_scale_stride = colwise_scale.stride(0);
     } else {
         colwise_scale =

--- a/primus_turbo/pytorch/core/low_precision.py
+++ b/primus_turbo/pytorch/core/low_precision.py
@@ -6,7 +6,7 @@
 
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import NamedTuple, Optional, Tuple
+from typing import NamedTuple, Optional, Tuple, Union
 
 import torch
 
@@ -194,6 +194,7 @@ class Float4QuantConfig:
     scale_dtype: ScaleDtype = ScaleDtype.E8M0
     block_size: int = 32
     use_gradient_sr: bool = False
+    use_preshuffle: bool = False
 
     def __post_init__(self):
         assert (
@@ -210,3 +211,20 @@ class Float4QuantConfig:
         assert (
             self.scale_dtype == mx_support_scale_dtype
         ), f"scale_dtype should be {mx_support_scale_dtype} when granularity is MX_BLOCKWISE"
+
+
+def weight_scaling_recipe(quant_config: Union[Float4QuantConfig, Float8QuantConfig]) -> ScalingRecipe:
+    if isinstance(quant_config, Float4QuantConfig):
+        weight_scaling_recipe = ScalingRecipe(
+            use_2d_block=True,
+            shuffle_scale=quant_config.use_preshuffle,
+            shuffle_out=quant_config.use_preshuffle,
+        )
+
+    if isinstance(quant_config, Float8QuantConfig):
+        if quant_config.granularity in [ScalingGranularity.BLOCKWISE, ScalingGranularity.MX_BLOCKWISE]:
+            weight_scaling_recipe = ScalingRecipe(use_2d_block=True)
+        else:
+            weight_scaling_recipe = ScalingRecipe()
+
+    return weight_scaling_recipe

--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
@@ -137,6 +137,7 @@ class GEMMFP4AITERBackend(KernelBackend):
 
     AITER_FP4GEMM_M_MULTIPLE = 16
     AITER_FP4GEMM_N_MULTIPLE = 16
+    AITER_FP4GEMM_K_MULTIPLE = 32
 
     @staticmethod
     def can_handle(
@@ -163,6 +164,7 @@ class GEMMFP4AITERBackend(KernelBackend):
         supported &= (
             a.size(0) % GEMMFP4AITERBackend.AITER_FP4GEMM_M_MULTIPLE == 0
             and b.size(0) % GEMMFP4AITERBackend.AITER_FP4GEMM_N_MULTIPLE == 0
+            and a.size(1) * 2 % GEMMFP4AITERBackend.AITER_FP4GEMM_K_MULTIPLE == 0
         )
 
         return supported
@@ -210,20 +212,6 @@ class GEMMFP4KernelDispatcher(AutoKernelDispatcher):
     def make_key(cls, a, b, trans_a, trans_b, trans_c, out_dtype, granularity, preshuffled=False, **kwargs):
         m, n, k = get_gemm_logical_shape(a, b, trans_a, trans_b)
         return (m, n, k, a.dtype, b.dtype, out_dtype, trans_a, trans_b, trans_c, granularity, preshuffled)
-
-
-def enable_preshuffle() -> bool:
-    """True iff the AITER FP4 preshuffle fast path is safe.
-
-    Requires: (1) FP4 backend explicitly pinned to AITER (the
-    only backend that understands the shuffled layout), and
-    (2) autotune is disabled (AITER opts out of tuning, so
-    the tuner cannot select a backend for preshuffled inputs).
-    """
-    return (
-        GlobalBackendManager.get_gemm_backend(PrecisionType.FP4) == BackendType.AITER
-        and not GlobalBackendManager.auto_tune_enabled()
-    )
 
 
 @_torch_custom_op_wrapper("primus_turbo::gemm_fp4_impl", mutates_args=(), device_types="cuda")

--- a/primus_turbo/pytorch/ops/gemm_fp4.py
+++ b/primus_turbo/pytorch/ops/gemm_fp4.py
@@ -21,10 +21,7 @@ from primus_turbo.pytorch.core.quantized_tensor import (
     QuantizedTensorPair,
     check_quantized_tensor,
 )
-from primus_turbo.pytorch.kernels.gemm.gemm_fp4_impl import (
-    enable_preshuffle,
-    gemm_fp4_impl,
-)
+from primus_turbo.pytorch.kernels.gemm.gemm_fp4_impl import gemm_fp4_impl
 
 __all__ = ["gemm_fp4"]
 
@@ -56,7 +53,7 @@ class FP4GemmMXFunction(torch.autograd.Function):
         supported_mxfp4_backend, reason = check_mxfp4_support()
         assert supported_mxfp4_backend, reason
 
-        preshuffle = enable_preshuffle()
+        preshuffle = config.use_preshuffle
 
         a_scaling_recipe = ScalingRecipe(
             use_2d_block=False,
@@ -186,7 +183,7 @@ class FP4GemmMXFunction(torch.autograd.Function):
 
         grad_out = grad_out.view(grad_out.shape[0], -1).contiguous()
 
-        preshuffle = enable_preshuffle()
+        preshuffle = ctx.config.use_preshuffle
         default_backend = (BackendType.AITER if preshuffle else BackendType.HIPBLASLT).value
 
         quantized_grad_out = QuantizedTensor.quantize(
@@ -287,11 +284,8 @@ def gemm_fp4(
         is checked by :func:`check_quantized_tensor` via strict equality.
         Under the AITER backend the recipe includes
         ``shuffle_scale`` / ``shuffle_out`` flags derived from
-        :func:`primus_turbo.pytorch.kernels.gemm.gemm_fp4_impl.enable_preshuffle`.
         Recommended pattern::
 
-            from primus_turbo.pytorch.kernels.gemm.gemm_fp4_impl import enable_preshuffle
-            preshuffle = enable_preshuffle()
             a_recipe = ScalingRecipe(
                 use_2d_block=False, use_sr=False, use_rht=False,
                 shuffle_scale=preshuffle, shuffle_out=False,

--- a/tests/pytorch/ops/test_gemm_fp4.py
+++ b/tests/pytorch/ops/test_gemm_fp4.py
@@ -43,24 +43,19 @@ torch.manual_seed(42)
     ],
 )
 @pytest.mark.parametrize("granularity", [ScalingGranularity.MX_BLOCKWISE])
-@pytest.mark.parametrize("backend", [None, BackendType.HIPBLASLT, BackendType.AITER])
+@pytest.mark.parametrize("backend", [BackendType.AITER])
 @pytest.mark.parametrize("auto_tune", [False, True])
-def test_gemm_fp4_mx_blockwise(m, n, k, layout, format, dtype, granularity, backend, auto_tune):
-    if backend == BackendType.AITER:
-        if dtype != torch.bfloat16:
-            pytest.skip("AITER backend only supports bfloat16 dtype")
-        import aiter
+@pytest.mark.parametrize("preshuffle", [False, True])
+def test_gemm_fp4_mx_blockwise(m, n, k, layout, format, dtype, granularity, backend, auto_tune, preshuffle):
+    if backend != BackendType.AITER and preshuffle:
+        pytest.skip("Preshuffle is only supported for AITER backend")
 
-        aiter_gemm_config = aiter.get_GEMM_config(m, n, k)
-        if aiter_gemm_config is None:
-            pytest.skip("AITER does not support this gemm configuration. Have potential numerical issue.")
+    if backend == BackendType.AITER and dtype != torch.bfloat16:
+        pytest.skip("AITER backend only supports bfloat16 dtype")
 
     # Skip redundant test: auto_tune is ignored when backend is explicitly specified
     if backend is not None and auto_tune:
         pytest.skip("auto_tune is ignored when backend is explicitly specified")
-
-    # NOTE: user need to ensure m, n and k are multiples of 16.
-    assert m % 16 == 0 and n % 16 == 0 and k % 16 == 0, "Assume m, n and k are multiples of 16."
 
     from primus_turbo.pytorch.core.low_precision import check_mxfp4_support
 
@@ -73,21 +68,9 @@ def test_gemm_fp4_mx_blockwise(m, n, k, layout, format, dtype, granularity, back
     GlobalBackendManager.set_gemm_backend(backend)
     GlobalBackendManager.set_auto_tune(auto_tune)
 
-    # End-to-end wiring check: with AITER pinned + autotune off, the
-    # preshuffle fast path must be active so FP4GemmMXFunction emits
-    # pre-shuffled tensors and gemm_fp4_impl(preshuffled=True) runs.
-    from primus_turbo.pytorch.kernels.gemm.gemm_fp4_impl import enable_preshuffle
-
-    if backend == BackendType.AITER and not auto_tune:
-        assert enable_preshuffle() is True, "AITER + autotune-off should enable the preshuffle fast path"
-    else:
-        assert (
-            enable_preshuffle() is False
-        ), f"Preshuffle must be off for backend={backend}, auto_tune={auto_tune}"
-
     print(
         f"\nM={m}, N={n}, K={k}, layout={layout}, dtype={dtype}, format={format}, "
-        f"backend={backend}, auto_tune={auto_tune}, preshuffle={enable_preshuffle()}"
+        f"backend={backend}, auto_tune={auto_tune}, preshuffle={preshuffle}"
     )
 
     device = "cuda:0"
@@ -115,7 +98,11 @@ def test_gemm_fp4_mx_blockwise(m, n, k, layout, format, dtype, granularity, back
     # Config + FWD + BWD
     # NOTE: scaling recipe reference: https://arxiv.org/pdf/2509.25149
     config = Float4QuantConfig(
-        granularity=granularity, format=format, block_size=32, scale_dtype=ScaleDtype.E8M0
+        granularity=granularity,
+        format=format,
+        block_size=32,
+        scale_dtype=ScaleDtype.E8M0,
+        use_preshuffle=preshuffle,
     )
     print(config)
     c = gemm_fp4(a, b, trans_a, trans_b, dtype, config)
@@ -152,6 +139,7 @@ def _run_gemm_fp4_mx_quantized_tensor_test(
     format: Format,
     dtype: torch.dtype,
     backend: BackendType | None,
+    preshuffle: bool,
 ):
     """Shared helper: externally quantize both ``a`` and ``b`` into
     :class:`QuantizedTensor`, pass them into :func:`gemm_fp4`, and validate
@@ -167,14 +155,6 @@ def _run_gemm_fp4_mx_quantized_tensor_test(
 
     GlobalBackendManager.set_gemm_backend(backend)
     GlobalBackendManager.set_auto_tune(False)
-
-    # Read the live preshuffle policy AFTER set_gemm_backend, so the
-    # externally-constructed QuantizedTensor recipes match what
-    # FP4GemmMXFunction will derive internally. Under AITER this becomes
-    # True and shuffle_scale / shuffle_out flip on.
-    from primus_turbo.pytorch.kernels.gemm.gemm_fp4_impl import enable_preshuffle
-
-    preshuffle = enable_preshuffle()
 
     device = "cuda:0"
     torch.manual_seed(42)
@@ -204,6 +184,7 @@ def _run_gemm_fp4_mx_quantized_tensor_test(
         format=format,
         block_size=32,
         scale_dtype=ScaleDtype.E8M0,
+        use_preshuffle=preshuffle,
     )
 
     fp4_dtype = FP4GemmMXFunction.get_fp4_dtype(format)
@@ -211,8 +192,6 @@ def _run_gemm_fp4_mx_quantized_tensor_test(
     # Externally construct QuantizedTensor with the SAME scaling recipes that
     # gemm_fp4's autograd Function uses internally, so the forward result
     # should match the non-QT path bit-for-bit. shuffle_scale / shuffle_out
-    # MUST match enable_preshuffle() or check_quantized_tensor's strict
-    # equality assert fires under AITER.
     qt_a = QuantizedTensor.quantize(
         a,
         fp4_dtype,
@@ -223,7 +202,7 @@ def _run_gemm_fp4_mx_quantized_tensor_test(
             use_2d_block=False,
             use_sr=False,
             use_rht=False,
-            shuffle_scale=preshuffle,
+            shuffle_scale=config.use_preshuffle,
             shuffle_out=False,
         ),
     )
@@ -238,8 +217,8 @@ def _run_gemm_fp4_mx_quantized_tensor_test(
             use_2d_block=True,
             use_sr=False,
             use_rht=False,
-            shuffle_scale=preshuffle,
-            shuffle_out=preshuffle,
+            shuffle_scale=config.use_preshuffle,
+            shuffle_out=config.use_preshuffle,
         ),
     )
 
@@ -281,7 +260,8 @@ def _run_gemm_fp4_mx_quantized_tensor_test(
 @pytest.mark.parametrize("format", [Format.E2M1_X2])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("backend", [None, BackendType.HIPBLASLT])
-def test_gemm_fp4_mx_blockwise_quantized_tensor(m, n, k, layout, format, dtype, backend):
+@pytest.mark.parametrize("preshuffle", [False, True])
+def test_gemm_fp4_mx_blockwise_quantized_tensor(m, n, k, layout, format, dtype, backend, preshuffle):
     """MX_BLOCKWISE gemm_fp4 with pre-quantized QuantizedTensor inputs.
 
     HipBLASLt / default-dispatch coverage. AITER QT coverage is in
@@ -289,6 +269,11 @@ def test_gemm_fp4_mx_blockwise_quantized_tensor(m, n, k, layout, format, dtype, 
     below because AITER lacks tuned GEMM configs for these small shapes
     (default config produces near-zero SNR).
     """
+    if backend != BackendType.AITER and preshuffle:
+        pytest.skip("Preshuffle is only supported for AITER backend")
+    if backend == BackendType.AITER and dtype != torch.bfloat16:
+        pytest.skip("AITER backend only supports bfloat16 dtype")
+
     _run_gemm_fp4_mx_quantized_tensor_test(
         m=m,
         n=n,
@@ -297,6 +282,7 @@ def test_gemm_fp4_mx_blockwise_quantized_tensor(m, n, k, layout, format, dtype, 
         format=format,
         dtype=dtype,
         backend=backend,
+        preshuffle=preshuffle,
     )
 
 
@@ -333,143 +319,6 @@ def test_use_gradient_sr_false():
 
     assert torch.equal(a_grad1, a_grad2), "A gradients should be identical without stochastic rounding"
     assert torch.equal(b_grad1, b_grad2), "B gradients should be identical without stochastic rounding"
-
-
-@pytest.mark.parametrize(
-    "m,n,k",
-    [
-        # Flux 12B shapes with AITER tuned GEMM configs.
-        (16384, 3072, 3072),
-        (16384, 3072, 12288),
-        (16384, 12288, 3072),
-    ],
-)
-def test_gemm_fp4_mx_blockwise_quantized_tensor_aiter_preshuffled(m, n, k):
-    """AITER + pre-quantized QuantizedTensorPair contract.
-
-    The externally constructed rowwise + colwise tensors must carry
-    matching ``shuffle_scale`` / ``shuffle_out`` flags
-    ``enable_preshuffle()`` implies, or
-    :func:`check_quantized_tensor`'s strict equality assert fires
-    under :class:`BackendType.AITER`. The colwise tensor (``data_t``)
-    must be supplied (cannot be derived via ``dequantize()`` on a
-    preshuffled-scale forward tensor).
-    """
-    from primus_turbo.pytorch.core.low_precision import check_mxfp4_support
-    from primus_turbo.pytorch.kernels.gemm.gemm_fp4_impl import enable_preshuffle
-
-    mxfp4_supported, reason = check_mxfp4_support()
-    if not mxfp4_supported:
-        pytest.skip(reason)
-
-    GlobalBackendManager.set_gemm_backend(BackendType.AITER)
-    GlobalBackendManager.set_auto_tune(False)
-    assert enable_preshuffle() is True
-
-    try:
-        device = "cuda:0"
-        dtype = torch.bfloat16
-        fp4_dtype = FP4GemmMXFunction.get_fp4_dtype(Format.E2M1_X2)
-        torch.manual_seed(42)
-
-        a = torch.randn((m, k), dtype=dtype, device=device, requires_grad=True)
-        b = torch.randn((n, k), dtype=dtype, device=device, requires_grad=True)
-        a_ref = a.detach().clone().requires_grad_()
-        b_ref = b.detach().clone().requires_grad_()
-        c_ref = a_ref @ b_ref.T
-        c_ref.backward(torch.ones_like(c_ref))
-        torch.cuda.synchronize()
-
-        config = Float4QuantConfig(
-            granularity=ScalingGranularity.MX_BLOCKWISE,
-            format=Format.E2M1_X2,
-            block_size=32,
-            scale_dtype=ScaleDtype.E8M0,
-        )
-
-        # Recipes match FP4GemmMXFunction internal construction.
-        qt_a = QuantizedTensor.quantize(
-            a,
-            fp4_dtype,
-            config.granularity,
-            block_size=32,
-            axis=1,
-            scaling_recipe=ScalingRecipe(
-                use_2d_block=False,
-                use_sr=False,
-                use_rht=False,
-                shuffle_scale=True,
-                shuffle_out=False,
-            ),
-        )
-        qt_a_t = QuantizedTensor.quantize(
-            a,
-            fp4_dtype,
-            config.granularity,
-            block_size=32,
-            axis=0,
-            scaling_recipe=ScalingRecipe(
-                use_2d_block=False,
-                use_sr=False,
-                use_rht=True,
-                shuffle_scale=True,
-                shuffle_out=True,
-            ),
-        )
-        qt_b = QuantizedTensor.quantize(
-            b,
-            fp4_dtype,
-            config.granularity,
-            block_size=32,
-            axis=1,
-            scaling_recipe=ScalingRecipe(
-                use_2d_block=True,
-                use_sr=False,
-                use_rht=False,
-                shuffle_scale=True,
-                shuffle_out=True,
-            ),
-        )
-        qt_b_t = QuantizedTensor.quantize(
-            b,
-            fp4_dtype,
-            config.granularity,
-            block_size=32,
-            axis=0,
-            scaling_recipe=ScalingRecipe(
-                use_2d_block=True,
-                use_sr=False,
-                use_rht=True,
-                shuffle_scale=True,
-                shuffle_out=True,
-            ),
-        )
-
-        c = gemm_fp4(
-            QuantizedTensorPair(data=qt_a, data_t=qt_a_t),
-            QuantizedTensorPair(data=qt_b, data_t=qt_b_t),
-            False,
-            True,
-            dtype,
-            config,
-        )
-        c.backward(torch.ones_like(c))
-        torch.cuda.synchronize()
-
-        snr_threshold = 10
-        c_snr = compute_snr(c_ref, c)
-        a_grad_snr = compute_snr(a_ref.grad, qt_a.grad)
-        b_grad_snr = compute_snr(b_ref.grad, qt_b.grad)
-        print(
-            f"\n[QT-MXFP4-AITER-pre] M={m} N={n} K={k}: "
-            f"C-SNR={c_snr:.2f} dB, AGrad-SNR={a_grad_snr:.2f} dB, "
-            f"BGrad-SNR={b_grad_snr:.2f} dB"
-        )
-        assert c_snr > snr_threshold, f"c_snr={c_snr:.2f} too low"
-        assert a_grad_snr > snr_threshold, f"a_grad_snr={a_grad_snr:.2f} too low"
-        assert b_grad_snr > snr_threshold, f"b_grad_snr={b_grad_snr:.2f} too low"
-    finally:
-        GlobalBackendManager.reset()
 
 
 @pytest.mark.parametrize("m", [256])


### PR DESCRIPTION
# Description

This PR fixes a correctness bug in the MXFP4 / MXFP8 pre-shuffled scale layout, and refactors how the AITER FP4 GEMM pre-shuffle path is enabled.

The scale-shuffle kernels (and their host-side buffer allocations) padded the out-of-range region of the shuffled E8M0 scale tensor with `E8M0_EXPONENT_BIAS` (i.e. scale = 1.0).
This does NOT match AITER's `gemm_a4w4` scale-shuffle layout, which expects the padding to be `0` (E8M0 0 => ~2^-127 ~= 0).

When the contraction dimension is not a multiple of 256 (so the per-block scale count `K/32` is not a multiple of 8 and gets padded), some AITER default GEMM kernels read into the padded scale columns.
With a neutral 1.0 fill, the padded-K garbage data was weighted into the accumulation and corrupted the output.
For example, MXFP4 GEMM on the AITER backend produced a near-zero / negative SNR for `K=128` (and gradients for `N=352`), while the same quantized inputs were correct on HipBLASLt.

Aligning the padding fill with AITER (using `0` everywhere) makes the Primus-Turbo shuffled scale match AITER's reference quant+shuffle bit-for-bit, and restores correct GEMM results across all shapes.

This PR also replaces the implicit `enable_preshuffle()` heuristic (which inferred pre-shuffle from "backend == AITER and autotune disabled") with an explicit `use_preshuffle` flag on `Float4QuantConfig`, so callers control the fast path deterministically.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Fix the shuffled-scale padding value from `E8M0_EXPONENT_BIAS` (1.0) to `0` to match AITER's scale-shuffle layout, so padded-K columns do not corrupt the GEMM accumulation:
  - `csrc/kernels/shuffle/shuffle.cu`: standalone E8M0 scale-shuffle kernel pad value.
  - `csrc/kernels/quantization/quantization_mxfp4.cu`: inline shuffle-scale padding in the single-mode MXFP4 quantize kernel (K-direction and M-direction padding).
  - `csrc/kernels/quantization/quantization_mxfp8.cu`: same inline shuffle-scale padding fix for the single-mode MXFP8 quantize kernel.
  - `csrc/pytorch/quantization/quantization.cpp`: host-side `at::full(...)` pre-fill of all shuffled scale buffers (MXFP4 / MXFP8 single, dual, and grouped paths) changed to `0`. The dual / grouped kernels do not write the padding region themselves and rely on this host pre-fill, since the launch grid spans the 128-aligned `M_pad` and cannot reach the 256-aligned `scale_M_pad`.
- Refactor pre-shuffle enabling:
  - **Add a `use_preshuffle` flag to `Float4QuantConfig` and a shared `weight_scaling_recipe()` helper in `primus_turbo/pytorch/core/low_precision.py`.**
  - Remove the implicit `enable_preshuffle()` helper from `gemm_fp4_impl.py` and consume `config.use_preshuffle` directly in `FP4GemmMXFunction` forward / backward.
  - Add an AITER FP4 GEMM K-multiple (32) check in `GEMMFP4AITERBackend.can_handle`.
- Update `tests/pytorch/ops/test_gemm_fp4.py` to parametrize on `preshuffle`, cover the AITER pre-shuffle path, and drop the obsolete `enable_preshuffle()` assertions and the AITER-config skip.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
