### PR TITLE
chore(lint): migrate to ruff and tighten linting (bugbear)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,28 +42,14 @@ jobs:
             python-version: ${{ matrix.python-version }}
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
-      - name: Install Autoflake
-        run: pip install autoflake==v2.3.1
-      - name: Run Autoflake
+      - name: Install Ruff
+        run: pip install ruff==0.15.12
+      - name: Ruff lint check
         if: always()
-        run: |
-          output=$(autoflake . --remove-all-unused-imports --remove-unused-variables --expand-star-imports --ignore-init-module-imports --recursive)
-          if [[ -n $output ]]
-          then
-            echo "Autoflake check failed: $output"
-            exit 1
-          else
-            echo "Autoflake check success."
-            exit 0
-          fi
-      - uses: isort/isort-action@v1
+        run: ruff check --output-format=github .
+      - name: Ruff format check
         if: always()
-        with:
-            configuration: "--profile black --check-only --diff"
-      - uses: psf/black@24.8.0
-        if: always()
-        with:
-          options: "--check --diff --color --verbose --line-length=110"
+        run: ruff format --check --diff .
 
   install-dependencies:
     # GPU runner job: for PRs, only run when a maintainer adds the 'ci:gpu'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,12 +11,17 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+      - id: check-toml
+      - id: check-ast
+      - id: check-case-conflict
       - id: check-added-large-files
       - id: check-merge-conflict
+      - id: debug-statements
+      - id: detect-private-key
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/shellcheck-py/shellcheck-py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,37 +6,19 @@
 # 2. pre-commit install(the first time you download the repo, it will be cached for future use)
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
       - id: check-merge-conflict
-  - repo: https://github.com/pycqa/isort
-    rev: 5.11.5
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
     hooks:
