### PR TITLE
[feat] add mxfp4 triton grouped gemm support

### DIFF
--- a/csrc/include/primus_turbo/device/reduce.cuh
+++ b/csrc/include/primus_turbo/device/reduce.cuh
@@ -171,24 +171,26 @@ template <template <class> class Func, typename T> PRIMUS_TURBO_DEVICE T BlockRe
  * Reference: AMD CDNA4 ISA, ds_swizzle_b32 (page 480)
  */
 
-// NOTE on the ``"memory"`` clobber below:
-//   ``ds_swizzle_b32`` is an LDS-pipe op whose result only becomes valid after
-//   ``s_waitcnt lgkmcnt(0)``. Without a ``"memory"`` clobber the compiler is
-//   free to software-pipeline / reorder consecutive swizzles (and intervening
-//   ``__shared__`` stores that bump the same ``lgkmcnt`` counter) across each
-//   other. When the producing tile's ``s_tile`` LDS stores are still in flight
-//   (the rowwise path has no ``__syncthreads`` before its reduction, unlike the
-//   colwise path) this reordering let a fraction (~1%) of per-row ``amax``
-//   reductions latch stale lane data, making the rowwise FP4 scale -- and thus
-//   the packed FP4 -- non-deterministic run-to-run. The clobber forces each
-//   swizzle+wait to act as a scheduling barrier so the reduction is bit-exact.
+// NOTE on the single-asm-block form below:
+//   ``ds_swizzle_b32`` is an LDS-pipe op whose result is only valid after
+//   ``s_waitcnt lgkmcnt(0)``. The swizzle and its wait MUST live in one
+//   ``asm volatile`` block with ``result`` as the output operand: that ties
+//   "result is ready" to "after the wait", so the compiler cannot hoist the
+//   consumer of ``result`` ahead of the wait. Emitting the wait as a separate
+//   operand-less asm (the compiler sees no dependency on ``result``) let the
+//   reduction read the swizzle result early -- stale lane data that made a
+//   fraction (~1%) of the rowwise per-row ``amax``, and thus the FP4 scale,
+//   non-deterministic run-to-run. The single block is the fix. No ``"memory"``
+//   clobber is needed: the swizzle is register-only (it does not order against
+//   the ``s_tile`` LDS traffic -- rowwise never reads ``s_tile`` and colwise
+//   reads it only after ``__syncthreads``), and the clobber would needlessly
+//   block memory-op scheduling around this VALU-bound reduction.
 PRIMUS_TURBO_DEVICE float ds_swizzle_xor1(float val) {
     float result;
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x041F\n\t"
                  "s_waitcnt lgkmcnt(0)"
                  : "=v"(result)
-                 : "v"(val)
-                 : "memory");
+                 : "v"(val));
     return result;
 }
 
@@ -197,8 +199,7 @@ PRIMUS_TURBO_DEVICE float ds_swizzle_xor2(float val) {
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x081F\n\t"
                  "s_waitcnt lgkmcnt(0)"
                  : "=v"(result)
-                 : "v"(val)
-                 : "memory");
+                 : "v"(val));
     return result;
 }
 
@@ -207,8 +208,7 @@ PRIMUS_TURBO_DEVICE float ds_swizzle_xor8(float val) {
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x201F\n\t"
                  "s_waitcnt lgkmcnt(0)"
                  : "=v"(result)
-                 : "v"(val)
-                 : "memory");
+                 : "v"(val));
     return result;
 }
 
@@ -217,8 +217,7 @@ PRIMUS_TURBO_DEVICE float ds_swizzle_xor16(float val) {
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x401F\n\t"
                  "s_waitcnt lgkmcnt(0)"
                  : "=v"(result)
-                 : "v"(val)
-                 : "memory");
+                 : "v"(val));
     return result;
 }
 
@@ -241,18 +240,17 @@ PRIMUS_TURBO_DEVICE float warp_reduce_max_8_dpp(float val) {
     uint32_t v = float_as_uint(val);
     uint32_t tmp;
 
-    // Each swizzle+wait is fused into a single ``"memory"``-clobbering asm so the
-    // compiler cannot pipeline/reorder the three reduction steps (or hoist
-    // in-flight ``__shared__`` stores between them). See the note on the
-    // ``ds_swizzle_xor*`` helpers: without this the per-row reduction is
-    // non-deterministic when the producing tile's LDS stores are still pending.
+    // Each swizzle is fused with its ``s_waitcnt lgkmcnt(0)`` in one asm block
+    // with ``tmp`` as the output operand, so the following ``fmaxf`` cannot
+    // consume ``tmp`` before the wait completes. See the note on the
+    // ``ds_swizzle_xor*`` helpers for why the single block (not a ``"memory"``
+    // clobber) is what makes the per-row reduction deterministic.
 
     // Step 1: Exchange with thread 4 positions away
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x101F\n\t"
                  "s_waitcnt lgkmcnt(0)"
                  : "=v"(tmp)
-                 : "v"(v)
-                 : "memory");
+                 : "v"(v));
     val = fmaxf(val, uint_as_float(tmp));
     v   = float_as_uint(val);
 
@@ -260,8 +258,7 @@ PRIMUS_TURBO_DEVICE float warp_reduce_max_8_dpp(float val) {
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x081F\n\t"
                  "s_waitcnt lgkmcnt(0)"
                  : "=v"(tmp)
-                 : "v"(v)
-                 : "memory");
+                 : "v"(v));
     val = fmaxf(val, uint_as_float(tmp));
     v   = float_as_uint(val);
 
@@ -269,8 +266,7 @@ PRIMUS_TURBO_DEVICE float warp_reduce_max_8_dpp(float val) {
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x041F\n\t"
                  "s_waitcnt lgkmcnt(0)"
                  : "=v"(tmp)
-                 : "v"(v)
-                 : "memory");
+                 : "v"(v));
     val = fmaxf(val, uint_as_float(tmp));
 
     return val;

--- a/csrc/include/primus_turbo/device/reduce.cuh
+++ b/csrc/include/primus_turbo/device/reduce.cuh
@@ -171,12 +171,24 @@ template <template <class> class Func, typename T> PRIMUS_TURBO_DEVICE T BlockRe
  * Reference: AMD CDNA4 ISA, ds_swizzle_b32 (page 480)
  */
 
+// NOTE on the ``"memory"`` clobber below:
+//   ``ds_swizzle_b32`` is an LDS-pipe op whose result only becomes valid after
+//   ``s_waitcnt lgkmcnt(0)``. Without a ``"memory"`` clobber the compiler is
+//   free to software-pipeline / reorder consecutive swizzles (and intervening
+//   ``__shared__`` stores that bump the same ``lgkmcnt`` counter) across each
+//   other. When the producing tile's ``s_tile`` LDS stores are still in flight
+//   (the rowwise path has no ``__syncthreads`` before its reduction, unlike the
+//   colwise path) this reordering let a fraction (~1%) of per-row ``amax``
+//   reductions latch stale lane data, making the rowwise FP4 scale -- and thus
+//   the packed FP4 -- non-deterministic run-to-run. The clobber forces each
+//   swizzle+wait to act as a scheduling barrier so the reduction is bit-exact.
 PRIMUS_TURBO_DEVICE float ds_swizzle_xor1(float val) {
     float result;
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x041F\n\t"
                  "s_waitcnt lgkmcnt(0)"
                  : "=v"(result)
-                 : "v"(val));
+                 : "v"(val)
+                 : "memory");
     return result;
 }
 
@@ -185,7 +197,8 @@ PRIMUS_TURBO_DEVICE float ds_swizzle_xor2(float val) {
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x081F\n\t"
                  "s_waitcnt lgkmcnt(0)"
                  : "=v"(result)
-                 : "v"(val));
+                 : "v"(val)
+                 : "memory");
     return result;
 }
 
@@ -194,7 +207,8 @@ PRIMUS_TURBO_DEVICE float ds_swizzle_xor8(float val) {
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x201F\n\t"
                  "s_waitcnt lgkmcnt(0)"
                  : "=v"(result)
-                 : "v"(val));
+                 : "v"(val)
+                 : "memory");
     return result;
 }
 
@@ -203,7 +217,8 @@ PRIMUS_TURBO_DEVICE float ds_swizzle_xor16(float val) {
     asm volatile("ds_swizzle_b32 %0, %1 offset:0x401F\n\t"
                  "s_waitcnt lgkmcnt(0)"
                  : "=v"(result)
-                 : "v"(val));
+                 : "v"(val)
+                 : "memory");
     return result;
 }
 
