### PR TITLE
feat: force use nt layout gemm in bwd

### DIFF
--- a/primus_turbo/pytorch/core/low_precision.py
+++ b/primus_turbo/pytorch/core/low_precision.py
@@ -6,7 +6,7 @@
 
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import NamedTuple, Optional, Tuple, Union
+from typing import NamedTuple, Optional, Tuple
 
 import torch
 
@@ -211,20 +211,3 @@ class Float4QuantConfig:
         assert (
             self.scale_dtype == mx_support_scale_dtype
         ), f"scale_dtype should be {mx_support_scale_dtype} when granularity is MX_BLOCKWISE"
-
-
-def weight_scaling_recipe(quant_config: Union[Float4QuantConfig, Float8QuantConfig]) -> ScalingRecipe:
-    if isinstance(quant_config, Float4QuantConfig):
-        weight_scaling_recipe = ScalingRecipe(
-            use_2d_block=True,
-            shuffle_scale=quant_config.use_preshuffle,
-            shuffle_out=quant_config.use_preshuffle,
-        )
-
-    if isinstance(quant_config, Float8QuantConfig):
-        if quant_config.granularity in [ScalingGranularity.BLOCKWISE, ScalingGranularity.MX_BLOCKWISE]:
-            weight_scaling_recipe = ScalingRecipe(use_2d_block=True)
-        else:
-            weight_scaling_recipe = ScalingRecipe()
-
-    return weight_scaling_recipe

--- a/primus_turbo/pytorch/core/low_precision.py
+++ b/primus_turbo/pytorch/core/low_precision.py
@@ -6,7 +6,7 @@
 
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import NamedTuple, Optional, Tuple, Union
+from typing import NamedTuple, Optional, Tuple
 
 import torch
 
@@ -211,20 +211,3 @@ class Float4QuantConfig:
         assert self.scale_dtype == mx_support_scale_dtype, (
             f"scale_dtype should be {mx_support_scale_dtype} when granularity is MX_BLOCKWISE"
         )
-
-
-def weight_scaling_recipe(quant_config: Union[Float4QuantConfig, Float8QuantConfig]) -> ScalingRecipe:
-    if isinstance(quant_config, Float4QuantConfig):
-        weight_scaling_recipe = ScalingRecipe(
-            use_2d_block=True,
-            shuffle_scale=quant_config.use_preshuffle,
-            shuffle_out=quant_config.use_preshuffle,
-        )
-
-    if isinstance(quant_config, Float8QuantConfig):
-        if quant_config.granularity in [ScalingGranularity.BLOCKWISE, ScalingGranularity.MX_BLOCKWISE]:
-            weight_scaling_recipe = ScalingRecipe(use_2d_block=True)
-        else:
-            weight_scaling_recipe = ScalingRecipe()
-
-    return weight_scaling_recipe

--- a/primus_turbo/pytorch/core/quantized_tensor.py
+++ b/primus_turbo/pytorch/core/quantized_tensor.py
@@ -15,6 +15,8 @@ from primus_turbo.pytorch.core.low_precision import (
     MXFP4_PADDING_ALIGN_SIZE,
     MXFP8_BLOCK_SIZE,
     MXFP8_PADDING_ALIGN_SIZE,
+    Float4QuantConfig,
+    Float8QuantConfig,
     ScalingGranularity,
     ScalingRecipe,
     check_mxfp4_support,
@@ -543,6 +545,43 @@ class QuantizedTensor(torch.Tensor):
         """Reshape without dequantizing (autograd-aware)."""
         return _ReshapeFunc.apply(self, shape)
 
+    @classmethod
+    def _transpose(cls, tensor: "QuantizedTensor", dim0: int, dim1: int) -> "QuantizedTensor":
+        """Return the transpose of *tensor* as a ``QuantizedTensor``.
+
+        * TENSORWISE: the scale is a single scalar, so the transpose is exact -
+          we just transpose the quantized buffer (no dequantize round-trip).
+        * ROWWISE / MX_BLOCKWISE: per-row / per-block scales do not transpose
+          trivially (a scaled row becomes a column), so we dequantize and then
+          re-quantize the transposed tensor into the (colwise) layout.
+        """
+        ndim = tensor.dim()
+        d0 = dim0 if dim0 >= 0 else dim0 + ndim
+        d1 = dim1 if dim1 >= 0 else dim1 + ndim
+        if d0 == d1:
+            return cls._make_like(tensor, data=tensor._data, scale_inv=tensor._scale_inv, shape=tensor.shape)
+
+        assert not tensor._is_grouped_tensor, "transpose is not supported for grouped QuantizedTensor"
+
+        new_shape = list(tensor.shape)
+        new_shape[d0], new_shape[d1] = new_shape[d1], new_shape[d0]
+        new_shape = torch.Size(new_shape)
+
+        if tensor._granularity == ScalingGranularity.TENSORWISE:
+            new_data = tensor._data.transpose(d0, d1).contiguous()
+            return cls._make_like(tensor, data=new_data, scale_inv=tensor._scale_inv, shape=new_shape)
+
+        # Rowwise / MX blockwise: dequantize -> transpose -> re-quantize colwise.
+        hp_t = tensor.dequantize()
+        return cls.quantize(
+            hp_t,
+            tensor._dest_dtype,
+            tensor._granularity,
+            axis=-2,
+            block_size=tensor._block_size,
+            scaling_recipe=tensor._scaling_recipe,
+        )
+
     # ------------------------------------------------------------------
     # Dispatch hooks
     # ------------------------------------------------------------------
@@ -588,6 +627,16 @@ class QuantizedTensor(torch.Tensor):
                     scale_inv=tensor._scale_inv.detach(),
                     shape=tensor.shape,
                 )
+
+        if func in (torch.ops.aten.t.default, torch.ops.aten.transpose.int):
+            tensor = args[0]
+            if isinstance(tensor, QuantizedTensor):
+                if func is torch.ops.aten.t.default:
+                    assert tensor.dim() == 2, "t() expects a 2D QuantizedTensor"
+                    dim0, dim1 = 0, 1
+                else:
+                    dim0, dim1 = args[1], args[2]
+                return cls._transpose(tensor, dim0, dim1)
 
         raise NotImplementedError(f"Unsupported dispatch: {func}")
 
@@ -645,9 +694,71 @@ class QuantizedTensorPair(NamedTuple):
     Wrapper for quantized tensors.
 
     Args:
-        data: Row-major quantized tensor.
-        data_t: Transposed quantized tensor.
+        data_rowwise: Row-wise quantized tensor.
+        data_colwise: Column-wise quantized tensor.
     """
 
-    data: QuantizedTensor
-    data_t: Optional[QuantizedTensor] = None
+    data_rowwise: QuantizedTensor
+    data_colwise: Optional[QuantizedTensor] = None
+
+
+def create_quantized_weight(
+    weight,
+    dest_dtype: torch.dtype,
+    quant_config: Union[Float4QuantConfig, Float8QuantConfig],
+    need_cache_colwise: bool = False,
+) -> Tuple[QuantizedTensor, Optional[QuantizedTensor]]:
+    def _weight_scaling_recipe(quant_config: Union[Float4QuantConfig, Float8QuantConfig]) -> ScalingRecipe:
+        if isinstance(quant_config, Float4QuantConfig):
+            weight_scaling_recipe = ScalingRecipe(
+                use_2d_block=True,
+                shuffle_scale=quant_config.use_preshuffle,
+                shuffle_out=quant_config.use_preshuffle,
+            )
+
+        if isinstance(quant_config, Float8QuantConfig):
+            if quant_config.granularity in [ScalingGranularity.BLOCKWISE, ScalingGranularity.MX_BLOCKWISE]:
+                weight_scaling_recipe = ScalingRecipe(use_2d_block=True)
+            else:
+                weight_scaling_recipe = ScalingRecipe()
+
+        return weight_scaling_recipe
+
+    quantized_weight_rowwise = QuantizedTensor.quantize(
+        weight,
+        dest_dtype=dest_dtype,
+        granularity=quant_config.granularity,
+        block_size=quant_config.block_size,
+        scaling_recipe=_weight_scaling_recipe(quant_config),
+        axis=-1,
+    )
+
+    quantized_weight_colwise = None
+    if need_cache_colwise:
+        granularity = quant_config.granularity
+        if granularity == ScalingGranularity.TENSORWISE:
+            quantized_weight_colwise = quantized_weight_rowwise.transpose(-2, -1)
+        elif granularity == ScalingGranularity.ROWWISE:
+            # NOTE: rowwise quantization not support transpose, so we need to quantize the transposed weight manually.
+            quantized_weight_colwise = QuantizedTensor.quantize(
+                weight.transpose(-2, -1),
+                dest_dtype=dest_dtype,
+                granularity=quant_config.granularity,
+                block_size=quant_config.block_size,
+                scaling_recipe=_weight_scaling_recipe(quant_config),
+                axis=-2,
+            )
+        elif granularity in [ScalingGranularity.BLOCKWISE, ScalingGranularity.MX_BLOCKWISE]:
+            quantized_weight_colwise = QuantizedTensor.quantize(
+                weight,
+                dest_dtype=dest_dtype,
+                granularity=quant_config.granularity,
+                block_size=quant_config.block_size,
+                scaling_recipe=_weight_scaling_recipe(quant_config),
+                # axis=-2 means quant weight along axis 2 which will get a transposed quantized weight.
+                axis=-2,
+            )
+        else:
+            raise ValueError(f"Unsupported granularity: {granularity}")
+
+    return quantized_weight_rowwise, quantized_weight_colwise

--- a/primus_turbo/pytorch/core/quantized_tensor.py
+++ b/primus_turbo/pytorch/core/quantized_tensor.py
@@ -706,7 +706,7 @@ def create_quantized_weight(
     weight,
     dest_dtype: torch.dtype,
     quant_config: Union[Float4QuantConfig, Float8QuantConfig],
-    need_cache_colwise: bool = False,
+    need_weight_transpose_cache: bool = False,
 ) -> Tuple[QuantizedTensor, Optional[QuantizedTensor]]:
     def _weight_scaling_recipe(quant_config: Union[Float4QuantConfig, Float8QuantConfig]) -> ScalingRecipe:
         if isinstance(quant_config, Float4QuantConfig):
@@ -734,7 +734,7 @@ def create_quantized_weight(
     )
 
     quantized_weight_t = None
-    if need_cache_colwise:
+    if need_weight_transpose_cache:
         granularity = quant_config.granularity
         if granularity == ScalingGranularity.TENSORWISE:
             quantized_weight_t = quantized_weight.transpose(-2, -1)

--- a/primus_turbo/pytorch/core/quantized_tensor.py
+++ b/primus_turbo/pytorch/core/quantized_tensor.py
@@ -694,12 +694,12 @@ class QuantizedTensorPair(NamedTuple):
     Wrapper for quantized tensors.
 
     Args:
-        data_rowwise: Row-wise quantized tensor.
-        data_colwise: Column-wise quantized tensor.
+        data: Row-wise quantized tensor.
+        data_t: Column-wise quantized tensor.
     """
 
