### PR TITLE
ci: add 10-min per-test timeout (thread method) to catch hangs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,7 +201,7 @@ jobs:
           command: >
             timeout -k 60s 130m
             bash -lc
-            "exec pytest -v tests/pytorch -n 8 --log-cli-level=INFO"
+            "exec pytest -v tests/pytorch -n 8 --timeout=600 --timeout-method=thread --max-worker-restart=8 --log-cli-level=INFO"
         env:
           XLA_PYTHON_CLIENT_PREALLOCATE: "false"
       - name: Run deterministic tests (parallel)
@@ -213,7 +213,7 @@ jobs:
           command: >
             timeout -k 60s 55m
             bash -lc
-            "exec pytest -v tests/pytorch -n 8 --deterministic-only --log-cli-level=INFO"
+            "exec pytest -v tests/pytorch -n 8 --deterministic-only --timeout=600 --timeout-method=thread --max-worker-restart=8 --log-cli-level=INFO"
         env:
           XLA_PYTHON_CLIENT_PREALLOCATE: "false"
       - name: Run distributed tests
@@ -221,7 +221,7 @@ jobs:
         with:
           timeout_minutes: 60
           max_attempts: 2
-          command: pytest -v tests/pytorch --dist-only --log-cli-level=INFO
+          command: pytest -v tests/pytorch --dist-only --timeout=600 --timeout-method=thread --log-cli-level=INFO
         env:
           XLA_PYTHON_CLIENT_PREALLOCATE: "false"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ ninja
 expecttest
 pytest
 pytest-xdist
+pytest-timeout
 setuptools==69.5.1
 setuptools_scm[toml]>=8
 wheel


### PR DESCRIPTION
Add pytest-timeout and a per-test timeout to the PyTorch CI jobs so a single hanging case fails fast with a stack dump instead of wedging the whole job until the 130-min wall-clock kill.

- requirements.txt: add pytest-timeout
- ci.yaml: --timeout=600 --timeout-method=thread on the pytorch test steps (+ --max-worker-restart=8 on the parallel -n 8 steps so xdist restarts a killed worker and keeps going)

thread method is required because native (ROCm/HIP) deadlocks do not return to Python, so the signal method cannot interrupt them; a watchdog thread can.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
