### PR TITLE
test: skip TurboStream tests to unblock CI (ROCm hipExtStreamCreateWi…

### DIFF
--- a/tests/pytorch/core/test_stream.py
+++ b/tests/pytorch/core/test_stream.py
@@ -3,6 +3,17 @@ import torch
 
 from primus_turbo.pytorch.core import TurboStream
 
+# NOTE: Temporarily skipped to unblock CI.
+# Under concurrent multi-process GPU load (pytest -n 8), hipExtStreamCreateWithCUMask
+# deadlocks inside the ROCm runtime: an HSA background thread holds the libamdhip64
+# global mutex while blocked in the kernel AMDKFD_IOC_WAIT_EVENTS ioctl, so this call
+# waits on that mutex forever and the whole CI job times out.
+# Root cause is in the ROCm runtime (libamdhip64 + libhsa-runtime64 + amdkfd), not in
+# this wrapper. Re-enable once the ROCm fix lands / is verified on a newer image.
+pytestmark = pytest.mark.skip(
+    reason="TurboStream hipExtStreamCreateWithCUMask deadlocks in ROCm runtime under parallel GPU load (CI hang)"
+)
+
 
 @pytest.mark.parametrize("device", [0, "cuda", "cuda:0", torch.device("cuda:0")])
 @pytest.mark.parametrize("cu_masks", [None, [0xFFFFFFFF], [0xFFFFFFFF, 0xFFFFFFFF]])


### PR DESCRIPTION
…thCUMask deadlock)

Under parallel runs (pytest -n 8), test_turbo_stream hangs the whole CI job: hipExtStreamCreateWithCUMask deadlocks inside the ROCm runtime when an HSA background thread holds the libamdhip64 global mutex while blocked in the kernel AMDKFD_IOC_WAIT_EVENTS ioctl, so stream creation waits on that mutex forever and the job times out.

Root cause is in the ROCm runtime (libamdhip64 + libhsa-runtime64 + amdkfd), not in the wrapper. Skip the tests for now; re-enable once the runtime fix lands or is verified on a newer image.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