-    data_rowwise: QuantizedTensor
-    data_colwise: Optional[QuantizedTensor] = None
+    data: QuantizedTensor
+    data_t: Optional[QuantizedTensor] = None
 
 
 def create_quantized_weight(
@@ -724,7 +724,7 @@ def create_quantized_weight(
 
         return weight_scaling_recipe
 
-    quantized_weight_rowwise = QuantizedTensor.quantize(
+    quantized_weight = QuantizedTensor.quantize(
         weight,
         dest_dtype=dest_dtype,
         granularity=quant_config.granularity,
@@ -733,14 +733,14 @@ def create_quantized_weight(
         axis=-1,
     )
 
-    quantized_weight_colwise = None
+    quantized_weight_t = None
     if need_cache_colwise:
         granularity = quant_config.granularity
         if granularity == ScalingGranularity.TENSORWISE:
-            quantized_weight_colwise = quantized_weight_rowwise.transpose(-2, -1)
+            quantized_weight_t = quantized_weight.transpose(-2, -1)
         elif granularity == ScalingGranularity.ROWWISE:
             # NOTE: rowwise quantization not support transpose, so we need to quantize the transposed weight manually.
-            quantized_weight_colwise = QuantizedTensor.quantize(
+            quantized_weight_t = QuantizedTensor.quantize(
                 weight.transpose(-2, -1),
                 dest_dtype=dest_dtype,
                 granularity=quant_config.granularity,
@@ -749,7 +749,7 @@ def create_quantized_weight(
                 axis=-2,
             )
         elif granularity in [ScalingGranularity.BLOCKWISE, ScalingGranularity.MX_BLOCKWISE]:
-            quantized_weight_colwise = QuantizedTensor.quantize(
+            quantized_weight_t = QuantizedTensor.quantize(
                 weight,
                 dest_dtype=dest_dtype,
                 granularity=quant_config.granularity,
@@ -761,4 +761,4 @@ def create_quantized_weight(
         else:
             raise ValueError(f"Unsupported granularity: {granularity}")
 
-    return quantized_weight_rowwise, quantized_weight_colwise
+    return quantized_weight, quantized_weight_t

--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
@@ -148,10 +148,23 @@ class GEMMFP8CKBackend(KernelBackend):
         # check dtype
         supported &= (a.dtype, b.dtype, out_dtype) in GEMMFP8CKBackend.SUPPORTED_DTYPES
 
-        # TODO: check layout
-        # supported &= (trans_a, trans_b, trans_c) in GEMMFP8CKBackend.SUPPORTED_LAYOUTS
+        if trans_c:
+            lhs, rhs = b, a
+            trans_lhs, trans_rhs = (not trans_b), (not trans_a)
+        else:
+            lhs, rhs = a, b
+            trans_lhs, trans_rhs = trans_a, trans_b
 
-        # TODO: check shape
+        k = lhs.shape[0] if trans_lhs else lhs.shape[1]
+        n = rhs.shape[0] if trans_rhs else rhs.shape[1]
+
+        # NT / NN layout (transA == False): the contraction dim k must be a
+        # multiple of 32.
+        if not trans_lhs:
+            supported &= k % 32 == 0
+            # BLOCKWISE additionally requires k, n multiples of 128 and k >= 128.
+            if granularity == ScalingGranularity.BLOCKWISE:
+                supported &= (k % 128 == 0) and (n % 128 == 0) and (k >= 128)
 
         return supported
 

--- a/primus_turbo/pytorch/ops/gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/gemm_fp8.py
@@ -23,6 +23,7 @@ from primus_turbo.pytorch.core.quantized_tensor import (
     QuantizedTensorPair,
     check_quantized_tensor,
 )
+from primus_turbo.pytorch.core.utils import is_gfx942
 from primus_turbo.pytorch.kernels.gemm.gemm_fp8_impl import gemm_fp8_impl
 from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
     quant_fp8_blockwise_dual_impl,
@@ -42,6 +43,15 @@ def _get_fp8_dtype(format: Format, is_fwd_stage: bool):
         raise ValueError(f"Unsupported FP8 format: {format}")
 
 
+def _deter_use_nt_layout_gemm_in_bwd(trans_a: bool, trans_b: bool):
+    if is_gfx942():
+        return False
+
+    # NOTE: the non-NT layout gemm is not optimized for mi350/mi450.
+    # Force to use NT layout GEMM in backward for now.
+    return trans_a == False and trans_b == True
+
+
 class FP8GemmTensorFunction(torch.autograd.Function):
 
     @staticmethod
@@ -49,11 +59,15 @@ class FP8GemmTensorFunction(torch.autograd.Function):
         ctx,
         a: Union[torch.Tensor, QuantizedTensor],
         b: Union[torch.Tensor, QuantizedTensor],
-        trans_a: bool,  # trans_a has to be False
+        a_colwise: Optional[QuantizedTensor],
+        b_colwise: Optional[QuantizedTensor],
+        trans_a: bool,
         trans_b: bool,
         out_dtype: torch.dtype,
         config: Float8QuantConfig,
     ):
+        use_nt_layout_gemm_in_bwd = _deter_use_nt_layout_gemm_in_bwd(trans_a, trans_b)
+
         if isinstance(a, QuantizedTensor):
             quantized_a = a
             check_quantized_tensor(quantized_a, config)
@@ -66,6 +80,12 @@ class FP8GemmTensorFunction(torch.autograd.Function):
                 axis=-1,
                 block_size=config.block_size,
             )
+
+        if use_nt_layout_gemm_in_bwd:
+            if a_colwise is not None and isinstance(a_colwise, QuantizedTensor):
+                quantized_a_colwise = a_colwise
+            else:
+                quantized_a_colwise = quantized_a.t().contiguous()
 
         if isinstance(b, QuantizedTensor):
             quantized_b = b
@@ -80,6 +100,12 @@ class FP8GemmTensorFunction(torch.autograd.Function):
                 block_size=config.block_size,
             )
 
+        if use_nt_layout_gemm_in_bwd:
+            if b_colwise is not None and isinstance(b_colwise, QuantizedTensor):
+                quantized_b_colwise = b_colwise
+            else:
+                quantized_b_colwise = quantized_b.t().contiguous()
+
         out = gemm_fp8_impl(
             quantized_a.qdata,
             quantized_a.scale_inv,
@@ -92,13 +118,24 @@ class FP8GemmTensorFunction(torch.autograd.Function):
             granularity=config.granularity.value,
             default_backend=BackendType.HIPBLASLT.value,
         )
-        ctx.save_for_backward(
-            quantized_a.qdata, quantized_a.scale_inv, quantized_b.qdata, quantized_b.scale_inv
-        )
+
+        if use_nt_layout_gemm_in_bwd:
+            ctx.save_for_backward(
+                quantized_a_colwise.qdata,
+                quantized_a_colwise.scale_inv,
+                quantized_b_colwise.qdata,
+                quantized_b_colwise.scale_inv,
+            )
+        else:
+            ctx.save_for_backward(
+                quantized_a.qdata, quantized_a.scale_inv, quantized_b.qdata, quantized_b.scale_inv
+            )
+
         ctx.trans_a = trans_a
         ctx.trans_b = trans_b
         ctx.out_dtype = out_dtype
         ctx.config = config
+        ctx.use_nt_layout_gemm_in_bwd = use_nt_layout_gemm_in_bwd
 
         return out
 
@@ -106,7 +143,12 @@ class FP8GemmTensorFunction(torch.autograd.Function):
     def backward(ctx, grad_out: torch.Tensor):
         if not grad_out.is_contiguous():
             grad_out = grad_out.contiguous()
-        a_fp8_data, a_scale_inv, b_fp8_data, b_scale_inv = ctx.saved_tensors
+
+        if ctx.use_nt_layout_gemm_in_bwd:
+            a_fp8_colwise, a_colwise_scale_inv, b_fp8_colwise, b_colwise_scale_inv = ctx.saved_tensors
+        else:
+            a_fp8, a_scale_inv, b_fp8, b_scale_inv = ctx.saved_tensors
+
         grad_out_dtype = _get_fp8_dtype(ctx.config.format, False)
 
         quantized_grad_out = QuantizedTensor.quantize(
@@ -116,33 +158,77 @@ class FP8GemmTensorFunction(torch.autograd.Function):
             axis=-1,
         )
 
-        a_grad = gemm_fp8_impl(
-            quantized_grad_out.qdata,
-            quantized_grad_out.scale_inv,
-            False,
-            b_fp8_data,
-            b_scale_inv,
-            not ctx.trans_b,
-            ctx.out_dtype,
-            ctx.trans_a,
-            granularity=ctx.config.granularity.value,
-            default_backend=BackendType.HIPBLASLT.value,
-        )
+        if ctx.use_nt_layout_gemm_in_bwd:
+            a_grad = gemm_fp8_impl(
+                quantized_grad_out.qdata,
+                quantized_grad_out.scale_inv,
+                False,
+                b_fp8_colwise,
+                b_colwise_scale_inv,
+                True,
+                ctx.out_dtype,
+                False,
+                granularity=ctx.config.granularity.value,
+                default_backend=BackendType.HIPBLASLT.value,
+            )
+        else:
+            a_grad = gemm_fp8_impl(
+                quantized_grad_out.qdata,
+                quantized_grad_out.scale_inv,
+                False,
+                b_fp8,
+                b_scale_inv,
+                not ctx.trans_b,
+                ctx.out_dtype,
+                ctx.trans_a,
+                granularity=ctx.config.granularity.value,
+                default_backend=BackendType.HIPBLASLT.value,
+            )
 
-        b_grad = gemm_fp8_impl(
-            a_fp8_data,
-            a_scale_inv,
-            not ctx.trans_a,
-            quantized_grad_out.qdata,
-            quantized_grad_out.scale_inv,
-            False,
-            ctx.out_dtype,
-            ctx.trans_b,
-            granularity=ctx.config.granularity.value,
-            default_backend=BackendType.HIPBLASLT.value,
-        )
+        if ctx.use_nt_layout_gemm_in_bwd:
+            quantized_grad_out_t = QuantizedTensor.quantize(
+                grad_out.t().contiguous(),
+                grad_out_dtype,
+                ctx.config.granularity,
+                axis=-1,
+            )
 
-        return (a_grad, b_grad, None, None, None, None)
+            b_grad = gemm_fp8_impl(
+                a_fp8_colwise,
+                a_colwise_scale_inv,
+                False,
+                quantized_grad_out_t.qdata,
+                quantized_grad_out_t.scale_inv,
+                True,
+                ctx.out_dtype,
+                ctx.trans_b,
+                granularity=ctx.config.granularity.value,
+                default_backend=BackendType.HIPBLASLT.value,
+            )
+        else:
+            b_grad = gemm_fp8_impl(
+                a_fp8,
+                a_scale_inv,
+                not ctx.trans_a,
+                quantized_grad_out.qdata,
+                quantized_grad_out.scale_inv,
+                False,
+                ctx.out_dtype,
+                ctx.trans_b,
+                granularity=ctx.config.granularity.value,
+                default_backend=BackendType.HIPBLASLT.value,
+            )
+
+        return (
+            a_grad,  # a
+            b_grad,  # b
+            None,  # a_colwise
+            None,  # b_colwise
+            None,  # trans_a
+            None,  # trans_b
+            None,  # out_dtype
+            None,  # config
+        )
 
 
 class FP8GemmRowFunction(torch.autograd.Function):
@@ -152,8 +238,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
         ctx,
         a: Union[torch.Tensor, QuantizedTensor],
         b: Union[torch.Tensor, QuantizedTensor],
-        a_t: Optional[QuantizedTensor],
-        b_t: Optional[QuantizedTensor],
+        a_colwise: Optional[QuantizedTensor],
+        b_colwise: Optional[QuantizedTensor],
         trans_a: bool,
         trans_b: bool,
         out_dtype: torch.dtype,
@@ -174,8 +260,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
                 block_size=config.block_size,
             )
 
-        if a_t is None:
-            quantized_a_t = QuantizedTensor.quantize(
+        if a_colwise is None:
+            quantized_a_colwise = QuantizedTensor.quantize(
                 quantized_a.dequantize(),
                 quantized_a.real_dtype,
                 config.granularity,
@@ -183,8 +269,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
                 block_size=config.block_size,
             )
         else:
-            assert isinstance(a_t, QuantizedTensor)
-            quantized_a_t = a_t
+            assert isinstance(a_colwise, QuantizedTensor)
+            quantized_a_colwise = a_colwise
 
         if isinstance(b, QuantizedTensor):
             check_quantized_tensor(b, config, axis=-1 if trans_b else -2)
@@ -199,10 +285,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
                 block_size=config.block_size,
             )
 
-        if b_t is None:
-            # B's row-wise axis is (-1 if trans_b else -2); the col-wise / trans
-            # cache used by backward is the other axis.
-            quantized_b_t = QuantizedTensor.quantize(
+        if b_colwise is None:
+            quantized_b_colwise = QuantizedTensor.quantize(
                 quantized_b.dequantize(),
                 quantized_b.real_dtype,
                 config.granularity,
@@ -210,8 +294,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
                 block_size=config.block_size,
             )
         else:
-            assert isinstance(b_t, QuantizedTensor)
-            quantized_b_t = b_t
+            assert isinstance(b_colwise, QuantizedTensor)
+            quantized_b_colwise = b_colwise
 
         out = gemm_fp8_impl(
             quantized_a.qdata,
@@ -223,12 +307,14 @@ class FP8GemmRowFunction(torch.autograd.Function):
             out_dtype,
             False,
             granularity=config.granularity.value,
-            default_backend=BackendType.HIPBLASLT.value,
+            default_backend=BackendType.TRITON.value,
         )
 
-        # a_fp8.qdata = axis=-1 (row-wise), a_fp8.t() = axis=-2 (col-wise / transposed)
         ctx.save_for_backward(
-            quantized_a_t.qdata, quantized_a_t.scale_inv, quantized_b_t.qdata, quantized_b_t.scale_inv
+            quantized_a_colwise.qdata,
+            quantized_a_colwise.scale_inv,
+            quantized_b_colwise.qdata,
+            quantized_b_colwise.scale_inv,
         )
         ctx.trans_a = trans_a
         ctx.trans_b = trans_b
@@ -242,10 +328,9 @@ class FP8GemmRowFunction(torch.autograd.Function):
         if not grad_out.is_contiguous():
             grad_out = grad_out.contiguous()
 
-        a_fp8_t, a_t_scale_inv, b_fp8_t, b_t_scale_inv = ctx.saved_tensors
+        a_fp8_colwise, a_colwise_scale_inv, b_fp8_colwise, b_colwise_scale_inv = ctx.saved_tensors
         grad_out_dtype = _get_fp8_dtype(ctx.config.format, False)
 
-        # Quantize grad_out row-wise (axis=-1), then transpose to derive col-wise (axis=-2) version.
         quantized_grad_out = QuantizedTensor.quantize(
             grad_out,
             grad_out_dtype,
@@ -259,13 +344,13 @@ class FP8GemmRowFunction(torch.autograd.Function):
             quantized_grad_out.qdata,
             quantized_grad_out.scale_inv,
             False,
-            b_fp8_t,
-            b_t_scale_inv,
+            b_fp8_colwise,
+            b_colwise_scale_inv,
             not ctx.trans_b,
             ctx.out_dtype,
             ctx.trans_a,
             granularity=ctx.config.granularity.value,
-            default_backend=BackendType.HIPBLASLT.value,
+            default_backend=BackendType.TRITON.value,
         )
 
         quantized_grad_out_t = QuantizedTensor.quantize(
@@ -274,8 +359,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
 
         # TN
         b_grad = gemm_fp8_impl(
-            a_fp8_t,
-            a_t_scale_inv,
+            a_fp8_colwise,
+            a_colwise_scale_inv,
             not ctx.trans_a,
             quantized_grad_out_t.qdata,
             quantized_grad_out_t.scale_inv,
@@ -283,12 +368,19 @@ class FP8GemmRowFunction(torch.autograd.Function):
             ctx.out_dtype,
             ctx.trans_b,
             granularity=ctx.config.granularity.value,
-            default_backend=BackendType.HIPBLASLT.value,
+            default_backend=BackendType.TRITON.value,
         )
 
-        # Grads correspond to forward args:
-        #   (a, b, a_t, b_t, trans_a, trans_b, out_dtype, config)
-        return (a_grad, b_grad, None, None, None, None, None, None)
+        return (
+            a_grad,  # a
+            b_grad,  # b
+            None,  # a_colwise
+            None,  # b_colwise
+            None,  # trans_a
+            None,  # trans_b
+            None,  # out_dtype
+            None,  # config
+        )
 
 
 # TODO(ruibin): Add support for quantized tensor
@@ -416,7 +508,14 @@ class FP8GemmBlockFunction(torch.autograd.Function):
             default_backend=BackendType.CK.value,
         )
 
-        return a_grad, b_grad, None, None, None, None
+        return (
+            a_grad,  # a
+            b_grad,  # b
+            None,  # trans_a
+            None,  # trans_b
+            None,  # out_dtype
+            None,  # config
+        )
 
 
 class FP8GemmMXFunction(torch.autograd.Function):
@@ -426,8 +525,8 @@ class FP8GemmMXFunction(torch.autograd.Function):
         ctx,
         a: Union[torch.Tensor, QuantizedTensor],
         b: Union[torch.Tensor, QuantizedTensor],
-        a_t: Optional[QuantizedTensor],
-        b_t: Optional[QuantizedTensor],
+        a_colwise: Optional[QuantizedTensor],
+        b_colwise: Optional[QuantizedTensor],
         trans_a: bool,
         trans_b: bool,
         out_dtype: torch.dtype,
@@ -453,10 +552,10 @@ class FP8GemmMXFunction(torch.autograd.Function):
                 scaling_recipe=a_scaling_recipe,
             )
 
-        if a_t is None:
+        if a_colwise is None:
             # MX_BLOCKWISE requires a scaling_recipe; reuse the forward recipe
             # for A's col-wise direction (same recipe as forward).
-            quantized_a_t = QuantizedTensor.quantize(
+            quantized_a_colwise = QuantizedTensor.quantize(
                 quantized_a.dequantize(),
                 quantized_a.real_dtype,
                 config.granularity,
@@ -465,8 +564,8 @@ class FP8GemmMXFunction(torch.autograd.Function):
                 scaling_recipe=a_scaling_recipe,
             )
         else:
-            assert isinstance(a_t, QuantizedTensor)
-            quantized_a_t = a_t
+            assert isinstance(a_colwise, QuantizedTensor)
+            quantized_a_colwise = a_colwise
 
         b_scaling_recipe = ScalingRecipe(use_2d_block=True)
         if isinstance(b, QuantizedTensor):
@@ -483,8 +582,10 @@ class FP8GemmMXFunction(torch.autograd.Function):
                 scaling_recipe=b_scaling_recipe,
             )
 
-        if b_t is None:
-            quantized_b_t = QuantizedTensor.quantize(
+        if b_colwise is None:
+            # MX_BLOCKWISE requires a scaling_recipe; reuse the forward recipe
+            # for B's col-wise direction (same recipe as forward).
+            quantized_b_colwise = QuantizedTensor.quantize(
                 quantized_b.dequantize(),
                 quantized_b.real_dtype,
                 config.granularity,
@@ -493,8 +594,8 @@ class FP8GemmMXFunction(torch.autograd.Function):
                 scaling_recipe=b_scaling_recipe,
             )
         else:
-            assert isinstance(b_t, QuantizedTensor)
-            quantized_b_t = b_t
+            assert isinstance(b_colwise, QuantizedTensor)
+            quantized_b_colwise = b_colwise
 
         # NT layout
         out = gemm_fp8_impl(
@@ -511,7 +612,10 @@ class FP8GemmMXFunction(torch.autograd.Function):
         )
 
         ctx.save_for_backward(
-            quantized_a_t.qdata, quantized_a_t.scale_inv, quantized_b_t.qdata, quantized_b_t.scale_inv
+            quantized_a_colwise.qdata,
+            quantized_a_colwise.scale_inv,
+            quantized_b_colwise.qdata,
+            quantized_b_colwise.scale_inv,
         )
 
         ctx.trans_a = trans_a
@@ -523,12 +627,9 @@ class FP8GemmMXFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_out: torch.Tensor):
-        a_fp8_t, a_t_scale_inv, b_fp8_t, b_t_scale_inv = ctx.saved_tensors
+        a_fp8_colwise, a_colwise_scale_inv, b_fp8_colwise, b_colwise_scale_inv = ctx.saved_tensors
 
         grad_out_dtype = _get_fp8_dtype(ctx.config.format, False)
-        # The MXFP8 quant below (QuantizedTensor.quantize, single-direction along
-        # axis=-1 then axis=-2) asserts a contiguous input; a strided grad_out
-        # (e.g. from a transpose upstream) trips it. reshape+contiguous.
         grad_out = grad_out.reshape(grad_out.shape[0], -1).contiguous()
 
         grad_out_scaling_recipe = ScalingRecipe()
@@ -546,8 +647,8 @@ class FP8GemmMXFunction(torch.autograd.Function):
             quantized_grad_out.qdata,
             quantized_grad_out.scale_inv,
             False,
-            b_fp8_t,
-            b_t_scale_inv,
+            b_fp8_colwise,
+            b_colwise_scale_inv,
             True,
             ctx.out_dtype,
             False,
@@ -570,8 +671,8 @@ class FP8GemmMXFunction(torch.autograd.Function):
             quantized_grad_out_t.qdata,
             quantized_grad_out_t.scale_inv,
             False,
-            a_fp8_t,
-            a_t_scale_inv,
+            a_fp8_colwise,
+            a_colwise_scale_inv,
             True,
             ctx.out_dtype,
             False,
@@ -579,9 +680,16 @@ class FP8GemmMXFunction(torch.autograd.Function):
             default_backend=BackendType.TURBO.value,
         )
 
-        # Grads correspond to forward args:
-        #   (a, b, a_t, b_t, trans_a, trans_b, out_dtype, config)
-        return grad_a, grad_b, None, None, None, None, None, None
+        return (
+            grad_a,  # a
+            grad_b,  # b
+            None,  # a_colwise
+            None,  # b_colwise
+            None,  # trans_a
+            None,  # trans_b
+            None,  # out_dtype
+            None,  # config
+        )
 
 
 @torch._dynamo.disable(
@@ -645,14 +753,14 @@ def gemm_fp8(
         config = Float8QuantConfig()
 
     if isinstance(a, QuantizedTensorPair):
-        a_data, a_data_t = a.data, a.data_t
+        a_data, a_data_colwise = a.data_rowwise, a.data_colwise
     else:
-        a_data, a_data_t = a, None
+        a_data, a_data_colwise = a, None
 
     if isinstance(b, QuantizedTensorPair):
-        b_data, b_data_t = b.data, b.data_t
+        b_data, b_data_colwise = b.data_rowwise, b.data_colwise
     else:
-        b_data, b_data_t = b, None
+        b_data, b_data_colwise = b, None
 
     assert a_data.ndim == 2, "Only 2D tensors are supported"
     assert b_data.ndim == 2, "Only 2D tensors are supported"
@@ -661,10 +769,12 @@ def gemm_fp8(
         out_dtype = torch.promote_types(a_data.dtype, b_data.dtype)
 
     if config.granularity == ScalingGranularity.TENSORWISE:
-        return FP8GemmTensorFunction.apply(a_data, b_data, trans_a, trans_b, out_dtype, config)
+        return FP8GemmTensorFunction.apply(
+            a_data, b_data, a_data_colwise, b_data_colwise, trans_a, trans_b, out_dtype, config
+        )
     elif config.granularity == ScalingGranularity.ROWWISE:
         return FP8GemmRowFunction.apply(
-            a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config
+            a_data, b_data, a_data_colwise, b_data_colwise, trans_a, trans_b, out_dtype, config
         )
     elif config.granularity == ScalingGranularity.BLOCKWISE:
         # BLOCKWISE does not yet support pre-quantized inputs; preserve the
@@ -672,7 +782,7 @@ def gemm_fp8(
         return FP8GemmBlockFunction.apply(a, b, trans_a, trans_b, out_dtype, config)
     elif config.granularity == ScalingGranularity.MX_BLOCKWISE:
         return FP8GemmMXFunction.apply(
-            a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config
+            a_data, b_data, a_data_colwise, b_data_colwise, trans_a, trans_b, out_dtype, config
         )
     else:
         raise ValueError(f"Unsupported FP8 ScalingGranularity: {config.granularity}")

--- a/primus_turbo/pytorch/ops/gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/gemm_fp8.py
@@ -58,8 +58,8 @@ class FP8GemmTensorFunction(torch.autograd.Function):
         ctx,
         a: Union[torch.Tensor, QuantizedTensor],
         b: Union[torch.Tensor, QuantizedTensor],
-        a_colwise: Optional[QuantizedTensor],
-        b_colwise: Optional[QuantizedTensor],
+        a_t: Optional[QuantizedTensor],
+        b_t: Optional[QuantizedTensor],
         trans_a: bool,
         trans_b: bool,
         out_dtype: torch.dtype,
@@ -81,10 +81,10 @@ class FP8GemmTensorFunction(torch.autograd.Function):
             )
 
         if use_nt_layout_gemm_in_bwd:
-            if a_colwise is not None and isinstance(a_colwise, QuantizedTensor):
-                quantized_a_colwise = a_colwise
+            if a_t is not None and isinstance(a_t, QuantizedTensor):
+                quantized_a_t = a_t
             else:
-                quantized_a_colwise = quantized_a.t().contiguous()
+                quantized_a_t = quantized_a.t().contiguous()
 
         if isinstance(b, QuantizedTensor):
             quantized_b = b
@@ -100,10 +100,10 @@ class FP8GemmTensorFunction(torch.autograd.Function):
             )
 
         if use_nt_layout_gemm_in_bwd:
-            if b_colwise is not None and isinstance(b_colwise, QuantizedTensor):
-                quantized_b_colwise = b_colwise
+            if b_t is not None and isinstance(b_t, QuantizedTensor):
+                quantized_b_t = b_t
             else:
-                quantized_b_colwise = quantized_b.t().contiguous()
+                quantized_b_t = quantized_b.t().contiguous()
 
         out = gemm_fp8_impl(
             quantized_a.qdata,
@@ -120,10 +120,10 @@ class FP8GemmTensorFunction(torch.autograd.Function):
 
         if use_nt_layout_gemm_in_bwd:
             ctx.save_for_backward(
-                quantized_a_colwise.qdata,
-                quantized_a_colwise.scale_inv,
-                quantized_b_colwise.qdata,
-                quantized_b_colwise.scale_inv,
+                quantized_a_t.qdata,
+                quantized_a_t.scale_inv,
+                quantized_b_t.qdata,
+                quantized_b_t.scale_inv,
             )
         else:
             ctx.save_for_backward(
@@ -144,7 +144,7 @@ class FP8GemmTensorFunction(torch.autograd.Function):
             grad_out = grad_out.contiguous()
 
         if ctx.use_nt_layout_gemm_in_bwd:
-            a_fp8_colwise, a_colwise_scale_inv, b_fp8_colwise, b_colwise_scale_inv = ctx.saved_tensors
+            a_fp8_t, a_t_scale_inv, b_fp8_t, b_t_scale_inv = ctx.saved_tensors
         else:
             a_fp8, a_scale_inv, b_fp8, b_scale_inv = ctx.saved_tensors
 
@@ -162,8 +162,8 @@ class FP8GemmTensorFunction(torch.autograd.Function):
                 quantized_grad_out.qdata,
                 quantized_grad_out.scale_inv,
                 False,
-                b_fp8_colwise,
-                b_colwise_scale_inv,
+                b_fp8_t,
+                b_t_scale_inv,
                 True,
                 ctx.out_dtype,
                 False,
@@ -188,8 +188,8 @@ class FP8GemmTensorFunction(torch.autograd.Function):
             quantized_grad_out_t = quantized_grad_out.t().contiguous()
 
             b_grad = gemm_fp8_impl(
-                a_fp8_colwise,
-                a_colwise_scale_inv,
+                a_fp8_t,
+                a_t_scale_inv,
                 False,
                 quantized_grad_out_t.qdata,
                 quantized_grad_out_t.scale_inv,
@@ -216,8 +216,8 @@ class FP8GemmTensorFunction(torch.autograd.Function):
         return (
             a_grad,  # a
             b_grad,  # b
-            None,  # a_colwise
-            None,  # b_colwise
+            None,  # a_t
+            None,  # b_t
             None,  # trans_a
             None,  # trans_b
             None,  # out_dtype
@@ -231,8 +231,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
         ctx,
         a: Union[torch.Tensor, QuantizedTensor],
         b: Union[torch.Tensor, QuantizedTensor],
-        a_colwise: Optional[QuantizedTensor],
-        b_colwise: Optional[QuantizedTensor],
+        a_t: Optional[QuantizedTensor],
+        b_t: Optional[QuantizedTensor],
         trans_a: bool,
         trans_b: bool,
         out_dtype: torch.dtype,
@@ -253,8 +253,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
                 block_size=config.block_size,
             )
 
-        if a_colwise is None:
-            quantized_a_colwise = QuantizedTensor.quantize(
+        if a_t is None:
+            quantized_a_t = QuantizedTensor.quantize(
                 quantized_a.dequantize(),
                 quantized_a.real_dtype,
                 config.granularity,
@@ -262,8 +262,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
                 block_size=config.block_size,
             )
         else:
-            assert isinstance(a_colwise, QuantizedTensor)
-            quantized_a_colwise = a_colwise
+            assert isinstance(a_t, QuantizedTensor)
+            quantized_a_t = a_t
 
         if isinstance(b, QuantizedTensor):
             check_quantized_tensor(b, config, axis=-1 if trans_b else -2)
@@ -278,8 +278,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
                 block_size=config.block_size,
             )
 
-        if b_colwise is None:
-            quantized_b_colwise = QuantizedTensor.quantize(
+        if b_t is None:
+            quantized_b_t = QuantizedTensor.quantize(
                 quantized_b.dequantize(),
                 quantized_b.real_dtype,
                 config.granularity,
@@ -287,8 +287,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
                 block_size=config.block_size,
             )
         else:
-            assert isinstance(b_colwise, QuantizedTensor)
-            quantized_b_colwise = b_colwise
+            assert isinstance(b_t, QuantizedTensor)
+            quantized_b_t = b_t
 
         out = gemm_fp8_impl(
             quantized_a.qdata,
@@ -304,10 +304,10 @@ class FP8GemmRowFunction(torch.autograd.Function):
         )
 
         ctx.save_for_backward(
-            quantized_a_colwise.qdata,
-            quantized_a_colwise.scale_inv,
-            quantized_b_colwise.qdata,
-            quantized_b_colwise.scale_inv,
+            quantized_a_t.qdata,
+            quantized_a_t.scale_inv,
+            quantized_b_t.qdata,
+            quantized_b_t.scale_inv,
         )
         ctx.trans_a = trans_a
         ctx.trans_b = trans_b
@@ -321,7 +321,7 @@ class FP8GemmRowFunction(torch.autograd.Function):
         if not grad_out.is_contiguous():
             grad_out = grad_out.contiguous()
 
-        a_fp8_colwise, a_colwise_scale_inv, b_fp8_colwise, b_colwise_scale_inv = ctx.saved_tensors
+        a_fp8_t, a_t_scale_inv, b_fp8_t, b_t_scale_inv = ctx.saved_tensors
         grad_out_dtype = _get_fp8_dtype(ctx.config.format, False)
 
         quantized_grad_out = QuantizedTensor.quantize(
@@ -337,8 +337,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
             quantized_grad_out.qdata,
             quantized_grad_out.scale_inv,
             False,
-            b_fp8_colwise,
-            b_colwise_scale_inv,
+            b_fp8_t,
+            b_t_scale_inv,
             not ctx.trans_b,
             ctx.out_dtype,
             ctx.trans_a,
@@ -352,8 +352,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
 
         # TN
         b_grad = gemm_fp8_impl(
-            a_fp8_colwise,
-            a_colwise_scale_inv,
+            a_fp8_t,
+            a_t_scale_inv,
             not ctx.trans_a,
             quantized_grad_out_t.qdata,
             quantized_grad_out_t.scale_inv,
@@ -367,8 +367,8 @@ class FP8GemmRowFunction(torch.autograd.Function):
         return (
             a_grad,  # a
             b_grad,  # b
-            None,  # a_colwise
-            None,  # b_colwise
+            None,  # a_t
+            None,  # b_t
             None,  # trans_a
             None,  # trans_b
             None,  # out_dtype
@@ -516,8 +516,8 @@ class FP8GemmMXFunction(torch.autograd.Function):
         ctx,
         a: Union[torch.Tensor, QuantizedTensor],
         b: Union[torch.Tensor, QuantizedTensor],
-        a_colwise: Optional[QuantizedTensor],
-        b_colwise: Optional[QuantizedTensor],
+        a_t: Optional[QuantizedTensor],
+        b_t: Optional[QuantizedTensor],
         trans_a: bool,
         trans_b: bool,
         out_dtype: torch.dtype,
@@ -543,10 +543,10 @@ class FP8GemmMXFunction(torch.autograd.Function):
                 scaling_recipe=a_scaling_recipe,
             )
 
-        if a_colwise is None:
+        if a_t is None:
             # MX_BLOCKWISE requires a scaling_recipe; reuse the forward recipe
             # for A's col-wise direction (same recipe as forward).
-            quantized_a_colwise = QuantizedTensor.quantize(
+            quantized_a_t = QuantizedTensor.quantize(
                 quantized_a.dequantize(),
                 quantized_a.real_dtype,
                 config.granularity,
@@ -555,8 +555,8 @@ class FP8GemmMXFunction(torch.autograd.Function):
                 scaling_recipe=a_scaling_recipe,
             )
         else:
-            assert isinstance(a_colwise, QuantizedTensor)
-            quantized_a_colwise = a_colwise
+            assert isinstance(a_t, QuantizedTensor)
+            quantized_a_t = a_t
 
         b_scaling_recipe = ScalingRecipe(use_2d_block=True)
         if isinstance(b, QuantizedTensor):
@@ -573,10 +573,10 @@ class FP8GemmMXFunction(torch.autograd.Function):
                 scaling_recipe=b_scaling_recipe,
             )
 
-        if b_colwise is None:
+        if b_t is None:
             # MX_BLOCKWISE requires a scaling_recipe; reuse the forward recipe
             # for B's col-wise direction (same recipe as forward).
-            quantized_b_colwise = QuantizedTensor.quantize(
+            quantized_b_t = QuantizedTensor.quantize(
                 quantized_b.dequantize(),
                 quantized_b.real_dtype,
                 config.granularity,
@@ -585,8 +585,8 @@ class FP8GemmMXFunction(torch.autograd.Function):
                 scaling_recipe=b_scaling_recipe,
             )
         else:
-            assert isinstance(b_colwise, QuantizedTensor)
-            quantized_b_colwise = b_colwise
+            assert isinstance(b_t, QuantizedTensor)
+            quantized_b_t = b_t
 
         # NT layout
         out = gemm_fp8_impl(
@@ -603,10 +603,10 @@ class FP8GemmMXFunction(torch.autograd.Function):
         )
 
         ctx.save_for_backward(
-            quantized_a_colwise.qdata,
-            quantized_a_colwise.scale_inv,
-            quantized_b_colwise.qdata,
-            quantized_b_colwise.scale_inv,
+            quantized_a_t.qdata,
+            quantized_a_t.scale_inv,
+            quantized_b_t.qdata,
+            quantized_b_t.scale_inv,
         )
 
         ctx.trans_a = trans_a
@@ -618,7 +618,7 @@ class FP8GemmMXFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_out: torch.Tensor):
-        a_fp8_colwise, a_colwise_scale_inv, b_fp8_colwise, b_colwise_scale_inv = ctx.saved_tensors
+        a_fp8_t, a_t_scale_inv, b_fp8_t, b_t_scale_inv = ctx.saved_tensors
 
         grad_out_dtype = _get_fp8_dtype(ctx.config.format, False)
         grad_out = grad_out.reshape(grad_out.shape[0], -1).contiguous()
@@ -638,8 +638,8 @@ class FP8GemmMXFunction(torch.autograd.Function):
             quantized_grad_out.qdata,
             quantized_grad_out.scale_inv,
             False,
-            b_fp8_colwise,
-            b_colwise_scale_inv,
+            b_fp8_t,
+            b_t_scale_inv,
             True,
             ctx.out_dtype,
             False,
@@ -662,8 +662,8 @@ class FP8GemmMXFunction(torch.autograd.Function):
             quantized_grad_out_t.qdata,
             quantized_grad_out_t.scale_inv,
             False,
-            a_fp8_colwise,
-            a_colwise_scale_inv,
+            a_fp8_t,
+            a_t_scale_inv,
             True,
             ctx.out_dtype,
             False,
@@ -674,8 +674,8 @@ class FP8GemmMXFunction(torch.autograd.Function):
         return (
             grad_a,  # a
             grad_b,  # b
-            None,  # a_colwise
-            None,  # b_colwise
+            None,  # a_t
+            None,  # b_t
             None,  # trans_a
             None,  # trans_b
             None,  # out_dtype
@@ -744,14 +744,14 @@ def gemm_fp8(
         config = Float8QuantConfig()
 
     if isinstance(a, QuantizedTensorPair):
-        a_data, a_data_colwise = a.data_rowwise, a.data_colwise
+        a_data, a_data_t = a.data, a.data_t
     else:
-        a_data, a_data_colwise = a, None
+        a_data, a_data_t = a, None
 
     if isinstance(b, QuantizedTensorPair):
-        b_data, b_data_colwise = b.data_rowwise, b.data_colwise
+        b_data, b_data_t = b.data, b.data_t
     else:
-        b_data, b_data_colwise = b, None
+        b_data, b_data_t = b, None
 
     assert a_data.ndim == 2, "Only 2D tensors are supported"
     assert b_data.ndim == 2, "Only 2D tensors are supported"
@@ -761,11 +761,11 @@ def gemm_fp8(
 
     if config.granularity == ScalingGranularity.TENSORWISE:
         return FP8GemmTensorFunction.apply(
-            a_data, b_data, a_data_colwise, b_data_colwise, trans_a, trans_b, out_dtype, config
+            a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config
         )
     elif config.granularity == ScalingGranularity.ROWWISE:
         return FP8GemmRowFunction.apply(
-            a_data, b_data, a_data_colwise, b_data_colwise, trans_a, trans_b, out_dtype, config
+            a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config
         )
     elif config.granularity == ScalingGranularity.BLOCKWISE:
         # BLOCKWISE does not yet support pre-quantized inputs; preserve the
@@ -773,7 +773,7 @@ def gemm_fp8(
         return FP8GemmBlockFunction.apply(a, b, trans_a, trans_b, out_dtype, config)
     elif config.granularity == ScalingGranularity.MX_BLOCKWISE:
         return FP8GemmMXFunction.apply(
-            a_data, b_data, a_data_colwise, b_data_colwise, trans_a, trans_b, out_dtype, config
+            a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config
         )
     else:
         raise ValueError(f"Unsupported FP8 ScalingGranularity: {config.granularity}")

--- a/primus_turbo/pytorch/ops/gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/gemm_fp8.py
@@ -186,12 +186,7 @@ class FP8GemmTensorFunction(torch.autograd.Function):
             )
 
         if ctx.use_nt_layout_gemm_in_bwd:
-            quantized_grad_out_t = QuantizedTensor.quantize(
-                grad_out.t().contiguous(),
-                grad_out_dtype,
-                ctx.config.granularity,
-                axis=-1,
-            )
+            quantized_grad_out_t = quantized_grad_out.t().contiguous()
 
             b_grad = gemm_fp8_impl(
                 a_fp8_colwise,

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -21,6 +21,7 @@ from primus_turbo.pytorch.core.quantized_tensor import (
     QuantizedTensorPair,
     check_quantized_tensor,
 )
+from primus_turbo.pytorch.core.utils import is_gfx942
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_fp8_impl import (
     grouped_gemm_fp8_impl,
     grouped_gemm_fp8_variable_k_impl,
@@ -57,6 +58,15 @@ def _ensure_contiguous_grad_out(grad_out: torch.Tensor) -> torch.Tensor:
     # Some upstream reductions can produce expanded zero-stride grad_out views.
     # Custom grouped GEMM kernels expect dense layouts.
     return grad_out if grad_out.is_contiguous() else grad_out.contiguous()
+
+
+def _deter_use_nt_layout_gemm_in_bwd(trans_a: bool, trans_b: bool):
+    if is_gfx942():
+        return False
+
+    # NOTE: the non-NT layout gemm is not optimized for mi350/mi450.
+    # Force to use NT layout GEMM in backward for now.
+    return trans_a == False and trans_b == True
 
 
 class FP8GroupedGemmBlockFunc(torch.autograd.Function):
@@ -187,7 +197,16 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
             default_backend=BackendType.TRITON.value,
         )
 
-        return grad_a, grad_b, None, None, None, None, None, None
+        return (
+            grad_a,  # a
+            grad_b,  # b
+            None,  # group_lens
+            None,  # group_offs
+            None,  # trans_b
+            None,  # out_dtype
+            None,  # config
+            None,  # num_cu
+        )
 
 
 class FP8GroupedGemmRowFunc(torch.autograd.Function):
@@ -197,8 +216,8 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
         ctx,
         a: Union[torch.Tensor, QuantizedTensor],
         b: Union[torch.Tensor, QuantizedTensor],
-        a_t: Optional[QuantizedTensor],
-        b_t: Optional[QuantizedTensor],
+        a_colwise: Optional[QuantizedTensor],
+        b_colwise: Optional[QuantizedTensor],
         group_lens: torch.Tensor,  # [B,] int64
         group_offs: torch.Tensor,  # [B + 1,] int64
         trans_b: bool,
@@ -260,13 +279,13 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
         )
 
         # Col-wise trans cache for backward. If the caller pre-quantized this
-        # and passed it via ``a_t`` / ``b_t``, reuse it directly; otherwise
+        # and passed it via ``a_colwise`` / ``b_colwise``, reuse it directly; otherwise
         # derive it (dequantize + re-quantize along the other axis), mirroring
         # FP8GemmRowFunction in gemm_fp8.py.
-        if a_t is not None:
-            quantized_a_t = a_t
+        if a_colwise is not None:
+            quantized_a_colwise = a_colwise
         else:
-            quantized_a_t = QuantizedTensor.quantize(
+            quantized_a_colwise = QuantizedTensor.quantize(
                 quantized_a.dequantize(),
                 quantized_a.real_dtype,
                 config.granularity,
@@ -275,10 +294,10 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
                 group_lens=group_lens,
             )
 
-        if b_t is not None:
-            quantized_b_t = b_t
+        if b_colwise is not None:
+            quantized_b_colwise = b_colwise
         else:
-            quantized_b_t = QuantizedTensor.quantize(
+            quantized_b_colwise = QuantizedTensor.quantize(
                 quantized_b.dequantize(),
                 quantized_b.real_dtype,
                 config.granularity,
@@ -287,10 +306,10 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
             )
 
         ctx.save_for_backward(
-            quantized_a_t.qdata,
-            quantized_b_t.qdata,
-            quantized_a_t.scale_inv,
-            quantized_b_t.scale_inv,
+            quantized_a_colwise.qdata,
+            quantized_b_colwise.qdata,
+            quantized_a_colwise.scale_inv,
+            quantized_b_colwise.scale_inv,
             group_lens,
             group_offs,
         )
@@ -359,9 +378,18 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
             default_backend=BackendType.TRITON.value,
         )
 
-        # Grads correspond to forward args:
-        #   (a, b, a_t, b_t, group_lens, group_offs, trans_b, out_dtype, config, num_cu)
-        return grad_a, grad_b, None, None, None, None, None, None, None, None
+        return (
+            grad_a,  # a
+            grad_b,  # b
+            None,  # a_colwise
+            None,  # b_colwise
+            None,  # group_lens
+            None,  # group_offs
+            None,  # trans_b
+            None,  # out_dtype
+            None,  # config
+            None,  # num_cu
+        )
 
 
 class FP8GroupedGemmTensorFunc(torch.autograd.Function):
@@ -371,6 +399,8 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
         ctx,
         a: Union[torch.Tensor, QuantizedTensor],
         b: Union[torch.Tensor, QuantizedTensor],
+        a_colwise: Optional[QuantizedTensor],  # not used
+        b_colwise: Optional[QuantizedTensor],
         group_lens: torch.Tensor,  # [B,] int64
         group_offs: torch.Tensor,  # [B + 1,] int64
         trans_b: bool,
@@ -378,10 +408,10 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
         config: Float8QuantConfig,
         num_cu: int | None,
     ):
+        use_nt_layout_gemm_in_bwd = _deter_use_nt_layout_gemm_in_bwd(False, trans_b)
+
         assert config.granularity == ScalingGranularity.TENSORWISE
 
-        # TENSORWISE has a single scalar scale, so the same buffers feed both
-        # forward and backward (no separate trans cache needed).
         if isinstance(a, QuantizedTensor):
             assert a._is_grouped_tensor, "A QuantizedTensor input must be a grouped tensor"
             check_quantized_tensor(a, config)
@@ -412,6 +442,12 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
                 block_size=config.block_size,
             )
 
+        if use_nt_layout_gemm_in_bwd:
+            if b_colwise is not None and isinstance(b_colwise, QuantizedTensor):
+                quantized_b_colwise = b_colwise
+            else:
+                quantized_b_colwise = quantized_b.transpose(-1, -2).contiguous()
+
         out = grouped_gemm_fp8_impl(
             quantized_a.qdata,
             quantized_b.qdata,
@@ -428,19 +464,31 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
             maybe_pre_sync=True,
         )
 
-        ctx.save_for_backward(
-            quantized_a.qdata,
-            quantized_b.qdata,
-            quantized_a.scale_inv,
-            quantized_b.scale_inv,
-            group_lens,
-            group_offs,
-        )
+        if use_nt_layout_gemm_in_bwd:
+            ctx.save_for_backward(
+                quantized_a.qdata,
+                quantized_b_colwise.qdata,
+                quantized_a.scale_inv,
+                quantized_b_colwise.scale_inv,
+                group_lens,
+                group_offs,
+            )
+        else:
+            ctx.save_for_backward(
+                quantized_a.qdata,
+                quantized_b.qdata,
+                quantized_a.scale_inv,
+                quantized_b.scale_inv,
+                group_lens,
+                group_offs,
+            )
         ctx.trans_a = False
         ctx.trans_b = trans_b
+        ctx.use_nt_layout_gemm_in_bwd = use_nt_layout_gemm_in_bwd
         ctx.config = config
         ctx.out_dtype = out_dtype
         ctx.num_cu = num_cu
+
         return out
 
     @staticmethod
@@ -458,20 +506,37 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
             group_lens=group_lens,
         )
 
-        grad_a = grouped_gemm_fp8_impl(
-            quantized_grad_out.qdata,
-            b_fp8,
-            quantized_grad_out.scale_inv,
-            b_scale_inv,
-            group_lens,
-            group_offs,
-            trans_a=False,
-            trans_b=not ctx.trans_b,
-            out_dtype=ctx.out_dtype,
-            granularity=ctx.config.granularity.value,
-            num_cu=ctx.num_cu,
-            default_backend=BackendType.TRITON.value,
-        )
+        if ctx.use_nt_layout_gemm_in_bwd:
+            # b_fp8 is the per-group (K, N) transpose cache; grad_a runs as NT.
+            grad_a = grouped_gemm_fp8_impl(
+                quantized_grad_out.qdata,
+                b_fp8,
+                quantized_grad_out.scale_inv,
+                b_scale_inv,
+                group_lens,
+                group_offs,
+                trans_a=False,
+                trans_b=True,
+                out_dtype=ctx.out_dtype,
+                granularity=ctx.config.granularity.value,
+                num_cu=ctx.num_cu,
+                default_backend=BackendType.TRITON.value,
+            )
+        else:
+            grad_a = grouped_gemm_fp8_impl(
+                quantized_grad_out.qdata,
+                b_fp8,
+                quantized_grad_out.scale_inv,
+                b_scale_inv,
+                group_lens,
+                group_offs,
+                trans_a=False,
+                trans_b=not ctx.trans_b,
+                out_dtype=ctx.out_dtype,
+                granularity=ctx.config.granularity.value,
+                num_cu=ctx.num_cu,
+                default_backend=BackendType.TRITON.value,
+            )
 
         grad_b = grouped_gemm_fp8_variable_k_impl(
             a_fp8,
@@ -489,7 +554,18 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
             default_backend=BackendType.TRITON.value,
         )
 
-        return grad_a, grad_b, None, None, None, None, None, None
+        return (
+            grad_a,  # a
+            grad_b,  # b
+            None,  # a_colwise
+            None,  # b_colwise
+            None,  # group_lens
+            None,  # group_offs
+            None,  # trans_b
+            None,  # out_dtype
+            None,  # config
+            None,  # num_cu
+        )
 
 
 class FP8GroupedGemmMXFunc(torch.autograd.Function):
@@ -666,7 +742,7 @@ def grouped_gemm_fp8(
         a: Input tensor A with shape [bs * m, k] (float16 or bfloat16).
             Can also be a pre-quantized :class:`QuantizedTensor` (grouped), or
             a :class:`QuantizedTensorPair` carrying both ``data`` (row-wise) and
-            the backward-direction ``data_t`` (col-wise) for ROWWISE granularity.
+            the backward-direction ``data_colwise`` (col-wise) for ROWWISE granularity.
         b: Input tensor B with shape [bs, k, n] or [bs, n, k] if trans_b (float16 or bfloat16).
             Same pre-quantized variants as ``a`` are accepted.
         group_lens: Group lengths tensor [bs] (int64)
@@ -685,30 +761,39 @@ def grouped_gemm_fp8(
     if group_offs is None:
         group_offs = group_offs_from_lens(group_lens)
     if isinstance(a, QuantizedTensorPair):
-        a_data, a_data_t = a.data, a.data_t
+        a_data, a_data_colwise = a.data_rowwise, a.data_colwise
     else:
-        a_data, a_data_t = a, None
+        a_data, a_data_colwise = a, None
 
     if isinstance(b, QuantizedTensorPair):
-        b_data, b_data_t = b.data, b.data_t
+        b_data, b_data_colwise = b.data_rowwise, b.data_colwise
     else:
-        b_data, b_data_t = b, None
+        b_data, b_data_colwise = b, None
 
     if out_dtype is None:
         out_dtype = torch.promote_types(a_data.dtype, b_data.dtype)
 
     if config.granularity == ScalingGranularity.TENSORWISE:
         # TENSORWISE has a single scalar scale (no col-wise trans cache needed);
-        # the inner ``data_t`` is ignored if provided.
+        # the inner ``data_colwise`` is ignored if provided.
         return FP8GroupedGemmTensorFunc.apply(
-            a_data, b_data, group_lens, group_offs, trans_b, out_dtype, config, num_cu
+            a_data,
+            b_data,
+            a_data_colwise,
+            b_data_colwise,
+            group_lens,
+            group_offs,
+            trans_b,
+            out_dtype,
+            config,
+            num_cu,
         )
     elif config.granularity == ScalingGranularity.ROWWISE:
         return FP8GroupedGemmRowFunc.apply(
             a_data,
             b_data,
-            a_data_t,
-            b_data_t,
+            a_data_colwise,
+            b_data_colwise,
             group_lens,
             group_offs,
             trans_b,

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -214,8 +214,8 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
         ctx,
         a: Union[torch.Tensor, QuantizedTensor],
         b: Union[torch.Tensor, QuantizedTensor],
-        a_colwise: Optional[QuantizedTensor],
-        b_colwise: Optional[QuantizedTensor],
+        a_t: Optional[QuantizedTensor],
+        b_t: Optional[QuantizedTensor],
         group_lens: torch.Tensor,  # [B,] int64
         group_offs: torch.Tensor,  # [B + 1,] int64
         trans_b: bool,
@@ -277,13 +277,13 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
         )
 
         # Col-wise trans cache for backward. If the caller pre-quantized this
-        # and passed it via ``a_colwise`` / ``b_colwise``, reuse it directly; otherwise
+        # and passed it via ``a_t`` / ``b_t``, reuse it directly; otherwise
         # derive it (dequantize + re-quantize along the other axis), mirroring
         # FP8GemmRowFunction in gemm_fp8.py.
-        if a_colwise is not None:
-            quantized_a_colwise = a_colwise
+        if a_t is not None:
+            quantized_a_t = a_t
         else:
-            quantized_a_colwise = QuantizedTensor.quantize(
+            quantized_a_t = QuantizedTensor.quantize(
                 quantized_a.dequantize(),
                 quantized_a.real_dtype,
                 config.granularity,
@@ -292,10 +292,10 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
                 group_lens=group_lens,
             )
 
-        if b_colwise is not None:
-            quantized_b_colwise = b_colwise
+        if b_t is not None:
+            quantized_b_t = b_t
         else:
-            quantized_b_colwise = QuantizedTensor.quantize(
+            quantized_b_t = QuantizedTensor.quantize(
                 quantized_b.dequantize(),
                 quantized_b.real_dtype,
                 config.granularity,
@@ -304,10 +304,10 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
             )
 
         ctx.save_for_backward(
-            quantized_a_colwise.qdata,
-            quantized_b_colwise.qdata,
-            quantized_a_colwise.scale_inv,
-            quantized_b_colwise.scale_inv,
+            quantized_a_t.qdata,
+            quantized_b_t.qdata,
+            quantized_a_t.scale_inv,
+            quantized_b_t.scale_inv,
             group_lens,
             group_offs,
         )
@@ -379,8 +379,8 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
         return (
             grad_a,  # a
             grad_b,  # b
-            None,  # a_colwise
-            None,  # b_colwise
+            None,  # a_t
+            None,  # b_t
             None,  # group_lens
             None,  # group_offs
             None,  # trans_b
@@ -396,8 +396,8 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
         ctx,
         a: Union[torch.Tensor, QuantizedTensor],
         b: Union[torch.Tensor, QuantizedTensor],
-        a_colwise: Optional[QuantizedTensor],  # not used
-        b_colwise: Optional[QuantizedTensor],
+        a_t: Optional[QuantizedTensor],  # not used
+        b_t: Optional[QuantizedTensor],
         group_lens: torch.Tensor,  # [B,] int64
         group_offs: torch.Tensor,  # [B + 1,] int64
         trans_b: bool,
@@ -440,10 +440,10 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
             )
 
         if use_nt_layout_gemm_in_bwd:
-            if b_colwise is not None and isinstance(b_colwise, QuantizedTensor):
-                quantized_b_colwise = b_colwise
+            if b_t is not None and isinstance(b_t, QuantizedTensor):
+                quantized_b_t = b_t
             else:
-                quantized_b_colwise = quantized_b.transpose(-1, -2).contiguous()
+                quantized_b_t = quantized_b.transpose(-1, -2).contiguous()
 
         out = grouped_gemm_fp8_impl(
             quantized_a.qdata,
@@ -464,9 +464,9 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
         if use_nt_layout_gemm_in_bwd:
             ctx.save_for_backward(
                 quantized_a.qdata,
-                quantized_b_colwise.qdata,
+                quantized_b_t.qdata,
                 quantized_a.scale_inv,
-                quantized_b_colwise.scale_inv,
+                quantized_b_t.scale_inv,
                 group_lens,
                 group_offs,
             )
@@ -554,8 +554,8 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
         return (
             grad_a,  # a
             grad_b,  # b
-            None,  # a_colwise
-            None,  # b_colwise
+            None,  # a_t
+            None,  # b_t
             None,  # group_lens
             None,  # group_offs
             None,  # trans_b
@@ -739,7 +739,7 @@ def grouped_gemm_fp8(
         a: Input tensor A with shape [bs * m, k] (float16 or bfloat16).
             Can also be a pre-quantized :class:`QuantizedTensor` (grouped), or
             a :class:`QuantizedTensorPair` carrying both ``data`` (row-wise) and
-            the backward-direction ``data_colwise`` (col-wise) for ROWWISE granularity.
+            the backward-direction ``data_t`` (col-wise) for ROWWISE granularity.
         b: Input tensor B with shape [bs, k, n] or [bs, n, k] if trans_b (float16 or bfloat16).
             Same pre-quantized variants as ``a`` are accepted.
         group_lens: Group lengths tensor [bs] (int64)
@@ -758,26 +758,26 @@ def grouped_gemm_fp8(
     if group_offs is None:
         group_offs = group_offs_from_lens(group_lens)
     if isinstance(a, QuantizedTensorPair):
-        a_data, a_data_colwise = a.data_rowwise, a.data_colwise
+        a_data, a_data_t = a.data, a.data_t
     else:
-        a_data, a_data_colwise = a, None
+        a_data, a_data_t = a, None
 
     if isinstance(b, QuantizedTensorPair):
-        b_data, b_data_colwise = b.data_rowwise, b.data_colwise
+        b_data, b_data_t = b.data, b.data_t
     else:
-        b_data, b_data_colwise = b, None
+        b_data, b_data_t = b, None
 
     if out_dtype is None:
         out_dtype = torch.promote_types(a_data.dtype, b_data.dtype)
 
     if config.granularity == ScalingGranularity.TENSORWISE:
         # TENSORWISE has a single scalar scale (no col-wise trans cache needed);
-        # the inner ``data_colwise`` is ignored if provided.
+        # the inner ``data_t`` is ignored if provided.
         return FP8GroupedGemmTensorFunc.apply(
             a_data,
             b_data,
-            a_data_colwise,
-            b_data_colwise,
+            a_data_t,
+            b_data_t,
             group_lens,
             group_offs,
             trans_b,
@@ -789,8 +789,8 @@ def grouped_gemm_fp8(
         return FP8GroupedGemmRowFunc.apply(
             a_data,
             b_data,
-            a_data_colwise,
-            b_data_colwise,
+            a_data_t,
+            b_data_t,
             group_lens,
             group_offs,
             trans_b,

--- a/tests/pytorch/ops/test_gemm_fp8.py
+++ b/tests/pytorch/ops/test_gemm_fp8.py
@@ -429,8 +429,8 @@ def _run_gemm_fp8_quantized_tensor_test(
     c_ref.backward(grad_c)
 
     c = gemm_fp8(
-        QuantizedTensorPair(data_rowwise=qt_a, data_colwise=None),
-        QuantizedTensorPair(data_rowwise=qt_b, data_colwise=None),
+        QuantizedTensorPair(data=qt_a, data_t=None),
+        QuantizedTensorPair(data=qt_b, data_t=None),
         trans_a,
         trans_b,
         dtype,

--- a/tests/pytorch/ops/test_gemm_fp8.py
+++ b/tests/pytorch/ops/test_gemm_fp8.py
@@ -214,88 +214,7 @@ def _run_gemm_fp8_deterministic_test(
         GlobalBackendManager.reset()
 
 
-# Regression test for the hipBLASLt FP8 workspace shortage on MI300X (gfx942).
-#
-# Background:
-#   The HIPBLASLT FP8 backend uses a fixed-size workspace returned by
-#   ``get_hipblaslt_workspace_size_in_byte()`` in
-#   ``csrc/kernels/gemm/hipblaslt_gemm.cu``. Before commit
-#   ``fix/gemm-fp8-workspace-invalid-value-mi300x`` that value was 32 MiB
-#   on gfx942. For the specific FLUX-12B backward grad_weight GEMM
-#   ``(M=3072, N=3072, K=8192)`` with mixed E4M3 x E5M2 -> BF16
-#   tensorwise scaling, hipBLASLt's heuristic returns an algorithm whose
-#   actual workspace requirement is ~72 MiB. ``hipblasLtMatmul`` then
-#   returns ``HIPBLAS_STATUS_INVALID_VALUE`` at execution time (visible
-#   in hipBLASLt logs as ``runContractionProblem: Input workspace size
-#   33554432 is less than the required workspace size 75497472``).
-#
-#   This test reproduces the exact failing problem shape, dtype mix,
-#   layout, granularity and backend. It must succeed (no
-#   ``HIPBLAS_STATUS_INVALID_VALUE``, finite gradients) once the workspace
-#   is bumped to >= 75 497 472 bytes; it fails with a ``RuntimeError``
-#   from ``hipblaslt_gemm_impl`` if the regression is reintroduced.
-@pytest.mark.parametrize(
-    "m,n,k,layout,format,dtype,backend",
-    [
-        # FLUX-12B backward grad_weight GEMM that triggered the original crash.
-        (3072, 3072, 8192, "NT", Format.HYBRID, torch.bfloat16, BackendType.HIPBLASLT),
-    ],
-)
-def test_gemm_fp8_hipblaslt_workspace_regression(m, n, k, layout, format, dtype, backend):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA not available")
-    _run_gemm_fp8_test(
-        m=m,
-        n=n,
-        k=k,
-        layout=layout,
-        format=format,
-        dtype=dtype,
-        granularity=ScalingGranularity.TENSORWISE,
-        backend=backend,
-        auto_tune=False,
-    )
-
-
-# Regression: MXFP8 backward must accept a NON-CONTIGUOUS grad_out.
-#
-#   ``FP8GemmMXFunction.backward`` quantizes ``grad_out`` with MXFP8 in
-#   single-direction mode (``QuantizedTensor.quantize`` along ``axis=-1`` then
-#   ``axis=-2``), whose HIP kernel asserts ``input.is_contiguous()``. When the
-#   downstream graph produces a strided gradient (e.g. a transpose/slice before
-#   the reduction — common in real attention/MLP backward), the incoming
-#   ``grad_out`` is non-contiguous and the assertion fired:
-#       quantization_hip.cpp: Assertion failed: input.is_contiguous().
-#                             Input must be contiguous
-#   Fixed by ``grad_out = grad_out.reshape(...).contiguous()`` before the
-#   quant. This test reproduces the strided-grad backward; it must run without
-#   raising and produce finite gradients.
-@pytest.mark.parametrize("m,n,k", [(4096, 512, 7168), (4096, 8192, 1536)])
-def test_gemm_fp8_mxfp8_noncontiguous_grad_regression(m, n, k):
-    if not torch.cuda.is_available():
-        pytest.skip("CUDA not available")
-    mxfp8_supported, reason = check_mxfp8_support()
-    if not mxfp8_supported:
-        pytest.skip(reason)
-    torch.manual_seed(0)
-    a = torch.randn(m, k, device="cuda", dtype=torch.bfloat16, requires_grad=True)
-    b = torch.randn(n, k, device="cuda", dtype=torch.bfloat16, requires_grad=True)
-    config = Float8QuantConfig(
-        granularity=ScalingGranularity.MX_BLOCKWISE,
-        format=Format.E4M3,
-        block_size=32,
-        scale_dtype=ScaleDtype.E8M0,
-    )
-    # NT layout: c = a @ b^T -> [m, n]
-    c = gemm_fp8(a, b, False, True, torch.bfloat16, config)
-    # Route the output through a transpose so the gradient that reaches
-    # FP8GemmMXFunction.backward is a strided (non-contiguous) tensor.
-    c.t().reshape(-1).sum().backward()
-    assert a.grad is not None and torch.isfinite(a.grad).all()
-    assert b.grad is not None and torch.isfinite(b.grad).all()
-
-
-@pytest.mark.parametrize("m", [255, 507, 1032, 2056])
+@pytest.mark.parametrize("m", [255, 256, 507, 512])
 @pytest.mark.parametrize("n", [512, 1024, 2048, 4096])
 @pytest.mark.parametrize("k", [256, 512, 576, 1024, 2048])
 @pytest.mark.parametrize("layout", ["NN", "NT"])
@@ -306,6 +225,9 @@ def test_gemm_fp8_mxfp8_noncontiguous_grad_regression(m, n, k):
 )
 @pytest.mark.parametrize("auto_tune", [False, True])
 def test_gemm_fp8_tensorwise(m, n, k, layout, format, dtype, backend, auto_tune):
+    if m % 32 != 0 and backend == BackendType.CK:
+        pytest.skip("CK backend requires m to be a multiple of 32")
+
     _run_gemm_fp8_test(
         m=m,
         n=n,
@@ -319,7 +241,7 @@ def test_gemm_fp8_tensorwise(m, n, k, layout, format, dtype, backend, auto_tune)
     )
 
 
-@pytest.mark.parametrize("m", [255, 507, 1032, 2056])
+@pytest.mark.parametrize("m", [255, 256, 507, 512])
 @pytest.mark.parametrize("n", [512, 1024, 2048, 4096])
 @pytest.mark.parametrize("k", [256, 512, 576, 1024, 2048])
 @pytest.mark.parametrize("layout", ["NN", "NT"])
@@ -328,6 +250,9 @@ def test_gemm_fp8_tensorwise(m, n, k, layout, format, dtype, backend, auto_tune)
 @pytest.mark.parametrize("backend", [None, BackendType.TRITON, BackendType.CK])
 @pytest.mark.parametrize("auto_tune", [False, True])
 def test_gemm_fp8_rowwise(m, n, k, layout, format, dtype, backend, auto_tune):
+    if m % 32 != 0 and backend == BackendType.CK:
+        pytest.skip("CK backend requires m to be a multiple of 32")
+
     _run_gemm_fp8_test(
         m=m,
         n=n,
@@ -504,8 +429,8 @@ def _run_gemm_fp8_quantized_tensor_test(
     c_ref.backward(grad_c)
 
     c = gemm_fp8(
-        QuantizedTensorPair(data=qt_a, data_t=None),
-        QuantizedTensorPair(data=qt_b, data_t=None),
+        QuantizedTensorPair(data_rowwise=qt_a, data_colwise=None),
+        QuantizedTensorPair(data_rowwise=qt_b, data_colwise=None),
         trans_a,
         trans_b,
         dtype,

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -211,15 +211,6 @@ def _run_grouped_gemm_fp8_deterministic_test(
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
 
-    # gfx942: hipBLASLt path can hang/flake when M <= 512 (known issue).
-    if (
-        get_device_compute_capability() == (9, 4)
-        and M <= 512
-        and backend is BackendType.HIPBLASLT
-        and granularity == ScalingGranularity.TENSORWISE
-    ):
-        pytest.skip("gfx942: hipBLASLt path can hang/flake when M <= 512 (deterministic)")
-
     # Deterministic suite: fixed backend / no autotune.
     GlobalBackendManager.set_grouped_gemm_backend(backend)
     GlobalBackendManager.set_auto_tune(False)
@@ -435,15 +426,6 @@ def test_grouped_gemm_fp8_tensorwise(B, M, NK, ori_dtype, format, trans_b, balan
 
     if backend == BackendType.FLYDSL and get_device_compute_capability() < (9, 5):
         pytest.skip("FlyDSL fp8 grouped GEMM is gfx950-only")
-    # TODO(xiaobochen-amd): On gfx942, the hipBLASLt path can hang/flake when M <= 512.
-    # This has been observed under pytest; root cause not yet identified. MI355 works normally.
-    # Skip also when auto_tune=True because the tuner may select hipBLASLt.
-    if (
-        get_device_compute_capability() == (9, 4)
-        and M <= 512
-        and (backend is BackendType.HIPBLASLT or auto_tune is True)
-    ):
-        pytest.skip("gfx942: hipBLASLt path can hang/flake when M <= 512")
 
     N, K = NK
     _run_grouped_gemm_fp8_test(
@@ -680,16 +662,6 @@ def test_grouped_gemm_fp8_tensorwise_quantized_tensor(
         pytest.skip("FlyDSL fp8 grouped GEMM is gfx950-only")
     if backend == BackendType.TRITON and format == Format.HYBRID:
         pytest.skip("TRITON backend not support HYBRID format currently")
-
-    # TODO(xiaobochen-amd): On gfx942, the hipBLASLt path can hang/flake when M <= 512.
-    # This has been observed under pytest; root cause not yet identified. MI355 works normally.
-    # Skip also when auto_tune=True because the tuner may select hipBLASLt.
-    if (
-        get_device_compute_capability() == (9, 4)
-        and M <= 512
-        and (backend is BackendType.HIPBLASLT or auto_tune is True)
-    ):
-        pytest.skip("gfx942: hipBLASLt path can hang/flake when M <= 512")
 
     N, K = NK
     _run_grouped_gemm_fp8_quantized_tensor_test(

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -211,6 +211,15 @@ def _run_grouped_gemm_fp8_deterministic_test(
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
 
+    # gfx942: hipBLASLt path can hang/flake when M <= 512 (known issue).
+    if (
+        get_device_compute_capability() == (9, 4)
+        and M <= 512
+        and backend is BackendType.HIPBLASLT
+        and granularity == ScalingGranularity.TENSORWISE
+    ):
+        pytest.skip("gfx942: hipBLASLt path can hang/flake when M <= 512 (deterministic)")
+
     # Deterministic suite: fixed backend / no autotune.
     GlobalBackendManager.set_grouped_gemm_backend(backend)
     GlobalBackendManager.set_auto_tune(False)
@@ -426,6 +435,15 @@ def test_grouped_gemm_fp8_tensorwise(B, M, NK, ori_dtype, format, trans_b, balan
 
     if backend == BackendType.FLYDSL and get_device_compute_capability() < (9, 5):
         pytest.skip("FlyDSL fp8 grouped GEMM is gfx950-only")
+    # TODO(xiaobochen-amd): On gfx942, the hipBLASLt path can hang/flake when M <= 512.
+    # This has been observed under pytest; root cause not yet identified. MI355 works normally.
+    # Skip also when auto_tune=True because the tuner may select hipBLASLt.
+    if (
+        get_device_compute_capability() == (9, 4)
+        and M <= 512
+        and (backend is BackendType.HIPBLASLT or auto_tune is True)
+    ):
+        pytest.skip("gfx942: hipBLASLt path can hang/flake when M <= 512")
 
     N, K = NK
     _run_grouped_gemm_fp8_test(
@@ -662,6 +680,16 @@ def test_grouped_gemm_fp8_tensorwise_quantized_tensor(
         pytest.skip("FlyDSL fp8 grouped GEMM is gfx950-only")
     if backend == BackendType.TRITON and format == Format.HYBRID:
         pytest.skip("TRITON backend not support HYBRID format currently")
+
+    # TODO(xiaobochen-amd): On gfx942, the hipBLASLt path can hang/flake when M <= 512.
+    # This has been observed under pytest; root cause not yet identified. MI355 works normally.
+    # Skip also when auto_tune=True because the tuner may select hipBLASLt.
+    if (
+        get_device_compute_capability() == (9, 4)
+        and M <= 512
+        and (backend is BackendType.HIPBLASLT or auto_tune is True)
+    ):
+        pytest.skip("gfx942: hipBLASLt path can hang/flake when M <= 512")
 
     N, K = NK
     _run_grouped_gemm_fp8_quantized_tensor_test(

--- a/tests/pytorch/ops/test_quantization.py
+++ b/tests/pytorch/ops/test_quantization.py
@@ -244,7 +244,7 @@ def test_quantize_mxfp8_with_trans(orig_dtype, dest_dtype, B, M, N, granularity,
     M_actual = x_2d.size(0)
     N_actual = x_2d.size(1)
 
-    x_fp8_rowwise, x_scale_inv_rowwise, x_fp8_colwise, x_scale_inv_colwise = quantize_fp8_with_trans(
+    x_fp8_rowwise, x_scale_inv_rowwise, x_fp8_t, x_scale_inv_colwise = quantize_fp8_with_trans(
         x_2d,
         dest_dtype,
         granularity=granularity,
@@ -294,7 +294,7 @@ def test_quantize_mxfp8_with_trans(orig_dtype, dest_dtype, B, M, N, granularity,
     )
 
     out_colwise = dequantize_fp8(
-        x_fp8_colwise,
+        x_fp8_t,
         orig_dtype,
         granularity=granularity,
         block_size=MX_BLOCK_SIZE,


### PR DESCRIPTION
# Description

This PR forces NT-layout FP8 GEMM in the backward pass for tensorwise scaling on MI355 (and other non-gfx942 targets such as MI350/MI450), where the previous TN/non-NT backward paths were not well optimized.

For standard linear FP8 GEMM with `trans_a=False` and `trans_b=True` (NT forward), backward now reuses or builds column-wise quantized weight caches and routes `grad_a` / `grad_b` through NT-layout kernels instead of the legacy TN paths.
The gfx942 (MI300X) code path is unchanged via `is_gfx942()` guard.

To support this, the PR introduces colwise quantized-tensor plumbing end-to-end:
`QuantizedTensorPair` fields are renamed from `data` / `data_t` to `data_rowwise` / `data_colwise`, and `gemm_fp8` / `grouped_gemm_fp8` accept optional pre-cached colwise tensors from callers.
A new `create_quantized_weight()` helper centralizes rowwise/colwise weight quantization logic (moved out of `low_precision.py`), and `QuantizedTensor` gains autograd-aware `transpose` / `t()` support so tensorwise colwise caches can be obtained cheaply via transpose without a dequantize round-trip.

CK backend support checks are also tightened for NT/NN layouts (contraction dim `k` must be a multiple of 32; blockwise additionally requires `k`, `n` multiples of 128 and `k >= 128).
ROWWISE FP8 GEMM default backend is switched from HIPBLASLT to TRITON for consistency with the updated backward paths.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `_deter_use_nt_layout_gemm_in_bwd()` in `gemm_fp8.py` and `grouped_gemm_fp8.py` to enable NT-layout backward on non-gfx942 when forward uses NT layout (`trans_a=False`, `trans_b=True`).
- Update `FP8GemmTensorFunction` to accept optional `a_colwise` / `b_colwise`, cache colwise quantized tensors for backward on MI355+, and run NT-layout `gemm_fp8_impl` in backward for `grad_a` and `grad_b`.
- Update `FP8GroupedGemmTensorFunc` with the same NT-layout backward strategy for tensorwise grouped GEMM, including optional `b_colwise` reuse and colwise transpose fallback.
- Rename `QuantizedTensorPair` fields from `data` / `data_t` to `data_rowwise` / `data_colwise` across ops and tests.
- Rename internal `a_t` / `b_t` parameters to `a_colwise` / `b_colwise` in ROWWISE and MX FP8 GEMM autograd functions.
- Add `QuantizedTensor._transpose()` and dispatch hooks for `aten.t` / `aten.transpose` (tensorwise exact transpose; rowwise/MX blockwise dequantize-and-requantize).
- Add `create_quantized_weight()` in `quantized_tensor.py` and remove the standalone `weight_scaling_recipe()` from `low_precision.py`.
- Tighten CK FP8 GEMM support checks in `gemm_fp8_impl.py` for NT/NN layout shape constraints.
- Switch `FP8GemmRowFunction` default backend from HIPBLASLT to TRITON.
- Update `test_gemm_fp8.py`: adjust tensorwise/rowwise shape parametrization, skip CK when `m % 32 != 0`, update `QuantizedTensorPair` usage, and remove obsolete gfx942 hipBLASLt workspace / MXFP8 non-contiguous grad regression tests.
- Update `test_grouped_gemm_fp8.py`: remove gfx942 hipBLASLt hang/flake skip conditions for small `M` now that backward no longer relies on that path.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
