### PR TITLE
docs: add CI status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Primus-Turbo
+
+[![Primus-Turbo-CI](https://github.com/AMD-AGI/Primus-Turbo/actions/workflows/ci.yaml/badge.svg)](https://github.com/AMD-AGI/Primus-Turbo/actions/workflows/ci.yaml)
+[![Primus-Turbo-Benchmark](https://github.com/AMD-AGI/Primus-Turbo/actions/workflows/benchmark.yaml/badge.svg)](https://github.com/AMD-AGI/Primus-Turbo/actions/workflows/benchmark.yaml)
+
 [What's Primus-Turbo?](#-whats-primus-turbo) | [What's New](#-whats-new) | [Primus Product Matrix](#-primus-product-matrix) | [Quick Start](#-quick-start) | [Example](#-example) | [Performance](#-performance) | [Roadmap](#-roadmap) | [License](#-license)
 
 ## 🔍 What's Primus-Turbo?


### PR DESCRIPTION
## Summary
- Adds status badges for the main CI workflows at the top of the `README.md`:
  - **Primus-Turbo-CI** (`ci.yaml`)
  - **Primus-Turbo-Benchmark** (`benchmark.yaml`)
- Each badge links to its workflow's Actions page so CI status is visible at a glance.

## Notes
- These two workflows actively run on `main`. The **Release** workflow (`release.yml`) was intentionally omitted because it only triggers on version tags (e.g. `v0.3.1`) and has no `main`-branch runs, so its badge would show "no status." Happy to add it if preferred.

## Test plan
- [ ] Confirm badges render and resolve to the correct workflow runs once merged to `main`.