@@ -226,21 +241,36 @@ PRIMUS_TURBO_DEVICE float warp_reduce_max_8_dpp(float val) {
     uint32_t v = float_as_uint(val);
     uint32_t tmp;
 
+    // Each swizzle+wait is fused into a single ``"memory"``-clobbering asm so the
+    // compiler cannot pipeline/reorder the three reduction steps (or hoist
+    // in-flight ``__shared__`` stores between them). See the note on the
+    // ``ds_swizzle_xor*`` helpers: without this the per-row reduction is
+    // non-deterministic when the producing tile's LDS stores are still pending.
+
     // Step 1: Exchange with thread 4 positions away
-    asm volatile("ds_swizzle_b32 %0, %1 offset:0x101F" : "=v"(tmp) : "v"(v));
-    asm volatile("s_waitcnt lgkmcnt(0)" :::);
+    asm volatile("ds_swizzle_b32 %0, %1 offset:0x101F\n\t"
+                 "s_waitcnt lgkmcnt(0)"
+                 : "=v"(tmp)
+                 : "v"(v)
+                 : "memory");
     val = fmaxf(val, uint_as_float(tmp));
     v   = float_as_uint(val);
 
     // Step 2: Exchange with thread 2 positions away
-    asm volatile("ds_swizzle_b32 %0, %1 offset:0x081F" : "=v"(tmp) : "v"(v));
-    asm volatile("s_waitcnt lgkmcnt(0)" :::);
+    asm volatile("ds_swizzle_b32 %0, %1 offset:0x081F\n\t"
+                 "s_waitcnt lgkmcnt(0)"
+                 : "=v"(tmp)
+                 : "v"(v)
+                 : "memory");
     val = fmaxf(val, uint_as_float(tmp));
     v   = float_as_uint(val);
 
     // Step 3: Exchange with adjacent thread
-    asm volatile("ds_swizzle_b32 %0, %1 offset:0x041F" : "=v"(tmp) : "v"(v));
-    asm volatile("s_waitcnt lgkmcnt(0)" :::);
+    asm volatile("ds_swizzle_b32 %0, %1 offset:0x041F\n\t"
+                 "s_waitcnt lgkmcnt(0)"
+                 : "=v"(tmp)
+                 : "v"(v)
+                 : "memory");
     val = fmaxf(val, uint_as_float(tmp));
 
     return val;

--- a/csrc/include/primus_turbo/quantization.h
+++ b/csrc/include/primus_turbo/quantization.h
@@ -106,7 +106,7 @@ constexpr int E8M0_EXPONENT_BIAS = 127;
 template <typename DType>
 void quantize_mxfp4_dual_impl(const DType *input, dtype::float4x2_e2m1 *rowwise_output,
                               uint8_t *rowwise_scale, dtype::float4x2_e2m1 *colwise_output,
-                              uint8_t *colwise_scale, int M, int N, int M_pad, int N_pad,
+                              uint8_t *colwise_scale, int G, int M, int N, int M_pad, int N_pad,
                               int rowwise_scale_stride, int colwise_scale_stride,
                               int rowwise_scale_N, int rowwise_scale_M_pad, int rowwise_scale_N_pad,
                               int colwise_scale_M, int colwise_scale_N, int colwise_scale_M_pad,
@@ -144,6 +144,17 @@ void grouped_quantize_mxfp8_dual_impl(
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
     int colwise_scale_M_pad, int colwise_scale_N_pad, detail::ScalingRecipe rowwise_recipe,
     detail::ScalingRecipe colwise_recipe, hipStream_t stream);
+
+// Grouped MXFP4 dual quant: rowwise output is the tight (un-padded) M layout
+// (row i == input row i), colwise output is the 128-padded per-group M layout
+// (variable-K wgrad).  Shuffle layouts are not supported.
+template <typename DType>
+void grouped_quantize_mxfp4_dual_impl(
+    const DType *input, dtype::float4x2_e2m1 *rowwise_output, uint8_t *rowwise_scale,
+    dtype::float4x2_e2m1 *colwise_output, uint8_t *colwise_scale, const int64_t *group_offs,
+    const int64_t *group_offs_padded_colwise, int G, int total_M, int N, int M_pad_col, int N_pad,
+    int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N, int colwise_scale_N,
+    detail::ScalingRecipe rowwise_recipe, detail::ScalingRecipe colwise_recipe, hipStream_t stream);
 
 // *************** Grouped Padded Layout ***************
 //

--- a/csrc/kernels/quantization/quantization_mxfp4.cu
+++ b/csrc/kernels/quantization/quantization_mxfp4.cu
@@ -634,12 +634,14 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp4_dual_kern
     const int64_t colwise_scale_per_group_stride = 0) {
     // Per-group offsets for batched (3D) input (no-op when launched with
     // grid_z == 1); each blockIdx.z slice quantizes one (M, N) weight group.
-    const int      g             = blockIdx.z;
+    const int g                     = blockIdx.z;
     const DType *__restrict__ input = input_base + (int64_t) g * input_per_group_stride;
-    uint8_t *__restrict__ rowwise_fp4 = rowwise_fp4_base + (int64_t) g * rowwise_fp4_per_group_stride;
+    uint8_t *__restrict__ rowwise_fp4 =
+        rowwise_fp4_base + (int64_t) g * rowwise_fp4_per_group_stride;
     uint8_t *__restrict__ rowwise_scale =
         rowwise_scale_base + (int64_t) g * rowwise_scale_per_group_stride;
-    uint8_t *__restrict__ colwise_fp4 = colwise_fp4_base + (int64_t) g * colwise_fp4_per_group_stride;
+    uint8_t *__restrict__ colwise_fp4 =
+        colwise_fp4_base + (int64_t) g * colwise_fp4_per_group_stride;
     uint8_t *__restrict__ colwise_scale =
         colwise_scale_base + (int64_t) g * colwise_scale_per_group_stride;
 
@@ -1312,7 +1314,7 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void grouped_quantize_mxfp4_d
 
     const int tid           = threadIdx.x;
     const int warp_id       = tid / WARP_SIZE;
-    const int lane_id        = tid % WARP_SIZE;
+    const int lane_id       = tid % WARP_SIZE;
     const int row_in_warp   = lane_id / THREADS_PER_ROW;
     const int thread_in_row = lane_id % THREADS_PER_ROW;
 
@@ -1427,9 +1429,9 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void grouped_quantize_mxfp4_d
 
             const int global_row = tile_m + pass * ROWS_PER_PASS + row_in_warp;
             if (global_row < real_end_in_pad) {
-                packed_uint16x4_to_floatx4<kIshalf>(r_tile[pass], r_rowwise_vals[pass][0],
-                                                    r_rowwise_vals[pass][1], r_rowwise_vals[pass][2],
-                                                    r_rowwise_vals[pass][3]);
+                packed_uint16x4_to_floatx4<kIshalf>(
+                    r_tile[pass], r_rowwise_vals[pass][0], r_rowwise_vals[pass][1],
+                    r_rowwise_vals[pass][2], r_rowwise_vals[pass][3]);
                 if constexpr (ROWWISE_USE_RHT) {
                     rht16_inplace(r_rowwise_vals[pass][0], r_rowwise_vals[pass][1],
                                   r_rowwise_vals[pass][2], r_rowwise_vals[pass][3], thread_in_row);
@@ -1485,11 +1487,10 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void grouped_quantize_mxfp4_d
                     uint16_t fp4x4;
                     if constexpr (ROWWISE_USE_SR) {
                         uint32_t rng = sr_hash(sr_seed ^ (blockDim.x * blockIdx.x + threadIdx.x));
-                        fp4x4 = cvt_f32x4_to_fp4x4_sr(r_rowwise_vals[pass][0],
-                                                      r_rowwise_vals[pass][1],
-                                                      r_rowwise_vals[pass][2],
-                                                      r_rowwise_vals[pass][3],
-                                                      r_rowwise_scale_native[pass], rng);
+                        fp4x4 =
+                            cvt_f32x4_to_fp4x4_sr(r_rowwise_vals[pass][0], r_rowwise_vals[pass][1],
+                                                  r_rowwise_vals[pass][2], r_rowwise_vals[pass][3],
+                                                  r_rowwise_scale_native[pass], rng);
                     } else {
                         fp4x4 = cvt_f32x4_to_fp4x4(r_rowwise_vals[pass][0], r_rowwise_vals[pass][1],
                                                    r_rowwise_vals[pass][2], r_rowwise_vals[pass][3],
@@ -1595,21 +1596,19 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void grouped_quantize_mxfp4_d
                     uint16_t fp4x4;
                     if constexpr (COLWISE_USE_SR) {
                         uint32_t rng = sr_hash(sr_seed ^ (blockDim.x * blockIdx.x + threadIdx.x));
-                        fp4x4 = cvt_f32x4_to_fp4x4_sr(r_colwise_vals[pass][0],
-                                                      r_colwise_vals[pass][1],
-                                                      r_colwise_vals[pass][2],
-                                                      r_colwise_vals[pass][3],
-                                                      r_colwise_scale_native[pass], rng);
+                        fp4x4 =
+                            cvt_f32x4_to_fp4x4_sr(r_colwise_vals[pass][0], r_colwise_vals[pass][1],
+                                                  r_colwise_vals[pass][2], r_colwise_vals[pass][3],
+                                                  r_colwise_scale_native[pass], rng);
                     } else {
                         fp4x4 = cvt_f32x4_to_fp4x4(r_colwise_vals[pass][0], r_colwise_vals[pass][1],
                                                    r_colwise_vals[pass][2], r_colwise_vals[pass][3],
                                                    r_colwise_scale_native[pass]);
                     }
 
-                    s_colwise_fp4[chunk_n][pass * ROWS_PER_PASS + row_in_warp]
-                                 [chunk_m * THREADS_PER_ROW + thread_in_row] =
-                                     (global_row_base < M_pad_col) ? fp4x4
-                                                                   : static_cast<uint16_t>(0);
+                    s_colwise_fp4[chunk_n][pass * ROWS_PER_PASS +
+                                           row_in_warp][chunk_m * THREADS_PER_ROW + thread_in_row] =
+                        (global_row_base < M_pad_col) ? fp4x4 : static_cast<uint16_t>(0);
 
                     if (thread_in_row == 0) {
                         const int scale_col = block_m * NUM_CHUNKS_M + chunk_m;
@@ -1671,12 +1670,14 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void grouped_quantize_mxfp4_d
 }
 
 template <typename DType>
-void grouped_quantize_mxfp4_dual_impl(
-    const DType *input, dtype::float4x2_e2m1 *rowwise_output, uint8_t *rowwise_scale,
-    dtype::float4x2_e2m1 *colwise_output, uint8_t *colwise_scale, const int64_t *group_offs,
-    const int64_t *group_offs_padded_colwise, int G, int total_M, int N, int M_pad_col, int N_pad,
-    int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N, int colwise_scale_N,
-    ScalingRecipe rowwise_recipe, ScalingRecipe colwise_recipe, hipStream_t stream) {
+void grouped_quantize_mxfp4_dual_impl(const DType *input, dtype::float4x2_e2m1 *rowwise_output,
+                                      uint8_t *rowwise_scale, dtype::float4x2_e2m1 *colwise_output,
+                                      uint8_t *colwise_scale, const int64_t *group_offs,
+                                      const int64_t *group_offs_padded_colwise, int G, int total_M,
+                                      int N, int M_pad_col, int N_pad, int rowwise_scale_stride,
+                                      int colwise_scale_stride, int rowwise_scale_N,
+                                      int colwise_scale_N, ScalingRecipe rowwise_recipe,
+                                      ScalingRecipe colwise_recipe, hipStream_t stream) {
     PRIMUS_TURBO_CHECK(rowwise_recipe.shuffle_out == false && rowwise_recipe.shuffle_scale == false,
                        "grouped MXFP4 dual does not support shuffle");
     PRIMUS_TURBO_CHECK(colwise_recipe.shuffle_out == false && colwise_recipe.shuffle_scale == false,
@@ -1686,17 +1687,17 @@ void grouped_quantize_mxfp4_dual_impl(
     dim3           block(THREADS_PER_BLOCK);
     const uint32_t sr_seed = global_sr_counter.fetch_add(1, std::memory_order_relaxed);
 
-#define GROUPED_QUANTIZE_MXFP4_DUAL_ARGS                                                            \
+#define GROUPED_QUANTIZE_MXFP4_DUAL_ARGS                                                           \
     input, reinterpret_cast<uint8_t *>(rowwise_output), rowwise_scale,                             \
         reinterpret_cast<uint8_t *>(colwise_output), colwise_scale, group_offs,                    \
         group_offs_padded_colwise, G, N, M_pad_col, N_pad, rowwise_scale_stride,                   \
         colwise_scale_stride, rowwise_scale_N, colwise_scale_N, sr_seed
 
-#define GROUPED_QUANTIZE_MXFP4_DUAL_LAUNCH(R_RHT, C_RHT, R_2D, C_2D, R_SR, C_SR)                    \
-    grouped_quantize_mxfp4_dual_kernel<DType, R_RHT, C_RHT, R_2D, C_2D, R_SR, C_SR>                 \
+#define GROUPED_QUANTIZE_MXFP4_DUAL_LAUNCH(R_RHT, C_RHT, R_2D, C_2D, R_SR, C_SR)                   \
+    grouped_quantize_mxfp4_dual_kernel<DType, R_RHT, C_RHT, R_2D, C_2D, R_SR, C_SR>                \
         <<<grid, block, 0, stream>>>(GROUPED_QUANTIZE_MXFP4_DUAL_ARGS)
 
-#define GROUPED_DISPATCH_2D(R_RHT, C_RHT, R_SR, C_SR)                                               \
+#define GROUPED_DISPATCH_2D(R_RHT, C_RHT, R_SR, C_SR)                                              \
     if (rowwise_recipe.use_2d_block) {                                                             \
         if (colwise_recipe.use_2d_block) {                                                         \
             GROUPED_QUANTIZE_MXFP4_DUAL_LAUNCH(R_RHT, C_RHT, true, true, R_SR, C_SR);              \
@@ -1711,7 +1712,7 @@ void grouped_quantize_mxfp4_dual_impl(
         }                                                                                          \
     }
 
-#define GROUPED_DISPATCH_RHT(R_SR, C_SR)                                                            \
+#define GROUPED_DISPATCH_RHT(R_SR, C_SR)                                                           \
     if (rowwise_recipe.use_rht) {                                                                  \
         if (colwise_recipe.use_rht) {                                                              \
             GROUPED_DISPATCH_2D(true, true, R_SR, C_SR);                                           \

--- a/csrc/kernels/quantization/quantization_mxfp4.cu
+++ b/csrc/kernels/quantization/quantization_mxfp4.cu
@@ -412,7 +412,15 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp4_kernel(
                         float local_amax =
                             fmaxf(fmaxf(fabsf(r_vals[pass][0]), fabsf(r_vals[pass][1])),
                                   fmaxf(fabsf(r_vals[pass][2]), fabsf(r_vals[pass][3])));
-                        r_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+                        // 2D-block scale reduces over the whole 32x32 tile, so the
+                        // per-row/col warp_reduce_max_8 here is redundant -- defer to the
+                        // single tile-wide warp_reduce_max_64 below. max is
+                        // order-independent, so the scale (and packed FP4) stay bit-exact.
+                        if constexpr (USE_2D_BLOCK) {
+                            r_amax[pass] = local_amax;
+                        } else {
+                            r_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+                        }
                     }
                 } else {
                     // Colwise: each pass processes one col, read from shared memory (transposed)
@@ -438,7 +446,15 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp4_kernel(
                         float local_amax =
                             fmaxf(fmaxf(fabsf(r_vals[pass][0]), fabsf(r_vals[pass][1])),
                                   fmaxf(fabsf(r_vals[pass][2]), fabsf(r_vals[pass][3])));
-                        r_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+                        // 2D-block scale reduces over the whole 32x32 tile, so the
+                        // per-row/col warp_reduce_max_8 here is redundant -- defer to the
+                        // single tile-wide warp_reduce_max_64 below. max is
+                        // order-independent, so the scale (and packed FP4) stay bit-exact.
+                        if constexpr (USE_2D_BLOCK) {
+                            r_amax[pass] = local_amax;
+                        } else {
+                            r_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+                        }
                     }
                 }
             }
@@ -604,14 +620,29 @@ template <typename DType, bool ROWWISE_USE_RHT = false, bool COLWISE_USE_RHT = f
           bool ROWWISE_USE_2D_BLOCK = false, bool COLWISE_USE_2D_BLOCK = false,
           bool ROWWISE_USE_SR = false, bool COLWISE_USE_SR = false>
 __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp4_dual_kernel(
-    const DType *__restrict__ input, uint8_t *__restrict__ rowwise_fp4,
-    uint8_t *__restrict__ rowwise_scale, uint8_t *__restrict__ colwise_fp4,
-    uint8_t *__restrict__ colwise_scale, const int M, const int N, const int M_pad, const int N_pad,
-    const int rowwise_scale_stride, const int colwise_scale_stride, const int rowwise_scale_N,
-    const int rowwise_scale_M_pad, const int rowwise_scale_N_pad, const int colwise_scale_M,
-    const int colwise_scale_N, const int colwise_scale_M_pad, const int colwise_scale_N_pad,
-    const bool shuffle_rowwise, const bool shuffle_colwise, const bool shuffle_rowwise_scale,
-    const bool shuffle_colwise_scale, const uint32_t sr_seed) {
+    const DType *__restrict__ input_base, uint8_t *__restrict__ rowwise_fp4_base,
+    uint8_t *__restrict__ rowwise_scale_base, uint8_t *__restrict__ colwise_fp4_base,
+    uint8_t *__restrict__ colwise_scale_base, const int M, const int N, const int M_pad,
+    const int N_pad, const int rowwise_scale_stride, const int colwise_scale_stride,
+    const int rowwise_scale_N, const int rowwise_scale_M_pad, const int rowwise_scale_N_pad,
+    const int colwise_scale_M, const int colwise_scale_N, const int colwise_scale_M_pad,
+    const int colwise_scale_N_pad, const bool shuffle_rowwise, const bool shuffle_colwise,
+    const bool shuffle_rowwise_scale, const bool shuffle_colwise_scale, const uint32_t sr_seed,
+    const int64_t input_per_group_stride = 0, const int64_t rowwise_fp4_per_group_stride = 0,
+    const int64_t rowwise_scale_per_group_stride = 0,
+    const int64_t colwise_fp4_per_group_stride   = 0,
+    const int64_t colwise_scale_per_group_stride = 0) {
+    // Per-group offsets for batched (3D) input (no-op when launched with
+    // grid_z == 1); each blockIdx.z slice quantizes one (M, N) weight group.
+    const int      g             = blockIdx.z;
+    const DType *__restrict__ input = input_base + (int64_t) g * input_per_group_stride;
+    uint8_t *__restrict__ rowwise_fp4 = rowwise_fp4_base + (int64_t) g * rowwise_fp4_per_group_stride;
+    uint8_t *__restrict__ rowwise_scale =
+        rowwise_scale_base + (int64_t) g * rowwise_scale_per_group_stride;
+    uint8_t *__restrict__ colwise_fp4 = colwise_fp4_base + (int64_t) g * colwise_fp4_per_group_stride;
+    uint8_t *__restrict__ colwise_scale =
+        colwise_scale_base + (int64_t) g * colwise_scale_per_group_stride;
+
     // ========================================================================
     // Thread and Block Identification
     // ========================================================================
@@ -753,7 +784,13 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp4_dual_kern
                     float local_amax = fmaxf(
                         fmaxf(fabsf(r_rowwise_vals[pass][0]), fabsf(r_rowwise_vals[pass][1])),
                         fmaxf(fabsf(r_rowwise_vals[pass][2]), fabsf(r_rowwise_vals[pass][3])));
-                    r_rowwise_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+                    // 2D-block scale spans the whole tile -> the per-row warp_reduce_max_8
+                    // is redundant; defer to the single warp_reduce_max_64 (bit-exact).
+                    if constexpr (ROWWISE_USE_2D_BLOCK) {
+                        r_rowwise_amax[pass] = local_amax;
+                    } else {
+                        r_rowwise_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+                    }
                 }
             }
         }
@@ -889,7 +926,13 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp4_dual_kern
                     float local_amax = fmaxf(
                         fmaxf(fabsf(r_colwise_vals[pass][0]), fabsf(r_colwise_vals[pass][1])),
                         fmaxf(fabsf(r_colwise_vals[pass][2]), fabsf(r_colwise_vals[pass][3])));
-                    r_colwise_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+                    // 2D-block scale spans the whole tile -> the per-col warp_reduce_max_8
+                    // is redundant; defer to the single warp_reduce_max_64 (bit-exact).
+                    if constexpr (COLWISE_USE_2D_BLOCK) {
+                        r_colwise_amax[pass] = local_amax;
+                    } else {
+                        r_colwise_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+                    }
                 }
             }
         }
@@ -1052,15 +1095,28 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp4_dual_kern
 template <typename DType>
 void quantize_mxfp4_dual_impl(const DType *input, dtype::float4x2_e2m1 *rowwise_output,
                               uint8_t *rowwise_scale, dtype::float4x2_e2m1 *colwise_output,
-                              uint8_t *colwise_scale, int M, int N, int M_pad, int N_pad,
+                              uint8_t *colwise_scale, int G, int M, int N, int M_pad, int N_pad,
                               int rowwise_scale_stride, int colwise_scale_stride,
                               int rowwise_scale_N, int rowwise_scale_M_pad, int rowwise_scale_N_pad,
                               int colwise_scale_M, int colwise_scale_N, int colwise_scale_M_pad,
                               int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
                               ScalingRecipe colwise_recipe, hipStream_t stream) {
-    dim3           grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
+    // Batched (G > 1) input is handled by replicating the per-matrix grid along
+    // blockIdx.z; each z-slice quantizes one (M, N) group offset by its stride.
+    dim3           grid((M_pad + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N, G);
     dim3           block(THREADS_PER_BLOCK);
     const uint32_t sr_seed = global_sr_counter.fetch_add(1, std::memory_order_relaxed);
+
+    // Per-group strides into the contiguous (G, ...) output/scale buffers. FP4
+    // outputs are 2-per-byte packed, so their strides use the /2 packed widths.
+    const int64_t input_per_group_stride       = (int64_t) M * N;
+    const int64_t rowwise_fp4_per_group_stride = (int64_t) M * (N_pad / 2);
+    const int64_t colwise_fp4_per_group_stride = (int64_t) N * (M_pad / 2);
+    const int64_t rowwise_scale_per_group_stride =
+        (int64_t) (rowwise_recipe.shuffle_scale ? rowwise_scale_M_pad : M) * rowwise_scale_stride;
+    const int64_t colwise_scale_per_group_stride =
+        (int64_t) (colwise_recipe.shuffle_scale ? colwise_scale_M_pad : colwise_scale_M) *
+        colwise_scale_stride;
 
 #define QUANTIZE_MXFP4_DUAL                                                                        \
     input, reinterpret_cast<uint8_t *>(rowwise_output), rowwise_scale,                             \
@@ -1068,7 +1124,9 @@ void quantize_mxfp4_dual_impl(const DType *input, dtype::float4x2_e2m1 *rowwise_
         rowwise_scale_stride, colwise_scale_stride, rowwise_scale_N, rowwise_scale_M_pad,          \
         rowwise_scale_N_pad, colwise_scale_M, colwise_scale_N, colwise_scale_M_pad,                \
         colwise_scale_N_pad, rowwise_recipe.shuffle_out, colwise_recipe.shuffle_out,               \
-        rowwise_recipe.shuffle_scale, colwise_recipe.shuffle_scale, sr_seed
+        rowwise_recipe.shuffle_scale, colwise_recipe.shuffle_scale, sr_seed,                       \
+        input_per_group_stride, rowwise_fp4_per_group_stride, rowwise_scale_per_group_stride,      \
+        colwise_fp4_per_group_stride, colwise_scale_per_group_stride
 
 #define QUANTIZE_MXFP4_DUAL_LAUNCH_KERNEL(ROWWISE_USE_RHT, COLWISE_USE_RHT, ROWWISE_USE_2D_BLOCK,  \
                                           COLWISE_USE_2D_BLOCK, ROWWISE_USE_SR, COLWISE_USE_SR)    \
@@ -1138,14 +1196,14 @@ void quantize_mxfp4_dual_impl(const DType *input, dtype::float4x2_e2m1 *rowwise_
 
 template void quantize_mxfp4_dual_impl<dtype::float16>(
     const dtype::float16 *x, dtype::float4x2_e2m1 *rowwise_output, uint8_t *rowwise_scale,
-    dtype::float4x2_e2m1 *colwise_output, uint8_t *colwise_scale, int M, int N, int M_pad,
+    dtype::float4x2_e2m1 *colwise_output, uint8_t *colwise_scale, int G, int M, int N, int M_pad,
     int N_pad, int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
     int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
     ScalingRecipe colwise_recipe, hipStream_t stream);
 template void quantize_mxfp4_dual_impl<dtype::bfloat16>(
     const dtype::bfloat16 *x, dtype::float4x2_e2m1 *rowwise_output, uint8_t *rowwise_scale,
-    dtype::float4x2_e2m1 *colwise_output, uint8_t *colwise_scale, int M, int N, int M_pad,
+    dtype::float4x2_e2m1 *colwise_output, uint8_t *colwise_scale, int G, int M, int N, int M_pad,
     int N_pad, int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
     int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
@@ -1216,5 +1274,489 @@ template void quantize_mxfp4_impl<dtype::bfloat16>(const dtype::bfloat16 *x,
                                                    int N_pad, int scale_stride, int scale_N,
                                                    int scale_M_pad, int scale_N_pad,
                                                    ScalingRecipe recipe, hipStream_t stream);
+
+// ============================================================================
+// Grouped MXFP4 dual (rowwise + colwise) quantization with per-group M zero-pad
+// ----------------------------------------------------------------------------
+// One bf16 read of the grouped activation ``input`` ([total_M, N], groups along
+// M defined by ``group_offs``) produces, in a single pass:
+//   * rowwise FP4 ([total_M, N_pad/2]) + E8M0 scale ([total_M, N_pad/32]) in the
+//     tight (un-padded) M layout -- used as the fwd/dgrad operand (row i maps to
+//     input row i), so the GEMM keeps reading the tight ``group_offs``.
+//   * colwise FP4 ([N, M_pad_col/2]) + E8M0 scale ([N, M_pad_col/32]) in the
+//     128-padded per-group M layout -- the variable-K wgrad operand.
+//
+// The grid walks the 128-padded M space (BLOCK_M == 128 == the colwise pad
+// align, so every 128-row tile lives entirely in one group, or beyond the last
+// group for the conservative ``M_pad_col`` upper bound).  Input rows are
+// remapped from padded coordinates back to the tight input via the per-group
+// offsets; padded (and out-of-bound) rows take the zero branch, yielding all
+// zero FP4 with the same scale convention the dense kernel uses for amax==0
+// tiles -- race-free for downstream consumers that read the over-allocated tail.
+//
+// Mirrors ``grouped_quantize_mxfp8_dual_kernel`` (padding framework) fused with
+// ``quantize_mxfp4_dual_kernel`` (RHT / SR / E2M1 packing / E8M0).  Shuffle
+// layouts are not used by the grouped MXFP4 GEMM, so those paths are dropped.
+// ============================================================================
+template <typename DType, bool ROWWISE_USE_RHT, bool COLWISE_USE_RHT, bool ROWWISE_USE_2D_BLOCK,
+          bool COLWISE_USE_2D_BLOCK, bool ROWWISE_USE_SR, bool COLWISE_USE_SR>
+__global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void grouped_quantize_mxfp4_dual_kernel(
+    const DType *__restrict__ input, uint8_t *__restrict__ rowwise_fp4,
+    uint8_t *__restrict__ rowwise_scale, uint8_t *__restrict__ colwise_fp4,
+    uint8_t *__restrict__ colwise_scale, const int64_t *__restrict__ group_offs,
+    const int64_t *__restrict__ group_offs_padded_colwise, const int G, const int N,
+    const int M_pad_col, const int N_pad, const int rowwise_scale_stride,
+    const int colwise_scale_stride, const int rowwise_scale_N, const int colwise_scale_N,
+    const uint32_t sr_seed) {
+    constexpr bool kIshalf = std::is_same_v<DType, dtype::float16>;
+
+    const int tid           = threadIdx.x;
+    const int warp_id       = tid / WARP_SIZE;
+    const int lane_id        = tid % WARP_SIZE;
+    const int row_in_warp   = lane_id / THREADS_PER_ROW;
+    const int thread_in_row = lane_id % THREADS_PER_ROW;
+
+    const int block_m = blockIdx.x;
+    const int block_n = blockIdx.y;
+    const int base_m  = block_m * BLOCK_M;
+    const int base_n  = block_n * BLOCK_N;
+
+    // Packed (2 FP4 / byte) output strides.  Rowwise M is tight (total_M rows);
+    // colwise M is the 128-padded upper bound.
+    const int K_packed = N_pad / 2;
+    const int M_packed = M_pad_col / 2;
+
+    constexpr int ROWS_PER_PASS   = WARP_SIZE / THREADS_PER_ROW;
+    constexpr int PASSES_PER_TILE = MXFP4_BLOCK_SIZE / ROWS_PER_PASS;
+    constexpr int TOTAL_CHUNKS    = NUM_CHUNKS_M * NUM_CHUNKS_N;
+
+    // ---- Per-tile group lookup (base_m is a multiple of BLOCK_M == 128 ==
+    // colwise pad align, so the whole tile is in one group or beyond the last) --
+    __shared__ int64_t s_group_offs_orig;
+    __shared__ int64_t s_group_offs_pad;
+    __shared__ int64_t s_real_end_in_pad;
+    if (tid == 0) {
+        int g = -1;
+        for (int i = 0; i < G; ++i) {
+            if (base_m >= group_offs_padded_colwise[i] &&
+                base_m < group_offs_padded_colwise[i + 1]) {
+                g = i;
+                break;
+            }
+        }
+        if (g >= 0) {
+            s_group_offs_orig = group_offs[g];
+            s_group_offs_pad  = group_offs_padded_colwise[g];
+            s_real_end_in_pad = group_offs_padded_colwise[g] + (group_offs[g + 1] - group_offs[g]);
+        } else {
+            s_group_offs_orig = 0;
+            s_group_offs_pad  = base_m;
+            s_real_end_in_pad = base_m; // every row → zero-pad branch
+        }
+    }
+    __syncthreads();
+    const int64_t group_offs_orig = s_group_offs_orig;
+    const int64_t group_offs_pad  = s_group_offs_pad;
+    const int64_t real_end_in_pad = s_real_end_in_pad;
+
+    __shared__ uint16_t s_tile[WARPS_PER_BLOCK][MXFP4_BLOCK_SIZE][MXFP4_BLOCK_SIZE + SMEM_PADDING];
+    __shared__ uint16_t
+        s_colwise_fp4[NUM_CHUNKS_N][MXFP4_BLOCK_SIZE][NUM_CHUNKS_M * THREADS_PER_ROW];
+    __shared__ uint8_t s_colwise_scale[NUM_CHUNKS_N][MXFP4_BLOCK_SIZE][NUM_CHUNKS_M];
+
+    static_assert(sizeof(s_colwise_fp4) == THREADS_PER_BLOCK * sizeof(uint64_t),
+                  "s_colwise_fp4 size must match thread count for zero-init");
+    reinterpret_cast<uint64_t *>(s_colwise_fp4)[tid] = 0;
+
+    for (int round = 0; round < TOTAL_CHUNKS; round += WARPS_PER_BLOCK) {
+        const int chunk_idx = round + warp_id;
+        if (chunk_idx >= TOTAL_CHUNKS)
+            break;
+
+        const int chunk_m = chunk_idx / NUM_CHUNKS_N;
+        const int chunk_n = chunk_idx % NUM_CHUNKS_N;
+        const int tile_m  = base_m + chunk_m * MXFP4_BLOCK_SIZE; // padded M coord
+        const int tile_n  = base_n + chunk_n * MXFP4_BLOCK_SIZE;
+
+        // ---------------- Load tile (input row remap + zero pad) -----------------
+        uint64_t r_tile[PASSES_PER_TILE];
+        {
+            const auto *input_u16  = reinterpret_cast<const uint16_t *>(input);
+            const int   col_base   = thread_in_row * ELEMS_PER_THREAD;
+            const int   global_col = tile_n + col_base;
+
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                const int local_row  = pass * ROWS_PER_PASS + row_in_warp;
+                const int global_row = tile_m + local_row; // padded coord
+
+                uint64_t packed = 0;
+                if (global_row < real_end_in_pad) {
+                    const int64_t input_row =
+                        group_offs_orig + (static_cast<int64_t>(global_row) - group_offs_pad);
+                    const int64_t row_offset = input_row * N + global_col;
+                    if (global_col + ELEMS_PER_THREAD - 1 < N) {
+                        packed = __ldg(reinterpret_cast<const uint64_t *>(&input_u16[row_offset]));
+                    } else {
+                        uint16_t s0 = (global_col < N) ? __ldg(&input_u16[row_offset]) : 0;
+                        uint16_t s1 = (global_col + 1 < N) ? __ldg(&input_u16[row_offset + 1]) : 0;
+                        uint16_t s2 = (global_col + 2 < N) ? __ldg(&input_u16[row_offset + 2]) : 0;
+                        uint16_t s3 = (global_col + 3 < N) ? __ldg(&input_u16[row_offset + 3]) : 0;
+                        packed = (uint64_t) s0 | ((uint64_t) s1 << 16) | ((uint64_t) s2 << 32) |
+                                 ((uint64_t) s3 << 48);
+                    }
+                }
+
+                *reinterpret_cast<uint32_t *>(&s_tile[warp_id][local_row][col_base]) =
+                    (uint32_t) packed;
+                *reinterpret_cast<uint32_t *>(&s_tile[warp_id][local_row][col_base + 2]) =
+                    (uint32_t) (packed >> 32);
+
+                r_tile[pass] = packed;
+            }
+        }
+
+        // ---------------- Rowwise: RHT + amax (tight M layout) -------------------
+        float r_rowwise_vals[PASSES_PER_TILE][ELEMS_PER_THREAD];
+        float r_rowwise_amax[PASSES_PER_TILE];
+#pragma unroll
+        for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+            r_rowwise_vals[pass][0] = r_rowwise_vals[pass][1] = r_rowwise_vals[pass][2] =
+                r_rowwise_vals[pass][3]                       = 0.f;
+            r_rowwise_amax[pass]                              = 0.f;
+
+            const int global_row = tile_m + pass * ROWS_PER_PASS + row_in_warp;
+            if (global_row < real_end_in_pad) {
+                packed_uint16x4_to_floatx4<kIshalf>(r_tile[pass], r_rowwise_vals[pass][0],
+                                                    r_rowwise_vals[pass][1], r_rowwise_vals[pass][2],
+                                                    r_rowwise_vals[pass][3]);
+                if constexpr (ROWWISE_USE_RHT) {
+                    rht16_inplace(r_rowwise_vals[pass][0], r_rowwise_vals[pass][1],
+                                  r_rowwise_vals[pass][2], r_rowwise_vals[pass][3], thread_in_row);
+                }
+                float local_amax =
+                    fmaxf(fmaxf(fabsf(r_rowwise_vals[pass][0]), fabsf(r_rowwise_vals[pass][1])),
+                          fmaxf(fabsf(r_rowwise_vals[pass][2]), fabsf(r_rowwise_vals[pass][3])));
+                // 2D-block scale spans the whole tile -> per-row warp_reduce_max_8 is
+                // redundant; defer to the single warp_reduce_max_64 (bit-exact).
+                if constexpr (ROWWISE_USE_2D_BLOCK) {
+                    r_rowwise_amax[pass] = local_amax;
+                } else {
+                    r_rowwise_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+                }
+            }
+        }
+
+        float   r_rowwise_scale_native[PASSES_PER_TILE];
+        uint8_t r_rowwise_scale_e8m0[PASSES_PER_TILE];
+        if constexpr (ROWWISE_USE_2D_BLOCK) {
+            float tile_amax = 0.f;
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++)
+                tile_amax = fmaxf(tile_amax, r_rowwise_amax[p]);
+            tile_amax = warp_reduce_max_64_dpp(tile_amax);
+            float   r_scale_native;
+            uint8_t r_scale_e8m0;
+            compute_tile_scale(tile_amax, r_scale_native, r_scale_e8m0);
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++) {
+                r_rowwise_scale_native[p] = r_scale_native;
+                r_rowwise_scale_e8m0[p]   = r_scale_e8m0;
+            }
+        } else {
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++)
+                compute_tile_scale(r_rowwise_amax[p], r_rowwise_scale_native[p],
+                                   r_rowwise_scale_e8m0[p]);
+        }
+
+        // ---------------- Rowwise: store FP4 + scale (tight input_row) -----------
+        {
+            const int col_base   = thread_in_row * ELEMS_PER_THREAD;
+            const int global_col = tile_n + col_base;
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                const int local_row  = pass * ROWS_PER_PASS + row_in_warp;
+                const int global_row = tile_m + local_row;
+
+                if (global_row < real_end_in_pad) {
+                    const int64_t input_row =
+                        group_offs_orig + (static_cast<int64_t>(global_row) - group_offs_pad);
+                    uint16_t fp4x4;
+                    if constexpr (ROWWISE_USE_SR) {
+                        uint32_t rng = sr_hash(sr_seed ^ (blockDim.x * blockIdx.x + threadIdx.x));
+                        fp4x4 = cvt_f32x4_to_fp4x4_sr(r_rowwise_vals[pass][0],
+                                                      r_rowwise_vals[pass][1],
+                                                      r_rowwise_vals[pass][2],
+                                                      r_rowwise_vals[pass][3],
+                                                      r_rowwise_scale_native[pass], rng);
+                    } else {
+                        fp4x4 = cvt_f32x4_to_fp4x4(r_rowwise_vals[pass][0], r_rowwise_vals[pass][1],
+                                                   r_rowwise_vals[pass][2], r_rowwise_vals[pass][3],
+                                                   r_rowwise_scale_native[pass]);
+                    }
+
+                    if (global_col < N_pad) {
+                        *reinterpret_cast<uint16_t *>(rowwise_fp4 + input_row * K_packed +
+                                                      global_col / 2) = fp4x4;
+                    }
+
+                    if (thread_in_row == 0) {
+                        int scale_col = block_n * NUM_CHUNKS_N + chunk_n;
+                        if (scale_col < rowwise_scale_N) {
+                            rowwise_scale[input_row * rowwise_scale_stride + scale_col] =
+                                r_rowwise_scale_e8m0[pass];
+                        }
+                    }
+                }
+            }
+        }
+
+        __syncthreads();
+
+        // ---------------- Colwise: read smem (transposed) + RHT + amax -----------
+        // s_tile already holds remapped real rows (pad rows are 0), so the
+        // colwise 32-row reduction sees the per-group M zero-pad for free.
+        float r_colwise_vals[PASSES_PER_TILE][ELEMS_PER_THREAD];
+        float r_colwise_amax[PASSES_PER_TILE];
+        {
+            const int row_base = thread_in_row * ELEMS_PER_THREAD;
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                const int local_col  = pass * ROWS_PER_PASS + row_in_warp;
+                const int global_col = tile_n + local_col;
+
+                r_colwise_vals[pass][0] = r_colwise_vals[pass][1] = r_colwise_vals[pass][2] =
+                    r_colwise_vals[pass][3]                       = 0.f;
+                r_colwise_amax[pass]                              = 0.f;
+
+                if (global_col < N) {
+                    r_colwise_vals[pass][0] =
+                        uint16_to_float<kIshalf>(s_tile[warp_id][row_base][local_col]);
+                    r_colwise_vals[pass][1] =
+                        uint16_to_float<kIshalf>(s_tile[warp_id][row_base + 1][local_col]);
+                    r_colwise_vals[pass][2] =
+                        uint16_to_float<kIshalf>(s_tile[warp_id][row_base + 2][local_col]);
+                    r_colwise_vals[pass][3] =
+                        uint16_to_float<kIshalf>(s_tile[warp_id][row_base + 3][local_col]);
+
+                    if constexpr (COLWISE_USE_RHT) {
+                        rht16_inplace(r_colwise_vals[pass][0], r_colwise_vals[pass][1],
+                                      r_colwise_vals[pass][2], r_colwise_vals[pass][3],
+                                      thread_in_row);
+                    }
+                    float local_amax = fmaxf(
+                        fmaxf(fabsf(r_colwise_vals[pass][0]), fabsf(r_colwise_vals[pass][1])),
+                        fmaxf(fabsf(r_colwise_vals[pass][2]), fabsf(r_colwise_vals[pass][3])));
+                    // 2D-block scale spans the whole tile -> the per-col warp_reduce_max_8
+                    // is redundant; defer to the single warp_reduce_max_64 (bit-exact).
+                    if constexpr (COLWISE_USE_2D_BLOCK) {
+                        r_colwise_amax[pass] = local_amax;
+                    } else {
+                        r_colwise_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+                    }
+                }
+            }
+        }
+
+        float   r_colwise_scale_native[PASSES_PER_TILE];
+        uint8_t r_colwise_scale_e8m0[PASSES_PER_TILE];
+        if constexpr (COLWISE_USE_2D_BLOCK) {
+            float tile_amax = 0.f;
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++)
+                tile_amax = fmaxf(tile_amax, r_colwise_amax[p]);
+            tile_amax = warp_reduce_max_64_dpp(tile_amax);
+            float   r_scale_native;
+            uint8_t r_scale_e8m0;
+            compute_tile_scale(tile_amax, r_scale_native, r_scale_e8m0);
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++) {
+                r_colwise_scale_native[p] = r_scale_native;
+                r_colwise_scale_e8m0[p]   = r_scale_e8m0;
+            }
+        } else {
+#pragma unroll
+            for (int p = 0; p < PASSES_PER_TILE; p++)
+                compute_tile_scale(r_colwise_amax[p], r_colwise_scale_native[p],
+                                   r_colwise_scale_e8m0[p]);
+        }
+
+        // ---------------- Colwise: stage FP4 + scale into LDS --------------------
+        {
+            const int row_base        = thread_in_row * ELEMS_PER_THREAD;
+            const int global_row_base = tile_m + row_base; // padded M coord
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                const int local_col  = pass * ROWS_PER_PASS + row_in_warp;
+                const int global_col = tile_n + local_col;
+
+                if (global_col < N) {
+                    uint16_t fp4x4;
+                    if constexpr (COLWISE_USE_SR) {
+                        uint32_t rng = sr_hash(sr_seed ^ (blockDim.x * blockIdx.x + threadIdx.x));
+                        fp4x4 = cvt_f32x4_to_fp4x4_sr(r_colwise_vals[pass][0],
+                                                      r_colwise_vals[pass][1],
+                                                      r_colwise_vals[pass][2],
+                                                      r_colwise_vals[pass][3],
+                                                      r_colwise_scale_native[pass], rng);
+                    } else {
+                        fp4x4 = cvt_f32x4_to_fp4x4(r_colwise_vals[pass][0], r_colwise_vals[pass][1],
+                                                   r_colwise_vals[pass][2], r_colwise_vals[pass][3],
+                                                   r_colwise_scale_native[pass]);
+                    }
+
+                    s_colwise_fp4[chunk_n][pass * ROWS_PER_PASS + row_in_warp]
+                                 [chunk_m * THREADS_PER_ROW + thread_in_row] =
+                                     (global_row_base < M_pad_col) ? fp4x4
+                                                                   : static_cast<uint16_t>(0);
+
+                    if (thread_in_row == 0) {
+                        const int scale_col = block_m * NUM_CHUNKS_M + chunk_m;
+                        if (scale_col < colwise_scale_N) {
+                            s_colwise_scale[chunk_n][pass * ROWS_PER_PASS + row_in_warp][chunk_m] =
+                                r_colwise_scale_e8m0[pass];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---------------- Coalesced colwise FP4 / scale write-out from LDS -----------
+    {
+        __syncthreads();
+
+        constexpr int SCALE_ITEMS = NUM_CHUNKS_N * MXFP4_BLOCK_SIZE * NUM_CHUNKS_M;
+        static_assert(SCALE_ITEMS <= THREADS_PER_BLOCK,
+                      "Scale write mapping expects one item per thread");
+        if (tid < SCALE_ITEMS) {
+            const int n_chunk      = tid / (MXFP4_BLOCK_SIZE * NUM_CHUNKS_M);
+            const int local_tid    = tid % (MXFP4_BLOCK_SIZE * NUM_CHUNKS_M);
+            const int col_in_chunk = local_tid / NUM_CHUNKS_M;
+            const int m_chunk      = local_tid % NUM_CHUNKS_M;
+
+            const int global_col = base_n + n_chunk * MXFP4_BLOCK_SIZE + col_in_chunk;
+            const int scale_col  = block_m * NUM_CHUNKS_M + m_chunk;
+
+            if (scale_col < colwise_scale_N && global_col < N) {
+                colwise_scale[global_col * colwise_scale_stride + scale_col] =
+                    s_colwise_scale[n_chunk][col_in_chunk][m_chunk];
+            }
+        }
+
+        constexpr int ITEMS_PER_COL = NUM_CHUNKS_M * THREADS_PER_ROW;
+        constexpr int SEGS_PER_COL  = ITEMS_PER_COL / 4; // uint64_t segments per column
+        static_assert(THREADS_PER_BLOCK == NUM_CHUNKS_N * MXFP4_BLOCK_SIZE * SEGS_PER_COL,
+                      "Thread count must exactly cover all colwise FP4 segments");
+
+        const int n_chunk      = tid / (MXFP4_BLOCK_SIZE * SEGS_PER_COL);
+        const int local_tid    = tid % (MXFP4_BLOCK_SIZE * SEGS_PER_COL);
+        const int col_in_chunk = local_tid / SEGS_PER_COL;
+        const int seg          = local_tid % SEGS_PER_COL;
+
+        const int global_col = base_n + n_chunk * MXFP4_BLOCK_SIZE + col_in_chunk;
+        if (global_col < N) {
+            const uint64_t data =
+                *reinterpret_cast<const uint64_t *>(&s_colwise_fp4[n_chunk][col_in_chunk][seg * 4]);
+            const int row_start = base_m + seg * (4 * ELEMS_PER_THREAD);
+            if (row_start < M_pad_col) {
+                __builtin_nontemporal_store(
+                    data, reinterpret_cast<uint64_t *>(colwise_fp4 +
+                                                       static_cast<int64_t>(global_col) * M_packed +
+                                                       base_m / 2 + seg * 8));
+            }
+        }
+    }
+}
+
+template <typename DType>
+void grouped_quantize_mxfp4_dual_impl(
+    const DType *input, dtype::float4x2_e2m1 *rowwise_output, uint8_t *rowwise_scale,
+    dtype::float4x2_e2m1 *colwise_output, uint8_t *colwise_scale, const int64_t *group_offs,
+    const int64_t *group_offs_padded_colwise, int G, int total_M, int N, int M_pad_col, int N_pad,
+    int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N, int colwise_scale_N,
+    ScalingRecipe rowwise_recipe, ScalingRecipe colwise_recipe, hipStream_t stream) {
+    PRIMUS_TURBO_CHECK(rowwise_recipe.shuffle_out == false && rowwise_recipe.shuffle_scale == false,
+                       "grouped MXFP4 dual does not support shuffle");
+    PRIMUS_TURBO_CHECK(colwise_recipe.shuffle_out == false && colwise_recipe.shuffle_scale == false,
+                       "grouped MXFP4 dual does not support shuffle");
+
+    dim3           grid((M_pad_col + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
+    dim3           block(THREADS_PER_BLOCK);
+    const uint32_t sr_seed = global_sr_counter.fetch_add(1, std::memory_order_relaxed);
+
+#define GROUPED_QUANTIZE_MXFP4_DUAL_ARGS                                                            \
+    input, reinterpret_cast<uint8_t *>(rowwise_output), rowwise_scale,                             \
+        reinterpret_cast<uint8_t *>(colwise_output), colwise_scale, group_offs,                    \
+        group_offs_padded_colwise, G, N, M_pad_col, N_pad, rowwise_scale_stride,                   \
+        colwise_scale_stride, rowwise_scale_N, colwise_scale_N, sr_seed
+
+#define GROUPED_QUANTIZE_MXFP4_DUAL_LAUNCH(R_RHT, C_RHT, R_2D, C_2D, R_SR, C_SR)                    \
+    grouped_quantize_mxfp4_dual_kernel<DType, R_RHT, C_RHT, R_2D, C_2D, R_SR, C_SR>                 \
+        <<<grid, block, 0, stream>>>(GROUPED_QUANTIZE_MXFP4_DUAL_ARGS)
+
+#define GROUPED_DISPATCH_2D(R_RHT, C_RHT, R_SR, C_SR)                                               \
+    if (rowwise_recipe.use_2d_block) {                                                             \
+        if (colwise_recipe.use_2d_block) {                                                         \
+            GROUPED_QUANTIZE_MXFP4_DUAL_LAUNCH(R_RHT, C_RHT, true, true, R_SR, C_SR);              \
+        } else {                                                                                   \
+            GROUPED_QUANTIZE_MXFP4_DUAL_LAUNCH(R_RHT, C_RHT, true, false, R_SR, C_SR);             \
+        }                                                                                          \
+    } else {                                                                                       \
+        if (colwise_recipe.use_2d_block) {                                                         \
+            GROUPED_QUANTIZE_MXFP4_DUAL_LAUNCH(R_RHT, C_RHT, false, true, R_SR, C_SR);             \
+        } else {                                                                                   \
+            GROUPED_QUANTIZE_MXFP4_DUAL_LAUNCH(R_RHT, C_RHT, false, false, R_SR, C_SR);            \
+        }                                                                                          \
+    }
+
+#define GROUPED_DISPATCH_RHT(R_SR, C_SR)                                                            \
+    if (rowwise_recipe.use_rht) {                                                                  \
+        if (colwise_recipe.use_rht) {                                                              \
+            GROUPED_DISPATCH_2D(true, true, R_SR, C_SR);                                           \
+        } else {                                                                                   \
+            GROUPED_DISPATCH_2D(true, false, R_SR, C_SR);                                          \
+        }                                                                                          \
+    } else {                                                                                       \
+        if (colwise_recipe.use_rht) {                                                              \
+            GROUPED_DISPATCH_2D(false, true, R_SR, C_SR);                                          \
+        } else {                                                                                   \
+            GROUPED_DISPATCH_2D(false, false, R_SR, C_SR);                                         \
+        }                                                                                          \
+    }
+
+    if (rowwise_recipe.use_sr) {
+        if (colwise_recipe.use_sr) {
+            GROUPED_DISPATCH_RHT(true, true);
+        } else {
+            GROUPED_DISPATCH_RHT(true, false);
+        }
+    } else {
+        if (colwise_recipe.use_sr) {
+            GROUPED_DISPATCH_RHT(false, true);
+        } else {
+            GROUPED_DISPATCH_RHT(false, false);
+        }
+    }
+
+#undef GROUPED_DISPATCH_RHT
+#undef GROUPED_DISPATCH_2D
+#undef GROUPED_QUANTIZE_MXFP4_DUAL_LAUNCH
+#undef GROUPED_QUANTIZE_MXFP4_DUAL_ARGS
+}
+
+template void grouped_quantize_mxfp4_dual_impl<dtype::float16>(
+    const dtype::float16 *input, dtype::float4x2_e2m1 *rowwise_output, uint8_t *rowwise_scale,
+    dtype::float4x2_e2m1 *colwise_output, uint8_t *colwise_scale, const int64_t *group_offs,
+    const int64_t *group_offs_padded_colwise, int G, int total_M, int N, int M_pad_col, int N_pad,
+    int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N, int colwise_scale_N,
+    ScalingRecipe rowwise_recipe, ScalingRecipe colwise_recipe, hipStream_t stream);
+template void grouped_quantize_mxfp4_dual_impl<dtype::bfloat16>(
+    const dtype::bfloat16 *input, dtype::float4x2_e2m1 *rowwise_output, uint8_t *rowwise_scale,
+    dtype::float4x2_e2m1 *colwise_output, uint8_t *colwise_scale, const int64_t *group_offs,
+    const int64_t *group_offs_padded_colwise, int G, int total_M, int N, int M_pad_col, int N_pad,
+    int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N, int colwise_scale_N,
+    ScalingRecipe rowwise_recipe, ScalingRecipe colwise_recipe, hipStream_t stream);
 
 } // namespace primus_turbo

--- a/csrc/pytorch/bindings_pytorch.cpp
+++ b/csrc/pytorch/bindings_pytorch.cpp
@@ -67,6 +67,10 @@ TORCH_LIBRARY(primus_turbo_cpp_extension, m) {
           "bool rowwise_use_2d_block, bool colwise_use_2d_block, "
           "bool shuffle_rowwise_scale=False, bool shuffle_rowwise=False, "
           "bool shuffle_colwise_scale=False, bool shuffle_colwise=False) -> Tensor[]");
+    m.def("grouped_quantize_mxfp4_dual(Tensor input, Tensor group_lens, Tensor group_offs, "
+          "ScalarType dest_dtype, "
+          "bool rowwise_use_2d_block, bool rowwise_use_sr, bool rowwise_use_rht, "
+          "bool colwise_use_2d_block, bool colwise_use_sr, bool colwise_use_rht) -> Tensor[]");
     m.def("quantize_mxfp8(Tensor input, ScalarType dest_dtype, int axis, "
           "int padding_align_size, "
           "bool use_2d_block, bool shuffle_scale=False, bool shuffle_out=False) -> Tensor[]");
@@ -134,6 +138,7 @@ TORCH_LIBRARY_IMPL(primus_turbo_cpp_extension, CUDA, m) {
     // ********* MXFP8 Quantization *********
     m.impl("quantize_mxfp8_dual", quantize_mxfp8_dual);
     m.impl("grouped_quantize_mxfp8_dual", grouped_quantize_mxfp8_dual);
+    m.impl("grouped_quantize_mxfp4_dual", grouped_quantize_mxfp4_dual);
     m.impl("quantize_mxfp8", quantize_mxfp8);
     m.impl("dequantize_mxfp8", dequantize_mxfp8);
 
@@ -180,6 +185,7 @@ TORCH_LIBRARY_IMPL(primus_turbo_cpp_extension, Meta, m) {
     // ********* MXFP8 Quantization *********
     m.impl("quantize_mxfp8_dual", quantize_mxfp8_dual_meta);
     m.impl("grouped_quantize_mxfp8_dual", grouped_quantize_mxfp8_dual_meta);
+    m.impl("grouped_quantize_mxfp4_dual", grouped_quantize_mxfp4_dual_meta);
     m.impl("quantize_mxfp8", quantize_mxfp8_meta);
     m.impl("dequantize_mxfp8", dequantize_mxfp8_meta);
 

--- a/csrc/pytorch/extensions.h
+++ b/csrc/pytorch/extensions.h
@@ -139,6 +139,18 @@ std::vector<at::Tensor> grouped_quantize_mxfp8_dual_meta(
     const bool shuffle_rowwise = false, const bool shuffle_colwise_scale = false,
     const bool shuffle_colwise = false);
 
+std::vector<at::Tensor> grouped_quantize_mxfp4_dual(
+    const at::Tensor input, const at::Tensor group_lens, const at::Tensor group_offs,
+    const at::ScalarType dest_dtype, const bool rowwise_use_2d_block, const bool rowwise_use_sr,
+    const bool rowwise_use_rht, const bool colwise_use_2d_block, const bool colwise_use_sr,
+    const bool colwise_use_rht);
+
+std::vector<at::Tensor> grouped_quantize_mxfp4_dual_meta(
+    const at::Tensor input, const at::Tensor group_lens, const at::Tensor group_offs,
+    const at::ScalarType dest_dtype, const bool rowwise_use_2d_block, const bool rowwise_use_sr,
+    const bool rowwise_use_rht, const bool colwise_use_2d_block, const bool colwise_use_sr,
+    const bool colwise_use_rht);
+
 std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarType dest_dtype,
                                        const int64_t axis, const int64_t padding_align_size,
                                        const bool use_2d_block, const bool shuffle_scale = false,

--- a/csrc/pytorch/quantization/quantization.cpp
+++ b/csrc/pytorch/quantization/quantization.cpp
@@ -396,7 +396,6 @@ std::vector<at::Tensor> quantize_mxfp4_dual(
     PRIMUS_TURBO_CHECK(input.is_cuda(), "Input must be a CUDA tensor");
     PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
                        "Input must be BFloat16 or Half");
-    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
     PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
     PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat4_e2m1fn_x2, "Output must be Float4_e2m1fn_x2.");
     // Guard the public op argument against zero/negative values (would otherwise
@@ -405,8 +404,23 @@ std::vector<at::Tensor> quantize_mxfp4_dual(
                        "padding_align_size must be ", MXFP4_K_DIM_PADDING_ALIGN_SIZE,
                        " for MXFP4. But got padding_align_size=", padding_align_size);
 
-    const int64_t M = input.size(0);
-    const int64_t N = input.size(1);
+    // Mirror ``quantize_mxfp8_dual``: 2D keeps ``G == 1`` and the original 2D
+    // output layout; 3D (batched, e.g. the MX grouped GEMM weight ``[G, N, K]``)
+    // carries a leading group dim on every per-group buffer and returns 3D views.
+    int64_t G, M, N;
+    if (input.dim() == 2) {
+        G = 1;
+        M = input.size(0);
+        N = input.size(1);
+    } else if (input.dim() == 3) {
+        G = input.size(0);
+        M = input.size(1);
+        N = input.size(2);
+    } else {
+        PRIMUS_TURBO_ERROR("Input must be 2D or 3D");
+    }
+    const bool    is_batched = (input.dim() == 3);
+    const int64_t Gout       = is_batched ? G : 1;
 
     const int64_t M_pad = cdiv(M, padding_align_size) * padding_align_size;
     const int64_t N_pad = cdiv(N, padding_align_size) * padding_align_size;
@@ -432,18 +446,18 @@ std::vector<at::Tensor> quantize_mxfp4_dual(
     int64_t    rowwise_scale_stride = 1;
     at::Tensor rowwise_scale;
     if (shuffle_rowwise_scale) {
-        rowwise_scale        = at::full({rowwise_scale_M_pad, rowwise_scale_N_pad}, /*scale pad=*/0,
-                                        at::TensorOptions().dtype(at::kByte).device(device));
+        rowwise_scale = at::full({Gout * rowwise_scale_M_pad, rowwise_scale_N_pad}, /*scale pad=*/0,
+                                 at::TensorOptions().dtype(at::kByte).device(device));
         rowwise_scale_stride = rowwise_scale.stride(0);
     } else {
-        rowwise_scale =
-            at::empty({M, rowwise_scale_N}, at::TensorOptions().dtype(at::kByte).device(device));
+        rowwise_scale        = at::empty({Gout * M, rowwise_scale_N},
+                                         at::TensorOptions().dtype(at::kByte).device(device));
         rowwise_scale_stride = rowwise_scale_N;
     }
 
     // packed 2 fp4 values in N dimension
     at::Tensor rowwise_output =
-        at::empty({M, N_pad / 2}, at::TensorOptions().dtype(at::kByte).device(device));
+        at::empty({Gout * M, N_pad / 2}, at::TensorOptions().dtype(at::kByte).device(device));
 
     int64_t colwise_scale_M_pad = cdiv(N, 256) * 256;
     int64_t colwise_scale_N     = cdiv(M_pad, MXFP4_BLOCK_SIZE);
@@ -452,18 +466,18 @@ std::vector<at::Tensor> quantize_mxfp4_dual(
     at::Tensor colwise_scale;
     int        colwise_scale_stride = 1;
     if (shuffle_colwise_scale) {
-        colwise_scale        = at::full({colwise_scale_M_pad, colwise_scale_N_pad}, /*scale pad=*/0,
-                                        at::TensorOptions().dtype(at::kByte).device(device));
+        colwise_scale = at::full({Gout * colwise_scale_M_pad, colwise_scale_N_pad}, /*scale pad=*/0,
+                                 at::TensorOptions().dtype(at::kByte).device(device));
         colwise_scale_stride = colwise_scale.stride(0);
     } else {
-        colwise_scale =
-            at::empty({N, colwise_scale_N}, at::TensorOptions().dtype(at::kByte).device(device));
+        colwise_scale        = at::empty({Gout * N, colwise_scale_N},
+                                         at::TensorOptions().dtype(at::kByte).device(device));
         colwise_scale_stride = colwise_scale_N;
     }
 
     // packed 2 fp4 values in N dimension
     at::Tensor colwise_output =
-        at::empty({N, M_pad / 2}, at::TensorOptions().dtype(at::kByte).device(device));
+        at::empty({Gout * N, M_pad / 2}, at::TensorOptions().dtype(at::kByte).device(device));
 
     TORCH_TYPE_SWITCH_FP16_BF16(input.scalar_type(), DType, {
         quantize_mxfp4_dual_impl<DType>(
@@ -471,7 +485,7 @@ std::vector<at::Tensor> quantize_mxfp4_dual(
             reinterpret_cast<dtype::float4x2_e2m1 *>(rowwise_output.data_ptr()),
             rowwise_scale.data_ptr<uint8_t>(),
             reinterpret_cast<dtype::float4x2_e2m1 *>(colwise_output.data_ptr()),
-            colwise_scale.data_ptr<uint8_t>(), M, N, M_pad, N_pad, rowwise_scale_stride,
+            colwise_scale.data_ptr<uint8_t>(), G, M, N, M_pad, N_pad, rowwise_scale_stride,
             colwise_scale_stride, rowwise_scale_N, rowwise_scale_M_pad, rowwise_scale_N_pad, N,
             colwise_scale_N, colwise_scale_M_pad, colwise_scale_N_pad,
             ScalingRecipe(rowwise_use_2d_block, rowwise_use_sr, rowwise_use_rht,
@@ -480,6 +494,15 @@ std::vector<at::Tensor> quantize_mxfp4_dual(
                           shuffle_colwise_scale, shuffle_colwise),
             stream);
     });
+
+    if (is_batched) {
+        const int64_t rowwise_scale_rows = shuffle_rowwise_scale ? rowwise_scale_M_pad : M;
+        const int64_t colwise_scale_rows = shuffle_colwise_scale ? colwise_scale_M_pad : N;
+        return {rowwise_output.view({G, M, N_pad / 2}).view(at::kFloat4_e2m1fn_x2),
+                rowwise_scale.view({G, rowwise_scale_rows, -1}).view(at::kFloat8_e8m0fnu),
+                colwise_output.view({G, N, M_pad / 2}).view(at::kFloat4_e2m1fn_x2),
+                colwise_scale.view({G, colwise_scale_rows, -1}).view(at::kFloat8_e8m0fnu)};
+    }
 
     return {rowwise_output.view(at::kFloat4_e2m1fn_x2), rowwise_scale.view(at::kFloat8_e8m0fnu),
             colwise_output.view(at::kFloat4_e2m1fn_x2), colwise_scale.view(at::kFloat8_e8m0fnu)};
@@ -931,6 +954,100 @@ grouped_quantize_mxfp8_dual(const at::Tensor input, const at::Tensor group_lens,
             colwise_output.view(dest_dtype), colwise_scale.view(at::kFloat8_e8m0fnu),
             group_lens_padded_rowwise,       group_offs_padded_rowwise,
             group_lens_padded_colwise,       group_offs_padded_colwise};
+}
+
+// Fused single-pass grouped dual (rowwise + colwise) MXFP4 quant for grouped GEMM.
+// One bf16/fp16 read of grouped activation ``input`` [total_M, N] (groups along M
+// via ``group_offs``) emits, in one pass:
+//   * rowwise FP4 [total_M, N_pad/2] + E8M0 scale [total_M, N_pad/32] in the tight
+//     (un-padded) M layout -- the fwd/dgrad operand (row i == input row i);
+//   * colwise FP4 [N, M_pad_col/2] + E8M0 scale [N, M_pad_col/32] in the 128-padded
+//     per-group M layout -- the variable-K wgrad operand.
+// ``M_pad_col`` is the static upper bound ``total_M + G*128`` so the output shapes
+// never depend on the runtime group distribution (CUDA-graph capturable, no D2H).
+// Shuffle layouts are unused by the grouped MXFP4 GEMM, so they are not exposed.
+std::vector<at::Tensor>
+grouped_quantize_mxfp4_dual(const at::Tensor input, const at::Tensor group_lens,
+                            const at::Tensor group_offs, const at::ScalarType dest_dtype,
+                            const bool rowwise_use_2d_block, const bool rowwise_use_sr,
+                            const bool rowwise_use_rht, const bool colwise_use_2d_block,
+                            const bool colwise_use_sr, const bool colwise_use_rht) {
+    using namespace primus_turbo::detail;
+
+    PRIMUS_TURBO_CHECK(input.is_cuda(), "Input must be a CUDA tensor");
+    PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
+                       "Input must be BFloat16 or Half");
+    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
+    PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
+    PRIMUS_TURBO_CHECK(group_lens.is_cuda() && group_offs.is_cuda(),
+                       "group_lens / group_offs must be CUDA tensors");
+    PRIMUS_TURBO_CHECK(group_lens.scalar_type() == at::kLong &&
+                           group_offs.scalar_type() == at::kLong,
+                       "group_lens / group_offs must be int64");
+    PRIMUS_TURBO_CHECK(group_lens.dim() == 1 && group_offs.dim() == 1,
+                       "group_lens / group_offs must be 1D");
+    PRIMUS_TURBO_CHECK(group_offs.size(0) == group_lens.size(0) + 1,
+                       "group_offs.size(0) must equal group_lens.size(0) + 1");
+    PRIMUS_TURBO_CHECK(group_lens.size(0) >= 1, "must have at least one group");
+    PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat4_e2m1fn_x2, "Output must be Float4_e2m1fn_x2");
+
+    constexpr int64_t COL_ALIGN = MXFP4_K_DIM_PADDING_ALIGN_SIZE; // = 128
+
+    const int64_t G         = group_lens.size(0);
+    const int64_t total_M   = input.size(0);
+    const int64_t N         = input.size(1);
+    const int64_t M_pad_col = cdiv(total_M + G * COL_ALIGN, COL_ALIGN) * COL_ALIGN;
+    const int64_t N_pad     = cdiv(N, COL_ALIGN) * COL_ALIGN;
+
+    PRIMUS_TURBO_CHECK(N % MXFP4_BLOCK_SIZE == 0, "N must be divisible by ", MXFP4_BLOCK_SIZE);
+
+    auto device = input.device();
+    auto stream = at::cuda::getCurrentCUDAStream();
+
+    // colwise (wgrad A): 128-padded per-group M layout; also drives the kernel
+    // grid + tile->group mapping (BLOCK_M = 128).
+    auto group_lens_padded_colwise = at::empty_like(group_lens);
+    auto group_offs_padded_colwise = at::empty({G + 1}, group_offs.options());
+    primus_turbo::compute_padded_layout_gpu(
+        group_lens.data_ptr<int64_t>(), group_lens_padded_colwise.data_ptr<int64_t>(),
+        group_offs_padded_colwise.data_ptr<int64_t>(), static_cast<int>(G), COL_ALIGN, stream);
+
+    // Rowwise (fwd/dgrad A): tight M layout (total_M rows, row i == input row i).
+    int64_t    rowwise_scale_N      = cdiv(N_pad, MXFP4_BLOCK_SIZE);
+    int64_t    rowwise_scale_stride = rowwise_scale_N;
+    at::Tensor rowwise_scale =
+        at::empty({total_M, rowwise_scale_N}, at::TensorOptions().dtype(at::kByte).device(device));
+    at::Tensor rowwise_output =
+        at::empty({total_M, N_pad / 2}, at::TensorOptions().dtype(at::kByte).device(device));
+
+    // Colwise (wgrad A): 128-padded M layout (M_pad_col upper bound).
+    int64_t    colwise_scale_N      = cdiv(M_pad_col, MXFP4_BLOCK_SIZE);
+    int64_t    colwise_scale_stride = colwise_scale_N;
+    at::Tensor colwise_scale =
+        at::empty({N, colwise_scale_N}, at::TensorOptions().dtype(at::kByte).device(device));
+    at::Tensor colwise_output =
+        at::empty({N, M_pad_col / 2}, at::TensorOptions().dtype(at::kByte).device(device));
+
+    TORCH_TYPE_SWITCH_FP16_BF16(input.scalar_type(), IType, {
+        grouped_quantize_mxfp4_dual_impl<IType>(
+            reinterpret_cast<IType *>(input.data_ptr()),
+            reinterpret_cast<dtype::float4x2_e2m1 *>(rowwise_output.data_ptr()),
+            rowwise_scale.data_ptr<uint8_t>(),
+            reinterpret_cast<dtype::float4x2_e2m1 *>(colwise_output.data_ptr()),
+            colwise_scale.data_ptr<uint8_t>(), group_offs.data_ptr<int64_t>(),
+            group_offs_padded_colwise.data_ptr<int64_t>(), static_cast<int>(G),
+            static_cast<int>(total_M), static_cast<int>(N), static_cast<int>(M_pad_col),
+            static_cast<int>(N_pad), static_cast<int>(rowwise_scale_stride),
+            static_cast<int>(colwise_scale_stride), static_cast<int>(rowwise_scale_N),
+            static_cast<int>(colwise_scale_N),
+            ScalingRecipe(rowwise_use_2d_block, rowwise_use_sr, rowwise_use_rht, false, false),
+            ScalingRecipe(colwise_use_2d_block, colwise_use_sr, colwise_use_rht, false, false),
+            stream);
+    });
+
+    return {rowwise_output.view(dest_dtype),  rowwise_scale.view(at::kFloat8_e8m0fnu),
+            colwise_output.view(dest_dtype),  colwise_scale.view(at::kFloat8_e8m0fnu),
+            group_lens_padded_colwise,        group_offs_padded_colwise};
 }
 
 // Fused single-pass row + segment-padded col blockwise FP8 quant for grouped GEMM.

--- a/csrc/pytorch/quantization/quantization_meta.cpp
+++ b/csrc/pytorch/quantization/quantization_meta.cpp
@@ -86,7 +86,6 @@ std::vector<at::Tensor> quantize_mxfp4_dual_meta(
 
     PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
                        "Input must be BFloat16 or Half");
-    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
     PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
     PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat4_e2m1fn_x2, "Output must be Float4_e2m1fn_x2");
     // Guard the public op argument against zero/negative values (would otherwise
@@ -95,8 +94,22 @@ std::vector<at::Tensor> quantize_mxfp4_dual_meta(
                        "padding_align_size must be ", MXFP4_K_DIM_PADDING_ALIGN_SIZE,
                        " for MXFP4. But got padding_align_size=", padding_align_size);
 
-    const int64_t M = input.size(0);
-    const int64_t N = input.size(1);
+    // Mirror the CUDA impl: 2D keeps ``G == 1`` and the 2D layout; 3D carries a
+    // leading group dim ``G`` on every per-group buffer and returns 3D views.
+    int64_t G, M, N;
+    if (input.dim() == 2) {
+        G = 1;
+        M = input.size(0);
+        N = input.size(1);
+    } else if (input.dim() == 3) {
+        G = input.size(0);
+        M = input.size(1);
+        N = input.size(2);
+    } else {
+        PRIMUS_TURBO_ERROR("Input must be 2D or 3D");
+    }
+    const bool    is_batched = (input.dim() == 3);
+    const int64_t Gout       = is_batched ? G : 1;
 
     const int64_t M_pad = cdiv(M, padding_align_size) * padding_align_size;
     const int64_t N_pad = cdiv(N, padding_align_size) * padding_align_size;
@@ -122,16 +135,16 @@ std::vector<at::Tensor> quantize_mxfp4_dual_meta(
 
     at::Tensor rowwise_scale;
     if (shuffle_rowwise_scale) {
-        rowwise_scale = at::empty({rowwise_scale_M_pad, rowwise_scale_N_pad},
+        rowwise_scale = at::empty({Gout * rowwise_scale_M_pad, rowwise_scale_N_pad},
                                   at::TensorOptions().dtype(at::kByte).device(at::kMeta));
     } else {
-        rowwise_scale =
-            at::empty({M, rowwise_scale_N}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+        rowwise_scale = at::empty({Gout * M, rowwise_scale_N},
+                                  at::TensorOptions().dtype(at::kByte).device(at::kMeta));
     }
 
     // packed 2 fp4 values in N dimension
     at::Tensor rowwise_output =
-        at::empty({M, N_pad / 2}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+        at::empty({Gout * M, N_pad / 2}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
 
     int64_t colwise_scale_M_pad = cdiv(N, 256) * 256;
     int64_t colwise_scale_N     = cdiv(M_pad, MXFP4_BLOCK_SIZE);
@@ -139,16 +152,25 @@ std::vector<at::Tensor> quantize_mxfp4_dual_meta(
 
     at::Tensor colwise_scale;
     if (shuffle_colwise_scale) {
-        colwise_scale = at::empty({colwise_scale_M_pad, colwise_scale_N_pad},
+        colwise_scale = at::empty({Gout * colwise_scale_M_pad, colwise_scale_N_pad},
                                   at::TensorOptions().dtype(at::kByte).device(at::kMeta));
     } else {
-        colwise_scale =
-            at::empty({N, colwise_scale_N}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+        colwise_scale = at::empty({Gout * N, colwise_scale_N},
+                                  at::TensorOptions().dtype(at::kByte).device(at::kMeta));
     }
 
     // packed 2 fp4 values in N dimension
     at::Tensor colwise_output =
-        at::empty({N, M_pad / 2}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+        at::empty({Gout * N, M_pad / 2}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+
+    if (is_batched) {
+        const int64_t rowwise_scale_rows = shuffle_rowwise_scale ? rowwise_scale_M_pad : M;
+        const int64_t colwise_scale_rows = shuffle_colwise_scale ? colwise_scale_M_pad : N;
+        return {rowwise_output.view({G, M, N_pad / 2}).view(at::kFloat4_e2m1fn_x2),
+                rowwise_scale.view({G, rowwise_scale_rows, -1}).view(at::kFloat8_e8m0fnu),
+                colwise_output.view({G, N, M_pad / 2}).view(at::kFloat4_e2m1fn_x2),
+                colwise_scale.view({G, colwise_scale_rows, -1}).view(at::kFloat8_e8m0fnu)};
+    }
 
     return {rowwise_output.view(at::kFloat4_e2m1fn_x2), rowwise_scale.view(at::kFloat8_e8m0fnu),
             colwise_output.view(at::kFloat4_e2m1fn_x2), colwise_scale.view(at::kFloat8_e8m0fnu)};
@@ -370,6 +392,48 @@ grouped_quantize_mxfp8_dual_meta(const at::Tensor input, const at::Tensor group_
             colwise_output.view(dest_dtype), colwise_scale.view(at::kFloat8_e8m0fnu),
             group_lens_padded_rowwise,       group_offs_padded_rowwise,
             group_lens_padded_colwise,       group_offs_padded_colwise};
+}
+
+std::vector<at::Tensor> grouped_quantize_mxfp4_dual_meta(
+    const at::Tensor input, const at::Tensor group_lens, const at::Tensor group_offs,
+    const at::ScalarType dest_dtype, const bool rowwise_use_2d_block, const bool rowwise_use_sr,
+    const bool rowwise_use_rht, const bool colwise_use_2d_block, const bool colwise_use_sr,
+    const bool colwise_use_rht) {
+    using namespace primus_turbo::detail;
+    auto cdiv = [](int64_t a, int64_t b) -> int64_t { return (a + b - 1) / b; };
+
+    PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
+                       "Input must be BFloat16 or Half");
+    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
+    PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat4_e2m1fn_x2, "Output must be Float4_e2m1fn_x2");
+
+    constexpr int64_t COL_ALIGN = MXFP4_K_DIM_PADDING_ALIGN_SIZE; // = 128
+
+    const int64_t G         = group_lens.size(0);
+    const int64_t total_M   = input.size(0);
+    const int64_t N         = input.size(1);
+    const int64_t M_pad_col = cdiv(total_M + G * COL_ALIGN, COL_ALIGN) * COL_ALIGN;
+    const int64_t N_pad     = cdiv(N, COL_ALIGN) * COL_ALIGN;
+
+    int64_t    rowwise_scale_N = cdiv(N_pad, MXFP4_BLOCK_SIZE);
+    at::Tensor rowwise_scale   = at::empty({total_M, rowwise_scale_N},
+                                           at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+    at::Tensor rowwise_output =
+        at::empty({total_M, N_pad / 2}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+
+    int64_t    colwise_scale_N = cdiv(M_pad_col, MXFP4_BLOCK_SIZE);
+    at::Tensor colwise_scale   = at::empty({N, colwise_scale_N},
+                                           at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+    at::Tensor colwise_output =
+        at::empty({N, M_pad_col / 2}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+
+    auto group_lens_padded_colwise =
+        at::empty_like(group_lens, group_lens.options().device(at::kMeta));
+    auto group_offs_padded_colwise = at::empty({G + 1}, group_offs.options().device(at::kMeta));
+
+    return {rowwise_output.view(at::kFloat4_e2m1fn_x2), rowwise_scale.view(at::kFloat8_e8m0fnu),
+            colwise_output.view(at::kFloat4_e2m1fn_x2), colwise_scale.view(at::kFloat8_e8m0fnu),
+            group_lens_padded_colwise,                  group_offs_padded_colwise};
 }
 
 std::vector<at::Tensor> quantize_mxfp8_meta(const at::Tensor input, const at::ScalarType dest_dtype,

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
@@ -1,0 +1,131 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""MXFP4 grouped GEMM dispatch (Triton-only, gfx950).
+
+Thin ``torch.library`` custom-op wrappers around the Triton MXFP4 grouped
+kernels. Unlike the FP8 path (which fans out to CK / hipBLASLt / FlyDSL), MXFP4
+grouped GEMM currently has a single Triton block-scaled backend, so the ops call
+it directly. The forward op over-allocates the output to the (padded) input rows
+and the caller slices ``[:total_m]``; ``group_offs_out`` packs each group tight.
+"""
+
+import torch
+
+from primus_turbo.pytorch.core.low_precision import float4_e2m1fn_x2
+from primus_turbo.triton.grouped_gemm.grouped_gemm_fp4_kernel import (
+    grouped_gemm_mxfp4_triton_kernel,
+    grouped_gemm_mxfp4_variable_k_triton_kernel,
+)
+
+_torch_custom_op_wrapper = torch.library.custom_op
+
+
+@_torch_custom_op_wrapper("primus_turbo::grouped_gemm_fp4_impl", mutates_args=(), device_types="cuda")
+def grouped_gemm_fp4_impl(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_offs: torch.Tensor,
+    N: int,
+    K: int,
+    num_cu: int | None,
+    out_dtype: torch.dtype,
+    group_offs_out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Forward (NT): C[g] = A[g] @ B[g]^T.
+
+    a (total_M, K/2) fp4, a_scales (total_M, K/32) e8m0,
+    b (G, N, K/2) fp4, b_scales (G, N, K/32) e8m0. K is logical.
+    """
+    return grouped_gemm_mxfp4_triton_kernel(
+        a,
+        a_scales,
+        b,
+        b_scales,
+        group_offs,
+        N,
+        K,
+        group_offs_out=group_offs_out,
+        out_dtype=out_dtype,
+        num_cu=num_cu,
+    )
+
+
+@grouped_gemm_fp4_impl.register_fake
+def grouped_gemm_fp4_impl_meta(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_offs: torch.Tensor,
+    N: int,
+    K: int,
+    num_cu: int | None,
+    out_dtype: torch.dtype,
+    group_offs_out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    assert a.dim() == 2, f"a must be 2D, got {a.shape}"
+    assert b.dim() == 3, f"b must be 3D, got {b.shape}"
+    assert a.dtype == float4_e2m1fn_x2, f"a must be fp4, got {a.dtype}"
+    assert b.dtype == float4_e2m1fn_x2, f"b must be fp4, got {b.dtype}"
+    assert out_dtype in (torch.float16, torch.bfloat16)
+    # Output over-allocated to padded input rows; caller slices [:total_m].
+    return torch.empty((a.shape[0], N), device=a.device, dtype=out_dtype)
+
+
+@_torch_custom_op_wrapper(
+    "primus_turbo::grouped_gemm_fp4_variable_k_impl", mutates_args=(), device_types="cuda"
+)
+def grouped_gemm_fp4_variable_k_impl(
+    lhs: torch.Tensor,
+    rhs: torch.Tensor,
+    lhs_scales: torch.Tensor,
+    rhs_scales: torch.Tensor,
+    group_offs: torch.Tensor,
+    OUT_M: int,
+    OUT_N: int,
+    G: int,
+    num_cu: int | None,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Backward wgrad: C[g] (OUT_M, OUT_N) = lhs[:,g] @ rhs[:,g]^T, reduction over M_g.
+
+    lhs (OUT_M, M_total/2) fp4, rhs (OUT_N, M_total/2) fp4; scales (.., M_total/32) e8m0.
+    group_offs: padded per-group offsets along M (each M_g multiple of 128).
+    """
+    return grouped_gemm_mxfp4_variable_k_triton_kernel(
+        lhs,
+        lhs_scales,
+        rhs,
+        rhs_scales,
+        group_offs,
+        OUT_M,
+        OUT_N,
+        G,
+        out_dtype=out_dtype,
+        num_cu=num_cu,
+    )
+
+
+@grouped_gemm_fp4_variable_k_impl.register_fake
+def grouped_gemm_fp4_variable_k_impl_meta(
+    lhs: torch.Tensor,
+    rhs: torch.Tensor,
+    lhs_scales: torch.Tensor,
+    rhs_scales: torch.Tensor,
+    group_offs: torch.Tensor,
+    OUT_M: int,
+    OUT_N: int,
+    G: int,
+    num_cu: int | None,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    assert lhs.dim() == 2 and rhs.dim() == 2
+    assert lhs.dtype == float4_e2m1fn_x2 and rhs.dtype == float4_e2m1fn_x2
+    assert out_dtype in (torch.float16, torch.bfloat16)
+    return torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
@@ -6,20 +6,242 @@
 
 """MXFP4 grouped GEMM dispatch (Triton-only, gfx950).
 
-Thin ``torch.library`` custom-op wrappers around the Triton MXFP4 grouped
-kernels. Unlike the FP8 path (which fans out to CK / hipBLASLt / FlyDSL), MXFP4
-grouped GEMM currently has a single Triton block-scaled backend, so the ops call
-it directly. The forward op over-allocates the output to the (padded) input rows
-and the caller slices ``[:total_m]``; ``group_offs_out`` packs each group tight.
+Mirrors the FP8 grouped GEMM dispatch (``grouped_gemm_fp8_impl``): the
+``torch.library`` custom ops keep the same argument lists and select the kernel
+through an :class:`AutoKernelDispatcher`, so the backend is controlled the same
+way (env / ``GlobalBackendManager`` / autotune / default). Unlike FP8 (which
+fans out to CK / hipBLASLt / FlyDSL), MXFP4 grouped GEMM currently has a single
+Triton block-scaled backend, so only ``BackendType.TRITON`` is registered.
+
+The forward op over-allocates the output to the (padded) input rows and the
+caller slices ``[:total_m]``; ``group_offs_out`` packs each group tight.
 """
 
 import torch
 
-from primus_turbo.pytorch.core.low_precision import float4_e2m1fn_x2
+from primus_turbo.pytorch.core.backend import (
+    BackendEntry,
+    BackendType,
+    GlobalBackendManager,
+    KernelBackend,
+    PrecisionType,
+    TuneCache,
+)
+from primus_turbo.pytorch.core.low_precision import ScalingGranularity, float4_e2m1fn_x2
+from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
+    BaseGroupedGEMMKernelDispatcher,
+    BaseGroupedGEMMVariableKKernelDispatcher,
+)
 from primus_turbo.triton.grouped_gemm.grouped_gemm_fp4_kernel import (
     grouped_gemm_mxfp4_triton_kernel,
     grouped_gemm_mxfp4_variable_k_triton_kernel,
 )
+
+
+class GroupedGEMMFP4TritonBackend(KernelBackend):
+    """Triton persistent-kernel backend for MXFP4 grouped GEMM (forward / dgrad).
+
+    MX_BLOCKWISE only, NT layout (trans_b=True). ``b`` is FP4-packed (G, N, K/2),
+    so the logical contraction ``K`` is ``b.shape[-1] * 2`` (already zero-padded
+    to BLOCK_SIZE_K=128 by the quantizer) and the free dim ``N`` is ``b.shape[-2]``.
+    """
+
+    SUPPORTED_GRANULARITIES = {ScalingGranularity.MX_BLOCKWISE}
+
+    @staticmethod
+    def can_handle(
+        a: torch.Tensor,
+        b: torch.Tensor,
+        a_scales: torch.Tensor,
+        b_scales: torch.Tensor,
+        group_lens: torch.Tensor,
+        group_offs: torch.Tensor,
+        trans_a: bool,
+        trans_b: bool,
+        out_dtype: torch.dtype,
+        granularity: ScalingGranularity,
+        num_cu: int | None,
+        **kwargs,
+    ) -> bool:
+        supported = True
+        supported &= a.dim() == 2 and b.dim() == 3
+        supported &= granularity in GroupedGEMMFP4TritonBackend.SUPPORTED_GRANULARITIES
+        supported &= a.dtype == float4_e2m1fn_x2 and b.dtype == float4_e2m1fn_x2
+        supported &= out_dtype in (torch.float16, torch.bfloat16)
+        # NT only: the kernel infers the contraction from the packed last dim.
+        supported &= trans_b and not trans_a
+        return supported
+
+    @staticmethod
+    def execute(
+        a: torch.Tensor,
+        b: torch.Tensor,
+        a_scales: torch.Tensor,
+        b_scales: torch.Tensor,
+        group_lens: torch.Tensor,
+        group_offs: torch.Tensor,
+        trans_a: bool,
+        trans_b: bool,
+        out_dtype: torch.dtype,
+        granularity: ScalingGranularity,
+        num_cu: int | None,
+        **kwargs,
+    ):
+        # b is (G, N, K/2) NT, FP4-packed. group_offs = padded read offsets;
+        # group_offs_out = real write offsets (output over-allocated to padded
+        # rows, sliced by the caller).
+        N = b.shape[-2]
+        K = b.shape[-1] * 2
+        group_offs_out = kwargs.get("group_offs_out", None)
+        return grouped_gemm_mxfp4_triton_kernel(
+            a,
+            a_scales,
+            b,
+            b_scales,
+            group_offs,
+            N,
+            K,
+            group_offs_out=group_offs_out,
+            out_dtype=out_dtype,
+            num_cu=num_cu,
+        )
+
+
+class GroupedGEMMFP4KernelDispatcher(BaseGroupedGEMMKernelDispatcher):
+    _backends = {
+        BackendType.TRITON: BackendEntry(GroupedGEMMFP4TritonBackend),
+    }
+    _cache = TuneCache(1024)
+
+    @classmethod
+    def make_key(
+        cls,
+        a,
+        b,
+        a_scales,
+        b_scales,
+        group_lens,
+        group_offs,
+        trans_a,
+        trans_b,
+        out_dtype,
+        granularity,
+        num_cu,
+        **kwargs,
+    ):
+        bs = b.shape[0]
+        m = a.shape[1] if trans_a else a.shape[0]
+        n = b.shape[-2] if trans_b else b.shape[-1]
+        k = a.shape[0] if trans_a else a.shape[1]
+        return (bs, m, n, k, a.dtype, b.dtype, out_dtype, trans_a, trans_b, False, granularity)
+
+
+class GroupedGEMMFP4VariableKTritonBackend(KernelBackend):
+    """Triton persistent-kernel backend for MXFP4 variable-K grouped GEMM (wgrad).
+
+    MX_BLOCKWISE only. Both operands are FP4-packed 2D ``(OUT_*, M_total/2)`` and
+    the kernel reduces over the (padded) per-group M, so it expects the
+    non-transposed layout (``not trans_a and not trans_b``).
+    """
+
+    SUPPORTED_GRANULARITIES = {ScalingGranularity.MX_BLOCKWISE}
+
+    @staticmethod
+    def can_handle(
+        a: torch.Tensor,
+        b: torch.Tensor,
+        a_scales: torch.Tensor,
+        b_scales: torch.Tensor,
+        group_lens: torch.Tensor,
+        group_offs: torch.Tensor,
+        trans_a: bool,
+        trans_b: bool,
+        trans_c: bool,
+        out_dtype: torch.dtype,
+        granularity: ScalingGranularity,
+        num_cu: int | None,
+        **kwargs,
+    ) -> bool:
+        supported = True
+        supported &= a.dim() == 2 and b.dim() == 2
+        supported &= granularity in GroupedGEMMFP4VariableKTritonBackend.SUPPORTED_GRANULARITIES
+        supported &= a.dtype == float4_e2m1fn_x2 and b.dtype == float4_e2m1fn_x2
+        supported &= out_dtype in (torch.float16, torch.bfloat16)
+        supported &= not trans_a and not trans_b
+        return supported
+
+    @staticmethod
+    def execute(
+        a: torch.Tensor,
+        b: torch.Tensor,
+        a_scales: torch.Tensor,
+        b_scales: torch.Tensor,
+        group_lens: torch.Tensor,
+        group_offs: torch.Tensor,
+        trans_a: bool,
+        trans_b: bool,
+        trans_c: bool,
+        out_dtype: torch.dtype,
+        granularity: ScalingGranularity,
+        num_cu: int | None,
+        **kwargs,
+    ):
+        # wgrad: C[g] (OUT_M, OUT_N) = lhs[:,g] @ rhs[:,g]^T, reduction over M.
+        # lhs/rhs swapped by trans_c (matches the FP8 variable-K backend).
+        if trans_c:
+            lhs, rhs = b, a
+            lhs_scales, rhs_scales = b_scales, a_scales
+        else:
+            lhs, rhs = a, b
+            lhs_scales, rhs_scales = a_scales, b_scales
+        OUT_M = lhs.shape[0]
+        OUT_N = rhs.shape[0]
+        G = group_lens.shape[0]
+        return grouped_gemm_mxfp4_variable_k_triton_kernel(
+            lhs,
+            lhs_scales,
+            rhs,
+            rhs_scales,
+            group_offs,
+            OUT_M,
+            OUT_N,
+            G,
+            out_dtype=out_dtype,
+            num_cu=num_cu,
+        )
+
+
+class GroupedGEMMFP4VariableKKernelDispatcher(BaseGroupedGEMMVariableKKernelDispatcher):
+    _backends = {
+        BackendType.TRITON: BackendEntry(GroupedGEMMFP4VariableKTritonBackend),
+    }
+    _cache = TuneCache(1024)
+
+    @classmethod
+    def make_key(
+        cls,
+        a,
+        b,
+        a_scales,
+        b_scales,
+        group_lens,
+        group_offs,
+        trans_a,
+        trans_b,
+        trans_c,
+        out_dtype,
+        granularity,
+        num_cu,
+        **kwargs,
+    ):
+        bs = group_lens.shape[0]
+        m = a.shape[1] if trans_a else a.shape[0]
+        n = b.shape[-2] if trans_b else b.shape[-1]
+        k = a.shape[0] if trans_a else a.shape[1]
+        if trans_c:
+            m, n = n, m
+        return (bs, m, n, k, a.dtype, b.dtype, out_dtype, trans_a, trans_b, trans_c, granularity)
+
 
 _torch_custom_op_wrapper = torch.library.custom_op
 
@@ -30,30 +252,82 @@ def grouped_gemm_fp4_impl(
     b: torch.Tensor,
     a_scales: torch.Tensor,
     b_scales: torch.Tensor,
+    group_lens: torch.Tensor,
     group_offs: torch.Tensor,
-    N: int,
-    K: int,
-    num_cu: int | None,
+    trans_a: bool,
+    trans_b: bool,
     out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: int | None,
+    default_backend: int,
+    maybe_pre_sync: bool = False,
     group_offs_out: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Forward (NT): C[g] = A[g] @ B[g]^T.
+    """Forward / dgrad (NT): C[g] = A[g] @ B[g]^T, contraction over (packed) K."""
+    default_backend_enum = BackendType(default_backend)
+    user_backend_enum = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP4)
+    granularity_enum = ScalingGranularity(granularity)
 
-    a (total_M, K/2) fp4, a_scales (total_M, K/32) e8m0,
-    b (G, N, K/2) fp4, b_scales (G, N, K/32) e8m0. K is logical.
-    """
-    return grouped_gemm_mxfp4_triton_kernel(
-        a,
-        a_scales,
-        b,
-        b_scales,
-        group_offs,
-        N,
-        K,
-        group_offs_out=group_offs_out,
+    kwargs = dict(
+        a=a,
+        b=b,
+        a_scales=a_scales,
+        b_scales=b_scales,
+        group_lens=group_lens,
+        group_offs=group_offs,
+        trans_a=trans_a,
+        trans_b=trans_b,
         out_dtype=out_dtype,
+        granularity=granularity_enum,
         num_cu=num_cu,
+        maybe_pre_sync=maybe_pre_sync,
+        group_offs_out=group_offs_out,
     )
+
+    return GroupedGEMMFP4KernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+
+
+@_torch_custom_op_wrapper(
+    "primus_turbo::grouped_gemm_fp4_variable_k_impl", mutates_args=(), device_types="cuda"
+)
+def grouped_gemm_fp4_variable_k_impl(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    trans_c: bool,
+    out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: int | None,
+    default_backend: int,
+    maybe_pre_sync: bool = False,
+) -> torch.Tensor:
+    """Backward wgrad: C[g] (OUT_M, OUT_N) = lhs[:,g] @ rhs[:,g]^T, reduction over M."""
+    default_backend_enum = BackendType(default_backend)
+    user_backend_enum = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP4)
+    granularity_enum = ScalingGranularity(granularity)
+
+    kwargs = dict(
+        a=a,
+        b=b,
+        a_scales=a_scales,
+        b_scales=b_scales,
+        group_lens=group_lens,
+        group_offs=group_offs,
+        trans_a=trans_a,
+        trans_b=trans_b,
+        trans_c=trans_c,
+        out_dtype=out_dtype,
+        granularity=granularity_enum,
+        num_cu=num_cu,
+        maybe_pre_sync=maybe_pre_sync,
+    )
+
+    return GroupedGEMMFP4VariableKKernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
 
 
 @grouped_gemm_fp4_impl.register_fake
@@ -62,70 +336,62 @@ def grouped_gemm_fp4_impl_meta(
     b: torch.Tensor,
     a_scales: torch.Tensor,
     b_scales: torch.Tensor,
+    group_lens: torch.Tensor,
     group_offs: torch.Tensor,
-    N: int,
-    K: int,
-    num_cu: int | None,
+    trans_a: bool,
+    trans_b: bool,
     out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: int | None,
+    default_backend: int,
+    maybe_pre_sync: bool = False,
     group_offs_out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     assert a.dim() == 2, f"a must be 2D, got {a.shape}"
     assert b.dim() == 3, f"b must be 3D, got {b.shape}"
     assert a.dtype == float4_e2m1fn_x2, f"a must be fp4, got {a.dtype}"
     assert b.dtype == float4_e2m1fn_x2, f"b must be fp4, got {b.dtype}"
-    assert out_dtype in (torch.float16, torch.bfloat16)
-    # Output over-allocated to padded input rows; caller slices [:total_m].
-    return torch.empty((a.shape[0], N), device=a.device, dtype=out_dtype)
+    assert out_dtype in (
+        torch.float16,
+        torch.bfloat16,
+    ), f"out_dtype must be float16 or bfloat16, got {out_dtype}"
+    assert trans_a == False, "Only trans_a=False is supported."
 
-
-@_torch_custom_op_wrapper(
-    "primus_turbo::grouped_gemm_fp4_variable_k_impl", mutates_args=(), device_types="cuda"
-)
-def grouped_gemm_fp4_variable_k_impl(
-    lhs: torch.Tensor,
-    rhs: torch.Tensor,
-    lhs_scales: torch.Tensor,
-    rhs_scales: torch.Tensor,
-    group_offs: torch.Tensor,
-    OUT_M: int,
-    OUT_N: int,
-    G: int,
-    num_cu: int | None,
-    out_dtype: torch.dtype,
-) -> torch.Tensor:
-    """Backward wgrad: C[g] (OUT_M, OUT_N) = lhs[:,g] @ rhs[:,g]^T, reduction over M_g.
-
-    lhs (OUT_M, M_total/2) fp4, rhs (OUT_N, M_total/2) fp4; scales (.., M_total/32) e8m0.
-    group_offs: padded per-group offsets along M (each M_g multiple of 128).
-    """
-    return grouped_gemm_mxfp4_variable_k_triton_kernel(
-        lhs,
-        lhs_scales,
-        rhs,
-        rhs_scales,
-        group_offs,
-        OUT_M,
-        OUT_N,
-        G,
-        out_dtype=out_dtype,
-        num_cu=num_cu,
-    )
+    # MX over-allocates to the padded input rows; group_offs_out maps each group
+    # into the tight layout and the caller slices [:total_m].
+    m = a.shape[1] if trans_a else a.shape[0]
+    n = b.shape[-2] if trans_b else b.shape[-1]
+    return torch.empty((m, n), device=a.device, dtype=out_dtype)
 
 
 @grouped_gemm_fp4_variable_k_impl.register_fake
 def grouped_gemm_fp4_variable_k_impl_meta(
-    lhs: torch.Tensor,
-    rhs: torch.Tensor,
-    lhs_scales: torch.Tensor,
-    rhs_scales: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_lens: torch.Tensor,
     group_offs: torch.Tensor,
-    OUT_M: int,
-    OUT_N: int,
-    G: int,
-    num_cu: int | None,
+    trans_a: bool,
+    trans_b: bool,
+    trans_c: bool,
     out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: int | None,
+    default_backend: int,
+    maybe_pre_sync: bool = False,
 ) -> torch.Tensor:
-    assert lhs.dim() == 2 and rhs.dim() == 2
-    assert lhs.dtype == float4_e2m1fn_x2 and rhs.dtype == float4_e2m1fn_x2
-    assert out_dtype in (torch.float16, torch.bfloat16)
-    return torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)
+    assert a.dim() == 2, f"a must be 2D, got {a.shape}"
+    assert b.dim() == 2, f"b must be 2D, got {b.shape}"
+    assert a.dtype == float4_e2m1fn_x2, f"a must be fp4, got {a.dtype}"
+    assert b.dtype == float4_e2m1fn_x2, f"b must be fp4, got {b.dtype}"
+    assert out_dtype in (
+        torch.float16,
+        torch.bfloat16,
+    ), f"out_dtype must be float16 or bfloat16, got {out_dtype}"
+
+    # wgrad: C[g] (OUT_M, OUT_N) = lhs[:,g] @ rhs[:,g]^T, lhs/rhs swapped by
+    # trans_c (matches the eager path). Output (G, OUT_M, OUT_N).
+    bs = group_lens.shape[0]
+    lhs, rhs = (b, a) if trans_c else (a, b)
+    return torch.empty((bs, lhs.shape[0], rhs.shape[0]), device=a.device, dtype=out_dtype)

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -17,6 +17,7 @@ from primus_turbo.pytorch.core.low_precision import (
     ScalingRecipe,
     check_mxfp4_support,
     check_mxfp8_support,
+    float4_e2m1fn_x2,
 )
 from primus_turbo.triton.quantization.quant_blockwise import (
     quant_fp8_blockwise_dual_kernel,
@@ -492,6 +493,63 @@ def grouped_quantize_mxfp8_impl(
         scaling_recipe.shuffle_out,
         scaling_recipe_for_trans.shuffle_scale,
         scaling_recipe_for_trans.shuffle_out,
+    )
+
+
+def grouped_quantize_mxfp4_impl(
+    x: torch.Tensor,
+    block_size: int,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    rowwise_recipe: Optional[ScalingRecipe] = None,
+    colwise_recipe: Optional[ScalingRecipe] = None,
+) -> Tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """Fused grouped dual (rowwise + colwise) MXFP4 quantization in one bf16 read.
+
+    One pass over the grouped activation ``x`` [total_m, N] (groups along M via
+    ``group_lens`` / ``group_offs``) emits:
+      * rowwise FP4 [total_m, N_pad/2] + E8M0 scale [total_m, N_pad/32] in the
+        tight (un-padded) M layout -- the fwd/dgrad operand (row i == input row i);
+      * colwise FP4 [N, M_pad_col/2] + E8M0 scale [N, M_pad_col/32] in the
+        128-padded per-group M layout -- the variable-K wgrad operand.
+    The per-group 128-padding offsets are computed on-GPU (no D2H sync), so the
+    op is CUDA-graph capturable.
+
+    Returns ``(rowwise_out, rowwise_scale, colwise_out, colwise_scale,
+    group_lens_padded_colwise, group_offs_padded_colwise)``.
+    """
+    mxfp4_support, reason = check_mxfp4_support()
+    assert mxfp4_support, reason
+
+    assert block_size == MXFP4_BLOCK_SIZE, f"The block size must be {MXFP4_BLOCK_SIZE} for MXFP4 quantization"
+
+    rowwise_recipe = ScalingRecipe() if rowwise_recipe is None else rowwise_recipe
+    colwise_recipe = ScalingRecipe() if colwise_recipe is None else colwise_recipe
+    assert not (
+        rowwise_recipe.shuffle_scale
+        or rowwise_recipe.shuffle_out
+        or colwise_recipe.shuffle_scale
+        or colwise_recipe.shuffle_out
+    ), "Grouped MXFP4 dual quant does not support shuffle layouts."
+
+    return torch.ops.primus_turbo_cpp_extension.grouped_quantize_mxfp4_dual(
+        x,
+        group_lens,
+        group_offs,
+        float4_e2m1fn_x2,
+        rowwise_recipe.use_2d_block,
+        rowwise_recipe.use_sr,
+        rowwise_recipe.use_rht,
+        colwise_recipe.use_2d_block,
+        colwise_recipe.use_sr,
+        colwise_recipe.use_rht,
     )
 
 

--- a/primus_turbo/pytorch/ops/__init__.py
+++ b/primus_turbo/pytorch/ops/__init__.py
@@ -15,6 +15,7 @@ from .gemm import *
 from .gemm_fp4 import *
 from .gemm_fp8 import *
 from .grouped_gemm import *
+from .grouped_gemm_fp4 import *
 from .grouped_gemm_fp8 import *
 from .moe import *
 from .normalization import *

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp4.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp4.py
@@ -184,7 +184,16 @@ class FP4GroupedGemmMXFunc(torch.autograd.Function):
         # contraction = N (zero-padded to 128 by the quantizer); output free dim K
         # stays logical (kernel `% N` + `c_mask`).
         grad_a = grouped_gemm_fp4_impl(
-            go_row, b_col, go_row_s, b_col_s, group_offs, K, _pad_contraction(N), num_cu, out_dtype, group_offs
+            go_row,
+            b_col,
+            go_row_s,
+            b_col_s,
+            group_offs,
+            K,
+            _pad_contraction(N),
+            num_cu,
+            out_dtype,
+            group_offs,
         )
 
         # --- wgrad: grad_b[g] = gradO_col(rht=T) @ A_col(rht=T)^T, contract M_g -> [G, N, K] ---

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp4.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp4.py
@@ -1,0 +1,248 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""MXFP4 grouped GEMM (MX_BLOCKWISE, Triton backend, gfx950).
+
+Mirrors :class:`FP8GroupedGemmMXFunc` but for E2M1 FP4. The MXFP4 training
+recipe (https://arxiv.org/pdf/2509.25149) keeps the forward operands plain MX
+and applies a 16-point Random Hadamard Transform (RHT) to the backward operands
+(grad_out + the cached col-wise transposes). Because the Hadamard is orthogonal
+it cancels inside each GEMM **only when both contracted operands share it**, so
+the recipes are paired exactly like the dense ``gemm_fp4``:
+
+    fwd   : C    = A_row(rht=F)         @ B_row(rht=F)^T          (contract K)
+    dgrad : dA   = gradO_row(rht=T)     @ B_col(rht=T)^T          (contract N)
+    wgrad : dB   = gradO_col(rht=T)     @ A_col(rht=T)^T          (contract M_g)
+
+Quantization reuses the dense ``quantize_fp4`` kernel (which already implements
+RHT / SR / 2D-block / fp4 packing) composed per direction:
+  * row-wise operands (fwd A, dgrad grad_out) quantize the whole activation —
+    K-blocks never cross per-group M boundaries, so no padding is needed;
+  * col-wise operands (wgrad A / grad_out) need per-group M zero-padding to 128
+    so the variable-K reduction is block-aligned and never mixes groups. We
+    build a 128-aligned padded activation and col-quantize it once (32-blocks and
+    16-pt RHT both divide 128, so no cross-group contamination).
+
+A future fused C++ ``grouped_quantize_mxfp4_dual`` can replace the Python
+composition without touching the GEMM kernels.
+"""
+
+from typing import List, Tuple, Union
+
+import torch
+
+from primus_turbo.pytorch.core.low_precision import (
+    MXFP4_BLOCK_SIZE,
+    Float4QuantConfig,
+    Format,
+    ScalingGranularity,
+    ScalingRecipe,
+    check_mxfp4_support,
+    float4_e2m1fn_x2,
+)
+from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_fp4_impl import (
+    grouped_gemm_fp4_impl,
+    grouped_gemm_fp4_variable_k_impl,
+)
+from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
+    group_offs_from_lens,
+)
+from primus_turbo.pytorch.ops.quantization import quantize_fp4
+
+__all__ = ["grouped_gemm_fp4"]
+
+_PAD = 128  # per-group M padding for the variable-K wgrad (BLOCK_SIZE_K).
+
+
+def _get_fp4_dtype(format: Format):
+    if format == Format.E2M1_X2:
+        return float4_e2m1fn_x2
+    raise ValueError(f"Unsupported FP4 format: {format}")
+
+
+def _q_row(x: torch.Tensor, rht: bool, sr: bool, two_d: bool):
+    """Row-wise (axis=1) MXFP4 quant -> (packed [M, K/2], e8m0 scale [M, K/32])."""
+    return quantize_fp4(
+        x,
+        float4_e2m1fn_x2,
+        ScalingGranularity.MX_BLOCKWISE,
+        block_size=MXFP4_BLOCK_SIZE,
+        axis=1,
+        scaling_recipe=ScalingRecipe(use_2d_block=two_d, use_sr=sr, use_rht=rht),
+    )
+
+
+def _q_col(x: torch.Tensor, rht: bool, sr: bool, two_d: bool):
+    """Col-wise (axis=0) MXFP4 quant -> (packed [K, M_pad/2], e8m0 scale [K, M_pad/32])."""
+    return quantize_fp4(
+        x,
+        float4_e2m1fn_x2,
+        ScalingGranularity.MX_BLOCKWISE,
+        block_size=MXFP4_BLOCK_SIZE,
+        axis=0,
+        scaling_recipe=ScalingRecipe(use_2d_block=two_d, use_sr=sr, use_rht=rht),
+    )
+
+
+def _padded_offs(group_lens_host: List[int], device) -> Tuple[torch.Tensor, int, List[int]]:
+    """Per-group offsets after padding each group's M up to a multiple of _PAD."""
+    padded = [((gl + _PAD - 1) // _PAD) * _PAD for gl in group_lens_host]
+    offs = [0]
+    for p in padded:
+        offs.append(offs[-1] + p)
+    return torch.tensor(offs, dtype=torch.int64, device=device), offs[-1], offs
+
+
+def _pad_rows(
+    x: torch.Tensor, group_offs_host: List[int], padded_offs_host: List[int], total_pad: int
+) -> torch.Tensor:
+    """Scatter each per-group row-block of ``x`` into a 128-aligned zero buffer."""
+    if total_pad == x.shape[0] and group_offs_host == padded_offs_host:
+        return x  # already 128-aligned per group (balanced) -> no copy
+    out = x.new_zeros((total_pad, x.shape[1]))
+    for g in range(len(group_offs_host) - 1):
+        s, e = group_offs_host[g], group_offs_host[g + 1]
+        ps = padded_offs_host[g]
+        out[ps : ps + (e - s)] = x[s:e]
+    return out
+
+
+def _quant_weight_dual(b: torch.Tensor):
+    """Per-group dual MXFP4 quant of the 3D weight ``b`` (G, N, K).
+
+    Returns (b_row, b_row_scale, b_col, b_col_scale):
+      b_row      (G, N, K/2)  rht=False  -> fwd B operand
+      b_col      (G, K, N/2)  rht=True   -> dgrad B operand (col-wise of [N, K])
+    """
+    G = b.shape[0]
+    rows, row_s, cols, col_s = [], [], [], []
+    for g in range(G):
+        bg = b[g].contiguous()
+        br, brs = _q_row(bg, rht=False, sr=False, two_d=True)
+        bc, bcs = _q_col(bg, rht=True, sr=False, two_d=True)
+        rows.append(br)
+        row_s.append(brs)
+        cols.append(bc)
+        col_s.append(bcs)
+    return torch.stack(rows), torch.stack(row_s), torch.stack(cols), torch.stack(col_s)
+
+
+class FP4GroupedGemmMXFunc(torch.autograd.Function):
+    """MXFP4 grouped GEMM autograd (MX_BLOCKWISE, NT-only, Triton backend)."""
+
+    @staticmethod
+    def forward(ctx, a, b, group_lens, group_offs, trans_b, out_dtype, config, num_cu):
+        assert config.granularity == ScalingGranularity.MX_BLOCKWISE
+        assert a.ndim == 2 and b.ndim == 3
+        assert out_dtype in (torch.float16, torch.bfloat16)
+        assert trans_b, "MXFP4 grouped GEMM only supports trans_b=True (NT layout)."
+        assert not config.use_preshuffle, "Triton MXFP4 grouped GEMM does not use preshuffle."
+        supported, reason = check_mxfp4_support()
+        assert supported, reason
+
+        N, K = int(b.shape[-2]), int(b.shape[-1])
+        assert K % _PAD == 0, f"K must be a multiple of {_PAD} (got {K})."
+        assert N % _PAD == 0, f"N must be a multiple of {_PAD} (got {N})."
+        total_m = int(a.size(0))
+        G = int(b.shape[0])
+
+        group_lens_host = group_lens.tolist()
+        group_offs_host = group_offs.tolist()
+        padded_offs, total_pad, padded_offs_host = _padded_offs(group_lens_host, a.device)
+
+        # --- forward: A_row(rht=F) @ B_row(rht=F)^T, contract K ---
+        a_row, a_row_s = _q_row(a, rht=False, sr=False, two_d=False)
+        b_row, b_row_s, b_col, b_col_s = _quant_weight_dual(b)
+
+        out = grouped_gemm_fp4_impl(
+            a_row, b_row, a_row_s, b_row_s, group_offs, N, K, num_cu, out_dtype, group_offs
+        )
+
+        # --- cache the col-wise (rht=T) A transpose for wgrad (per-group 128-padded) ---
+        a_pad = _pad_rows(a, group_offs_host, padded_offs_host, total_pad)
+        a_col, a_col_s = _q_col(a_pad, rht=True, sr=False, two_d=False)
+
+        ctx.save_for_backward(a_col, a_col_s, b_col, b_col_s, group_offs, padded_offs)
+        ctx.N, ctx.K, ctx.G = N, K, G
+        ctx.total_m, ctx.total_pad = total_m, total_pad
+        ctx.config = config
+        ctx.out_dtype = out_dtype
+        ctx.num_cu = num_cu
+        ctx.group_offs_host = group_offs_host
+        ctx.padded_offs_host = padded_offs_host
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        a_col, a_col_s, b_col, b_col_s, group_offs, padded_offs = ctx.saved_tensors
+        N, K, G = ctx.N, ctx.K, ctx.G
+        out_dtype, num_cu = ctx.out_dtype, ctx.num_cu
+        sr = ctx.config.use_gradient_sr
+
+        grad_out = grad_out.contiguous().view(ctx.total_m, N)
+
+        # --- dgrad: grad_a = gradO_row(rht=T) @ B_col(rht=T)^T, contract N -> [total_m, K] ---
+        go_row, go_row_s = _q_row(grad_out, rht=True, sr=sr, two_d=False)
+        grad_a = grouped_gemm_fp4_impl(
+            go_row, b_col, go_row_s, b_col_s, group_offs, K, N, num_cu, out_dtype, group_offs
+        )
+
+        # --- wgrad: grad_b[g] = gradO_col(rht=T) @ A_col(rht=T)^T, contract M_g -> [G, N, K] ---
+        go_pad = _pad_rows(grad_out, ctx.group_offs_host, ctx.padded_offs_host, ctx.total_pad)
+        go_col, go_col_s = _q_col(go_pad, rht=True, sr=sr, two_d=False)
+        grad_b = grouped_gemm_fp4_variable_k_impl(
+            go_col, a_col, go_col_s, a_col_s, padded_offs, N, K, G, num_cu, out_dtype
+        )
+
+        # forward args: (a, b, group_lens, group_offs, trans_b, out_dtype, config, num_cu)
+        return grad_a, grad_b, None, None, None, None, None, None
+
+
+@torch._dynamo.disable(
+    recursive=True,
+    reason=(
+        "Grouped MXFP4 GEMM composes the dense quantizer per direction and reads "
+        "packed FP4 / E8M0 inner tensors inside its autograd.Function.forward; "
+        "Dynamo cannot recover Python sources for those graph-internal tensors."
+    ),
+)
+def grouped_gemm_fp4(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: Union[torch.Tensor, None] = None,
+    trans_b: bool = True,
+    out_dtype: Union[torch.dtype, None] = None,
+    config: Union[Float4QuantConfig, None] = None,
+    num_cu: int | None = None,
+) -> torch.Tensor:
+    """Grouped GEMM with MXFP4 (E2M1) quantization, supporting autograd.
+
+    Args:
+        a: Activation [total_m, K] (float16 / bfloat16), grouped along M.
+        b: Weight [G, N, K] (trans_b=True, NT layout only).
+        group_lens: Per-group row counts [G] (int64).
+        group_offs: Optional per-group offsets [G+1]; derived from group_lens if None.
+        trans_b: Must be True (NT).
+        out_dtype: Output dtype (defaults to promote(a, b)).
+        config: Float4QuantConfig (MX_BLOCKWISE). use_preshuffle must be False.
+        num_cu: Optional cap on compute units for the persistent grid.
+
+    Returns:
+        Output [total_m, N].
+    """
+    if config is None:
+        config = Float4QuantConfig()
+    if group_offs is None:
+        group_offs = group_offs_from_lens(group_lens)
+    if out_dtype is None:
+        out_dtype = torch.promote_types(a.dtype, b.dtype)
+
+    assert a.ndim == 2, "a must be 2D [total_m, K]"
+    assert b.ndim == 3, "b must be 3D [G, N, K]"
+
+    if config.granularity == ScalingGranularity.MX_BLOCKWISE:
+        return FP4GroupedGemmMXFunc.apply(a, b, group_lens, group_offs, trans_b, out_dtype, config, num_cu)
+    raise ValueError(f"Unsupported FP4 ScalingGranularity: {config.granularity}")

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp4.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp4.py
@@ -36,10 +36,10 @@ from typing import Union
 
 import torch
 
+from primus_turbo.pytorch.core.backend import BackendType
 from primus_turbo.pytorch.core.low_precision import (
     MXFP4_BLOCK_SIZE,
     Float4QuantConfig,
-    Format,
     ScalingGranularity,
     ScalingRecipe,
     check_mxfp4_support,
@@ -58,26 +58,6 @@ from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
 from primus_turbo.pytorch.ops.quantization import quantize_fp4_with_trans
 
 __all__ = ["grouped_gemm_fp4"]
-
-_PAD = 128  # per-group M padding for the variable-K wgrad (BLOCK_SIZE_K).
-
-
-def _pad_contraction(v: int) -> int:
-    """Round a contraction length up to ``_PAD`` (=128, the GEMM BLOCK_SIZE_K).
-
-    ``quantize_fp4`` already zero-pads the quantized axis to
-    ``MXFP4_PADDING_ALIGN_SIZE`` (=128), so the row-/col-wise operands carry a
-    128-aligned contraction dim with zero-filled tail. Running the GEMM over this
-    padded length lets it accept any 32-multiple N/K: the padded region holds
-    fp4 zeros (and self-consistent E8M0 scales), contributing 0 to the dot.
-    """
-    return ((v + _PAD - 1) // _PAD) * _PAD
-
-
-def _get_fp4_dtype(format: Format):
-    if format == Format.E2M1_X2:
-        return float4_e2m1fn_x2
-    raise ValueError(f"Unsupported FP4 format: {format}")
 
 
 def _quant_weight_dual(b: torch.Tensor):
@@ -119,13 +99,12 @@ class FP4GroupedGemmMXFunc(torch.autograd.Function):
         N, K = int(b.shape[-2]), int(b.shape[-1])
         # MX scales cover one 32-element block, so the contraction must be a
         # 32-multiple. N/K need not be 128-multiples: the quantizer zero-pads the
-        # contraction to 128 and the GEMM runs over that padded length (see
-        # `_pad_contraction`), while free dims are handled by the kernel's `% N`
-        # wrap + `c_mask`.
+        # contraction to MXFP4_PADDING_ALIGN_SIZE (=128) and the GEMM runs over
+        # that padded length (the packed last dim already reflects it), while free
+        # dims are handled by the kernel's `% N` wrap + `c_mask`.
         assert K % MXFP4_BLOCK_SIZE == 0, f"K must be a multiple of {MXFP4_BLOCK_SIZE} (got {K})."
         assert N % MXFP4_BLOCK_SIZE == 0, f"N must be a multiple of {MXFP4_BLOCK_SIZE} (got {N})."
         total_m = int(a.size(0))
-        G = int(b.shape[0])
 
         # --- A: fused grouped dual-quant in one bf16 read. rowwise (rht=F) is the
         # tight-M fwd operand; colwise (rht=T) is the 128-padded-M wgrad operand.
@@ -142,16 +121,29 @@ class FP4GroupedGemmMXFunc(torch.autograd.Function):
         )
         b_row, b_row_s, b_col, b_col_s = _quant_weight_dual(b)
 
-        # contraction = K, zero-padded to 128 by the quantizer; output free dim N
-        # stays logical (kernel `% N` + `c_mask`).
+        # b_row is FP4-packed (G, N, K/2): the backend derives the (128-padded)
+        # contraction K = b.shape[-1]*2 and the free dim N = b.shape[-2]. a_row is
+        # the tight-M layout, so group_offs doubles as group_offs_out (no slice).
         out = grouped_gemm_fp4_impl(
-            a_row, b_row, a_row_s, b_row_s, group_offs, N, _pad_contraction(K), num_cu, out_dtype, group_offs
+            a_row,
+            b_row,
+            a_row_s,
+            b_row_s,
+            group_lens,
+            group_offs,
+            trans_a=False,
+            trans_b=True,
+            out_dtype=out_dtype,
+            granularity=ScalingGranularity.MX_BLOCKWISE.value,
+            num_cu=num_cu,
+            default_backend=BackendType.TRITON.value,
+            group_offs_out=group_offs,
         )
 
         # ``group_lens`` is re-saved so backward can fuse grad_out's dual-quant the
         # same way (its per-group 128-pad layout matches ``padded_offs``).
         ctx.save_for_backward(a_col, a_col_s, b_col, b_col_s, group_lens, group_offs, padded_offs)
-        ctx.N, ctx.K, ctx.G = N, K, G
+        ctx.N = N
         ctx.total_m = total_m
         ctx.config = config
         ctx.out_dtype = out_dtype
@@ -161,7 +153,7 @@ class FP4GroupedGemmMXFunc(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_out):
         a_col, a_col_s, b_col, b_col_s, group_lens, group_offs, padded_offs = ctx.saved_tensors
-        N, K, G = ctx.N, ctx.K, ctx.G
+        N = ctx.N
         out_dtype, num_cu = ctx.out_dtype, ctx.num_cu
         sr = ctx.config.use_gradient_sr
 
@@ -181,24 +173,41 @@ class FP4GroupedGemmMXFunc(torch.autograd.Function):
         )
 
         # --- dgrad: grad_a = gradO_row(rht=T) @ B_col(rht=T)^T, contract N -> [total_m, K] ---
-        # contraction = N (zero-padded to 128 by the quantizer); output free dim K
-        # stays logical (kernel `% N` + `c_mask`).
+        # b_col is FP4-packed (G, K, N/2): the backend derives the (128-padded)
+        # contraction from the packed last dim and the free dim K = b.shape[-2].
         grad_a = grouped_gemm_fp4_impl(
             go_row,
             b_col,
             go_row_s,
             b_col_s,
+            group_lens,
             group_offs,
-            K,
-            _pad_contraction(N),
-            num_cu,
-            out_dtype,
-            group_offs,
+            trans_a=False,
+            trans_b=True,
+            out_dtype=out_dtype,
+            granularity=ScalingGranularity.MX_BLOCKWISE.value,
+            num_cu=num_cu,
+            default_backend=BackendType.TRITON.value,
+            group_offs_out=group_offs,
         )
 
         # --- wgrad: grad_b[g] = gradO_col(rht=T) @ A_col(rht=T)^T, contract M_g -> [G, N, K] ---
+        # OUT_M = go_col.shape[0] (=N), OUT_N = a_col.shape[0] (=K), G = group count,
+        # all derived in the backend; padded_offs are the per-group M offsets.
         grad_b = grouped_gemm_fp4_variable_k_impl(
-            go_col, a_col, go_col_s, a_col_s, padded_offs, N, K, G, num_cu, out_dtype
+            go_col,
+            a_col,
+            go_col_s,
+            a_col_s,
+            group_lens,
+            padded_offs,
+            trans_a=False,
+            trans_b=False,
+            trans_c=False,
+            out_dtype=out_dtype,
+            granularity=ScalingGranularity.MX_BLOCKWISE.value,
+            num_cu=num_cu,
+            default_backend=BackendType.TRITON.value,
         )
 
         # forward args: (a, b, group_lens, group_offs, trans_b, out_dtype, config, num_cu)

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp4.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp4.py
@@ -16,20 +16,23 @@ the recipes are paired exactly like the dense ``gemm_fp4``:
     dgrad : dA   = gradO_row(rht=T)     @ B_col(rht=T)^T          (contract N)
     wgrad : dB   = gradO_col(rht=T)     @ A_col(rht=T)^T          (contract M_g)
 
-Quantization reuses the dense ``quantize_fp4`` kernel (which already implements
-RHT / SR / 2D-block / fp4 packing) composed per direction:
-  * row-wise operands (fwd A, dgrad grad_out) quantize the whole activation —
-    K-blocks never cross per-group M boundaries, so no padding is needed;
-  * col-wise operands (wgrad A / grad_out) need per-group M zero-padding to 128
-    so the variable-K reduction is block-aligned and never mixes groups. We
-    build a 128-aligned padded activation and col-quantize it once (32-blocks and
-    16-pt RHT both divide 128, so no cross-group contamination).
+Both grouped activations ``A`` (fwd) and ``grad_out`` (bwd) are quantized by the
+fused C++ ``grouped_quantize_mxfp4_dual`` kernel: one bf16 read emits both the
+tight-M row-wise operand (fwd/dgrad) and the 128-padded per-group col-wise
+operand (variable-K wgrad), with the per-group M zero-pad + GPU-computed offsets
+folded into the quant pass (no bf16 scatter, no extra read, no D2H sync ->
+CUDA-graph capturable). ``A`` uses rht=F row-wise; ``grad_out`` uses rht=T both
+directions (+ optional gradient SR).
 
-A future fused C++ ``grouped_quantize_mxfp4_dual`` can replace the Python
-composition without touching the GEMM kernels.
+The weight ``B`` ([G, N, K]) is dual-quantized in a single batched
+``quantize_fp4_with_trans`` call (rht=F row-wise for fwd, rht=T col-wise for
+dgrad): the FP4 ``quantize_mxfp4_dual`` kernel walks each group along
+``blockIdx.z``, so there is no Python per-group loop and no full-weight
+transpose/``contiguous`` copy. This mirrors the MXFP8 weight path
+(``FP8GroupedGemmMXFunc`` -> ``quantize_fp8_with_trans`` on the 3D ``(G, N, K)``).
 """
 
-from typing import List, Tuple, Union
+from typing import Union
 
 import torch
 
@@ -49,11 +52,26 @@ from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_fp4_impl import (
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
     group_offs_from_lens,
 )
-from primus_turbo.pytorch.ops.quantization import quantize_fp4
+from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
+    grouped_quantize_mxfp4_impl,
+)
+from primus_turbo.pytorch.ops.quantization import quantize_fp4_with_trans
 
 __all__ = ["grouped_gemm_fp4"]
 
 _PAD = 128  # per-group M padding for the variable-K wgrad (BLOCK_SIZE_K).
+
+
+def _pad_contraction(v: int) -> int:
+    """Round a contraction length up to ``_PAD`` (=128, the GEMM BLOCK_SIZE_K).
+
+    ``quantize_fp4`` already zero-pads the quantized axis to
+    ``MXFP4_PADDING_ALIGN_SIZE`` (=128), so the row-/col-wise operands carry a
+    128-aligned contraction dim with zero-filled tail. Running the GEMM over this
+    padded length lets it accept any 32-multiple N/K: the padded region holds
+    fp4 zeros (and self-consistent E8M0 scales), contributing 0 to the dot.
+    """
+    return ((v + _PAD - 1) // _PAD) * _PAD
 
 
 def _get_fp4_dtype(format: Format):
@@ -62,71 +80,27 @@ def _get_fp4_dtype(format: Format):
     raise ValueError(f"Unsupported FP4 format: {format}")
 
 
-def _q_row(x: torch.Tensor, rht: bool, sr: bool, two_d: bool):
-    """Row-wise (axis=1) MXFP4 quant -> (packed [M, K/2], e8m0 scale [M, K/32])."""
-    return quantize_fp4(
-        x,
-        float4_e2m1fn_x2,
-        ScalingGranularity.MX_BLOCKWISE,
-        block_size=MXFP4_BLOCK_SIZE,
-        axis=1,
-        scaling_recipe=ScalingRecipe(use_2d_block=two_d, use_sr=sr, use_rht=rht),
-    )
-
-
-def _q_col(x: torch.Tensor, rht: bool, sr: bool, two_d: bool):
-    """Col-wise (axis=0) MXFP4 quant -> (packed [K, M_pad/2], e8m0 scale [K, M_pad/32])."""
-    return quantize_fp4(
-        x,
-        float4_e2m1fn_x2,
-        ScalingGranularity.MX_BLOCKWISE,
-        block_size=MXFP4_BLOCK_SIZE,
-        axis=0,
-        scaling_recipe=ScalingRecipe(use_2d_block=two_d, use_sr=sr, use_rht=rht),
-    )
-
-
-def _padded_offs(group_lens_host: List[int], device) -> Tuple[torch.Tensor, int, List[int]]:
-    """Per-group offsets after padding each group's M up to a multiple of _PAD."""
-    padded = [((gl + _PAD - 1) // _PAD) * _PAD for gl in group_lens_host]
-    offs = [0]
-    for p in padded:
-        offs.append(offs[-1] + p)
-    return torch.tensor(offs, dtype=torch.int64, device=device), offs[-1], offs
-
-
-def _pad_rows(
-    x: torch.Tensor, group_offs_host: List[int], padded_offs_host: List[int], total_pad: int
-) -> torch.Tensor:
-    """Scatter each per-group row-block of ``x`` into a 128-aligned zero buffer."""
-    if total_pad == x.shape[0] and group_offs_host == padded_offs_host:
-        return x  # already 128-aligned per group (balanced) -> no copy
-    out = x.new_zeros((total_pad, x.shape[1]))
-    for g in range(len(group_offs_host) - 1):
-        s, e = group_offs_host[g], group_offs_host[g + 1]
-        ps = padded_offs_host[g]
-        out[ps : ps + (e - s)] = x[s:e]
-    return out
-
-
 def _quant_weight_dual(b: torch.Tensor):
-    """Per-group dual MXFP4 quant of the 3D weight ``b`` (G, N, K).
+    """Dual MXFP4 quant of the 3D weight ``b`` (G, N, K) in one batched launch.
 
     Returns (b_row, b_row_scale, b_col, b_col_scale):
-      b_row      (G, N, K/2)  rht=False  -> fwd B operand
-      b_col      (G, K, N/2)  rht=True   -> dgrad B operand (col-wise of [N, K])
+      b_row      (G, N, K_pad/2)  rht=False  -> fwd B operand   (2D-block, axis K)
+      b_col      (G, K, N_pad/2)  rht=True   -> dgrad B operand (2D-block, axis N)
+
+    Both directions come from a single batched ``quantize_fp4_with_trans`` call
+    over the 3D weight -- the FP4 ``quantize_mxfp4_dual`` kernel walks each group
+    with ``blockIdx.z``, so there is no Python per-group loop and no full-weight
+    transpose/contiguous copy. This mirrors the MXFP8 grouped GEMM weight path
+    (``FP8GroupedGemmMXFunc`` -> ``quantize_fp8_with_trans`` on ``(G, N, K)``).
     """
-    G = b.shape[0]
-    rows, row_s, cols, col_s = [], [], [], []
-    for g in range(G):
-        bg = b[g].contiguous()
-        br, brs = _q_row(bg, rht=False, sr=False, two_d=True)
-        bc, bcs = _q_col(bg, rht=True, sr=False, two_d=True)
-        rows.append(br)
-        row_s.append(brs)
-        cols.append(bc)
-        col_s.append(bcs)
-    return torch.stack(rows), torch.stack(row_s), torch.stack(cols), torch.stack(col_s)
+    return quantize_fp4_with_trans(
+        b,
+        float4_e2m1fn_x2,
+        ScalingGranularity.MX_BLOCKWISE,
+        block_size=MXFP4_BLOCK_SIZE,
+        scaling_recipe=ScalingRecipe(use_2d_block=True, use_sr=False, use_rht=False),
+        scaling_recipe_for_trans=ScalingRecipe(use_2d_block=True, use_sr=False, use_rht=True),
+    )
 
 
 class FP4GroupedGemmMXFunc(torch.autograd.Function):
@@ -143,55 +117,77 @@ class FP4GroupedGemmMXFunc(torch.autograd.Function):
         assert supported, reason
 
         N, K = int(b.shape[-2]), int(b.shape[-1])
-        assert K % _PAD == 0, f"K must be a multiple of {_PAD} (got {K})."
-        assert N % _PAD == 0, f"N must be a multiple of {_PAD} (got {N})."
+        # MX scales cover one 32-element block, so the contraction must be a
+        # 32-multiple. N/K need not be 128-multiples: the quantizer zero-pads the
+        # contraction to 128 and the GEMM runs over that padded length (see
+        # `_pad_contraction`), while free dims are handled by the kernel's `% N`
+        # wrap + `c_mask`.
+        assert K % MXFP4_BLOCK_SIZE == 0, f"K must be a multiple of {MXFP4_BLOCK_SIZE} (got {K})."
+        assert N % MXFP4_BLOCK_SIZE == 0, f"N must be a multiple of {MXFP4_BLOCK_SIZE} (got {N})."
         total_m = int(a.size(0))
         G = int(b.shape[0])
 
-        group_lens_host = group_lens.tolist()
-        group_offs_host = group_offs.tolist()
-        padded_offs, total_pad, padded_offs_host = _padded_offs(group_lens_host, a.device)
-
-        # --- forward: A_row(rht=F) @ B_row(rht=F)^T, contract K ---
-        a_row, a_row_s = _q_row(a, rht=False, sr=False, two_d=False)
+        # --- A: fused grouped dual-quant in one bf16 read. rowwise (rht=F) is the
+        # tight-M fwd operand; colwise (rht=T) is the 128-padded-M wgrad operand.
+        # The per-group M zero-pad and its GPU-computed offsets (``padded_offs``,
+        # the col layout used by the variable-K wgrad) are folded into the quant
+        # pass -- no bf16 scatter, no extra read, no D2H sync. ---
+        a_row, a_row_s, a_col, a_col_s, _, padded_offs = grouped_quantize_mxfp4_impl(
+            a,
+            MXFP4_BLOCK_SIZE,
+            group_lens,
+            group_offs,
+            rowwise_recipe=ScalingRecipe(use_2d_block=False, use_sr=False, use_rht=False),
+            colwise_recipe=ScalingRecipe(use_2d_block=False, use_sr=False, use_rht=True),
+        )
         b_row, b_row_s, b_col, b_col_s = _quant_weight_dual(b)
 
+        # contraction = K, zero-padded to 128 by the quantizer; output free dim N
+        # stays logical (kernel `% N` + `c_mask`).
         out = grouped_gemm_fp4_impl(
-            a_row, b_row, a_row_s, b_row_s, group_offs, N, K, num_cu, out_dtype, group_offs
+            a_row, b_row, a_row_s, b_row_s, group_offs, N, _pad_contraction(K), num_cu, out_dtype, group_offs
         )
 
-        # --- cache the col-wise (rht=T) A transpose for wgrad (per-group 128-padded) ---
-        a_pad = _pad_rows(a, group_offs_host, padded_offs_host, total_pad)
-        a_col, a_col_s = _q_col(a_pad, rht=True, sr=False, two_d=False)
-
-        ctx.save_for_backward(a_col, a_col_s, b_col, b_col_s, group_offs, padded_offs)
+        # ``group_lens`` is re-saved so backward can fuse grad_out's dual-quant the
+        # same way (its per-group 128-pad layout matches ``padded_offs``).
+        ctx.save_for_backward(a_col, a_col_s, b_col, b_col_s, group_lens, group_offs, padded_offs)
         ctx.N, ctx.K, ctx.G = N, K, G
-        ctx.total_m, ctx.total_pad = total_m, total_pad
+        ctx.total_m = total_m
         ctx.config = config
         ctx.out_dtype = out_dtype
         ctx.num_cu = num_cu
-        ctx.group_offs_host = group_offs_host
-        ctx.padded_offs_host = padded_offs_host
         return out
 
     @staticmethod
     def backward(ctx, grad_out):
-        a_col, a_col_s, b_col, b_col_s, group_offs, padded_offs = ctx.saved_tensors
+        a_col, a_col_s, b_col, b_col_s, group_lens, group_offs, padded_offs = ctx.saved_tensors
         N, K, G = ctx.N, ctx.K, ctx.G
         out_dtype, num_cu = ctx.out_dtype, ctx.num_cu
         sr = ctx.config.use_gradient_sr
 
         grad_out = grad_out.contiguous().view(ctx.total_m, N)
 
+        # --- grad_out: fused grouped dual-quant in one bf16 read (symmetric to A).
+        # rowwise (rht=T) is the tight-M dgrad operand; colwise (rht=T) is the
+        # 128-padded-M wgrad operand (same layout as ``padded_offs`` / a_col). SR
+        # (use_gradient_sr) applies to both directions. No bf16 scatter / D2H. ---
+        go_row, go_row_s, go_col, go_col_s, _, _ = grouped_quantize_mxfp4_impl(
+            grad_out,
+            MXFP4_BLOCK_SIZE,
+            group_lens,
+            group_offs,
+            rowwise_recipe=ScalingRecipe(use_2d_block=False, use_sr=sr, use_rht=True),
+            colwise_recipe=ScalingRecipe(use_2d_block=False, use_sr=sr, use_rht=True),
+        )
+
         # --- dgrad: grad_a = gradO_row(rht=T) @ B_col(rht=T)^T, contract N -> [total_m, K] ---
-        go_row, go_row_s = _q_row(grad_out, rht=True, sr=sr, two_d=False)
+        # contraction = N (zero-padded to 128 by the quantizer); output free dim K
+        # stays logical (kernel `% N` + `c_mask`).
         grad_a = grouped_gemm_fp4_impl(
-            go_row, b_col, go_row_s, b_col_s, group_offs, K, N, num_cu, out_dtype, group_offs
+            go_row, b_col, go_row_s, b_col_s, group_offs, K, _pad_contraction(N), num_cu, out_dtype, group_offs
         )
 
         # --- wgrad: grad_b[g] = gradO_col(rht=T) @ A_col(rht=T)^T, contract M_g -> [G, N, K] ---
-        go_pad = _pad_rows(grad_out, ctx.group_offs_host, ctx.padded_offs_host, ctx.total_pad)
-        go_col, go_col_s = _q_col(go_pad, rht=True, sr=sr, two_d=False)
         grad_b = grouped_gemm_fp4_variable_k_impl(
             go_col, a_col, go_col_s, a_col_s, padded_offs, N, K, G, num_cu, out_dtype
         )

--- a/primus_turbo/pytorch/ops/quantization.py
+++ b/primus_turbo/pytorch/ops/quantization.py
@@ -251,8 +251,11 @@ def quantize_fp4_with_trans(
 
     NOTE:
         For MXFP4 quantization:
-            1. The x must be 2D tensor.
-            2. The axis means direction of quantization. The 0 means along column direction and 1 means along row direction.
+            1. The x may be a 2D ``[M, N]`` tensor or a 3D ``[G, M, N]`` batched
+               (per-group) tensor. The MX grouped GEMM weight path calls this with
+               3D ``(G, N, K)`` weights; each group is walked by ``blockIdx.z``.
+            2. Both row-wise and col-wise outputs are produced in one pass; no
+               ``axis`` argument is taken (it is implied by the dual direction).
             3. The block size must be 32.
             4. The return value is x_rowwise, x_scale_inv_rowwise, x_colwise and x_scale_inv_colwise.
     """

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp4_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp4_kernel.py
@@ -20,8 +20,9 @@ with E8M0 (VEC_SIZE=32) scales.
 FP4 packing notes:
   * data tensors store K/2 (resp. M/2) bytes along the contraction axis;
   * scale tensors store K/32 (resp. M/32) E8M0 bytes (one per 1x32 block);
-  * scales are stored transposed (K/32, free) / (G, K/32, free) for a coalesced
-    per-K-iter load, transposed back in-reg for tl.dot_scaled.
+  * scales are stored free-major (free, K/32) / (G, free, K/32); each K-iter
+    loads a (K/32, free) tile (coalesced) and transposes it back in-reg for
+    tl.dot_scaled.
 
 Only EVEN contraction (a multiple of BLOCK_SIZE_K = 128 logical elements) is
 supported; the FP4 quantizer pads K to 128 and the MX wrapper pads per-group M
@@ -49,8 +50,8 @@ VEC_SIZE = 32
 
 # ###########################################################################
 #  Forward (NT):   C[g] = A[g] @ B[g]^T
-#    A (total_M, K/2) fp4-packed, A_scale (K/32, total_M) e8m0
-#    B (G, N, K/2)    fp4-packed, B_scale (G, K/32, N)   e8m0
+#    A (total_M, K/2) fp4-packed, A_scale (total_M, K/32) e8m0
+#    B (G, N, K/2)    fp4-packed, B_scale (G, N, K/32)   e8m0
 # ###########################################################################
 
 

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp4_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp4_kernel.py
@@ -1,0 +1,421 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Grouped MXFP4 (MX_BLOCKWISE) GEMM Triton persistent kernels (gfx950).
+
+Mirrors the MXFP8 grouped kernels in ``grouped_gemm_fp8_kernel.py`` but the
+operands are E2M1 FP4 packed two-values-per-byte along the contraction (K)
+axis, fed to the hardware block-scaled MMA via ``tl.dot_scaled(..., "e2m1", ...)``
+with E8M0 (VEC_SIZE=32) scales.
+
+  - _grouped_mxfp4_persistent_gemm_kernel:    Forward (NT)  C[g] = A[g] @ B[g]^T
+  - grouped_gemm_mxfp4_triton_kernel:         Forward public API
+  - _grouped_mxfp4_variable_k_gemm_kernel:    Backward wgrad C[g] = LHS[g] @ RHS[g]^T
+  - grouped_gemm_mxfp4_variable_k_triton_kernel: Backward (variable-K) public API
+
+FP4 packing notes:
+  * data tensors store K/2 (resp. M/2) bytes along the contraction axis;
+  * scale tensors store K/32 (resp. M/32) E8M0 bytes (one per 1x32 block);
+  * scales are stored transposed (K/32, free) / (G, K/32, free) for a coalesced
+    per-K-iter load, transposed back in-reg for tl.dot_scaled.
+
+Only EVEN contraction (a multiple of BLOCK_SIZE_K = 128 logical elements) is
+supported; the FP4 quantizer pads K to 128 and the MX wrapper pads per-group M
+to 128, so this always holds in practice.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+from primus_turbo.pytorch.core.utils import is_gfx950
+from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
+    NUM_XCDS,
+    _chiplet_transform_chunked,
+)
+from primus_turbo.triton.utils.triton_knobs_helper import set_triton_knobs_gfx950
+
+# E8M0 block size: one scale per 1x32 logical-element block (same as MXFP8).
+# tl.dot_scaled consumes the "e2m1" FP4 format string (inlined in the kernels;
+# @triton.jit cannot read module globals).
+VEC_SIZE = 32
+
+
+# ###########################################################################
+#  Forward (NT):   C[g] = A[g] @ B[g]^T
+#    A (total_M, K/2) fp4-packed, A_scale (K/32, total_M) e8m0
+#    B (G, N, K/2)    fp4-packed, B_scale (G, K/32, N)   e8m0
+# ###########################################################################
+
+
+@triton.jit
+def _grouped_mxfp4_persistent_gemm_kernel(
+    A,
+    B,
+    C,
+    A_scale,  # (total_M, K//32) uint8 e8m0
+    B_scale,  # (G, N, K//32) uint8 e8m0
+    rd_offs_ptr,  # (G+1) int64 — read base along M (A / A_scale)
+    out_offs_ptr,  # (G+1) int64 — write base along M (C, tile count)
+    G,
+    N,
+    K,  # logical contraction size (multiple of BLOCK_SIZE_K)
+    stride_am,
+    stride_ak,  # along packed K bytes
+    stride_bg,
+    stride_bn,
+    stride_bk,  # along packed K bytes
+    stride_cm,
+    stride_cn,
+    stride_asm,
+    stride_ask,
+    stride_bsg,
+    stride_bsn,
+    stride_bsk,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,  # logical K per iter
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+    CACHE_MODIFIER: tl.constexpr,
+    VEC: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    if NUM_XCDS != 1:
+        pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+
+    total_tiles: tl.int32 = 0
+    for _g in range(G):
+        m_g = (tl.load(out_offs_ptr + _g + 1) - tl.load(out_offs_ptr + _g)).to(tl.int32)
+        total_tiles += tl.cdiv(m_g, BLOCK_SIZE_M) * num_pid_n
+
+    tl.assume(stride_am > 0)
+    tl.assume(stride_cm > 0)
+
+    BK_PACK: tl.constexpr = BLOCK_SIZE_K // 2  # packed bytes per K-iter
+    BK_SCALE: tl.constexpr = BLOCK_SIZE_K // VEC  # scale entries per K-iter
+
+    for global_tile_id in range(pid, total_tiles, NUM_SMS):
+        # ── locate group (linear scan) ──
+        group_idx: tl.int32 = 0
+        tile_start: tl.int32 = 0
+        cumsum: tl.int32 = 0
+        for _g in range(G):
+            m_g_i = (tl.load(out_offs_ptr + _g + 1) - tl.load(out_offs_ptr + _g)).to(tl.int32)
+            tiles_g = tl.cdiv(m_g_i, BLOCK_SIZE_M) * num_pid_n
+            new_cumsum = cumsum + tiles_g
+            if global_tile_id >= new_cumsum:
+                group_idx = _g + 1
+                tile_start = new_cumsum
+            cumsum = new_cumsum
+
+        local_tile = global_tile_id - tile_start
+        m_rd = tl.load(rd_offs_ptr + group_idx)  # int64 read base (A / A_scale)
+        m_out = tl.load(out_offs_ptr + group_idx)  # int64 write base (C)
+        M_g = (tl.load(out_offs_ptr + group_idx + 1) - m_out).to(tl.int32)
+        tiles_m_g = tl.cdiv(M_g, BLOCK_SIZE_M)
+
+        # ── swizzle ──
+        num_pid_in_group = GROUP_SIZE_M * num_pid_n
+        swizzle_group = local_tile // num_pid_in_group
+        first_pid_m = swizzle_group * GROUP_SIZE_M
+        group_size_m = min(tiles_m_g - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + ((local_tile % num_pid_in_group) % group_size_m)
+        pid_n = (local_tile % num_pid_in_group) // group_size_m
+        tl.assume(pid_m >= 0)
+        tl.assume(pid_n >= 0)
+
+        rm = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M_g
+        rn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+        rk = tl.arange(0, BK_PACK)  # packed K bytes
+        rks = tl.arange(0, BK_SCALE)  # scale entries
+        rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
+
+        A_BASE = A + (m_rd + rm[:, None]) * stride_am + rk[None, :] * stride_ak
+        B_BASE = B + group_idx.to(tl.int64) * stride_bg + rk[:, None] * stride_bk + rn[None, :] * stride_bn
+        AS_BASE = A_scale + rks[:, None] * stride_ask + (m_rd + rm[None, :]) * stride_asm
+        BS_BASE = (
+            B_scale
+            + group_idx.to(tl.int64) * stride_bsg
+            + rks[:, None] * stride_bsk
+            + rn[None, :] * stride_bsn
+        )
+
+        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        loop_k = K // BLOCK_SIZE_K
+        for ki in range(0, loop_k):
+            a = tl.load(tl.multiple_of(A_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)  # (BM, BK/2)
+            b = tl.load(tl.multiple_of(B_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER)  # (BK/2, BN)
+            a_s = tl.trans(tl.load(AS_BASE))  # (BK/32, BM) -> (BM, BK/32)
+            b_s = tl.trans(tl.load(BS_BASE))  # (BK/32, BN) -> (BN, BK/32)
+            acc = tl.dot_scaled(a, a_s, "e2m1", b, b_s, "e2m1", acc)
+            A_BASE += BK_PACK * stride_ak
+            B_BASE += BK_PACK * stride_bk
+            AS_BASE += BK_SCALE * stride_ask
+            BS_BASE += BK_SCALE * stride_bsk
+
+        c = acc.to(C.type.element_ty)
+        rm_s = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M_g
+        rn_s = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+        rn_s = tl.max_contiguous(tl.multiple_of(rn_s, BLOCK_SIZE_N), BLOCK_SIZE_N)
+        c_mask = (rm_s[:, None] < M_g) & (rn_s[None, :] < N)
+        C_ = C + (m_out + rm_s[:, None]) * stride_cm + rn_s[None, :] * stride_cn
+        tl.store(C_, c, c_mask)
+
+
+def grouped_gemm_mxfp4_triton_kernel(
+    a,
+    a_scale,
+    b,
+    b_scale,
+    group_offs,
+    N,
+    K,
+    group_offs_out=None,
+    out_dtype=torch.bfloat16,
+    num_cu=None,
+):
+    """A(total_M, K/2) @ B(G, N, K/2)^T -> C. FP4-packed data, e8m0 uint8 scales.
+
+    group_offs:     read offsets along M for A / A_scale.
+    group_offs_out: write offsets along M for C (defaults to group_offs).
+    K is the logical contraction size (must be a multiple of BLOCK_SIZE_K=128).
+    """
+    if group_offs_out is None:
+        group_offs_out = group_offs
+    if is_gfx950():
+        set_triton_knobs_gfx950()
+    G = b.shape[0]
+    c = torch.empty((a.shape[0], N), dtype=out_dtype, device=a.device)
+    a_s = a_scale.view(torch.uint8)
+    b_s = b_scale.view(torch.uint8)
+    a_u8 = a.view(torch.uint8)
+    b_u8 = b.view(torch.uint8)
+    cu = num_cu if num_cu is not None else torch.cuda.get_device_properties(a.device).multi_processor_count
+    BM, BN, BK = 256, 256, 128
+    m_alloc = a.shape[0]
+    avg_m = max(m_alloc // max(G, 1), 1)
+    tiles_n = (N + BN - 1) // BN
+    GM = 8 if min((avg_m + BM - 1) // BM, tiles_n) < 16 else 4
+    total_tiles = ((m_alloc + BM - 1) // BM + G) * tiles_n
+    num_sms = min(total_tiles, cu)
+    chunk = 64 if num_sms >= NUM_XCDS * 64 else 32
+    grid = (num_sms,)
+    _grouped_mxfp4_persistent_gemm_kernel[grid](
+        a_u8,
+        b_u8,
+        c,
+        a_s,
+        b_s,
+        group_offs,
+        group_offs_out,
+        G,
+        N,
+        K,
+        a_u8.stride(0),
+        a_u8.stride(1),
+        b_u8.stride(0),
+        b_u8.stride(1),
+        b_u8.stride(2),
+        c.stride(0),
+        c.stride(1),
+        a_s.stride(0),  # stride_asm (M);   a_s is (total_M, K/32)
+        a_s.stride(1),  # stride_ask (K/32 contiguous)
+        b_s.stride(0),  # stride_bsg
+        b_s.stride(1),  # stride_bsn (N);   b_s is (G, N, K/32)
+        b_s.stride(2),  # stride_bsk (K/32 contiguous)
+        BLOCK_SIZE_M=BM,
+        BLOCK_SIZE_N=BN,
+        BLOCK_SIZE_K=BK,
+        GROUP_SIZE_M=GM,
+        NUM_SMS=num_sms,
+        NUM_XCDS=NUM_XCDS,
+        CHUNK_SIZE=chunk,
+        CACHE_MODIFIER=".ca",
+        VEC=VEC_SIZE,
+        num_warps=8,
+        num_stages=2,
+        waves_per_eu=0,
+        matrix_instr_nonkdim=16,
+        kpack=1,
+    )
+    return c
+
+
+# ###########################################################################
+#  Variable-K backward (wgrad): C[g] = LHS[g] @ RHS[g]^T, reduction over M_g
+#    LHS (OUT_M, M_total/2) fp4-packed, LHS_scale (OUT_M, M_total/32) e8m0
+#    RHS (OUT_N, M_total/2) fp4-packed, RHS_scale (OUT_N, M_total/32) e8m0
+#    C   (G, OUT_M, OUT_N)
+#    go_pad: padded per-group offsets along M (each M_g a multiple of 128)
+# ###########################################################################
+
+
+@triton.jit
+def _grouped_mxfp4_variable_k_gemm_kernel(
+    LHS,
+    RHS,
+    C,
+    LHS_scale,
+    RHS_scale,
+    go_pad_ptr,
+    G,
+    OUT_M,
+    OUT_N,
+    stride_lm,
+    stride_lk,  # along packed M bytes
+    stride_rm,
+    stride_rk,  # along packed M bytes
+    stride_cg,
+    stride_cm,
+    stride_cn,
+    stride_lsm,
+    stride_lsk,
+    stride_rsm,
+    stride_rsk,
+    BLOCK_SIZE_M: tl.constexpr,  # over OUT_M
+    BLOCK_SIZE_N: tl.constexpr,  # over OUT_N
+    BLOCK_SIZE_K: tl.constexpr,  # logical reduction over M_g
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+    CACHE_MODIFIER: tl.constexpr,
+    VEC: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    if NUM_XCDS != 1:
+        pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
+    tiles_m = tl.cdiv(OUT_M, BLOCK_SIZE_M)
+    tiles_n = tl.cdiv(OUT_N, BLOCK_SIZE_N)
+    tiles_per_group = tiles_m * tiles_n
+    total_tiles = G * tiles_per_group
+
+    tl.assume(stride_lm > 0)
+    tl.assume(stride_rm > 0)
+    tl.assume(stride_cm > 0)
+
+    BK_PACK: tl.constexpr = BLOCK_SIZE_K // 2
+    BK_SCALE: tl.constexpr = BLOCK_SIZE_K // VEC
+
+    for global_tile in range(pid, total_tiles, NUM_SMS):
+        group_idx = global_tile // tiles_per_group
+        local_tile = global_tile - group_idx * tiles_per_group
+
+        num_pid_in_group = GROUP_SIZE_M * tiles_n
+        swizzle_group = local_tile // num_pid_in_group
+        first_pid_m = swizzle_group * GROUP_SIZE_M
+        group_size_m = min(tiles_m - first_pid_m, GROUP_SIZE_M)
+        pid_m = first_pid_m + ((local_tile % num_pid_in_group) % group_size_m)
+        pid_n = (local_tile % num_pid_in_group) // group_size_m
+        tl.assume(pid_m >= 0)
+        tl.assume(pid_n >= 0)
+
+        m_start = tl.load(go_pad_ptr + group_idx)  # int64 (logical M, multiple of 128)
+        M_g = (tl.load(go_pad_ptr + group_idx + 1) - m_start).to(tl.int32)
+
+        rm = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % OUT_M
+        rn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % OUT_N
+        rk = tl.arange(0, BK_PACK)
+        rks = tl.arange(0, BK_SCALE)
+        rm = tl.max_contiguous(tl.multiple_of(rm, BLOCK_SIZE_M), BLOCK_SIZE_M)
+        rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
+
+        # packed M offset = m_start // 2 (M_g multiple of 128 -> even)
+        mp0 = (m_start // 2).to(tl.int64)
+        L_BASE = LHS + rm[:, None] * stride_lm + (mp0 + rk[None, :]) * stride_lk
+        R_BASE = RHS + (mp0 + rk[:, None]) * stride_rk + rn[None, :] * stride_rm
+        sk0 = (m_start // VEC).to(tl.int32)
+        LS_BASE = LHS_scale + (sk0 + rks[:, None]) * stride_lsk + rm[None, :] * stride_lsm
+        RS_BASE = RHS_scale + (sk0 + rks[:, None]) * stride_rsk + rn[None, :] * stride_rsm
+
+        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        loop_k = M_g // BLOCK_SIZE_K  # padded -> no mask
+        for _ in range(loop_k):
+            l = tl.load(tl.multiple_of(L_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)  # (BM, BK/2)
+            r = tl.load(tl.multiple_of(R_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER)  # (BK/2, BN)
+            ls = tl.trans(tl.load(LS_BASE))  # (BK/32, BM) -> (BM, BK/32)
+            rs = tl.trans(tl.load(RS_BASE))
+            acc = tl.dot_scaled(l, ls, "e2m1", r, rs, "e2m1", acc)
+            L_BASE += BK_PACK * stride_lk
+            R_BASE += BK_PACK * stride_rk
+            LS_BASE += BK_SCALE * stride_lsk
+            RS_BASE += BK_SCALE * stride_rsk
+
+        c = acc.to(C.type.element_ty)
+        rm_s = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        rn_s = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        cmask = (rm_s[:, None] < OUT_M) & (rn_s[None, :] < OUT_N)
+        C_ = C + group_idx.to(tl.int64) * stride_cg + rm_s[:, None] * stride_cm + rn_s[None, :] * stride_cn
+        tl.store(C_, c, cmask)
+
+
+def grouped_gemm_mxfp4_variable_k_triton_kernel(
+    lhs, lhs_scale, rhs, rhs_scale, go_pad, OUT_M, OUT_N, G, out_dtype=torch.bfloat16, num_cu=None
+):
+    """C[g] (OUT_M, OUT_N) = lhs[:,g] @ rhs[:,g]^T.
+
+    lhs (OUT_M, M_total/2) fp4-packed, rhs (OUT_N, M_total/2) fp4-packed.
+    go_pad: padded per-group offsets along M (each M_g a multiple of 128).
+    """
+    if is_gfx950():
+        set_triton_knobs_gfx950()
+    c = torch.empty((G, OUT_M, OUT_N), dtype=out_dtype, device=lhs.device)
+    ls = lhs_scale.view(torch.uint8)
+    rs = rhs_scale.view(torch.uint8)
+    l_u8 = lhs.view(torch.uint8)
+    r_u8 = rhs.view(torch.uint8)
+    cu = num_cu if num_cu is not None else torch.cuda.get_device_properties(lhs.device).multi_processor_count
+    BM, BN, BK = 256, 128, 128
+    tiles_m = (OUT_M + BM - 1) // BM
+    tiles_n = (OUT_N + BN - 1) // BN
+    GM = 8 if min(tiles_m, tiles_n) < 16 else 4
+    total_tiles = G * tiles_m * tiles_n
+    num_sms = min(total_tiles, cu)
+    chunk = 64 if num_sms >= NUM_XCDS * 64 else 32
+    _grouped_mxfp4_variable_k_gemm_kernel[(num_sms,)](
+        l_u8,
+        r_u8,
+        c,
+        ls,
+        rs,
+        go_pad,
+        G,
+        OUT_M,
+        OUT_N,
+        l_u8.stride(0),
+        l_u8.stride(1),
+        r_u8.stride(0),
+        r_u8.stride(1),
+        c.stride(0),
+        c.stride(1),
+        c.stride(2),
+        ls.stride(0),  # stride_lsm (OUT_M); ls is (OUT_M, M/32)
+        ls.stride(1),  # stride_lsk (M/32 contiguous)
+        rs.stride(0),  # stride_rsm (OUT_N); rs is (OUT_N, M/32)
+        rs.stride(1),  # stride_rsk (M/32 contiguous)
+        BLOCK_SIZE_M=BM,
+        BLOCK_SIZE_N=BN,
+        BLOCK_SIZE_K=BK,
+        GROUP_SIZE_M=GM,
+        NUM_SMS=num_sms,
+        NUM_XCDS=NUM_XCDS,
+        CHUNK_SIZE=chunk,
+        CACHE_MODIFIER=".ca",
+        VEC=VEC_SIZE,
+        num_warps=8,
+        num_stages=3,
+        waves_per_eu=2,
+        matrix_instr_nonkdim=16,
+        kpack=1,
+    )
+    return c

--- a/tests/pytorch/ops/test_grouped_gemm_fp4.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp4.py
@@ -1,0 +1,103 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+import pytest
+import torch
+
+from primus_turbo.pytorch.core.low_precision import (
+    Float4QuantConfig,
+    Format,
+    ScaleDtype,
+    ScalingGranularity,
+    check_mxfp4_support,
+)
+from primus_turbo.pytorch.ops.grouped_gemm_fp4 import grouped_gemm_fp4
+from tests.pytorch.ref.gemm_ref import (
+    generate_grouped_gemm_group_lens,
+    grouped_gemm_ref,
+)
+from tests.pytorch.test_utils import compute_snr
+
+torch.manual_seed(42)
+
+# N, K must be multiples of 128 (Triton MXFP4 BLOCK_SIZE_K) — they are the
+# fwd/dgrad contraction dims. M is grouped along rows (any size; the wgrad
+# wrapper zero-pads each group's M up to 128).
+B_VALUES = [1, 2, 4, 8]
+M_VALUES = [256, 512, 1024]
+NK_VALUES = [(2048, 1536), (1408, 2048), (3072, 5120), (7168, 2048)]
+DTYPE_VALUES = [torch.bfloat16, torch.float16]
+BALANCE_VALUES = [True, False]
+
+
+def _run(B, M, N, K, dtype, balance, use_gradient_sr=False):
+    seed = 42
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    supported, reason = check_mxfp4_support()
+    if not supported:
+        pytest.skip(reason)
+
+    device = "cuda:0"
+    group_lens = generate_grouped_gemm_group_lens(B, M, balance=balance).to(device)
+    print(f"\nB={B}, M={M}, N={N}, K={K}, dtype={dtype}, balance={balance}")
+
+    a = torch.randn((B * M, K), dtype=dtype, device=device, requires_grad=True)
+    b = torch.randn((B, N, K), dtype=dtype, device=device, requires_grad=True)
+    a_ref = a.detach().clone().requires_grad_(True)
+    b_ref = b.detach().clone().requires_grad_(True)
+    torch.cuda.synchronize()
+
+    out_ref = grouped_gemm_ref(a_ref, b_ref, group_lens, trans_b=True)
+    grad_out = torch.randn_like(out_ref)
+    out_ref.backward(grad_out)
+    torch.cuda.synchronize()
+
+    config = Float4QuantConfig(
+        granularity=ScalingGranularity.MX_BLOCKWISE,
+        format=Format.E2M1_X2,
+        block_size=32,
+        scale_dtype=ScaleDtype.E8M0,
+        use_gradient_sr=use_gradient_sr,
+    )
+    out = grouped_gemm_fp4(a, b, group_lens, trans_b=True, config=config)
+    out.backward(grad_out)
+    torch.cuda.synchronize()
+
+    assert out.shape == out_ref.shape
+    assert a.grad.shape == a_ref.grad.shape
+    assert b.grad.shape == b_ref.grad.shape
+
+    snr_threshold = 8.0  # E2M1 (1-bit mantissa) is intrinsically lossy
+    out_snr = compute_snr(out_ref, out)
+    a_grad_snr = compute_snr(a_ref.grad, a.grad)
+    b_grad_snr = compute_snr(b_ref.grad, b.grad)
+    print(f"Out-SNR={out_snr:.2f} dB  AGrad-SNR={a_grad_snr:.2f} dB  BGrad-SNR={b_grad_snr:.2f} dB")
+    assert out_snr > snr_threshold, f"out_snr={out_snr:.2f} too low"
+    assert a_grad_snr > snr_threshold, f"a_grad_snr={a_grad_snr:.2f} too low"
+    assert b_grad_snr > snr_threshold, f"b_grad_snr={b_grad_snr:.2f} too low"
+
+
+@pytest.mark.parametrize("B", B_VALUES)
+@pytest.mark.parametrize("M", M_VALUES)
+@pytest.mark.parametrize("NK", NK_VALUES)
+@pytest.mark.parametrize("dtype", DTYPE_VALUES)
+@pytest.mark.parametrize("balance", BALANCE_VALUES)
+def test_grouped_gemm_fp4_mx_blockwise(B, M, NK, dtype, balance):
+    """MXFP4 grouped GEMM fwd + dgrad + wgrad on the Triton backend."""
+    N, K = NK
+    _run(B, M, N, K, dtype, balance)
+
+
+@pytest.mark.parametrize("B", [4])
+@pytest.mark.parametrize("M", [512])
+@pytest.mark.parametrize("NK", [(2048, 1536)])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_grouped_gemm_fp4_gradient_sr(B, M, NK, dtype):
+    """Smoke test the stochastic-rounding gradient path."""
+    N, K = NK
+    _run(B, M, N, K, dtype, balance=False, use_gradient_sr=True)

--- a/tests/pytorch/ops/test_grouped_gemm_fp4.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp4.py
@@ -276,9 +276,7 @@ def _run_grouped_gemm_fp4_deterministic_test(B, M, N, K, dtype, balance, repeats
 
     device = "cuda:0"
     group_lens = generate_grouped_gemm_group_lens(B, M, balance=balance).to(device)
-    print(
-        f"\n[deterministic] B={B}, M={M}, N={N}, K={K}, dtype={dtype}, balance={balance}"
-    )
+    print(f"\n[deterministic] B={B}, M={M}, N={N}, K={K}, dtype={dtype}, balance={balance}")
 
     a0 = torch.randn((B * M, K), dtype=dtype, device=device)
     b0 = torch.randn((B, N, K), dtype=dtype, device=device)

--- a/tests/pytorch/ops/test_grouped_gemm_fp4.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp4.py
@@ -23,17 +23,59 @@ from tests.pytorch.test_utils import compute_snr
 
 torch.manual_seed(42)
 
-# N, K must be multiples of 128 (Triton MXFP4 BLOCK_SIZE_K) — they are the
-# fwd/dgrad contraction dims. M is grouped along rows (any size; the wgrad
+# ----------------------------------------------------------------------------
+# Sweep parameters.
+#
+# MXFP4 is NT-only (trans_b=True), single E2M1 format, and runs on the Triton
+# backend only -- so vs the MXFP8 grouped-GEMM sweep we drop the trans_b /
+# format / backend axes and keep the full B / M / NK / dtype / balance coverage.
+#
+# N, K need only be multiples of MXFP4_BLOCK_SIZE (=32, the MX scale block);
+# they are the fwd/dgrad contraction dims and the quantizer zero-pads them up to
+# 128, over which the GEMM runs. M is grouped along rows (any size; the wgrad
 # wrapper zero-pads each group's M up to 128).
-B_VALUES = [1, 2, 4, 8]
-M_VALUES = [256, 512, 1024]
-NK_VALUES = [(2048, 1536), (1408, 2048), (3072, 5120), (7168, 2048)]
+# ----------------------------------------------------------------------------
+B_VALUES = [1, 2, 3, 8, 16, 32]
+M_VALUES = [128, 256, 512, 1024, 2048]
+NK_VALUES = [
+    (2048, 1536),
+    (2048, 1408),
+    (1408, 2048),
+    (2816, 2048),
+    (3072, 5120),
+    (5120, 1536),
+    (4096, 7168),
+    (7168, 2048),
+]
+# 32-multiples that are NOT 128-multiples (exercises the padded-contraction +
+# free-dim c_mask path): covers N-unaligned, K-unaligned, and both-unaligned.
+NK_UNALIGNED_VALUES = [(96, 160), (160, 96), (288, 256), (256, 288), (1568, 2080)]
 DTYPE_VALUES = [torch.bfloat16, torch.float16]
 BALANCE_VALUES = [True, False]
 
+# E2M1 (1-bit mantissa) is intrinsically lossy, so the SNR bar is lower than the
+# FP8 suite's 20-25 dB. 8 dB cleanly separates "correct" from "broken layout".
+SNR_THRESHOLD = 8.0
 
-def _run(B, M, N, K, dtype, balance, use_gradient_sr=False):
+
+def _check_hit_int32_limit(B, M, N, K):
+    """Skip shapes whose largest operand would overflow int32 element indexing."""
+    a_elems = B * M * K
+    b_elems = B * N * K
+    out_elems = B * M * N
+    return max(a_elems, b_elems, out_elems) >= 2**31
+
+
+def _make_config():
+    return Float4QuantConfig(
+        granularity=ScalingGranularity.MX_BLOCKWISE,
+        format=Format.E2M1_X2,
+        block_size=32,
+        scale_dtype=ScaleDtype.E8M0,
+    )
+
+
+def _run(B, M, N, K, dtype, balance):
     seed = 42
     torch.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
@@ -41,6 +83,8 @@ def _run(B, M, N, K, dtype, balance, use_gradient_sr=False):
     supported, reason = check_mxfp4_support()
     if not supported:
         pytest.skip(reason)
+    if _check_hit_int32_limit(B, M, N, K):
+        pytest.skip("Shape hits int32 indexing limit (numel >= 2**31).")
 
     device = "cuda:0"
     group_lens = generate_grouped_gemm_group_lens(B, M, balance=balance).to(device)
@@ -57,13 +101,7 @@ def _run(B, M, N, K, dtype, balance, use_gradient_sr=False):
     out_ref.backward(grad_out)
     torch.cuda.synchronize()
 
-    config = Float4QuantConfig(
-        granularity=ScalingGranularity.MX_BLOCKWISE,
-        format=Format.E2M1_X2,
-        block_size=32,
-        scale_dtype=ScaleDtype.E8M0,
-        use_gradient_sr=use_gradient_sr,
-    )
+    config = _make_config()
     out = grouped_gemm_fp4(a, b, group_lens, trans_b=True, config=config)
     out.backward(grad_out)
     torch.cuda.synchronize()
@@ -72,16 +110,18 @@ def _run(B, M, N, K, dtype, balance, use_gradient_sr=False):
     assert a.grad.shape == a_ref.grad.shape
     assert b.grad.shape == b_ref.grad.shape
 
-    snr_threshold = 8.0  # E2M1 (1-bit mantissa) is intrinsically lossy
     out_snr = compute_snr(out_ref, out)
     a_grad_snr = compute_snr(a_ref.grad, a.grad)
     b_grad_snr = compute_snr(b_ref.grad, b.grad)
     print(f"Out-SNR={out_snr:.2f} dB  AGrad-SNR={a_grad_snr:.2f} dB  BGrad-SNR={b_grad_snr:.2f} dB")
-    assert out_snr > snr_threshold, f"out_snr={out_snr:.2f} too low"
-    assert a_grad_snr > snr_threshold, f"a_grad_snr={a_grad_snr:.2f} too low"
-    assert b_grad_snr > snr_threshold, f"b_grad_snr={b_grad_snr:.2f} too low"
+    assert out_snr > SNR_THRESHOLD, f"out_snr={out_snr:.2f} too low"
+    assert a_grad_snr > SNR_THRESHOLD, f"a_grad_snr={a_grad_snr:.2f} too low"
+    assert b_grad_snr > SNR_THRESHOLD, f"b_grad_snr={b_grad_snr:.2f} too low"
 
 
+# ----------------------------------------------------------------------------
+# Main sweep: fwd + dgrad + wgrad on the full B / M / NK / dtype / balance grid.
+# ----------------------------------------------------------------------------
 @pytest.mark.parametrize("B", B_VALUES)
 @pytest.mark.parametrize("M", M_VALUES)
 @pytest.mark.parametrize("NK", NK_VALUES)
@@ -93,11 +133,209 @@ def test_grouped_gemm_fp4_mx_blockwise(B, M, NK, dtype, balance):
     _run(B, M, N, K, dtype, balance)
 
 
-@pytest.mark.parametrize("B", [4])
-@pytest.mark.parametrize("M", [512])
-@pytest.mark.parametrize("NK", [(2048, 1536)])
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
-def test_grouped_gemm_fp4_gradient_sr(B, M, NK, dtype):
-    """Smoke test the stochastic-rounding gradient path."""
+# ----------------------------------------------------------------------------
+# 32-but-not-128 N/K (padded-contraction path) + unbalanced groups.
+# ----------------------------------------------------------------------------
+@pytest.mark.parametrize("B", [2, 4, 8])
+@pytest.mark.parametrize("M", [128, 256, 512])
+@pytest.mark.parametrize("NK", NK_UNALIGNED_VALUES)
+@pytest.mark.parametrize("dtype", DTYPE_VALUES)
+@pytest.mark.parametrize("balance", BALANCE_VALUES)
+def test_grouped_gemm_fp4_unaligned_nk(B, M, NK, dtype, balance):
+    """N/K are 32-multiples but not 128-multiples (+ unbalanced groups).
+
+    Validates the padded-contraction path: the quantizer zero-pads the
+    contraction to 128 (data + self-consistent E8M0 scales), the GEMM runs over
+    that padded length so the zero tail contributes 0, and the free dim is masked
+    by the kernel. Passing SNR also confirms the padding-region scales are not
+    NaN (a 0*NaN would poison the dot)."""
     N, K = NK
-    _run(B, M, N, K, dtype, balance=False, use_gradient_sr=True)
+    _run(B, M, N, K, dtype, balance)
+
+
+# ----------------------------------------------------------------------------
+# Zero-length groups (MoE routing where some experts get no tokens).
+# ----------------------------------------------------------------------------
+@pytest.mark.parametrize("dtype", DTYPE_VALUES)
+def test_grouped_gemm_fp4_zero_group_lens(dtype):
+    """group_lens containing zeros must not crash fwd/bwd (illegal-memory-access
+    regression guard) and must stay correct on the non-empty groups."""
+    supported, reason = check_mxfp4_support()
+    if not supported:
+        pytest.skip(reason)
+    device = "cuda:0"
+
+    E, K, N = 8, 2048, 8192
+    group_lens_list = [8192, 8192, 0, 0, 0, 0, 0, 0]
+    group_lens = torch.tensor(group_lens_list, dtype=torch.int64, device=device)
+    total_m = int(group_lens.sum().item())
+    print(f"\ngroup_lens={group_lens_list}, total_M={total_m}, N={N}, K={K}, dtype={dtype}")
+
+    a = torch.randn((total_m, K), dtype=dtype, device=device, requires_grad=True)
+    b = torch.randn((E, N, K), dtype=dtype, device=device, requires_grad=True)
+    a_ref = a.detach().clone().requires_grad_(True)
+    b_ref = b.detach().clone().requires_grad_(True)
+    torch.cuda.synchronize()
+
+    out_ref = grouped_gemm_ref(a_ref, b_ref, group_lens, trans_b=True)
+    grad_out = torch.randn_like(out_ref)
+    out_ref.backward(grad_out)
+    torch.cuda.synchronize()
+
+    config = _make_config()
+    out = grouped_gemm_fp4(a, b, group_lens, trans_b=True, config=config)
+    out.backward(grad_out)
+    torch.cuda.synchronize()
+
+    assert out.shape == out_ref.shape
+    assert a.grad.shape == a_ref.grad.shape
+    assert b.grad.shape == b_ref.grad.shape
+
+    out_snr = compute_snr(out_ref, out)
+    a_grad_snr = compute_snr(a_ref.grad, a.grad)
+    # b_grad of empty experts is 0 in both ref and turbo; SNR over the full
+    # tensor still reflects the populated experts.
+    b_grad_snr = compute_snr(b_ref.grad, b.grad)
+    print(f"Out-SNR={out_snr:.2f} dB  AGrad-SNR={a_grad_snr:.2f} dB  BGrad-SNR={b_grad_snr:.2f} dB")
+    assert out_snr > SNR_THRESHOLD, f"out_snr={out_snr:.2f} too low"
+    assert a_grad_snr > SNR_THRESHOLD, f"a_grad_snr={a_grad_snr:.2f} too low"
+    assert b_grad_snr > SNR_THRESHOLD, f"b_grad_snr={b_grad_snr:.2f} too low"
+
+
+# ----------------------------------------------------------------------------
+# CUDA-graph capturability (forward).
+#
+# The forward uses no D2H sync (per-group 128-padding offsets are computed
+# on-GPU with a static M+G*128 buffer bound), so it is graph-capturable, and a
+# replay with in-place-updated group_lens must re-route correctly.
+#
+# Only the forward is captured: fwd+bwd through autograd segfaults at
+# capture_end due to the AccumulateGrad-on-default-stream limitation (a generic
+# autograd-in-graph issue, reproducible identically on the reference MXFP8 MX
+# path, which likewise has no fwd+bwd graph test).
+# ----------------------------------------------------------------------------
+@pytest.mark.parametrize("balance", [True, False])
+@pytest.mark.parametrize("NK", [(2048, 1536), (4096, 4096), (160, 96)])
+def test_grouped_gemm_fp4_cuda_graph(NK, balance):
+    supported, reason = check_mxfp4_support()
+    if not supported:
+        pytest.skip(reason)
+    B, M = 4, 1024
+    N, K = NK
+    device = "cuda:0"
+    torch.manual_seed(0)
+    group_lens = generate_grouped_gemm_group_lens(B, M, balance=balance).to(device)
+    group_lens2 = generate_grouped_gemm_group_lens(B, M, balance=balance).to(device)
+
+    a = torch.randn((B * M, K), dtype=torch.bfloat16, device=device)
+    b = torch.randn((B, N, K), dtype=torch.bfloat16, device=device)
+    config = _make_config()
+
+    out_ref = grouped_gemm_ref(a, b, group_lens, trans_b=True)
+    out_ref2 = grouped_gemm_ref(a, b, group_lens2, trans_b=True)
+
+    # Warmup (JIT-compiles Triton kernels; graphs can't capture compilation).
+    with torch.no_grad():
+        grouped_gemm_fp4(a, b, group_lens, trans_b=True, config=config)
+    torch.cuda.synchronize()
+
+    g = torch.cuda.CUDAGraph()
+    with torch.no_grad():
+        with torch.cuda.graph(g):
+            out = grouped_gemm_fp4(a, b, group_lens, trans_b=True, config=config)
+    g.replay()
+    torch.cuda.synchronize()
+    assert out.shape == out_ref.shape
+    assert compute_snr(out_ref, out) > SNR_THRESHOLD
+
+    # Replay with a different group distribution (same total M) bound in-place.
+    group_lens.copy_(group_lens2)
+    g.replay()
+    torch.cuda.synchronize()
+    assert compute_snr(out_ref2, out) > SNR_THRESHOLD
+
+
+# ----------------------------------------------------------------------------
+# Determinism suite (run with --deterministic-only): bit-exact across repeats.
+# ----------------------------------------------------------------------------
+_DET_B_VALUES = [1, 8]
+_DET_M_VALUES = [256, 1024]
+_DET_NK_VALUES = [(2048, 1536), (4096, 7168)]
+
+
+def _run_grouped_gemm_fp4_deterministic_test(B, M, N, K, dtype, balance, repeats=10):
+    seed = 42
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    supported, reason = check_mxfp4_support()
+    if not supported:
+        pytest.skip(reason)
+    if _check_hit_int32_limit(B, M, N, K):
+        pytest.skip("Shape hits int32 indexing limit (numel >= 2**31).")
+
+    device = "cuda:0"
+    group_lens = generate_grouped_gemm_group_lens(B, M, balance=balance).to(device)
+    print(
+        f"\n[deterministic] B={B}, M={M}, N={N}, K={K}, dtype={dtype}, balance={balance}"
+    )
+
+    a0 = torch.randn((B * M, K), dtype=dtype, device=device)
+    b0 = torch.randn((B, N, K), dtype=dtype, device=device)
+    a0 = a0 / a0.abs().max()
+    b0 = b0 / b0.abs().max()
+
+    a_ref = a0.detach().clone().requires_grad_(True)
+    b_ref = b0.detach().clone().requires_grad_(True)
+    out_ref = grouped_gemm_ref(a_ref, b_ref, group_lens, trans_b=True)
+    grad_out = torch.randn_like(out_ref)
+    out_ref.backward(grad_out)
+    torch.cuda.synchronize()
+
+    config = _make_config()
+
+    def _run_once():
+        # Force clean memory each iter so the caching allocator can't alias a
+        # buffer still being written by a pending op from a prior case.
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+        a = a0.detach().clone().requires_grad_(True)
+        b = b0.detach().clone().requires_grad_(True)
+        out = grouped_gemm_fp4(a, b, group_lens, trans_b=True, config=config)
+        out.backward(grad_out)
+        return out.detach(), a.grad.detach(), b.grad.detach()
+
+    outs = []
+    for _ in range(repeats):
+        outs.append(_run_once())
+        torch.cuda.synchronize()
+
+    out0, da0_, db0_ = outs[0]
+    for i in range(1, repeats):
+        out_i, da_i, db_i = outs[i]
+        torch.testing.assert_close(out0, out_i, rtol=0, atol=0)
+        torch.testing.assert_close(da0_, da_i, rtol=0, atol=0)
+        torch.testing.assert_close(db0_, db_i, rtol=0, atol=0)
+
+    out_snr = compute_snr(out_ref, out0)
+    a_grad_snr = compute_snr(a_ref.grad, da0_)
+    b_grad_snr = compute_snr(b_ref.grad, db0_)
+    print(
+        f"[deterministic] Out-SNR={out_snr:.2f} dB, AGrad-SNR={a_grad_snr:.2f} dB, "
+        f"BGrad-SNR={b_grad_snr:.2f} dB"
+    )
+    assert out_snr > SNR_THRESHOLD, "out_snr too low"
+    assert a_grad_snr > SNR_THRESHOLD, "a_grad_snr too low"
+    assert b_grad_snr > SNR_THRESHOLD, "b_grad_snr too low"
+
+
+@pytest.mark.parametrize("B", _DET_B_VALUES)
+@pytest.mark.parametrize("M", _DET_M_VALUES)
+@pytest.mark.parametrize("NK", _DET_NK_VALUES)
+@pytest.mark.parametrize("dtype", DTYPE_VALUES)
+@pytest.mark.parametrize("balance", BALANCE_VALUES)
+@pytest.mark.deterministic
+def test_grouped_gemm_fp4_mx_blockwise_deterministic(B, M, NK, dtype, balance):
+    """fwd + dgrad + wgrad are bit-exact across 10 repeats (SR off)."""
+    N, K = NK
+    _run_grouped_gemm_fp4_deterministic_test(B, M, N, K, dtype, balance, repeats=10)

--- a/tests/pytorch/ref/gemm_ref.py
+++ b/tests/pytorch/ref/gemm_ref.py
@@ -12,17 +12,8 @@ import torch.nn as nn
 
 def grouped_gemm_ref(a, b, seg_lens, trans_b=True):
     # NOTE: the per-group matmul is accumulated in fp32 (operands upcast, result
-    # cast back to ``a.dtype``) for two reasons:
-    #   1. Correctness: an fp32-accumulated golden is the right reference for a
-    #      low-precision (fp4/fp8) product comparison.
-    #   2. Robustness: on ROCm/hipBLASLt a *bf16* NT GEMM (row-major A @ a
-    #      transposed, column-major B) selects a kernel that reads out of bounds
-    #      for some odd group M (e.g. a 2078-row slice with N=2816, K=2048),
-    #      hard-faulting the GPU ("Memory access fault ... Reason: Unknown") in
-    #      both the fwd matmul and the autograd bwd (which re-introduces a
-    #      transposed bf16 operand). Running in fp32 dodges the bad bf16 kernel.
-    #      The product kernel under test runs on Triton, so only this reference
-    #      hit the library bug.
+    # cast back to ``a.dtype``): an fp32-accumulated golden is the right reference
+    # for a low-precision (fp4/fp8) product comparison.
     seg_lens = seg_lens.cpu().numpy()
     out = []
     start = 0

--- a/tests/pytorch/ref/gemm_ref.py
+++ b/tests/pytorch/ref/gemm_ref.py
@@ -11,12 +11,24 @@ import torch.nn as nn
 
 
 def grouped_gemm_ref(a, b, seg_lens, trans_b=True):
+    # NOTE: the per-group matmul is accumulated in fp32 (operands upcast, result
+    # cast back to ``a.dtype``) for two reasons:
+    #   1. Correctness: an fp32-accumulated golden is the right reference for a
+    #      low-precision (fp4/fp8) product comparison.
+    #   2. Robustness: on ROCm/hipBLASLt a *bf16* NT GEMM (row-major A @ a
+    #      transposed, column-major B) selects a kernel that reads out of bounds
+    #      for some odd group M (e.g. a 2078-row slice with N=2816, K=2048),
+    #      hard-faulting the GPU ("Memory access fault ... Reason: Unknown") in
+    #      both the fwd matmul and the autograd bwd (which re-introduces a
+    #      transposed bf16 operand). Running in fp32 dodges the bad bf16 kernel.
+    #      The product kernel under test runs on Triton, so only this reference
+    #      hit the library bug.
     seg_lens = seg_lens.cpu().numpy()
     out = []
     start = 0
     for i, size in enumerate(seg_lens):
         rhs = b[i, :, :].t() if trans_b else b[i, :, :]
-        out.append(a[start : start + size, :] @ rhs)
+        out.append((a[start : start + size, :].float() @ rhs.float()).to(a.dtype))
         start += size
     return torch.cat(out)
 


### PR DESCRIPTION
# Description

Adds an MXFP4 (E2M1) grouped GEMM op for MoE-style training on AMD CDNA4
(gfx950), with full autograd (forward + dgrad + wgrad) on the Triton backend.
The activation and weight quantization is fused so each operand's bf16 tensor is
read once and emits both the row-wise (fwd/dgrad) and col-wise (wgrad/dgrad)
MXFP4 operands, with the per-group M zero-padding and offsets computed on-GPU
(no D2H sync), making the forward CUDA-graph capturable. The MXFP4 training
recipe's Random Hadamard Transform on the backward operands is made bit-exact
deterministic.

Fixes # (N/A)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Add `grouped_gemm_fp4` (MX_BLOCKWISE, E2M1, NT-only, Triton backend) with an
  autograd Function implementing fwd / dgrad / wgrad, paired RHT recipes per GEMM.
- Fuse the grouped **activation** dual-quant into one CUDA/HIP kernel: a single
  bf16 read produces the tight-M row-wise operand and the 128-padded per-group
  col-wise operand; pad offsets computed on-GPU (no bf16 scatter, no D2H sync).
- Batch the **weight** dual-quant over the 3D `(G, N, K)` weight in one launch
  (`blockIdx.z` per group) — removes the Python per-group loop and the
  full-weight transpose/contiguous copy.
- Make the row-wise-RHT quant bit-exact deterministic: fuse `ds_swizzle_b32` +
  `s_waitcnt lgkmcnt(0)` into one memory-clobbering asm so the reduction cannot
  latch stale lanes from in-flight LDS stores.
- Skip the redundant per-pass `warp_reduce_max_8` on the 2D-block scale path
  (the tile-wide `warp_reduce_max_64` already yields the same max) — bit-exact,
  cuts VALU on the VALU-bound weight quant.
- Use fp32 accumulation in the grouped-GEMM test reference (correct golden for a
  low-precision product comparison).
- Add an fp4 grouped-GEMM test suite aligned 1:1 with the fp8 suite (mx_blockwise
  sweep, zero-length groups, CUDA-graph, deterministic) plus an fp4-specific
  unaligned-N/K padded-contraction case.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