-      - id: isort
-        args: ["--profile", "black"]
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.3.1
-    hooks:
-      - id: autoflake
-        args:
-          [
-            "--remove-all-unused-imports",
-            "--remove-unused-variables",
-            "--expand-star-imports",
-            "--ignore-init-module-imports",
-            "--recursive",
-            "--in-place",
-          ]
-  # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.8.0
-    hooks:
-      - id: black
-        args: ["--verbose", "--line-length=110"]
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Welcome! We appreciate your interest in contributing to **Primus-Turbo**. This d
   - [Table of Contents](#table-of-contents)
   - [📋 Before You Start](#-before-you-start)
   - [📂 Project Structure](#-project-structure)
+  - [🎨 Code Style \& Linting](#-code-style--linting)
   - [🌿 Branch Naming Convention](#-branch-naming-convention)
     - [Type](#type)
     - [Scope (optional)](#scope-optional)
@@ -43,6 +44,27 @@ Primus-Turbo/
 ├── tests/                 # Unit & Integration Tests
 └── benchmark/             # Performance benchmarks
 ```
+
+
+## 🎨 Code Style & Linting
+
+We use [**Ruff**](https://docs.astral.sh/ruff/) for Python linting and formatting (it replaces black / isort / autoflake), and `clang-format` for C++/HIP code. All checks run through [pre-commit](https://pre-commit.com/) and are enforced in CI.
+
+Set up once after cloning:
+```bash
+pip install -r requirements.txt
+pre-commit install
+```
+After this, the hooks run automatically on every `git commit`. To check all files manually (e.g. before opening a PR):
+```bash
+pre-commit run --all-files
+```
+You can also run Ruff directly without pre-commit:
+```bash
+ruff check --fix .   # lint + auto-fix (import sorting, unused imports, ...)
+ruff format .        # format code
+```
+Ruff rules live in `pyproject.toml`; tool versions are pinned in `.pre-commit-config.yaml` and `requirements.txt`.
 
 
 ## 🌿 Branch Naming Convention

--- a/agent/skills/primus-turbo-develop/optimize-handoff/quick_test_bench.py
+++ b/agent/skills/primus-turbo-develop/optimize-handoff/quick_test_bench.py
@@ -226,9 +226,7 @@ def main() -> int:
 
     print(f"{'label':<22} {'Check':<5} {'Fwd TFLOPS':>12} {'Bwd TFLOPS':>12}")
     for r in rows:
-        print(
-            f"{r['label']:<22} {r['Check']:<5} " f"{r['Forward TFLOPS']:>12.2f} {r['Backward TFLOPS']:>12.2f}"
-        )
+        print(f"{r['label']:<22} {r['Check']:<5} {r['Forward TFLOPS']:>12.2f} {r['Backward TFLOPS']:>12.2f}")
 
     pass_fwd = [r["Forward TFLOPS"] for r in rows if r["Check"] == "PASS"]
     pass_bwd = [r["Backward TFLOPS"] for r in rows if r["Check"] == "PASS"]

--- a/benchmark/accuracy/eval_sf_accuracy.py
+++ b/benchmark/accuracy/eval_sf_accuracy.py
@@ -124,7 +124,7 @@ def benchmark(seed, report_dir_path, load_config_path=None, dump_dir_path=None):
                 results_with_gpu.append({k: "" for k in results_with_gpu[-1].keys()})
 
     report_with_cpu = report_dir / f"benchmark_{device_type}_special_func.xlsx"
-    report_with_gpu = report_dir / f"benchmark_GPU_special_func.xlsx"
+    report_with_gpu = report_dir / "benchmark_GPU_special_func.xlsx"
 
     save_to_excel(results_with_cpu, report_with_cpu)
     save_to_excel(results_with_gpu, report_with_gpu)

--- a/benchmark/ops/training/bench_attention_fa.py
+++ b/benchmark/ops/training/bench_attention_fa.py
@@ -277,13 +277,13 @@ def benchmark_attention_flashattn(flash_attn_func, fa_version: int, output_csv=N
             for batch in BATCH_SIZE_LIST:
                 test_id += 1
 
-                print(f"\n{'='*60}")
+                print(f"\n{'=' * 60}")
                 print(
                     f"TestID: {test_id}, batch={batch}, seqlen={seqlen}, "
                     f"heads={num_head_q}/{num_head_kv}, dim={head_dim_qk}/{head_dim_v}, "
                     f"causal={causal}, deterministic={deterministic}"
                 )
-                print(f"{'='*60}")
+                print(f"{'=' * 60}")
 
                 row = {
                     "TestID": test_id,

--- a/benchmark/ops/training/bench_attention_te.py
+++ b/benchmark/ops/training/bench_attention_te.py
@@ -375,13 +375,13 @@ def benchmark_attention(output_csv=None, deterministic=False):
             for batch in BATCH_SIZE_LIST:
                 test_id += 1
 
-                print(f"\n{'='*60}")
+                print(f"\n{'=' * 60}")
                 print(
                     f"TestID: {test_id}, batch={batch}, seqlen={seqlen}, "
                     f"heads={num_head_q}/{num_head_kv}, dim={head_dim_qk}/{head_dim_v}, "
                     f"causal={causal}, ck=v3, deterministic={deterministic}"
                 )
-                print(f"{'='*60}")
+                print(f"{'=' * 60}")
 
                 row = {
                     "TestID": test_id,

--- a/benchmark/ops/training/bench_attention_torch.py
+++ b/benchmark/ops/training/bench_attention_torch.py
@@ -123,13 +123,13 @@ def benchmark_attention_torch(output_csv=None):
             for batch in BATCH_SIZE_LIST:
                 test_id += 1
 
-                print(f"\n{'='*60}")
+                print(f"\n{'=' * 60}")
                 print(
                     f"TestID: {test_id}, batch={batch}, seqlen={seqlen}, "
                     f"heads={num_head_q}/{num_head_kv}, dim={head_dim_qk}/{head_dim_v}, "
                     f"causal={causal}"
                 )
-                print(f"{'='*60}")
+                print(f"{'=' * 60}")
 
                 row = {
                     "TestID": test_id,

--- a/benchmark/ops/training/bench_attention_turbo.py
+++ b/benchmark/ops/training/bench_attention_turbo.py
@@ -311,13 +311,13 @@ def benchmark_attention(output_csv=None, use_fp8=False, deterministic=False):
             for batch in BATCH_SIZE_LIST:
                 test_id += 1
 
-                print(f"\n{'='*60}")
+                print(f"\n{'=' * 60}")
                 print(
                     f"TestID: {test_id}, batch={batch}, seqlen={seqlen}, "
                     f"heads={num_head_q}/{num_head_kv}, dim={head_dim_qk}/{head_dim_v}, "
                     f"causal={causal}, fp8={use_fp8}, deterministic={deterministic}"
                 )
-                print(f"{'='*60}")
+                print(f"{'=' * 60}")
 
                 row = {
                     "TestID": test_id,

--- a/benchmark/ops/training/bench_deepep_intranode.py
+++ b/benchmark/ops/training/bench_deepep_intranode.py
@@ -119,12 +119,12 @@ def benchmark_intranode(local_rank: int, num_local_ranks: int, args: argparse.Na
             num_tokens *= MBS
 
             if local_rank == 0:
-                print(f"\n{'='*60}")
+                print(f"\n{'=' * 60}")
                 print(
                     f"TestID: {test_id}, Case: {model_name}, MBS: {MBS}, "
                     f"num_tokens: {num_tokens}, hidden: {hidden}, num_topk: {num_topk}, num_experts: {num_experts}"
                 )
-                print(f"{'='*60}")
+                print(f"{'=' * 60}")
 
             try:
                 torch.manual_seed(rank)
@@ -206,7 +206,6 @@ def benchmark_intranode(local_rank: int, num_local_ranks: int, args: argparse.Na
         filename = f"deep_ep_intranode_benchmark_results_{timestamp}_{gpu_name}.csv"
 
     if local_rank == 0:
-
         results.to_csv(filename, index=False)
 
         print(f"Results saved to {filename}")

--- a/benchmark/ops/training/bench_gemm_te.py
+++ b/benchmark/ops/training/bench_gemm_te.py
@@ -200,7 +200,7 @@ def benchmark_gemm_te(dtype_name="bf16", granularity_name="tensorwise", output_c
                 N = shape[1]
                 K = shape[2]
 
-                print(f"\n{'='*60}")
+                print(f"\n{'=' * 60}")
                 if is_fp8:
                     print(
                         f"TestID: {test_id}, Case: {model_name}, MBS: {MBS}, "
@@ -208,7 +208,7 @@ def benchmark_gemm_te(dtype_name="bf16", granularity_name="tensorwise", output_c
                     )
                 else:
                     print(f"TestID: {test_id}, Case: {model_name}, MBS: {MBS}, M: {M}, N: {N}, K: {K}")
-                print(f"{'='*60}")
+                print(f"{'=' * 60}")
 
                 try:
                     if is_fp8:

--- a/benchmark/ops/training/bench_gemm_torch.py
+++ b/benchmark/ops/training/bench_gemm_torch.py
@@ -207,7 +207,7 @@ def benchmark_gemm_torch(dtype_name="bf16", granularity_name="tensorwise", outpu
                 N = shape[1]
                 K = shape[2]
 
-                print(f"\n{'='*60}")
+                print(f"\n{'=' * 60}")
                 if is_fp8:
                     print(
                         f"TestID: {test_id}, Case: {model_name}, MBS: {MBS}, "
@@ -218,7 +218,7 @@ def benchmark_gemm_torch(dtype_name="bf16", granularity_name="tensorwise", outpu
                         f"TestID: {test_id}, Case: {model_name}, MBS: {MBS}, "
                         f"M: {M}, N: {N}, K: {K}, dtype: bf16"
                     )
-                print(f"{'='*60}")
+                print(f"{'=' * 60}")
 
                 try:
                     if is_fp8:

--- a/benchmark/ops/training/bench_gemm_turbo.py
+++ b/benchmark/ops/training/bench_gemm_turbo.py
@@ -268,7 +268,7 @@ def benchmark_gemm_turbo(
                 N = shape[1]
                 K = shape[2]
 
-                print(f"\n{'='*60}")
+                print(f"\n{'=' * 60}")
                 if is_fp8:
                     print(
                         f"TestID: {test_id}, Case: {model_name}, MBS: {MBS}, "
@@ -284,7 +284,7 @@ def benchmark_gemm_turbo(
                         f"TestID: {test_id}, Case: {model_name}, MBS: {MBS}, "
                         f"M: {M}, N: {N}, K: {K}, dtype: bf16"
                     )
-                print(f"{'='*60}")
+                print(f"{'=' * 60}")
 
                 try:
                     if is_fp8:

--- a/benchmark/ops/training/bench_grouped_gemm_gmm.py
+++ b/benchmark/ops/training/bench_grouped_gemm_gmm.py
@@ -114,11 +114,11 @@ def benchmark_grouped_gemm_gmm(output_csv=None):
 
         balance = case.get("balance", True)
         balance_str = "balanced" if balance else "unbalanced"
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(
             f"TestID: {test_id}, Case: {case['Case']}, B: {B}, M: {M}, N: {N}, K: {K}, dtype: bf16, {balance_str}"
         )
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
         try:
             fwd_time_ms, fwd_tflops, bwd_time_ms, bwd_tflops, correct = profile_grouped_gemm_gmm(

--- a/benchmark/ops/training/bench_grouped_gemm_te.py
+++ b/benchmark/ops/training/bench_grouped_gemm_te.py
@@ -224,7 +224,7 @@ def benchmark_grouped_gemm_te(dtype_name="bf16", granularity_name="tensorwise", 
         test_id += 1
         B, M, N, K = case["B"], case["M"], case["N"], case["K"]
 
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         if is_fp8:
             print(
                 f"TestID: {test_id}, Case: {case['Case']}, B: {B}, M: {M}, N: {N}, K: {K}, "
@@ -232,7 +232,7 @@ def benchmark_grouped_gemm_te(dtype_name="bf16", granularity_name="tensorwise", 
             )
         else:
             print(f"TestID: {test_id}, Case: {case['Case']}, B: {B}, M: {M}, N: {N}, K: {K}, dtype: bf16")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
         try:
             if is_fp8:

--- a/benchmark/ops/training/bench_grouped_gemm_torch.py
+++ b/benchmark/ops/training/bench_grouped_gemm_torch.py
@@ -94,9 +94,9 @@ def benchmark_grouped_gemm_torch(output_csv=None):
         K = case["K"]
         dtype = case["dtype"]
 
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"TestID: {test_id}, Case: {case['Case']}, B: {B}, M: {M}, N: {N}, K: {K}, dtype: bf16")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
         try:
             fwd_time_ms, fwd_tflops, bwd_time_ms, bwd_tflops, correct = profile_grouped_gemm(

--- a/benchmark/ops/training/bench_grouped_gemm_turbo.py
+++ b/benchmark/ops/training/bench_grouped_gemm_turbo.py
@@ -197,7 +197,7 @@ def benchmark_grouped_gemm_turbo(
         B, M, N, K = case["B"], case["M"], case["N"], case["K"]
         dtype = case["dtype"]
 
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         if is_fp8:
             print(
                 f"TestID: {test_id}, Case: {case['Case']}, B: {B}, M: {M}, N: {N}, K: {K}, "
@@ -205,7 +205,7 @@ def benchmark_grouped_gemm_turbo(
             )
         else:
             print(f"TestID: {test_id}, Case: {case['Case']}, B: {B}, M: {M}, N: {N}, K: {K}, dtype: bf16")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
         try:
             if is_fp8:

--- a/benchmark/ops/training/deep_ep/test_internode.py
+++ b/benchmark/ops/training/deep_ep/test_internode.py
@@ -149,7 +149,7 @@ def test_main(
                     is_rand = current_x is x_pure_rand or current_x is x_pure_rand_e4m3
                     if local_rank == 0:
                         print(
-                            f'[testing] Running with {"FP8" if isinstance(current_x, tuple) else "BF16"}, {"with" if with_topk else "without"} top-k (async={async_mode}, previous={previous_mode}) ...',
+                            f"[testing] Running with {'FP8' if isinstance(current_x, tuple) else 'BF16'}, {'with' if with_topk else 'without'} top-k (async={async_mode}, previous={previous_mode}) ...",
                             flush=True,
                             end="",
                         )
@@ -191,9 +191,9 @@ def test_main(
 
                     # Checks
                     recv_gbl_rank_prefix_sum = handle[-4]
-                    assert gbl_num_tokens_per_rank[rank].item() == recv_x.size(
-                        0
-                    ), f"{gbl_num_tokens_per_rank[rank].item()} != {recv_x.size(0)}"
+                    assert gbl_num_tokens_per_rank[rank].item() == recv_x.size(0), (
+                        f"{gbl_num_tokens_per_rank[rank].item()} != {recv_x.size(0)}"
+                    )
                     assert (
                         gbl_num_tokens_per_expert.view(num_ranks, -1)[rank].tolist()
                         == recv_num_tokens_per_expert_list
@@ -334,7 +334,7 @@ def test_main(
                     )
         if local_rank == 0:
             print(
-                f'[tuning] Best dispatch ({"FP8" if isinstance(current_x, tuple) else "BF16"}): SMs {best_results[0]}, NVL chunk {best_results[1]}, RDMA chunk {best_results[2]}: '
+                f"[tuning] Best dispatch ({'FP8' if isinstance(current_x, tuple) else 'BF16'}): SMs {best_results[0]}, NVL chunk {best_results[1]}, RDMA chunk {best_results[2]}: "
                 f"{best_results[3] * 1e6:.0f} + {best_time * 1e6:.0f} us, "
                 f"{rdma_send_bytes / 1e9 / best_time:.2f} GB/s (RDMA), {nvl_recv_bytes / 1e9 / best_time:.2f} GB/s (NVL)",
                 flush=True,

--- a/benchmark/ops/training/deep_ep/test_intranode.py
+++ b/benchmark/ops/training/deep_ep/test_intranode.py
@@ -116,7 +116,7 @@ def test_main(
                 for with_topk in (False, True):
                     if local_rank == 0:
                         print(
-                            f'[testing] Running with {"FP8" if isinstance(current_x, tuple) else "BF16"}, {"with" if with_topk else "without"} top-k (async={async_mode}, previous={previous_mode}) ...',
+                            f"[testing] Running with {'FP8' if isinstance(current_x, tuple) else 'BF16'}, {'with' if with_topk else 'without'} top-k (async={async_mode}, previous={previous_mode}) ...",
                             flush=True,
                             end="",
                         )
@@ -152,9 +152,9 @@ def test_main(
 
                     # Checks
                     rank_prefix_matrix = handle[0]
-                    assert gbl_num_tokens_per_rank[rank].item() == recv_x.size(
-                        0
-                    ), f"{gbl_num_tokens_per_rank[rank].item()} != {recv_x.size(0)}"
+                    assert gbl_num_tokens_per_rank[rank].item() == recv_x.size(0), (
+                        f"{gbl_num_tokens_per_rank[rank].item()} != {recv_x.size(0)}"
+                    )
                     assert (
                         gbl_num_tokens_per_expert.view(num_ranks, -1)[rank].tolist()
                         == recv_num_tokens_per_expert_list
@@ -276,13 +276,13 @@ def test_main(
                 best_time, best_results = t, (num_sms, nvl_chunk_size)
             if local_rank == 0:
                 print(
-                    f'[tuning] SMs {num_sms}, NVL chunk {nvl_chunk_size if nvl_chunk_size else "default"}: '
+                    f"[tuning] SMs {num_sms}, NVL chunk {nvl_chunk_size if nvl_chunk_size else 'default'}: "
                     f"{nvl_recv_bytes / 1e9 / t:.2f} GB/s (NVL), {t * 1e6:.2f} us",
                     flush=True,
                 )
         if local_rank == 0:
             print(
-                f'[tuning] Best dispatch ({"FP8" if isinstance(current_x, tuple) else "BF16"}): SMs {best_results[0]}, NVL chunk {best_results[1]}, {nvl_recv_bytes / 1e9 / best_time:.2f} GB/s (NVL), t: {best_time * 1e6:.2f} us',
+                f"[tuning] Best dispatch ({'FP8' if isinstance(current_x, tuple) else 'BF16'}): SMs {best_results[0]}, NVL chunk {best_results[1]}, {nvl_recv_bytes / 1e9 / best_time:.2f} GB/s (NVL), t: {best_time * 1e6:.2f} us",
                 flush=True,
             )
             print("", flush=True)
@@ -321,7 +321,7 @@ def test_main(
         t = bench(lambda: buffer.combine(**tune_args))[0]  # noqa: B023
         if local_rank == 0:
             print(
-                f'[tuning] SMs {num_sms}, NVL chunk {nvl_chunk_size if nvl_chunk_size else "default"}: '
+                f"[tuning] SMs {num_sms}, NVL chunk {nvl_chunk_size if nvl_chunk_size else 'default'}: "
                 f"{combine_bf16_nvl_send_bytes / 1e9 / t:.2f} GB/s (NVL), {t * 1e6:.2f} us",
                 flush=True,
             )
@@ -342,7 +342,7 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     test_ll_compatibility, num_rdma_bytes = False, 0
     deep_ep = get_deep_ep_backend(args.backend)
     if test_ll_compatibility:
-        ll_num_tokens, ll_hidden, ll_num_experts, ll_num_topk = 16, 5120, 256, 9
+        ll_num_tokens, ll_hidden, ll_num_experts, _ll_num_topk = 16, 5120, 256, 9
         num_rdma_bytes = deep_ep.Buffer.get_low_latency_rdma_size_hint(
             ll_num_tokens, ll_hidden, num_ranks, ll_num_experts
         )

--- a/benchmark/ops/training/deep_ep/utils.py
+++ b/benchmark/ops/training/deep_ep/utils.py
@@ -127,7 +127,6 @@ def bench(fn, num_warmups: int = 50, num_tests: int = 50, post_fn=None):
 
 
 class empty_suppress:
-
     def __enter__(self):
         return self
 
@@ -136,7 +135,6 @@ class empty_suppress:
 
 
 class suppress_stdout_stderr:
-
     def __enter__(self):
         self.outnull_file = open(os.devnull, "w")
         self.errnull_file = open(os.devnull, "w")
@@ -206,9 +204,9 @@ def bench_kineto(
     kernel_names = (kernel_names,) if isinstance(kernel_names, str) else kernel_names
     assert all([isinstance(name, str) for name in kernel_names])
     for name in kernel_names:
-        assert (
-            sum([name in line for line in prof_lines]) == 1
-        ), f"Errors of the kernel {name} in the profiling table"
+        assert sum([name in line for line in prof_lines]) == 1, (
+            f"Errors of the kernel {name} in the profiling table"
+        )
 
     # Save chrome traces
     if trace_path is not None:

--- a/benchmark/ops/training/run_suite.py
+++ b/benchmark/ops/training/run_suite.py
@@ -65,7 +65,7 @@ def load_config(config_path, groups=None, labels=None):
     for i, task in enumerate(tasks):
         missing = REQUIRED_TASK_FIELDS - task.keys()
         if missing:
-            raise ValueError(f"Task #{i} ({task.get('label', '?')}) " f"missing required fields: {missing}")
+            raise ValueError(f"Task #{i} ({task.get('label', '?')}) missing required fields: {missing}")
 
     if groups:
         group_set = set(groups)
@@ -262,7 +262,7 @@ def run_single_gpu_tasks(tasks, num_gpus, output_dir, script_dir, log_dir, total
 
         rc = entry.proc.returncode
         tag = "OK" if rc == 0 else f"FAIL(exit={rc})"
-        log(f"[{entry.task_id}/{total}] Done:  {entry.label} " f"(GPU {entry.gpu_id}, {elapsed:.0f}s, {tag})")
+        log(f"[{entry.task_id}/{total}] Done:  {entry.label} (GPU {entry.gpu_id}, {elapsed:.0f}s, {tag})")
         print_task_log(entry.label, rc, entry.log_path, elapsed)
 
         free_gpus.append(entry.gpu_id)

--- a/benchmark/ops/training/summarize_results.py
+++ b/benchmark/ops/training/summarize_results.py
@@ -218,9 +218,9 @@ def generate_summary_table(data_dir, date_str, gpus, output_file=None):
 
     summary_df = pd.DataFrame(summary_data)
 
-    print(f"\n{'='*80}")
+    print(f"\n{'=' * 80}")
     print(f"  Summary Table - GPU: {', '.join(gpus_to_process)}")
-    print(f"{'='*80}\n")
+    print(f"{'=' * 80}\n")
     print(tabulate(summary_df, headers="keys", tablefmt="grid", showindex=False))
 
     if output_file:

--- a/benchmark/pretrain/pytorch/pretrain_main.py
+++ b/benchmark/pretrain/pytorch/pretrain_main.py
@@ -48,7 +48,7 @@ def get_hf_torch_dtype(hf_config):
         try:
             torch_dtype = getattr(torch, hf_config.torch_dtype)
         except AttributeError:
-            raise ValueError(f"Invalid torch_dtype string: {hf_config.torch_dtype}")
+            raise ValueError(f"Invalid torch_dtype string: {hf_config.torch_dtype}") from None
     else:
         torch_dtype = hf_config.torch_dtype
     return torch_dtype

--- a/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
@@ -1399,7 +1399,7 @@ def gemm_fp8_tensorwise_flydsl_kernel(
         _run_dense(_autotune_nt_dispatch(args, M, N, K, cbsz, blgp, out_fp16), args)
     else:
         raise NotImplementedError(
-            f"FlyDSL fp8 GEMM does not support the TT layout " f"(trans_a={trans_a}, trans_b={trans_b})."
+            f"FlyDSL fp8 GEMM does not support the TT layout (trans_a={trans_a}, trans_b={trans_b})."
         )
     if trans_c:
         return out.t().contiguous()

--- a/primus_turbo/flydsl/utils/gemm_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_helper.py
@@ -9,9 +9,8 @@ from flydsl._mlir import ir
 from flydsl._mlir.dialects import fly as fly_dialect
 from flydsl._mlir.dialects import llvm as _llvm
 from flydsl._mlir.dialects.fly_rocdl import TargetAddressSpace
-from flydsl.expr import arith
+from flydsl.expr import arith, const_expr, range_constexpr, rocdl
 from flydsl.expr import buffer_ops as _buffer_ops
-from flydsl.expr import const_expr, range_constexpr, rocdl
 from flydsl.expr.arith import _to_raw as _raw
 from flydsl.expr.typing import T
 from flydsl.expr.typing import Vector as Vec

--- a/primus_turbo/jax/core/low_precision.py
+++ b/primus_turbo/jax/core/low_precision.py
@@ -91,7 +91,7 @@ try:
         float8_e4m3 = jnp.float8_e4m3fnuz
         float8_e5m2 = jnp.float8_e5m2fnuz
 except AttributeError:
-    raise RuntimeError("Your JAX build does not support FP8 types.")
+    raise RuntimeError("Your JAX build does not support FP8 types.") from None
 
 ###################################################
 

--- a/primus_turbo/jax/core/low_precision.py
+++ b/primus_turbo/jax/core/low_precision.py
@@ -132,9 +132,9 @@ class Float8QuantConfig:
 
         if self.granularity == ScalingGranularity.MX_BLOCKWISE:
             mx_support_block_size = [32]
-            assert (
-                self.block_size in mx_support_block_size
-            ), f"block_size should be {mx_support_block_size} when granularity is MX_BLOCKWISE"
+            assert self.block_size in mx_support_block_size, (
+                f"block_size should be {mx_support_block_size} when granularity is MX_BLOCKWISE"
+            )
 
 
 @dataclass
@@ -145,15 +145,15 @@ class Float4QuantConfig:
     block_size: Optional[int] = None
 
     def __post_init__(self):
-        assert (
-            self.granularity == ScalingGranularity.MX_BLOCKWISE
-        ), "Float4QuantConfig currently only supports MX_BLOCKWISE granularity"
+        assert self.granularity == ScalingGranularity.MX_BLOCKWISE, (
+            "Float4QuantConfig currently only supports MX_BLOCKWISE granularity"
+        )
 
         if self.block_size is None:
             self.block_size = 32
 
         mx_support_block_size = [32]
-        assert (
-            self.block_size in mx_support_block_size
-        ), f"block_size should be {mx_support_block_size} when granularity is MX_BLOCKWISE"
+        assert self.block_size in mx_support_block_size, (
+            f"block_size should be {mx_support_block_size} when granularity is MX_BLOCKWISE"
+        )
         assert self.format == Format.E2M1_X2, "Format must be E2M1_X2 for Float4QuantConfig"

--- a/primus_turbo/jax/deep_ep/runtime.py
+++ b/primus_turbo/jax/deep_ep/runtime.py
@@ -130,7 +130,7 @@ def pin_ep_group_from_jax_mesh(mesh, axis_name: str = "expert") -> None:
             break
     if coords_my is None:
         raise RuntimeError(
-            f"jax.process_index()={my_proc} not present in mesh.devices; " "cannot derive EP group."
+            f"jax.process_index()={my_proc} not present in mesh.devices; cannot derive EP group."
         )
     ep_ranks: List[int] = []
     for v in range(devices_arr.shape[expert_axis_idx]):
@@ -229,8 +229,7 @@ class LaunchMode(IntEnum):
         if normalized == "per_process":
             return cls.PER_PROCESS
         raise ValueError(
-            f"Unsupported JAX DeepEP mode '{raw_mode}'. "
-            f"Expected one of: {[mode.mode_name for mode in cls]}"
+            f"Unsupported JAX DeepEP mode '{raw_mode}'. Expected one of: {[mode.mode_name for mode in cls]}"
         )
 
 
@@ -282,7 +281,7 @@ def auto_detect_mode() -> None:
     if jax.local_device_count() == 1 and jax.process_count() > 1:
         os.environ[_MODE_ENV_VAR] = "per_process"
         log.info(
-            "Auto-detected per_process mode " "(1 GPU per process, %d JAX processes, ep_group_size=%d)",
+            "Auto-detected per_process mode (1 GPU per process, %d JAX processes, ep_group_size=%d)",
             jax.process_count(),
             _ep_group_size_or_world(),
         )

--- a/primus_turbo/jax/lax/grouped_gemm_fp8.py
+++ b/primus_turbo/jax/lax/grouped_gemm_fp8.py
@@ -300,8 +300,7 @@ def _grouped_gemm_fp8_blockwise(a, b, group_lens, group_offs, trans_b, config, n
     This is a placeholder for future implementation.
     """
     raise NotImplementedError(
-        "BLOCKWISE quantization is not yet implemented in JAX. "
-        "Please use TENSORWISE or ROWWISE granularity."
+        "BLOCKWISE quantization is not yet implemented in JAX. Please use TENSORWISE or ROWWISE granularity."
     )
 
 

--- a/primus_turbo/jax/lax/moe/moe_dispatch_combine.py
+++ b/primus_turbo/jax/lax/moe/moe_dispatch_combine.py
@@ -50,6 +50,7 @@ import jax.numpy as jnp
 
 from primus_turbo.jax.deep_ep import runtime as deep_ep_runtime
 from primus_turbo.jax.deep_ep.runtime import (
+    MODE_INPROC,  # noqa: F401  re-exported for callers that introspect mode (e.g. tests)
     MODE_PER_PROCESS,
     NUM_MAX_NVL_PEERS,
     LaunchMode,

--- a/primus_turbo/jax/lax/moe/moe_dispatch_combine.py
+++ b/primus_turbo/jax/lax/moe/moe_dispatch_combine.py
@@ -50,9 +50,6 @@ import jax.numpy as jnp
 
 from primus_turbo.jax.deep_ep import runtime as deep_ep_runtime
 from primus_turbo.jax.deep_ep.runtime import (
-    MODE_INPROC,  # re-export for callers that introspect mode (e.g. tests)
-)
-from primus_turbo.jax.deep_ep.runtime import (
     MODE_PER_PROCESS,
     NUM_MAX_NVL_PEERS,
     LaunchMode,
@@ -354,7 +351,7 @@ def setup(
     is_internode = locked_mode is MODE_PER_PROCESS and ep_size > NUM_MAX_NVL_PEERS
     if is_internode and ep_size % NUM_MAX_NVL_PEERS != 0:
         raise ValueError(
-            f"Internode mode requires ep_size %% {NUM_MAX_NVL_PEERS} == 0; " f"got ep_size={ep_size}."
+            f"Internode mode requires ep_size %% {NUM_MAX_NVL_PEERS} == 0; got ep_size={ep_size}."
         )
 
     # ----- Eager warmup -----

--- a/primus_turbo/jax/primitive/__init__.py
+++ b/primus_turbo/jax/primitive/__init__.py
@@ -10,5 +10,9 @@ TRANSPOSE_TABLE: Dict[Primitive, Any] = {}
 BATCHING_TABLE: Dict[Primitive, Any] = {}
 
 # Import primitives to register them
-from . import moe  # noqa: F401
-from . import grouped_gemm, normalization, quantization  # noqa: F401
+from . import (  # noqa: F401
+    grouped_gemm,
+    moe,  # noqa: F401
+    normalization,
+    quantization,
+)

--- a/primus_turbo/jax/primitive/grouped_gemm/grouped_gemm.py
+++ b/primus_turbo/jax/primitive/grouped_gemm/grouped_gemm.py
@@ -136,8 +136,8 @@ def _compute_group_offs_batch_rule(args, axes):
 batching.primitive_batchers[compute_group_offs_p] = _compute_group_offs_batch_rule
 # cumsum is cheap and shape-stable, so the SPMD path needs no dynamic-slice; the
 # fancy batcher (required once spmd_axis_name is set) just reuses the plain rule.
-batching.fancy_primitive_batchers[compute_group_offs_p] = (
-    lambda axis_data, args, axes: _compute_group_offs_batch_rule(args, axes)
+batching.fancy_primitive_batchers[compute_group_offs_p] = lambda axis_data, args, axes: (
+    _compute_group_offs_batch_rule(args, axes)
 )
 
 

--- a/primus_turbo/jax/primitive/moe/moe_dispatch.py
+++ b/primus_turbo/jax/primitive/moe/moe_dispatch.py
@@ -54,9 +54,9 @@ def _get_recv_x_scale_shape(x_scales: jnp.ndarray, num_worst_tokens: int) -> Sha
 
 
 def _get_num_rdma_ranks(ep_size: int) -> int:
-    assert (
-        ep_size % NUM_MAX_NVL_PEERS == 0
-    ), f"internode ep_size must be divisible by NUM_MAX_NVL_PEERS={NUM_MAX_NVL_PEERS}, got {ep_size}"
+    assert ep_size % NUM_MAX_NVL_PEERS == 0, (
+        f"internode ep_size must be divisible by NUM_MAX_NVL_PEERS={NUM_MAX_NVL_PEERS}, got {ep_size}"
+    )
     return ep_size // NUM_MAX_NVL_PEERS
 
 

--- a/primus_turbo/pytorch/core/backend.py
+++ b/primus_turbo/pytorch/core/backend.py
@@ -345,7 +345,7 @@ def _format_kwargs(kwargs: Dict[str, Any]) -> str:
     return ", ".join(f"{k}={_format_value(v)}" for k, v in kwargs.items())
 
 
-class AutoKernelDispatcher(ABC):
+class AutoKernelDispatcher(ABC):  # noqa: B024
     """
     Base class for auto kernel dispatcher.
     """

--- a/primus_turbo/pytorch/core/backend.py
+++ b/primus_turbo/pytorch/core/backend.py
@@ -24,7 +24,7 @@ from primus_turbo.triton.utils.origami import origami_clear_caches
 
 try:
     HAVE_DEEP_EP = True
-    import deep_ep  # fmt: skip
+    import deep_ep  # noqa: F401
 except ImportError:
     HAVE_DEEP_EP = False
 
@@ -245,9 +245,9 @@ class GlobalBackendManager:
                 )
 
             if backend == BackendType.DEEP_EP:
-                assert (
-                    HAVE_DEEP_EP
-                ), "DeepEP is required for this module. Install from https://github.com/uccl-project/uccl or https://github.com/ROCm/DeepEP"
+                assert HAVE_DEEP_EP, (
+                    "DeepEP is required for this module. Install from https://github.com/uccl-project/uccl or https://github.com/ROCm/DeepEP"
+                )
             return backend
 
         return None

--- a/primus_turbo/pytorch/core/low_precision.py
+++ b/primus_turbo/pytorch/core/low_precision.py
@@ -176,14 +176,14 @@ class Float8QuantConfig:
 
         if self.granularity == ScalingGranularity.MX_BLOCKWISE:
             mx_support_block_size = [MXFP8_BLOCK_SIZE]
-            assert (
-                self.block_size in mx_support_block_size
-            ), f"block_size should be {mx_support_block_size} when granularity is MX_BLOCKWISE"
+            assert self.block_size in mx_support_block_size, (
+                f"block_size should be {mx_support_block_size} when granularity is MX_BLOCKWISE"
+            )
 
             mx_support_scale_dtype = ScaleDtype.E8M0
-            assert (
-                self.scale_dtype == mx_support_scale_dtype
-            ), f"scale_dtype should be {mx_support_scale_dtype} when granularity is MX_BLOCKWISE"
+            assert self.scale_dtype == mx_support_scale_dtype, (
+                f"scale_dtype should be {mx_support_scale_dtype} when granularity is MX_BLOCKWISE"
+            )
 
 
 @dataclass
@@ -197,20 +197,20 @@ class Float4QuantConfig:
     use_preshuffle: bool = False
 
     def __post_init__(self):
-        assert (
-            self.granularity == ScalingGranularity.MX_BLOCKWISE
-        ), "Float4QuantConfig currently only supports MX_BLOCKWISE granularity"
+        assert self.granularity == ScalingGranularity.MX_BLOCKWISE, (
+            "Float4QuantConfig currently only supports MX_BLOCKWISE granularity"
+        )
 
         mx_support_block_size = [MXFP4_BLOCK_SIZE]
-        assert (
-            self.block_size in mx_support_block_size
-        ), f"block_size should be {mx_support_block_size} when granularity is MX_BLOCKWISE"
+        assert self.block_size in mx_support_block_size, (
+            f"block_size should be {mx_support_block_size} when granularity is MX_BLOCKWISE"
+        )
         assert self.format == Format.E2M1_X2, "Format must be E2M1_X2 for Float4QuantConfig"
 
         mx_support_scale_dtype = ScaleDtype.E8M0
-        assert (
-            self.scale_dtype == mx_support_scale_dtype
-        ), f"scale_dtype should be {mx_support_scale_dtype} when granularity is MX_BLOCKWISE"
+        assert self.scale_dtype == mx_support_scale_dtype, (
+            f"scale_dtype should be {mx_support_scale_dtype} when granularity is MX_BLOCKWISE"
+        )
 
 
 def weight_scaling_recipe(quant_config: Union[Float4QuantConfig, Float8QuantConfig]) -> ScalingRecipe:

--- a/primus_turbo/pytorch/core/low_precision.py
+++ b/primus_turbo/pytorch/core/low_precision.py
@@ -86,7 +86,7 @@ try:
     else:
         float4_e2m1fn_x2 = None
 except AttributeError:
-    raise RuntimeError("Your PyTorch build does not support FP8 types.")
+    raise RuntimeError("Your PyTorch build does not support FP8 types.") from None
 
 ###################################################
 

--- a/primus_turbo/pytorch/core/quantized_tensor.py
+++ b/primus_turbo/pytorch/core/quantized_tensor.py
@@ -414,7 +414,7 @@ class QuantizedTensor(torch.Tensor):
                 scaling_recipe=self._scaling_recipe,
             )
         else:
-            assert False, "Unsupported dtype"
+            raise AssertionError("Unsupported dtype")
 
         # TODO(ruibin): fused unpad in dequantize kernel
         if out.ndim == 2:
@@ -422,7 +422,7 @@ class QuantizedTensor(torch.Tensor):
         elif out.ndim == 3:
             out = out[:, :, : self.size(-1)].contiguous()
         else:
-            assert False, "Unsupported ndim"
+            raise AssertionError("Unsupported ndim")
 
         return out
 

--- a/primus_turbo/pytorch/core/quantized_tensor.py
+++ b/primus_turbo/pytorch/core/quantized_tensor.py
@@ -125,9 +125,9 @@ def check_quantized_tensor(
 
     if axis is not None:
         normalized_axis = _normalize_axis(axis, quantized_tensor.qdata.ndim)
-        assert (
-            quantized_tensor.quantized_axis == normalized_axis
-        ), f"QuantizedTensor quantized_axis {quantized_tensor.quantized_axis} does not match axis={normalized_axis}"
+        assert quantized_tensor.quantized_axis == normalized_axis, (
+            f"QuantizedTensor quantized_axis {quantized_tensor.quantized_axis} does not match axis={normalized_axis}"
+        )
 
     if scaling_recipe is not None:
         assert quantized_tensor.scaling_recipe == scaling_recipe, (
@@ -226,15 +226,15 @@ class QuantizedTensor(torch.Tensor):
 
         is_grouped_tensor = group_lens is not None
         if is_grouped_tensor:
-            assert (
-                granularity in _SUPPORTED_GROUPED_QUANTIZED_GRANS
-            ), f"Unsupported grouped granularity {granularity}"
-            assert (
-                hp_tensor.ndim == 2
-            ), f"Grouped quantized tensor expects a 2D packed-M tensor, got {hp_tensor.ndim}D"
-            assert (
-                dest_dtype in _SUPPORTED_QUANTIZED_DTYPES and dest_dtype != float4_e2m1fn_x2
-            ), "Unsupported quantized dtype (FP4 not supported for grouped activations)"
+            assert granularity in _SUPPORTED_GROUPED_QUANTIZED_GRANS, (
+                f"Unsupported grouped granularity {granularity}"
+            )
+            assert hp_tensor.ndim == 2, (
+                f"Grouped quantized tensor expects a 2D packed-M tensor, got {hp_tensor.ndim}D"
+            )
+            assert dest_dtype in _SUPPORTED_QUANTIZED_DTYPES and dest_dtype != float4_e2m1fn_x2, (
+                "Unsupported quantized dtype (FP4 not supported for grouped activations)"
+            )
         else:
             assert granularity in _SUPPORTED_QUANTIZED_GRANS, f"Unsupported granularity {granularity}"
 
@@ -248,14 +248,14 @@ class QuantizedTensor(torch.Tensor):
                 if dest_dtype == float4_e2m1fn_x2:
                     supported, reason = check_mxfp4_support()
                     assert supported, reason
-                    assert (
-                        block_size == MXFP4_BLOCK_SIZE
-                    ), "block_size must be MXFP4_BLOCK_SIZE for MX_BLOCKWISE"
+                    assert block_size == MXFP4_BLOCK_SIZE, (
+                        "block_size must be MXFP4_BLOCK_SIZE for MX_BLOCKWISE"
+                    )
                 elif dest_dtype in [float8_e4m3, float8_e5m2]:
                     supported, reason = check_mxfp8_support()
-                    assert (
-                        block_size == MXFP8_BLOCK_SIZE
-                    ), "block_size must be MXFP8_BLOCK_SIZE for MX_BLOCKWISE"
+                    assert block_size == MXFP8_BLOCK_SIZE, (
+                        "block_size must be MXFP8_BLOCK_SIZE for MX_BLOCKWISE"
+                    )
                     assert supported, reason
 
                 assert scaling_recipe is not None, "scaling_recipe must be provided for MX_BLOCKWISE"
@@ -320,7 +320,7 @@ class QuantizedTensor(torch.Tensor):
             assert granularity == ScalingGranularity.MX_BLOCKWISE
             # MXFP4 single-direction kernel only supports 2D input with axis in {0, 1};
             assert data.ndim == 2, (
-                f"FP4 single-direction quantization requires a 2D tensor, " f"got {data.ndim}D."
+                f"FP4 single-direction quantization requires a 2D tensor, got {data.ndim}D."
             )
 
             data_, scale_inv = quantize_fp4(
@@ -518,7 +518,7 @@ class QuantizedTensor(torch.Tensor):
 
         packing = _get_packing_factor(tensor)
         assert padded_target_shape[-1] % packing == 0, (
-            f"padded inner dim {padded_target_shape[-1]} must be divisible by " f"packing factor {packing}"
+            f"padded inner dim {padded_target_shape[-1]} must be divisible by packing factor {packing}"
         )
         data_target_shape = (
             *padded_target_shape[:-1],

--- a/primus_turbo/pytorch/deep_ep/buffer.py
+++ b/primus_turbo/pytorch/deep_ep/buffer.py
@@ -127,7 +127,7 @@ class Buffer:
             # Disable NVLink SHArP
             os.environ["NVSHMEM_DISABLE_NVLS"] = "1"
             # NOTES: NVSHMEM initialization requires at least 256 MiB
-            os.environ["NVSHMEM_CUMEM_GRANULARITY"] = f"{2 ** 29}"
+            os.environ["NVSHMEM_CUMEM_GRANULARITY"] = f"{2**29}"
 
             if not allow_mnnvl:
                 # Disable multi-node NVLink detection

--- a/primus_turbo/pytorch/kernels/async_tp/ag_gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/async_tp/ag_gemm_impl.py
@@ -106,7 +106,6 @@ def pipelined_all_gather_copy_send(
         barrier_ptrs[dst_rank] += num_ranks * 4
 
     class _CustomHandle:
-
         @staticmethod
         def wait():
             torch.cuda.current_stream().wait_event(comm_event)

--- a/primus_turbo/pytorch/kernels/async_tp/gemm_rs_impl.py
+++ b/primus_turbo/pytorch/kernels/async_tp/gemm_rs_impl.py
@@ -104,7 +104,7 @@ def _tiled_fused_matmul_scatter_out_impl(
     output: torch.Tensor,
     rs_output: torch.Tensor,
     out_dtype: torch.dtype,
-    stream: torch.cuda.Stream
+    stream: torch.cuda.Stream,
 ):
 
     M = input.shape[0]

--- a/primus_turbo/pytorch/kernels/attention/attention_aiter_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_aiter_impl.py
@@ -20,7 +20,7 @@ from primus_turbo.common.aiter_utils import (
     check_aiter_version_once,
     raise_aiter_missing,
 )
-from primus_turbo.pytorch.core.backend import KernelBackend
+from primus_turbo.pytorch.core.backend import KernelBackend, _format_kwargs
 
 _AITER_ATTN_KERNELS = None
 
@@ -80,7 +80,6 @@ _SUPPORTED_QKV_FORMATS = ["sbhd", "bshd", "bhsd"]
 
 
 class AttnFwdAiterBackend(KernelBackend):
-
     @staticmethod
     def can_handle(
         q: torch.Tensor,
@@ -199,7 +198,6 @@ class AttnFwdAiterBackend(KernelBackend):
 
 
 class AttnBwdAiterBackend(KernelBackend):
-
     @staticmethod
     def can_handle(
         dout: torch.Tensor,
@@ -523,7 +521,6 @@ def _attention_aiter_backward_impl_fake(
 
 
 class AttnFwdAiterVarlenBackend(KernelBackend):
-
     @staticmethod
     def can_handle(
         q: torch.Tensor,
@@ -608,7 +605,6 @@ class AttnFwdAiterVarlenBackend(KernelBackend):
 
 
 class AttnBwdAiterVarlenBackend(KernelBackend):
-
     @staticmethod
     def can_handle(
         dout: torch.Tensor,

--- a/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
@@ -68,9 +68,9 @@ def attention_triton_forward_impl(
     use_fp8: bool,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
 
-    assert (
-        window_size_left == -1 and window_size_right == -1
-    ), "in triton attn kernel, window_size_left and window_size_right must be -1."
+    assert window_size_left == -1 and window_size_right == -1, (
+        "in triton attn kernel, window_size_left and window_size_right must be -1."
+    )
     assert q.is_contiguous()
     assert k.is_contiguous()
     assert v.is_contiguous()
@@ -320,9 +320,9 @@ def attention_triton_backward_impl(
     use_fp8: bool,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
 
-    assert (
-        window_size_left == -1 and window_size_right == -1
-    ), "in triton attn kernel, window_size_left and window_size_right must be -1."
+    assert window_size_left == -1 and window_size_right == -1, (
+        "in triton attn kernel, window_size_left and window_size_right must be -1."
+    )
 
     use_exp2 = True
     layout = "bshd"

--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
@@ -30,9 +30,9 @@ def ceil_div(a, b):
 def get_gemm_logical_shape(
     a: torch.Tensor, b: torch.Tensor, trans_a: bool, trans_b: bool
 ) -> Tuple[int, int, int]:
-    assert (
-        a.ndim == 2 and b.ndim == 2
-    ), f"Expected both a and b to be 2D tensors, but got a.ndim={a.ndim}, b.ndim={b.ndim}"
+    assert a.ndim == 2 and b.ndim == 2, (
+        f"Expected both a and b to be 2D tensors, but got a.ndim={a.ndim}, b.ndim={b.ndim}"
+    )
     M = a.shape[1] if trans_a else a.shape[0]
     Ka = a.shape[0] if trans_a else a.shape[1]
     Kb = b.shape[1] if trans_b else b.shape[0]

--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
@@ -36,9 +36,9 @@ from primus_turbo.triton.gemm.gemm_fp8_kernel import (
 def get_gemm_logical_shape(
     a: torch.Tensor, b: torch.Tensor, trans_a: bool, trans_b: bool
 ) -> Tuple[int, int, int]:
-    assert (
-        a.ndim == 2 and b.ndim == 2
-    ), f"Expected both a and b to be 2D tensors, but got a.ndim={a.ndim}, b.ndim={b.ndim}"
+    assert a.ndim == 2 and b.ndim == 2, (
+        f"Expected both a and b to be 2D tensors, but got a.ndim={a.ndim}, b.ndim={b.ndim}"
+    )
     M = a.shape[1] if trans_a else a.shape[0]
     Ka = a.shape[0] if trans_a else a.shape[1]
     Kb = b.shape[1] if trans_b else b.shape[0]

--- a/primus_turbo/pytorch/kernels/gemm/gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_impl.py
@@ -24,7 +24,6 @@ _HIPBLASLT_SUPPORTED_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
 
 
 class GEMMHipBLASLtBackend(KernelBackend):
-
     @staticmethod
     def can_handle(
         a: torch.Tensor,
@@ -54,7 +53,6 @@ class GEMMHipBLASLtBackend(KernelBackend):
 
 
 class GEMMTritonBackend(KernelBackend):
-
     @staticmethod
     def can_handle(
         a: torch.Tensor,
@@ -136,9 +134,9 @@ def gemm_impl_meta(
     trans_c: bool,
     default_backend: int,
 ) -> torch.Tensor:
-    assert (
-        a.ndim == 2 and b.ndim == 2
-    ), f"Expected both a and b to be 2D tensors, but got a.ndim={a.ndim}, b.ndim={b.ndim}"
+    assert a.ndim == 2 and b.ndim == 2, (
+        f"Expected both a and b to be 2D tensors, but got a.ndim={a.ndim}, b.ndim={b.ndim}"
+    )
     M = a.shape[1] if trans_a else a.shape[0]
     N = b.shape[0] if trans_b else b.shape[1]
     if trans_c:

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
@@ -27,7 +27,6 @@ _COMMON_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16)
 
 
 class GroupedGEMMCKBackend(KernelBackend):
-
     @staticmethod
     def can_handle(
         a: torch.Tensor,

--- a/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
+++ b/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
@@ -4,6 +4,7 @@
 # See LICENSE for license information.
 ###############################################################################
 """Python-side wrappers that launch the Triton RMSNorm kernels."""
+
 from __future__ import annotations
 
 import functools

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -504,14 +504,14 @@ def dequantize_mxfp8_impl(
     assert scale_inv.is_contiguous(), "The scale_inv tensor must be contiguous."
     assert axis in (0, 1), "The axis must be 0 or 1."
     SUPPORTED_OUT_DTYPES = [torch.float16, torch.bfloat16, torch.float32]
-    assert (
-        out_dtype in SUPPORTED_OUT_DTYPES
-    ), f"The out dtype must be one of {SUPPORTED_OUT_DTYPES} but got {out_dtype}."
+    assert out_dtype in SUPPORTED_OUT_DTYPES, (
+        f"The out dtype must be one of {SUPPORTED_OUT_DTYPES} but got {out_dtype}."
+    )
 
     _, row_length = x.size()
-    assert (
-        row_length % block_size == 0
-    ), "The last dimension of the x tensor must be divisible by the block size."
+    assert row_length % block_size == 0, (
+        "The last dimension of the x tensor must be divisible by the block size."
+    )
 
     return torch.ops.primus_turbo_cpp_extension.dequantize_mxfp8(x, scale_inv, axis, block_size, out_dtype)
 
@@ -593,15 +593,15 @@ def dequantize_mxfp4_impl(
     ), "The axis must be 0 or 1."
     assert x.dtype == torch.float4_e2m1fn_x2, f"The x dtype must be torch.float4_e2m1fn_x2 but got {x.dtype}."
     SUPPORTED_OUT_DTYPES = [torch.float16, torch.bfloat16, torch.float32]
-    assert (
-        out_dtype in SUPPORTED_OUT_DTYPES
-    ), f"The out dtype must be one of {SUPPORTED_OUT_DTYPES} but got {out_dtype}."
+    assert out_dtype in SUPPORTED_OUT_DTYPES, (
+        f"The out dtype must be one of {SUPPORTED_OUT_DTYPES} but got {out_dtype}."
+    )
 
     num_rows, row_length = x.size()
     # NOTE: x is packed in last dimension
     row_length = row_length * 2
-    assert (
-        row_length % block_size == 0
-    ), "The last dimension of the x tensor must be divisible by the block size."
+    assert row_length % block_size == 0, (
+        "The last dimension of the x tensor must be divisible by the block size."
+    )
 
     return torch.ops.primus_turbo_cpp_extension.dequantize_mxfp4(x, scale_inv, axis, block_size, out_dtype)

--- a/primus_turbo/pytorch/modules/moe/token_dispatcher.py
+++ b/primus_turbo/pytorch/modules/moe/token_dispatcher.py
@@ -214,7 +214,7 @@ class DeepEPTokenDispatcher(TokenDispatcher):
             )
         if token_indices is not None:
             assert token_indices.dim() == 2 and token_indices.shape[0] == num_tokens, (
-                f"token_indices must be 2D with shape[0]={num_tokens}, " f"got {tuple(token_indices.shape)}"
+                f"token_indices must be 2D with shape[0]={num_tokens}, got {tuple(token_indices.shape)}"
             )
 
         probs = (

--- a/primus_turbo/pytorch/modules/normalization.py
+++ b/primus_turbo/pytorch/modules/normalization.py
@@ -17,7 +17,6 @@ __all__ = ["RMSNorm"]
 
 
 class RMSNorm(torch.nn.Module):
-
     def __init__(
         self,
         normalized_shape: Union[int, list[int], Size],

--- a/primus_turbo/pytorch/ops/activation.py
+++ b/primus_turbo/pytorch/ops/activation.py
@@ -35,9 +35,9 @@ class GLUWithProbs(torch.autograd.Function):
         assert probs.dtype == torch.float32, "probs must be float32"
 
         SUPPORTED_ACT_TYPES = ["silu", "gelu"]
-        assert (
-            act_type in SUPPORTED_ACT_TYPES
-        ), f"Unsupported act_type: {act_type}. Supported types: {SUPPORTED_ACT_TYPES}"
+        assert act_type in SUPPORTED_ACT_TYPES, (
+            f"Unsupported act_type: {act_type}. Supported types: {SUPPORTED_ACT_TYPES}"
+        )
 
         if row_mask is not None:
             assert row_mask.is_cuda, "row_mask must be a CUDA tensor"

--- a/primus_turbo/pytorch/ops/async_tp.py
+++ b/primus_turbo/pytorch/ops/async_tp.py
@@ -249,7 +249,7 @@ def fused_matmul_reduce_scatter(
 
     if comm_method == "tile" and ((M // group.size() < 256) or (M % 256) or (N % 256) or (K % 256)):
         raise ValueError(
-            f"M, N, and K must be divisible by 256, and M divided by group size must not be less than 256 when comm_method use tile."
+            "M, N, and K must be divisible by 256, and M divided by group size must not be less than 256 when comm_method use tile."
         )
 
     if rs_out is not None:
@@ -267,7 +267,7 @@ def fused_matmul_reduce_scatter(
             raise ValueError(f"Invalid dtype: output ({output.dtype}) is different with A ({A.dtype})!")
 
         if output.numel() != rs_out.numel() * group.size():
-            raise ValueError(f"output size must equal group size * rs_out size.")
+            raise ValueError("output size must equal group size * rs_out size.")
         output = output.view(-1, N)
 
     with torch.profiler.record_function(f"{comm_method}_fused_matmul_scatter_out"):

--- a/primus_turbo/pytorch/ops/attention/attention_utils.py
+++ b/primus_turbo/pytorch/ops/attention/attention_utils.py
@@ -63,7 +63,9 @@ def _infer_qkv_format(
         if s0 >= s2 >= s1:
             return "bhsd"
 
-        assert False, f"Cannot infer qkv layout from shape {tuple(t.size())} and strides {tuple(t.stride())}"
+        raise AssertionError(
+            f"Cannot infer qkv layout from shape {tuple(t.size())} and strides {tuple(t.stride())}"
+        )
 
     assert q.ndim == 4, f"Expected 4-D tensor for q, got {q.ndim}-D"
     q_format = _infer_format(q)
@@ -79,7 +81,7 @@ def _infer_qkv_format(
     return q_format
 
 
-def block_scaling_node(tensor, use_fp8, BLOCK_M=FIXED_BLOCK_M, float8_dtype=get_f8_fwd_dtype()):
+def block_scaling_node(tensor, use_fp8, BLOCK_M=FIXED_BLOCK_M, float8_dtype=None):
     """
     Used to scale tensor in per-block mode
 
@@ -92,6 +94,8 @@ def block_scaling_node(tensor, use_fp8, BLOCK_M=FIXED_BLOCK_M, float8_dtype=get_
         fp8tensor(Tensor): tensor after blockwise quant
         unscale_tensor(Tensor): tensor for unscale quanted tensor from fp8 to bf16
     """
+    if float8_dtype is None:
+        float8_dtype = get_f8_fwd_dtype()
     if use_fp8:
         tensor = tensor.permute(0, 2, 1, 3)  # [B, H, L, D]
         B, H, L, D = tensor.shape

--- a/primus_turbo/pytorch/ops/attention/attention_utils.py
+++ b/primus_turbo/pytorch/ops/attention/attention_utils.py
@@ -63,9 +63,7 @@ def _infer_qkv_format(
         if s0 >= s2 >= s1:
             return "bhsd"
 
-        assert False, (
-            f"Cannot infer qkv layout from shape {tuple(t.size())} " f"and strides {tuple(t.stride())}"
-        )
+        assert False, f"Cannot infer qkv layout from shape {tuple(t.size())} and strides {tuple(t.stride())}"
 
     assert q.ndim == 4, f"Expected 4-D tensor for q, got {q.ndim}-D"
     q_format = _infer_format(q)

--- a/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
+++ b/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
@@ -34,7 +34,6 @@ __all__ = ["flash_attn_func", "flash_attn_fp8_func", "flash_attn_varlen_func"]
 
 
 class AiterFlashAttnFunc(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx,
@@ -399,11 +398,11 @@ def flash_attn_fp8_func(
     # Check if config is supported
     if fp8_config.granularity != ScalingGranularity.BLOCKWISE:
         raise ValueError(
-            f"flash_attn_fp8_func only supports BLOCKWISE granularity, " f"but got {fp8_config.granularity}"
+            f"flash_attn_fp8_func only supports BLOCKWISE granularity, but got {fp8_config.granularity}"
         )
     if fp8_config.block_size != 64:
         raise ValueError(
-            f"flash_attn_fp8_func only supports block_size=64, " f"but got block_size={fp8_config.block_size}"
+            f"flash_attn_fp8_func only supports block_size=64, but got block_size={fp8_config.block_size}"
         )
 
     o = TritonFlashAttnFunc.apply(
@@ -436,7 +435,6 @@ def flash_attn_fp8_func(
 
 
 class AiterFlashAttnVarlenFunc(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx,

--- a/primus_turbo/pytorch/ops/attention/flash_attn_usp_interface.py
+++ b/primus_turbo/pytorch/ops/attention/flash_attn_usp_interface.py
@@ -338,9 +338,9 @@ class AttentionTritonFunctionCPA2A(torch.autograd.Function):
         ring_group,
     ):
         assert bias is None
-        assert (
-            dist.get_world_size(ring_group) == 1
-        ), "currently ring attention not supported for fp8, since triton implementation does not use the standard flash attention interface"
+        assert dist.get_world_size(ring_group) == 1, (
+            "currently ring attention not supported for fp8, since triton implementation does not use the standard flash attention interface"
+        )
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** (-0.5)
 
@@ -538,9 +538,9 @@ class AttentionVarlenCKFunctionCPA2A(torch.autograd.Function):
             raise NotImplementedError("varlen USP supports Ulysses A2A only; ring is not supported")
         assert dropout_p == 0.0, "varlen USP does not support dropout"
         assert q.dim() == 3 and k.dim() == 3, "varlen USP expects packed [t, h, d] (thd) inputs"
-        assert (
-            q.dtype is torch.bfloat16 and k.dtype is torch.bfloat16 and v.dtype is torch.bfloat16
-        ), "varlen USP (aiter) only supports bfloat16 q/k/v"
+        assert q.dtype is torch.bfloat16 and k.dtype is torch.bfloat16 and v.dtype is torch.bfloat16, (
+            "varlen USP (aiter) only supports bfloat16 q/k/v"
+        )
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** (-0.5)
 
@@ -858,11 +858,11 @@ def flash_attn_fp8_usp_func(
     # Check if config is supported
     if fp8_config.granularity != ScalingGranularity.BLOCKWISE:
         raise ValueError(
-            f"flash_attn_fp8_func only supports BLOCKWISE granularity, " f"but got {fp8_config.granularity}"
+            f"flash_attn_fp8_func only supports BLOCKWISE granularity, but got {fp8_config.granularity}"
         )
     if fp8_config.block_size != 64:
         raise ValueError(
-            f"flash_attn_fp8_func only supports block_size=64, " f"but got block_size={fp8_config.block_size}"
+            f"flash_attn_fp8_func only supports block_size=64, but got block_size={fp8_config.block_size}"
         )
 
     o = AttentionTritonFunctionCPA2A.apply(

--- a/primus_turbo/pytorch/ops/gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/gemm_fp8.py
@@ -43,7 +43,6 @@ def _get_fp8_dtype(format: Format, is_fwd_stage: bool):
 
 
 class FP8GemmTensorFunction(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx,
@@ -146,7 +145,6 @@ class FP8GemmTensorFunction(torch.autograd.Function):
 
 
 class FP8GemmRowFunction(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx,
@@ -293,7 +291,6 @@ class FP8GemmRowFunction(torch.autograd.Function):
 
 # TODO(ruibin): Add support for quantized tensor
 class FP8GemmBlockFunction(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx,
@@ -420,7 +417,6 @@ class FP8GemmBlockFunction(torch.autograd.Function):
 
 
 class FP8GemmMXFunction(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx,

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -60,7 +60,6 @@ def _ensure_contiguous_grad_out(grad_out: torch.Tensor) -> torch.Tensor:
 
 
 class FP8GroupedGemmBlockFunc(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx,
@@ -191,7 +190,6 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
 
 
 class FP8GroupedGemmRowFunc(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx,
@@ -365,7 +363,6 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
 
 
 class FP8GroupedGemmTensorFunc(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx,

--- a/primus_turbo/pytorch/ops/moe/moe_dispatch_combine.py
+++ b/primus_turbo/pytorch/ops/moe/moe_dispatch_combine.py
@@ -18,7 +18,6 @@ __all__ = ["moe_dispatch", "moe_combine"]
 
 
 class MoEDispatch(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx,
@@ -71,7 +70,6 @@ class MoEDispatch(torch.autograd.Function):
 
 
 class MoECombine(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx, x: torch.Tensor, group, handle: Tuple, async_finish=False, allocate_on_comm_stream=False

--- a/primus_turbo/pytorch/ops/moe/moe_permute.py
+++ b/primus_turbo/pytorch/ops/moe/moe_permute.py
@@ -59,9 +59,9 @@ class _MoEPermute(torch.autograd.Function):
         if use_fp8 and scaling_factor is not None:
             assert scales_per_token > 0, "scales_per_token must be > 0 when use_fp8=True"
         # backward asserts not use_fp8; catch the unsupported combo at the forward boundary.
-        assert not (
-            use_fp8 and probs is not None and tokens.requires_grad
-        ), "moe_permute: FP8 + probs backward is unsupported"
+        assert not (use_fp8 and probs is not None and tokens.requires_grad), (
+            "moe_permute: FP8 + probs backward is unsupported"
+        )
 
         # Fast path: preprocessing kernel asserts num_dispatched > 0.
         if num_dispatched == 0:

--- a/primus_turbo/pytorch/ops/moe/permutation.py
+++ b/primus_turbo/pytorch/ops/moe/permutation.py
@@ -16,7 +16,6 @@ __all__ = ["token_permute", "token_unpermute"]
 
 
 class TokenPermuteMaskMap(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx,
@@ -54,9 +53,9 @@ class TokenPermuteMaskMap(torch.autograd.Function):
         )
 
         if num_out_tokens < 0:
-            assert (
-                tokens_per_experts is not None
-            ), "tokens_per_experts must be provided to the fused permute function when num_out_tokens is -1"
+            assert tokens_per_experts is not None, (
+                "tokens_per_experts must be provided to the fused permute function when num_out_tokens is -1"
+            )
             num_out_tokens = tokens_per_experts.sum().item()
 
         use_fp8 = isinstance(inp, QuantizedTensor)
@@ -132,9 +131,9 @@ class TokenPermuteMaskMap(torch.autograd.Function):
         probs_grad = None
         if ctx.needs_input_grad[0]:
             (row_id_map,) = ctx.saved_tensors
-            assert not isinstance(
-                permuted_act_grad, QuantizedTensor
-            ), "The backward of token_permute does not support FP8."
+            assert not isinstance(permuted_act_grad, QuantizedTensor), (
+                "The backward of token_permute does not support FP8."
+            )
             act_grad, probs_grad = permutation.unpermute_with_mask_map(
                 permuted_act_grad,
                 row_id_map,
@@ -150,7 +149,6 @@ class TokenPermuteMaskMap(torch.autograd.Function):
 
 
 class TokenUnpermuteMaskMap(torch.autograd.Function):
-
     @staticmethod
     def forward(
         ctx,
@@ -234,9 +232,9 @@ class TokenUnpermuteMaskMap(torch.autograd.Function):
                 scale_hidden_dim = None
 
             if ctx.with_probs:
-                assert (
-                    not use_fp8
-                ), "The backward of TokenUnpermutation with merging probs does not support FP8."
+                assert not use_fp8, (
+                    "The backward of TokenUnpermutation with merging probs does not support FP8."
+                )
                 act_grad, probs_grad = permutation.unpermute_with_mask_map_bwd_with_merging_probs(
                     unpermuted_act_grad,
                     row_id_map,

--- a/primus_turbo/pytorch/ops/moe/tokens_per_expert_to_mask.py
+++ b/primus_turbo/pytorch/ops/moe/tokens_per_expert_to_mask.py
@@ -8,7 +8,6 @@ __all__ = ["tokens_per_expert_to_mask"]
 
 
 class TokensPerExpertToMask(torch.autograd.Function):
-
     @classmethod
     def forward(ctx, tokens_per_expert: torch.Tensor, num_tokens: int):
         assert tokens_per_expert.is_cuda, "tokens_per_expert must be a CUDA tensor."

--- a/primus_turbo/pytorch/ops/normalization.py
+++ b/primus_turbo/pytorch/ops/normalization.py
@@ -9,6 +9,7 @@ Public API:
     - ``rmsnorm(x, gamma, eps=1e-6, zero_centered=False) -> y``
     - ``rmsnorm_residual(x, residual, gamma, eps=1e-6) -> (y, x_plus_r)``
 """
+
 from __future__ import annotations
 
 from typing import Tuple
@@ -31,9 +32,9 @@ class _RMSNormFunction(torch.autograd.Function):
         assert x.is_cuda and gamma.is_cuda, "rmsnorm: x and gamma must be CUDA tensors"
         orig_shape = x.shape
         H = gamma.shape[0]
-        assert (
-            orig_shape[-1] == H
-        ), f"rmsnorm: last dim of x ({orig_shape[-1]}) must equal gamma.shape[0] ({H})"
+        assert orig_shape[-1] == H, (
+            f"rmsnorm: last dim of x ({orig_shape[-1]}) must equal gamma.shape[0] ({H})"
+        )
 
         y, x2, rstd, BLOCK_H, ROWS, num_warps, num_stages = rmsnorm_fwd_impl(x, gamma, eps, zero_centered)
 
@@ -65,15 +66,14 @@ class _RMSNormFunction(torch.autograd.Function):
 
 
 class _RMSNormResidualFunction(torch.autograd.Function):
-
     @staticmethod
     def forward(ctx, x: torch.Tensor, residual: torch.Tensor, gamma: torch.Tensor, eps: float = 1e-6):
-        assert (
-            x.is_cuda and residual.is_cuda and gamma.is_cuda
-        ), "rmsnorm_residual: x, residual and gamma must be CUDA tensors"
-        assert (
-            x.shape == residual.shape
-        ), f"rmsnorm_residual: shape mismatch {tuple(x.shape)} vs {tuple(residual.shape)}"
+        assert x.is_cuda and residual.is_cuda and gamma.is_cuda, (
+            "rmsnorm_residual: x, residual and gamma must be CUDA tensors"
+        )
+        assert x.shape == residual.shape, (
+            f"rmsnorm_residual: shape mismatch {tuple(x.shape)} vs {tuple(residual.shape)}"
+        )
         orig_shape = x.shape
         H = gamma.shape[0]
         assert orig_shape[-1] == H

--- a/primus_turbo/pytorch/ops/quantization.py
+++ b/primus_turbo/pytorch/ops/quantization.py
@@ -56,7 +56,6 @@ def quantize_fp8(
         return quantize_fp8_tensorwise_impl(x, out_dtype)
 
     elif granularity == ScalingGranularity.ROWWISE:
-
         return quantize_fp8_rowwise_impl(x, out_dtype, axis)
     elif granularity == ScalingGranularity.BLOCKWISE:
         assert block_size is not None, "block_size must be specified for BLOCKWISE quantization"
@@ -67,9 +66,9 @@ def quantize_fp8(
 
         return quant_fp8_blockwise_impl(x, out_dtype, axis=axis, block_size=block_size)
     elif granularity == ScalingGranularity.MX_BLOCKWISE:
-        assert (
-            block_size == MXFP8_BLOCK_SIZE
-        ), f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
+        assert block_size == MXFP8_BLOCK_SIZE, (
+            f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
+        )
 
         return quantize_mxfp8_impl(
             x,
@@ -106,9 +105,9 @@ def quantize_fp8_with_trans(
             4. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise.
     """
     if granularity == ScalingGranularity.MX_BLOCKWISE:
-        assert (
-            block_size == MXFP8_BLOCK_SIZE
-        ), f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
+        assert block_size == MXFP8_BLOCK_SIZE, (
+            f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
+        )
         return quantize_mxfp8_impl(
             x,
             out_dtype,
@@ -146,9 +145,9 @@ def grouped_quantize_fp8_with_trans(
     FP8 Grouped Quantize with trans
     """
     if granularity == ScalingGranularity.MX_BLOCKWISE:
-        assert (
-            block_size == MXFP8_BLOCK_SIZE
-        ), f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
+        assert block_size == MXFP8_BLOCK_SIZE, (
+            f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
+        )
 
         return grouped_quantize_mxfp8_impl(
             x,
@@ -193,9 +192,9 @@ def dequantize_fp8(
 
         return dequantize_fp8_rowwise_impl(x, out_dtype, axis, scale_inv)
     elif granularity == ScalingGranularity.MX_BLOCKWISE:
-        assert (
-            block_size == MXFP8_BLOCK_SIZE
-        ), f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
+        assert block_size == MXFP8_BLOCK_SIZE, (
+            f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
+        )
 
         return dequantize_mxfp8_impl(x, out_dtype, axis, block_size, scale_inv)
     else:
@@ -221,9 +220,9 @@ def quantize_fp4(
             3. The block size must be 32.
     """
     if granularity == ScalingGranularity.MX_BLOCKWISE:
-        assert (
-            block_size == MXFP4_BLOCK_SIZE
-        ), f"The block size must be {MXFP4_BLOCK_SIZE} for MXFP4 quantization"
+        assert block_size == MXFP4_BLOCK_SIZE, (
+            f"The block size must be {MXFP4_BLOCK_SIZE} for MXFP4 quantization"
+        )
         return quantize_mxfp4_impl(
             x,
             out_dtype,
@@ -257,9 +256,9 @@ def quantize_fp4_with_trans(
             4. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise.
     """
     if granularity == ScalingGranularity.MX_BLOCKWISE:
-        assert (
-            block_size == MXFP4_BLOCK_SIZE
-        ), f"The block size must be {MXFP4_BLOCK_SIZE} for MXFP4 quantization"
+        assert block_size == MXFP4_BLOCK_SIZE, (
+            f"The block size must be {MXFP4_BLOCK_SIZE} for MXFP4 quantization"
+        )
         return quantize_mxfp4_impl(
             x,
             out_dtype,
@@ -293,9 +292,9 @@ def dequantize_fp4(
             3. The block size must be 32.
     """
     if granularity == ScalingGranularity.MX_BLOCKWISE:
-        assert (
-            block_size == MXFP4_BLOCK_SIZE
-        ), f"The block size must be {MXFP4_BLOCK_SIZE} for MXFP4 quantization"
+        assert block_size == MXFP4_BLOCK_SIZE, (
+            f"The block size must be {MXFP4_BLOCK_SIZE} for MXFP4 quantization"
+        )
 
         return dequantize_mxfp4_impl(x, out_dtype, axis, block_size, scale_inv)
     else:

--- a/primus_turbo/triton/attention/attention_kernel.py
+++ b/primus_turbo/triton/attention/attention_kernel.py
@@ -80,7 +80,7 @@ def get_shape_from_layout(
             v.shape[2],
         )
     else:
-        assert False, "Got unsupported layout."
+        raise AssertionError("Got unsupported layout.")
 
     # assert
     assert batch_q == batch_k
@@ -97,7 +97,7 @@ def get_strides_from_layout(q, layout):
     elif layout == "bshd":
         q_strides = (q.stride(0), q.stride(2), q.stride(1), q.stride(3))
     else:
-        assert False, "Got unsupported layout."
+        raise AssertionError("Got unsupported layout.")
     return q_strides
 
 

--- a/primus_turbo/triton/attention/attention_kernel.py
+++ b/primus_turbo/triton/attention/attention_kernel.py
@@ -73,7 +73,7 @@ def get_shape_from_layout(
             k.shape[1],
             k.shape[2],
         )
-        batch_v, max_seqlen_v, nheads_v, head_size_v = (
+        _, _, _, head_size_v = (
             len(cu_seqlens_k) - 1,
             max_seqlen_k,
             v.shape[1],

--- a/primus_turbo/triton/normalization/rmsnorm_kernel.py
+++ b/primus_turbo/triton/normalization/rmsnorm_kernel.py
@@ -24,6 +24,7 @@ program over its ``ROWS_PER_BLOCK`` rows, so the partial buffer is
 huge-B shapes (e.g. q_norm in MoE attention) where ``(B, H)`` would otherwise
 cost an unreasonable amount of workspace memory.
 """
+
 from __future__ import annotations
 
 import triton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,21 @@ version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"
 write_to = "primus_turbo/_version.py"
 fallback_version = "0.0.0.dev0"
+
+[tool.ruff]
+line-length = 110
+target-version = "py310"
+extend-exclude = [
+    "3rdparty",
+    "build",
+    "primus_turbo/_version.py",
+    "primus_turbo/_build_info.py",
+]
+
+[tool.ruff.lint]
+select = ["F", "I", "W"]
+# F403/F405: package __init__ files use intentional star-imports for API aggregation.
+ignore = ["F403", "F405"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,18 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["F", "I", "W"]
-# F403/F405: package __init__ files use intentional star-imports for API aggregation.
-ignore = ["F403", "F405"]
+select = ["B", "F", "I", "W"]
+ignore = [
+    # F403/F405: package __init__ files use intentional star-imports for API aggregation.
+    "F403",
+    "F405",
+    # B905: zip(..., strict=) requires py3.10+ everywhere; revisit as a separate sweep.
+    "B905",
+    # B007: unused loop control variable is common and low-risk here.
+    "B007",
+    # B028: explicit stacklevel on every warnings.warn is noisy; skip it.
+    "B028",
+]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-pre-commit
+pre-commit==4.5.1
+ruff==0.15.12
 clang-format==20.1.6
 build
 ninja

--- a/tests/jax/lax/test_mp_dispatch_combine.py
+++ b/tests/jax/lax/test_mp_dispatch_combine.py
@@ -155,19 +155,19 @@ def _check_dispatch(cx, cw, rpm, rank, world_size, num_experts):
 
     recv_size = int(rpm[world_size - 1][rank])
 
-    assert np.allclose(
-        np.amin(cx[:recv_size], axis=1), np.amax(cx[:recv_size], axis=1)
-    ), f"Rank {rank}: received tokens should be constant per row"
+    assert np.allclose(np.amin(cx[:recv_size], axis=1), np.amax(cx[:recv_size], axis=1)), (
+        f"Rank {rank}: received tokens should be constant per row"
+    )
 
     start = 0
     for src in range(world_size):
         end = int(rpm[src][rank])
-        assert (
-            cx[start:end, :].astype(np.int32) - src
-        ).sum() == 0, f"Rank {rank}: tokens from src={src} should carry value {src}"
-        assert (
-            cw[start:end, :].astype(np.int32) - src
-        ).sum() == 0, f"Rank {rank}: weights from src={src} should carry value {src}"
+        assert (cx[start:end, :].astype(np.int32) - src).sum() == 0, (
+            f"Rank {rank}: tokens from src={src} should carry value {src}"
+        )
+        assert (cw[start:end, :].astype(np.int32) - src).sum() == 0, (
+            f"Rank {rank}: weights from src={src} should carry value {src}"
+        )
         start = end
 
 
@@ -302,9 +302,9 @@ def _worker_eval_shape_after_setup(rank, world_size):
     weights_shape = jax_mod.ShapeDtypeStruct((_NUM_TOKENS, _NUM_TOPK), jnp.float32)
 
     out_shape = jax_mod.eval_shape(model_fn, x_shape, idx_shape, weights_shape)
-    assert (
-        out_shape.shape[1] == _HIDDEN
-    ), f"Rank {rank}: expected hidden dim {_HIDDEN}, got {out_shape.shape[1]}"
+    assert out_shape.shape[1] == _HIDDEN, (
+        f"Rank {rank}: expected hidden dim {_HIDDEN}, got {out_shape.shape[1]}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/jax/lax/test_quantization.py
+++ b/tests/jax/lax/test_quantization.py
@@ -46,7 +46,7 @@ def test_quantize_fp8_tensorwise(orig_dtype, dest_dtype, numel, dynamic_quantize
     assert_allclose(
         x_fp8_ref.astype(jnp.float32) * x_scale_inv_ref,
         x_fp8.astype(jnp.float32) * x_scale_inv,
-        **get_tolerances(dest_dtype)
+        **get_tolerances(dest_dtype),
     )
 
     # DeQuantize
@@ -87,5 +87,5 @@ def test_quantize_fp8_rowwise(orig_dtype, dest_dtype, axis, B, M, N, dynamic_qua
     assert_allclose(
         x_fp8_ref.astype(jnp.float32) * x_scale_inv_ref,
         x_fp8.astype(jnp.float32) * x_scale_inv,
-        **get_tolerances(dest_dtype)
+        **get_tolerances(dest_dtype),
     )

--- a/tests/jax/lax/test_setup.py
+++ b/tests/jax/lax/test_setup.py
@@ -19,9 +19,8 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from primus_turbo.jax.lax.moe import moe_combine, moe_dispatch
+from primus_turbo.jax.lax.moe import moe_combine, moe_dispatch, reset_runtime, setup
 from primus_turbo.jax.lax.moe import moe_dispatch_combine as mdc
-from primus_turbo.jax.lax.moe import reset_runtime, setup
 
 
 @pytest.fixture(autouse=True)

--- a/tests/pytorch/core/test_global_backend_manager.py
+++ b/tests/pytorch/core/test_global_backend_manager.py
@@ -31,7 +31,6 @@ def clean_backend_state(monkeypatch):
 
 
 class TestGlobalBackendManagerEnvVar:
-
     def test_gemm_backend_single_format(self, monkeypatch):
         """Format 1: PRIMUS_TURBO_GEMM_BACKEND=ck -> all precisions use CK."""
         monkeypatch.setenv("PRIMUS_TURBO_GEMM_BACKEND", "ck")
@@ -82,7 +81,6 @@ class TestGlobalBackendManagerEnvVar:
 
 
 class TestGlobalBackendManagerFunction:
-
     @staticmethod
     def _init_gemm_backend():
         GlobalBackendManager._gemm_backend = {p: None for p in PrecisionType}

--- a/tests/pytorch/core/test_quantized_tensor.py
+++ b/tests/pytorch/core/test_quantized_tensor.py
@@ -114,7 +114,6 @@ _GRAN_CASES = [
 # Basic construction & properties (all granularities)
 # =====================================================================
 class TestQuantizedTensorBasic:
-
     @pytest.mark.parametrize("granularity,block_size,dest_dtype", _GRAN_CASES)
     @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
     def test_create_and_properties(self, granularity, block_size, dest_dtype, dtype):
@@ -138,9 +137,9 @@ class TestQuantizedTensorBasic:
         qt = _make_quantized_tensor(x, granularity=granularity, dest_dtype=dest_dtype, block_size=block_size)
 
         expected = _expected_scale_shape(granularity, M, N, block_size, use_2d_block=False)
-        assert (
-            tuple(qt.scale_inv.shape) == expected
-        ), f"{granularity.name}/{dest_dtype}: expected scale shape {expected}, got {tuple(qt.scale_inv.shape)}"
+        assert tuple(qt.scale_inv.shape) == expected, (
+            f"{granularity.name}/{dest_dtype}: expected scale shape {expected}, got {tuple(qt.scale_inv.shape)}"
+        )
 
 
 # =====================================================================
@@ -200,7 +199,6 @@ _DEQUANT_CASES = [
 
 
 class TestDequantize:
-
     @pytest.mark.parametrize("granularity,block_size,dest_dtype", _DEQUANT_CASES)
     def test_dequantize_roundtrip_close(self, granularity, block_size, dest_dtype):
         """Quant -> dequant roundtrip should be close to the original within
@@ -218,7 +216,6 @@ class TestDequantize:
 # Serialisation (flatten / unflatten)
 # =====================================================================
 class TestSerialization:
-
     @pytest.mark.parametrize("granularity,block_size,dest_dtype", _GRAN_CASES)
     def test_flatten_unflatten_roundtrip(self, granularity, block_size, dest_dtype):
         x = torch.randn(M, N, dtype=torch.bfloat16, device=DEVICE)
@@ -401,7 +398,6 @@ _GROUPED_DEQUANT_CASES = [
 # Basic construction & properties
 # ---------------------------------------------------------------------
 class TestGroupedQuantizedTensorBasic:
-
     @pytest.mark.parametrize("granularity,block_size,dest_dtype", _GROUPED_GRAN_CASES)
     @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
     def test_create_and_properties(self, granularity, block_size, dest_dtype, dtype):
@@ -441,9 +437,9 @@ class TestGroupedQuantizedTensorBasic:
         )
 
         expected = _expected_scale_shape(granularity, M, N, block_size, use_2d_block=False)
-        assert (
-            tuple(qt.scale_inv.shape) == expected
-        ), f"{granularity.name}/{dest_dtype}: expected scale shape {expected}, got {tuple(qt.scale_inv.shape)}"
+        assert tuple(qt.scale_inv.shape) == expected, (
+            f"{granularity.name}/{dest_dtype}: expected scale shape {expected}, got {tuple(qt.scale_inv.shape)}"
+        )
 
 
 # ---------------------------------------------------------------------
@@ -491,7 +487,6 @@ class TestGroupSpecific:
 # Dequantization accuracy
 # ---------------------------------------------------------------------
 class TestGroupedDequantize:
-
     @pytest.mark.parametrize("granularity,block_size,dest_dtype", _GROUPED_DEQUANT_CASES)
     def test_dequantize_roundtrip_close(self, granularity, block_size, dest_dtype):
         """Quant -> dequant roundtrip should be close to the original within
@@ -516,7 +511,6 @@ class TestGroupedDequantize:
 # Serialisation (flatten / unflatten)
 # ---------------------------------------------------------------------
 class TestGroupedSerialization:
-
     @pytest.mark.parametrize("granularity,block_size,dest_dtype", _GROUPED_GRAN_CASES)
     def test_flatten_unflatten_roundtrip(self, granularity, block_size, dest_dtype):
         x = torch.randn(M, N, dtype=torch.bfloat16, device=DEVICE)

--- a/tests/pytorch/modules/test_linear.py
+++ b/tests/pytorch/modules/test_linear.py
@@ -55,11 +55,11 @@ def test_linear_accuracy(bs, seq_len, in_features, out_features, bias, dtype, en
 
     assert torch.allclose(x1.grad, x2.grad, **get_tolerances(dtype)), "Forward output mismatch"
 
-    assert torch.allclose(
-        primus_linear.weight.grad, torch_linear.weight.grad, **get_tolerances(dtype)
-    ), "Weight grad mismatch"
+    assert torch.allclose(primus_linear.weight.grad, torch_linear.weight.grad, **get_tolerances(dtype)), (
+        "Weight grad mismatch"
+    )
 
     if bias:
-        assert torch.allclose(
-            primus_linear.bias.grad, torch_linear.bias.grad, **get_tolerances(dtype)
-        ), "Bias grad mismatch"
+        assert torch.allclose(primus_linear.bias.grad, torch_linear.bias.grad, **get_tolerances(dtype)), (
+            "Bias grad mismatch"
+        )

--- a/tests/pytorch/modules/test_token_dispatcher.py
+++ b/tests/pytorch/modules/test_token_dispatcher.py
@@ -134,17 +134,17 @@ def _run_dispatch_combine(
 
     restored_hidden_states = dispatcher.token_combine(permuted_local_hidden_states)
 
-    assert torch.allclose(
-        restored_hidden_states, ans
-    ), "Restored hidden states do not match original hidden states"
+    assert torch.allclose(restored_hidden_states, ans), (
+        "Restored hidden states do not match original hidden states"
+    )
 
     torch.autograd.backward(restored_hidden_states, hidden_states)
     assert torch.allclose(hidden_states.grad, ans), "Gradient does not match original hidden states"
 
     expected_device = "cuda" if deepep_use_cuda_num_tokens_per_expert else "cpu"
-    assert (
-        tokens_per_expert.device.type == expected_device
-    ), f"Expected tokens_per_expert on {expected_device}, got {tokens_per_expert.device.type}"
+    assert tokens_per_expert.device.type == expected_device, (
+        f"Expected tokens_per_expert on {expected_device}, got {tokens_per_expert.device.type}"
+    )
 
 
 @instantiate_parametrized_tests

--- a/tests/pytorch/ops/test_attention.py
+++ b/tests/pytorch/ops/test_attention.py
@@ -103,7 +103,7 @@ def test_attention_16bit(
         v_layout = (batch, seqlen_kv, num_head_kv, head_dim_v)
         o_layout = (batch, seqlen_q, num_head_q, head_dim_v)
     else:
-        assert False, f"Unsupported qkv format: {qkv_format}"
+        raise AssertionError(f"Unsupported qkv format: {qkv_format}")
 
     query = torch.randn(q_layout, device=device, dtype=dtype, requires_grad=True)
     key = torch.randn(k_layout, device=device, dtype=dtype, requires_grad=True)

--- a/tests/pytorch/ops/test_fused_all_gather_matmul.py
+++ b/tests/pytorch/ops/test_fused_all_gather_matmul.py
@@ -202,7 +202,6 @@ class FusedAllGatherMatmulTestBase(MultiProcessTestCase):
         torch.manual_seed(42 + rank)
 
         for M, N, K, batch_size, dtype in get_llama3_70b_cfg():
-
             A_shard = torch.rand(batch_size * M // self.world_size, K, dtype=dtype, device="cuda")
             Bs = [torch.rand(K, N, dtype=dtype, device="cuda")]
 

--- a/tests/pytorch/ops/test_fused_matmul_reduce_scatter.py
+++ b/tests/pytorch/ops/test_fused_matmul_reduce_scatter.py
@@ -198,9 +198,9 @@ class FusedMatmulReduceScatterTestBase(MultiProcessTestCase):
                 comm_method=comm_method,
             )
 
-            assert (
-                rs_output_native.stride() == rs_output_turbo.stride()
-            ), f"rs_output_native stride {rs_output_native.stride()} is not equal to rs_output_turbo stride {rs_output_turbo.stride()}"
+            assert rs_output_native.stride() == rs_output_turbo.stride(), (
+                f"rs_output_native stride {rs_output_native.stride()} is not equal to rs_output_turbo stride {rs_output_turbo.stride()}"
+            )
             diff = (rs_output_native - rs_output_turbo).abs().max()
             diff_mask = rs_output_native != rs_output_turbo
             print(

--- a/tests/pytorch/ops/test_gemm.py
+++ b/tests/pytorch/ops/test_gemm.py
@@ -200,9 +200,9 @@ def test_gemm_deterministic_subview(m, n, k, layout, dtype):
     buf_b /= buf_b.abs().max()
     b0 = torch.as_strided(buf_b, (rows_b, cols_b), (stride_b, 1), storage_offset=misalign)
 
-    assert (
-        a0.data_ptr() % (16 * elem_bytes) != 0
-    ), "test setup: a0 base pointer must NOT be 16-element-aligned"
+    assert a0.data_ptr() % (16 * elem_bytes) != 0, (
+        "test setup: a0 base pointer must NOT be 16-element-aligned"
+    )
     assert a0.stride(0) % 16 == 0, "test setup: a0 stride must be 16-aligned"
 
     # Reference output (correctness baseline uses contiguous copies)

--- a/tests/pytorch/ops/test_gemm_fp4.py
+++ b/tests/pytorch/ops/test_gemm_fp4.py
@@ -518,7 +518,7 @@ def test_gemm_fp4_impl_aiter_preshuffle_parity(m, n, k):
         # Both paths converge on the same aiter.gemm_a4w4(bpreshuffle=True)
         # consuming the same byte-identical shuffled inputs -> outputs match.
         assert torch.equal(out_no_pre, out_pre), (
-            "preshuffled=True must match preshuffled=False bit-for-bit " "on the AITER backend"
+            "preshuffled=True must match preshuffled=False bit-for-bit on the AITER backend"
         )
     finally:
         GlobalBackendManager.reset()

--- a/tests/pytorch/ops/test_grouped_gemm.py
+++ b/tests/pytorch/ops/test_grouped_gemm.py
@@ -233,9 +233,9 @@ def test_grouped_gemm_with_zero_length_groups(B, M, N_K, dtype, trans_b, backend
 
     zero_mask = group_lens == 0
     zero_count = int(zero_mask.sum().item())
-    assert (
-        zero_count == num_zero
-    ), f"expected num_zero={num_zero}, but got {zero_count}; group_lens={group_lens}"
+    assert zero_count == num_zero, (
+        f"expected num_zero={num_zero}, but got {zero_count}; group_lens={group_lens}"
+    )
     zero_indices = torch.nonzero(zero_mask, as_tuple=False).flatten().tolist()
     print(f"zero_indices: {zero_indices}")
 

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -849,15 +849,15 @@ def _test_grouped_gemm_fp8_hipgraph_test(
     # Verify out with group_lens2
     out2_snr = compute_snr(out_ref2, out)
     print(f"[group_lens2] Out-SNR: {out2_snr:.2f} dB")
-    assert out2_snr > snr_threshold, f"out2_snr too low"
+    assert out2_snr > snr_threshold, "out2_snr too low"
 
     a_grad_snr2 = compute_snr(a_ref2.grad, a.grad)
     print(f"[group_lens2] AGrad-SNR: {a_grad_snr2:.2f} dB")
-    assert a_grad_snr2 > snr_threshold, f"a_grad_snr2 too low"
+    assert a_grad_snr2 > snr_threshold, "a_grad_snr2 too low"
 
     b_grad_snr2 = compute_snr(b_ref2.grad, b.grad)
     print(f"[group_lens2] BGrad-SNR: {b_grad_snr2:.2f} dB")
-    assert b_grad_snr2 > snr_threshold, f"b_grad_snr2 too low"
+    assert b_grad_snr2 > snr_threshold, "b_grad_snr2 too low"
 
     del g
     torch.cuda.synchronize()

--- a/tests/pytorch/ops/test_moe_permute.py
+++ b/tests/pytorch/ops/test_moe_permute.py
@@ -4,8 +4,7 @@
 # See LICENSE for license information.
 ###############################################################################
 
-"""Unit tests for ``moe_permute`` / ``moe_unpermute`` (HIP MoE kernels).
-"""
+"""Unit tests for ``moe_permute`` / ``moe_unpermute`` (HIP MoE kernels)."""
 
 import pytest
 import torch

--- a/tests/pytorch/ops/test_quantization.py
+++ b/tests/pytorch/ops/test_quantization.py
@@ -652,6 +652,6 @@ def test_mxfp4_sr_consecutive_calls_differ():
         scaling_recipe=sr_recipe,
     )
 
-    assert not torch.equal(
-        out1.view(torch.uint8), out2.view(torch.uint8)
-    ), "SR-quantized outputs should differ across consecutive calls"
+    assert not torch.equal(out1.view(torch.uint8), out2.view(torch.uint8)), (
+        "SR-quantized outputs should differ across consecutive calls"
+    )

--- a/tests/pytorch/ref/deep_ep_ref.py
+++ b/tests/pytorch/ref/deep_ep_ref.py
@@ -158,7 +158,7 @@ def tune_and_verify_internode(
                 for with_topk in (False, True):
                     if local_rank == 0:
                         print(
-                            f'[testing] Running with {"FP8" if isinstance(current_x, tuple) else "BF16"}, {"with" if with_topk else "without"} top-k (async={async_mode}, previous={previous_mode}) ...',
+                            f"[testing] Running with {'FP8' if isinstance(current_x, tuple) else 'BF16'}, {'with' if with_topk else 'without'} top-k (async={async_mode}, previous={previous_mode}) ...",
                             flush=True,
                             end="",
                         )
@@ -195,9 +195,9 @@ def tune_and_verify_internode(
 
                     # Checks
                     recv_gbl_rank_prefix_sum = handle[-4]
-                    assert gbl_num_tokens_per_rank[rank].item() == recv_x.size(
-                        0
-                    ), f"{gbl_num_tokens_per_rank[rank].item()} != {recv_x.size(0)}"
+                    assert gbl_num_tokens_per_rank[rank].item() == recv_x.size(0), (
+                        f"{gbl_num_tokens_per_rank[rank].item()} != {recv_x.size(0)}"
+                    )
                     assert (
                         gbl_num_tokens_per_expert.view(num_ranks, -1)[rank].tolist()
                         == recv_num_tokens_per_expert_list
@@ -393,7 +393,7 @@ def tune_and_verify_intranode(
                 for with_topk in (False, True):
                     if local_rank == 0:
                         print(
-                            f'[testing] Running with {"FP8" if isinstance(current_x, tuple) else "BF16"}, {"with" if with_topk else "without"} top-k (async={async_mode}, previous={previous_mode}) ...',
+                            f"[testing] Running with {'FP8' if isinstance(current_x, tuple) else 'BF16'}, {'with' if with_topk else 'without'} top-k (async={async_mode}, previous={previous_mode}) ...",
                             flush=True,
                             end="",
                         )
@@ -429,9 +429,9 @@ def tune_and_verify_intranode(
 
                     # Checks
                     rank_prefix_matrix = handle[0]
-                    assert ref_gbl_num_tokens_per_rank[rank].item() == recv_x.size(
-                        0
-                    ), f"{ref_gbl_num_tokens_per_rank[rank].item()} != {recv_x.size(0)}"
+                    assert ref_gbl_num_tokens_per_rank[rank].item() == recv_x.size(0), (
+                        f"{ref_gbl_num_tokens_per_rank[rank].item()} != {recv_x.size(0)}"
+                    )
                     assert (
                         ref_gbl_num_tokens_per_expert.view(num_ranks, -1)[rank].tolist()
                         == recv_num_tokens_per_expert_list

--- a/tools/build_ext.py
+++ b/tools/build_ext.py
@@ -235,6 +235,7 @@ def _is_cuda_file(path: str) -> bool:
 
 def _get_rocm_gpu_rdc_flags(cflags: Optional[list[str]] = None) -> list[str]:
     has_gpu_rdc_flag = False
+    flags = []
     if cflags is not None:
         has_custom_flags = False
         for flag in cflags:
@@ -453,16 +454,16 @@ def _write_ninja_file(
             config.append(f"nvcc = {nvcc}")
 
     post_cflags = COMMON_HIP_FLAGS + post_cflags
-    flags = [f'cflags = {" ".join(cflags)}']
-    flags.append(f'post_cflags = {" ".join(post_cflags)}')
+    flags = [f"cflags = {' '.join(cflags)}"]
+    flags.append(f"post_cflags = {' '.join(post_cflags)}")
     if with_cuda:
-        flags.append(f'cuda_cflags = {" ".join(cuda_cflags)}')
-        flags.append(f'cuda_post_cflags = {" ".join(cuda_post_cflags)}')
+        flags.append(f"cuda_cflags = {' '.join(cuda_cflags)}")
+        flags.append(f"cuda_post_cflags = {' '.join(cuda_post_cflags)}")
         cuda_post_cflags_gfx942, _ = _filter_compile_arch_args(cuda_post_cflags, "gfx942")
-        flags.append(f'cuda_post_cflags_gfx942 = {" ".join(cuda_post_cflags_gfx942)}')
+        flags.append(f"cuda_post_cflags_gfx942 = {' '.join(cuda_post_cflags_gfx942)}")
         cuda_post_cflags_gfx950, _ = _filter_compile_arch_args(cuda_post_cflags, "gfx950")
-        flags.append(f'cuda_post_cflags_gfx950 = {" ".join(cuda_post_cflags_gfx950)}')
-    flags.append(f'cuda_dlink_post_cflags = {" ".join(cuda_dlink_post_cflags)}')
+        flags.append(f"cuda_post_cflags_gfx950 = {' '.join(cuda_post_cflags_gfx950)}")
+    flags.append(f"cuda_dlink_post_cflags = {' '.join(cuda_dlink_post_cflags)}")
 
     # Turn into absolute paths so we can emit them into the ninja build
     # file wherever it is.
@@ -510,7 +511,7 @@ def _write_ninja_file(
         cuda_devlink_out = os.path.join(os.path.dirname(objects[0]), "dlink.o")
         cuda_devlink_rule = ["rule cuda_devlink"]
         cuda_devlink_rule.append("  command = $nvcc $in -o $out $cuda_dlink_post_cflags")
-        cuda_devlink = [f'build {cuda_devlink_out}: cuda_devlink {" ".join(objects)}']
+        cuda_devlink = [f"build {cuda_devlink_out}: cuda_devlink {' '.join(objects)}"]
         objects += [cuda_devlink_out]
     else:
         cuda_devlink_rule, cuda_devlink = [], []
@@ -518,7 +519,7 @@ def _write_ninja_file(
     if library_target is not None:
         link_rule = ["rule link"]
         link_rule.append("  command = $cxx $in $ldflags -o $out")
-        link = [f'build {library_target}: link {" ".join(objects)}']
+        link = [f"build {library_target}: link {' '.join(objects)}"]
         default = [f"default {library_target}"]
     else:
         link_rule, link, default = [], [], []

--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -280,9 +280,9 @@ def get_gpu_arch(gpu_id: int = 0) -> str:
             check=True,
         )
     except FileNotFoundError:
-        raise RuntimeError("rocminfo not found. Please ensure ROCm is installed.")
+        raise RuntimeError("rocminfo not found. Please ensure ROCm is installed.") from None
     except subprocess.CalledProcessError as e:
-        raise RuntimeError(f"rocminfo failed: {e.stderr}")
+        raise RuntimeError(f"rocminfo failed: {e.stderr}") from e
 
     matches = GPU_ARCH_PATTERN.findall(result.stdout)
 


### PR DESCRIPTION
# Description

Migrate the formatting and linting toolchain from `black + isort + autoflake` to the unified `ruff`, and update pre-commit, CI, and dev dependencies accordingly. Along the way, fix a few real bugs and lint findings surfaced by the migration. The goal is to align with the mainstream community toolchain, simplify configuration, and improve consistency.

Fixes # (N/A)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- **Toolchain migration**: Replace `black`/`isort`/`autoflake` with `ruff` + `ruff-format`. Centralize configuration in `pyproject.toml` (`line-length=110`, enable `B/F/I/W` rules, with reasonable ignores for `F403/F405/B905/B007/B028`).
- **pre-commit / CI**: Update `.pre-commit-config.yaml` and the CI lint job to use `ruff check` + `ruff format --check`. Add common generic hooks (`check-toml`, `check-ast`, `check-case-conflict`, `debug-statements`, `detect-private-key`).
- **Dependency pinning**: Pin `ruff`, `pre-commit`, and `clang-format` versions in `requirements.txt` to match the container environment.
- **Bug fixes**: Initialize the uninitialized `flags` list in `tools/build_ext.py`; import the missing `_format_kwargs` helper in `attention_aiter_impl.py` to avoid a potential `NameError` on error paths.
- **Lint fixes (flake8-bugbear B)**: Replace `assert False` with `raise AssertionError` (B011), chain re-raised exceptions with `from` (B904), avoid a function call in a default argument (B008), mark an intentional ABC (B024), drop unused variables, and annotate intentional star-imports / unused imports.
- **Docs**: Add a "Code Style & Linting" section to `CONTRIBUTING.md` describing ruff usage and commands.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes