### PR TITLE
feat: add quantized tensor support for mxfp8 grouped gemm

### DIFF
--- a/csrc/include/primus_turbo/quantization.h
+++ b/csrc/include/primus_turbo/quantization.h
@@ -139,22 +139,28 @@ template <typename IType, typename OType>
 void grouped_quantize_mxfp8_dual_impl(
     const IType *input, OType *rowwise_output, uint8_t *rowwise_scale, OType *colwise_output,
     uint8_t *colwise_scale, const int64_t *group_offs, const int64_t *group_offs_padded_colwise,
-    const int64_t *group_offs_padded_rowwise, int G, int total_M_padded, int N, int N_pad,
+    const int64_t *group_offs_padded_rowwise, int G, int total_M, int N, int N_pad,
     int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
     int colwise_scale_M_pad, int colwise_scale_N_pad, detail::ScalingRecipe rowwise_recipe,
     detail::ScalingRecipe colwise_recipe, hipStream_t stream);
 
-// Grouped MXFP4 dual quant: rowwise output is the tight (un-padded) M layout
-// (row i == input row i), colwise output is the 128-padded per-group M layout
-// (variable-K wgrad).  Shuffle layouts are not supported.
+template <typename IType, typename OType>
+void grouped_quantize_mxfp8_impl(const IType *input, OType *output, uint8_t *scale,
+                                 const int64_t *group_offs, const int64_t *group_offs_padded,
+                                 detail::QuantizeMode mode, int G, int total_M, int N, int N_pad,
+                                 int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
+                                 detail::ScalingRecipe recipe, hipStream_t stream);
+
 template <typename DType>
-void grouped_quantize_mxfp4_dual_impl(
-    const DType *input, dtype::float4x2_e2m1 *rowwise_output, uint8_t *rowwise_scale,
-    dtype::float4x2_e2m1 *colwise_output, uint8_t *colwise_scale, const int64_t *group_offs,
-    const int64_t *group_offs_padded_colwise, int G, int total_M, int N, int M_pad_col, int N_pad,
-    int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N, int colwise_scale_N,
-    detail::ScalingRecipe rowwise_recipe, detail::ScalingRecipe colwise_recipe, hipStream_t stream);
+void grouped_quantize_mxfp4_dual_impl(const DType *input, dtype::float4x2_e2m1 *rowwise_output,
+                                      uint8_t *rowwise_scale, dtype::float4x2_e2m1 *colwise_output,
+                                      uint8_t *colwise_scale, const int64_t *group_offs,
+                                      const int64_t *group_offs_padded_colwise, int G, int total_M,
+                                      int N, int M_pad_col, int N_pad, int rowwise_scale_stride,
+                                      int colwise_scale_stride, int rowwise_scale_N,
+                                      int colwise_scale_N, detail::ScalingRecipe rowwise_recipe,
+                                      detail::ScalingRecipe colwise_recipe, hipStream_t stream);
 
 // *************** Grouped Padded Layout ***************
 //
@@ -192,6 +198,15 @@ void dequantize_mxfp8_impl(const QType *x, OType *y, const int64_t stride_x_row,
                            const int64_t stride_scale_col, const int scale_n_rows,
                            const int scale_n_cols, const int block_size, const bool use_rowwise,
                            hipStream_t stream);
+
+template <typename OType, typename QType>
+void grouped_dequantize_mxfp8_impl(const QType *x, OType *y, const int64_t stride_x_row,
+                                   const int64_t stride_y_row, const int total_M, const int n_rows,
+                                   const int n_cols, const uint8_t *scale_inv,
+                                   const int64_t stride_scale_row, const int64_t stride_scale_col,
+                                   const int scale_n_rows, const int scale_n_cols,
+                                   const int64_t *group_offs, const int64_t *group_offs_padded,
+                                   int G, int block_size, bool use_rowwise, hipStream_t stream);
 
 template <typename OType>
 void dequantize_mxfp4_impl(const uint8_t *x, OType *y, const int64_t stride_x_row,

--- a/csrc/kernels/quantization/dequantization_mxfp8.cu
+++ b/csrc/kernels/quantization/dequantization_mxfp8.cu
@@ -110,6 +110,173 @@ __global__ void dequantize_mxfp8_kernel(const QType *__restrict__ x, OType *__re
     }
 }
 
+// Map compact M row -> padded M row in grouped layout.
+__device__ __forceinline__ int64_t grouped_compact_to_padded_m(int            compact_m,
+                                                               const int64_t *group_offs,
+                                                               const int64_t *group_offs_padded,
+                                                               int            G) {
+    for (int g = 0; g < G; ++g) {
+        if (compact_m >= group_offs[g] && compact_m < group_offs[g + 1]) {
+            return group_offs_padded[g] + (compact_m - group_offs[g]);
+        }
+    }
+    return compact_m;
+}
+
+// Map padded M row -> compact M row; returns -1 for padding rows.
+__device__ __forceinline__ int64_t grouped_padded_to_compact_m(int            padded_m,
+                                                               const int64_t *group_offs,
+                                                               const int64_t *group_offs_padded,
+                                                               int            G) {
+    for (int g = 0; g < G; ++g) {
+        const int64_t pad_start = group_offs_padded[g];
+        if (padded_m >= pad_start && padded_m < group_offs_padded[g + 1]) {
+            const int64_t offset_in_group = padded_m - pad_start;
+            const int64_t group_len       = group_offs[g + 1] - group_offs[g];
+            if (offset_in_group < group_len) {
+                return group_offs[g] + offset_in_group;
+            }
+            return -1;
+        }
+    }
+    return -1;
+}
+
+// Rowwise grouped dequant: grid covers compact [total_M, n_cols], reads padded input rows.
+template <typename OType, typename QType>
+__global__ void grouped_dequantize_mxfp8_rowwise_kernel(
+    const QType *__restrict__ x, OType *__restrict__ y, const int64_t stride_x_row,
+    const int64_t stride_y_row, const int total_M, const int n_cols,
+    const uint8_t *__restrict__ scale_inv, const int64_t stride_scale_row,
+    const int64_t stride_scale_col, const int scale_n_rows, const int scale_n_cols,
+    const int64_t *__restrict__ group_offs, const int64_t *__restrict__ group_offs_padded, int G,
+    const int block_size) {
+    constexpr int VEC            = 16 / static_cast<int>(sizeof(OType));
+    constexpr int CHUNKS_PER_ROW = BLOCK_N / VEC;
+    constexpr int TOTAL_CHUNKS   = BLOCK_M * CHUNKS_PER_ROW;
+
+    const int nthreads = blockDim.x * blockDim.y;
+    const int tid      = threadIdx.y * blockDim.x + threadIdx.x;
+    const int c0       = blockIdx.x * BLOCK_N;
+    const int r0       = blockIdx.y * BLOCK_M;
+
+    for (int ci = tid; ci < TOTAL_CHUNKS; ci += nthreads) {
+        const int row = r0 + ci / CHUNKS_PER_ROW;
+        const int col = c0 + (ci % CHUNKS_PER_ROW) * VEC;
+        if (row < total_M && col < n_cols) {
+            const int64_t padded_row =
+                grouped_compact_to_padded_m(row, group_offs, group_offs_padded, G);
+            const int col_block = col / block_size;
+            uint8_t   e8m0      = static_cast<uint8_t>(E8M0_EXPONENT_BIAS);
+            if (padded_row < scale_n_rows && col_block < scale_n_cols) {
+                e8m0 = scale_inv[static_cast<int64_t>(padded_row) * stride_scale_row +
+                                 static_cast<int64_t>(col_block) * stride_scale_col];
+            }
+            const float scale = e8m0_to_scale(e8m0);
+            QType       x_reg[VEC];
+            OType       y_reg[VEC];
+            load_data<QType, VEC>(x + static_cast<int64_t>(padded_row) * stride_x_row + col, x_reg);
+#pragma unroll
+            for (int i = 0; i < VEC; ++i) {
+                y_reg[i] = static_cast<OType>(static_cast<float>(x_reg[i]) * scale);
+            }
+            store_data<OType, VEC>(y + static_cast<int64_t>(row) * stride_y_row + col, y_reg);
+        }
+    }
+}
+
+// Colwise grouped dequant: phase 1 identical to dequantize_mxfp8 colwise; phase 2 writes compact
+// rows.
+template <typename OType, typename QType>
+__global__ void grouped_dequantize_mxfp8_colwise_kernel(
+    const QType *__restrict__ x, OType *__restrict__ y, const int64_t stride_x_row,
+    const int64_t stride_y_row, const int total_M, const int m_padded, const int n_cols,
+    const uint8_t *__restrict__ scale_inv, const int64_t stride_scale_row,
+    const int64_t stride_scale_col, const int scale_n_rows, const int scale_n_cols,
+    const int64_t *__restrict__ group_offs, const int64_t *__restrict__ group_offs_padded, int G,
+    const int block_size) {
+    constexpr int VEC            = 16 / static_cast<int>(sizeof(OType));
+    constexpr int CHUNKS_PER_ROW = BLOCK_N / VEC;
+    constexpr int TOTAL_CHUNKS   = BLOCK_M * CHUNKS_PER_ROW;
+    constexpr int COL_STEP       = THREADS_PER_BLOCK / BLOCK_M;
+
+    const int nthreads = blockDim.x * blockDim.y;
+    const int tid      = threadIdx.y * blockDim.x + threadIdx.x;
+    const int c0       = blockIdx.x * BLOCK_N;
+    const int r0       = blockIdx.y * BLOCK_M;
+
+    __shared__ OType s_tile[BLOCK_M][BLOCK_N + 1];
+
+    // Phase 1: dequant padded input [n_cols, m_padded] into smem tile.
+    for (int ci = tid; ci < TOTAL_CHUNKS; ci += nthreads) {
+        const int local_row = ci / CHUNKS_PER_ROW;
+        const int local_col = (ci % CHUNKS_PER_ROW) * VEC;
+        const int grow      = r0 + local_row;
+        const int gcol      = c0 + local_col;
+        if (grow < n_cols && gcol < m_padded) {
+            const int col_block = gcol / block_size;
+            uint8_t   e8m0      = static_cast<uint8_t>(E8M0_EXPONENT_BIAS);
+            if (grow < scale_n_rows && col_block < scale_n_cols) {
+                e8m0 = scale_inv[static_cast<int64_t>(grow) * stride_scale_row +
+                                 static_cast<int64_t>(col_block) * stride_scale_col];
+            }
+            const float scale = e8m0_to_scale(e8m0);
+            QType       x_reg[VEC];
+            load_data<QType, VEC>(x + static_cast<int64_t>(grow) * stride_x_row + gcol, x_reg);
+#pragma unroll
+            for (int i = 0; i < VEC; ++i) {
+                s_tile[local_row][local_col + i] =
+                    static_cast<OType>(static_cast<float>(x_reg[i]) * scale);
+            }
+        }
+    }
+    __syncthreads();
+
+    // Phase 2: scatter transposed tile into compact [total_M, n_cols].
+    const int tx = threadIdx.x;
+    const int ty = threadIdx.y;
+    const int n  = r0 + tx;
+#pragma unroll
+    for (int j = 0; j < BLOCK_N; j += COL_STEP) {
+        const int m_padded_row = c0 + ty + j;
+        if (n < n_cols && m_padded_row < m_padded) {
+            const int64_t compact_m =
+                grouped_padded_to_compact_m(m_padded_row, group_offs, group_offs_padded, G);
+            if (compact_m >= 0 && compact_m < total_M) {
+                y[static_cast<int64_t>(compact_m) * stride_y_row + static_cast<int64_t>(n)] =
+                    s_tile[tx][ty + j];
+            }
+        }
+    }
+}
+
+template <typename OType, typename QType>
+void grouped_dequantize_mxfp8_impl(const QType *x, OType *y, const int64_t stride_x_row,
+                                   const int64_t stride_y_row, const int total_M, const int n_rows,
+                                   const int n_cols, const uint8_t *scale_inv,
+                                   const int64_t stride_scale_row, const int64_t stride_scale_col,
+                                   const int scale_n_rows, const int scale_n_cols,
+                                   const int64_t *group_offs, const int64_t *group_offs_padded,
+                                   int G, int block_size, bool use_rowwise, hipStream_t stream) {
+    if (total_M == 0 || n_cols == 0)
+        return;
+
+    const dim3 block(BLOCK_M, THREADS_PER_BLOCK / BLOCK_M);
+    if (use_rowwise) {
+        const dim3 grid((n_cols + BLOCK_N - 1) / BLOCK_N, (total_M + BLOCK_M - 1) / BLOCK_M);
+        grouped_dequantize_mxfp8_rowwise_kernel<OType, QType><<<grid, block, 0, stream>>>(
+            x, y, stride_x_row, stride_y_row, total_M, n_cols, scale_inv, stride_scale_row,
+            stride_scale_col, scale_n_rows, scale_n_cols, group_offs, group_offs_padded, G,
+            block_size);
+    } else {
+        const dim3 grid((n_rows + BLOCK_N - 1) / BLOCK_N, (n_cols + BLOCK_M - 1) / BLOCK_M);
+        grouped_dequantize_mxfp8_colwise_kernel<OType, QType><<<grid, block, 0, stream>>>(
+            x, y, stride_x_row, stride_y_row, total_M, n_rows, n_cols, scale_inv, stride_scale_row,
+            stride_scale_col, scale_n_rows, scale_n_cols, group_offs, group_offs_padded, G,
+            block_size);
+    }
+}
+
 template <typename OType, typename QType>
 void dequantize_mxfp8_impl(const QType *x, OType *y, const int64_t stride_x_row,
                            const int64_t stride_x_col, const int64_t stride_y_row,
@@ -156,5 +323,22 @@ DECL_DEQUANT_MXFP8_INSTANCE(dtype::float32, dtype::float8_e4m3)
 DECL_DEQUANT_MXFP8_INSTANCE(dtype::float32, dtype::float8_e5m2)
 
 #undef DECL_DEQUANT_MXFP8_INSTANCE
+
+#define DECL_GROUPED_DEQUANT_MXFP8_INSTANCE(OType, QType)                                          \
+    template void grouped_dequantize_mxfp8_impl<OType, QType>(                                     \
+        const QType *x, OType *y, const int64_t stride_x_row, const int64_t stride_y_row,          \
+        const int total_M, const int n_rows, const int n_cols, const uint8_t *scale_inv,           \
+        const int64_t stride_scale_row, const int64_t stride_scale_col, const int scale_n_rows,    \
+        const int scale_n_cols, const int64_t *group_offs, const int64_t *group_offs_padded,       \
+        int G, int block_size, bool use_rowwise, hipStream_t stream);
+
+DECL_GROUPED_DEQUANT_MXFP8_INSTANCE(dtype::float16, dtype::float8_e4m3)
+DECL_GROUPED_DEQUANT_MXFP8_INSTANCE(dtype::float16, dtype::float8_e5m2)
+DECL_GROUPED_DEQUANT_MXFP8_INSTANCE(dtype::bfloat16, dtype::float8_e4m3)
+DECL_GROUPED_DEQUANT_MXFP8_INSTANCE(dtype::bfloat16, dtype::float8_e5m2)
+DECL_GROUPED_DEQUANT_MXFP8_INSTANCE(dtype::float32, dtype::float8_e4m3)
+DECL_GROUPED_DEQUANT_MXFP8_INSTANCE(dtype::float32, dtype::float8_e5m2)
+
+#undef DECL_GROUPED_DEQUANT_MXFP8_INSTANCE
 
 } // namespace primus_turbo

--- a/csrc/kernels/quantization/quantization_mxfp8.cu
+++ b/csrc/kernels/quantization/quantization_mxfp8.cu
@@ -923,6 +923,326 @@ __global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void quantize_mxfp8_dual_kern
 }
 
 /*
+ * MXFP8 Single-Direction Quantization with per-group M-axis zero-padding.
+ * -----------------------------------------------------------------------
+ * Same as ``quantize_mxfp8_kernel`` but each per-group region is
+ * zero-padded along M in the OUTPUT tensors, with no intermediate padded
+ * copy of ``input``.  The kernel grid covers the already-padded M extent
+ * (``M_pad = total_M_padded``); within each 128-row tile (which by
+ * construction is fully contained in a single group when
+ * ``group_offs_padded`` is a multiple of BLOCK_M=128):
+ *
+ *   - Real rows (input row index = ``group_offs[g] + (global_row -
+ *     group_offs_padded[g])``) are loaded from ``input``.
+ *   - Padded rows (``global_row >= group_offs_padded[g] + M_g``) are
+ *     treated as zero data; their per-row / per-32 amax becomes 0 so we
+ *     force scale = 1.0 (E8M0_EXPONENT_BIAS) to keep output fp8 = 0
+ *     instead of NaN from a 0/0 conversion.
+ */
+template <typename IType, typename OType, QuantizeMode MODE, bool USE_2D_BLOCK = false>
+__global__ __launch_bounds__(THREADS_PER_BLOCK, 4) void grouped_quantize_mxfp8_kernel(
+    const IType *__restrict__ input, OType *__restrict__ out_fp8, uint8_t *__restrict__ out_scale,
+    const int64_t *__restrict__ group_offs, const int64_t *__restrict__ group_offs_padded,
+    const int G, const int N, const int M_pad, const int N_pad, const int scale_stride,
+    const int scale_N, const int scale_M_pad, const int scale_N_pad, const bool shuffle_out,
+    const bool shuffle_scale) {
+    constexpr bool kIsHalf    = std::is_same_v<IType, dtype::float16>;
+    constexpr bool kIsRowwise = (MODE == QuantizeMode::ROWWISE);
+
+    const int tid           = threadIdx.x;
+    const int warp_id       = tid / WARP_SIZE;
+    const int lane_id       = tid % WARP_SIZE;
+    const int row_in_warp   = lane_id / THREADS_PER_ROW;
+    const int thread_in_row = lane_id % THREADS_PER_ROW;
+
+    const int block_m = blockIdx.x;
+    const int block_n = blockIdx.y;
+    const int base_m  = block_m * BLOCK_M;
+    const int base_n  = block_n * BLOCK_N;
+
+    const int output_packed_stride = kIsRowwise ? N_pad : M_pad;
+
+    constexpr int ROWS_PER_PASS   = WARP_SIZE / THREADS_PER_ROW;
+    constexpr int PASSES_PER_TILE = MXFP8_BLOCK_SIZE / ROWS_PER_PASS;
+    constexpr int TOTAL_CHUNKS    = NUM_CHUNKS_M * NUM_CHUNKS_N;
+
+    constexpr int64_t  TILE_ALIGN = BLOCK_M; // = 128
+    __shared__ int64_t s_group_offs_orig;
+    __shared__ int64_t s_group_offs_pad;
+    __shared__ int64_t s_group_offs_pad_out;
+    __shared__ int64_t s_real_end_in_pad;
+    if (tid == 0) {
+        int64_t pad_tile = 0; // running 128-aligned prefix (tile space)
+        int     g        = -1;
+        for (int i = 0; i < G; ++i) {
+            const int64_t len   = group_offs[i + 1] - group_offs[i];
+            const int64_t ctile = (len + TILE_ALIGN - 1) / TILE_ALIGN * TILE_ALIGN;
+            if (base_m >= pad_tile && base_m < pad_tile + ctile) {
+                g = i;
+                break;
+            }
+            pad_tile += ctile;
+        }
+        if (g >= 0) {
+            s_group_offs_orig    = group_offs[g];
+            s_group_offs_pad     = pad_tile;
+            s_group_offs_pad_out = group_offs_padded[g];
+            s_real_end_in_pad    = pad_tile + (group_offs[g + 1] - group_offs[g]);
+        } else {
+            s_group_offs_orig    = 0;
+            s_group_offs_pad     = base_m;
+            s_group_offs_pad_out = base_m;
+            s_real_end_in_pad    = base_m;
+        }
+    }
+    __syncthreads();
+    const int64_t group_offs_orig    = s_group_offs_orig;
+    const int64_t group_offs_pad     = s_group_offs_pad;
+    const int64_t group_offs_pad_out = s_group_offs_pad_out;
+    const int64_t real_end_in_pad    = s_real_end_in_pad;
+
+    constexpr int       s_tile_DEPTH = kIsRowwise ? 1 : (MXFP8_BLOCK_SIZE + SMEM_PADDING);
+    __shared__ uint16_t s_tile[WARPS_PER_BLOCK][MXFP8_BLOCK_SIZE][s_tile_DEPTH];
+
+    for (int round = 0; round < TOTAL_CHUNKS; round += WARPS_PER_BLOCK) {
+        const int chunk_index = round + warp_id;
+        if (chunk_index >= TOTAL_CHUNKS)
+            break;
+
+        const int chunk_m = chunk_index / NUM_CHUNKS_N;
+        const int chunk_n = chunk_index % NUM_CHUNKS_N;
+        const int tile_m  = base_m + chunk_m * MXFP8_BLOCK_SIZE;
+        const int tile_n  = base_n + chunk_n * MXFP8_BLOCK_SIZE;
+
+        uint64_t r_tile[PASSES_PER_TILE];
+        {
+            const auto *input_as_uint16 = reinterpret_cast<const uint16_t *>(input);
+            const int   col_base        = thread_in_row * ELEMS_PER_THREAD;
+            const int   global_col      = tile_n + col_base;
+
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                const int local_row  = pass * ROWS_PER_PASS + row_in_warp;
+                const int global_row = tile_m + local_row;
+
+                uint64_t packed = 0;
+                if (global_row < real_end_in_pad) {
+                    const int64_t input_row =
+                        group_offs_orig + (static_cast<int64_t>(global_row) - group_offs_pad);
+                    const int64_t row_offset = input_row * N + global_col;
+                    if (global_col + ELEMS_PER_THREAD - 1 < N) {
+                        packed =
+                            __ldg(reinterpret_cast<const uint64_t *>(&input_as_uint16[row_offset]));
+                    } else {
+                        uint16_t elem0 = (global_col < N) ? __ldg(&input_as_uint16[row_offset]) : 0;
+                        uint16_t elem1 =
+                            (global_col + 1 < N) ? __ldg(&input_as_uint16[row_offset + 1]) : 0;
+                        uint16_t elem2 =
+                            (global_col + 2 < N) ? __ldg(&input_as_uint16[row_offset + 2]) : 0;
+                        uint16_t elem3 =
+                            (global_col + 3 < N) ? __ldg(&input_as_uint16[row_offset + 3]) : 0;
+                        packed = (uint64_t) elem0 | ((uint64_t) elem1 << 16) |
+                                 ((uint64_t) elem2 << 32) | ((uint64_t) elem3 << 48);
+                    }
+                }
+
+                if constexpr (!kIsRowwise) {
+                    *reinterpret_cast<uint32_t *>(&s_tile[warp_id][local_row][col_base]) =
+                        (uint32_t) packed;
+                    *reinterpret_cast<uint32_t *>(&s_tile[warp_id][local_row][col_base + 2]) =
+                        (uint32_t) (packed >> 32);
+                }
+
+                r_tile[pass] = packed;
+            }
+        }
+
+        if constexpr (!kIsRowwise) {
+            __syncthreads();
+        }
+
+        float r_vals[PASSES_PER_TILE][ELEMS_PER_THREAD];
+        float r_amax[PASSES_PER_TILE];
+
+        {
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                r_vals[pass][0] = r_vals[pass][1] = r_vals[pass][2] = r_vals[pass][3] = 0.f;
+                r_amax[pass]                                                          = 0.f;
+
+                if constexpr (kIsRowwise) {
+                    const int global_row = tile_m + pass * ROWS_PER_PASS + row_in_warp;
+
+                    if (global_row < real_end_in_pad) {
+                        packed_uint16x4_to_floatx4<kIsHalf>(r_tile[pass], r_vals[pass][0],
+                                                            r_vals[pass][1], r_vals[pass][2],
+                                                            r_vals[pass][3]);
+
+                        float local_amax =
+                            fmaxf(fmaxf(fabsf(r_vals[pass][0]), fabsf(r_vals[pass][1])),
+                                  fmaxf(fabsf(r_vals[pass][2]), fabsf(r_vals[pass][3])));
+                        r_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+                    }
+                } else {
+                    const int row_base   = thread_in_row * ELEMS_PER_THREAD;
+                    const int local_col  = pass * ROWS_PER_PASS + row_in_warp;
+                    const int global_col = tile_n + local_col;
+
+                    if (global_col < N) {
+                        r_vals[pass][0] =
+                            uint16_to_float<kIsHalf>(s_tile[warp_id][row_base][local_col]);
+                        r_vals[pass][1] =
+                            uint16_to_float<kIsHalf>(s_tile[warp_id][row_base + 1][local_col]);
+                        r_vals[pass][2] =
+                            uint16_to_float<kIsHalf>(s_tile[warp_id][row_base + 2][local_col]);
+                        r_vals[pass][3] =
+                            uint16_to_float<kIsHalf>(s_tile[warp_id][row_base + 3][local_col]);
+
+                        float local_amax =
+                            fmaxf(fmaxf(fabsf(r_vals[pass][0]), fabsf(r_vals[pass][1])),
+                                  fmaxf(fabsf(r_vals[pass][2]), fabsf(r_vals[pass][3])));
+                        r_amax[pass] = warp_reduce_max_8_dpp(local_amax);
+                    }
+                }
+            }
+        }
+
+        float   r_scale_native[PASSES_PER_TILE];
+        uint8_t r_scale_e8m0[PASSES_PER_TILE];
+
+        if constexpr (USE_2D_BLOCK) {
+            float tile_amax = 0.f;
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++)
+                tile_amax = fmaxf(tile_amax, r_amax[pass]);
+            tile_amax = warp_reduce_max_64_dpp(tile_amax);
+            float   tile_scale_native;
+            uint8_t tile_scale_e8m0;
+            if (tile_amax == 0.f) {
+                tile_scale_native = 1.0f;
+                tile_scale_e8m0   = E8M0_EXPONENT_BIAS;
+            } else {
+                compute_tile_scale<OType>(tile_amax, tile_scale_native, tile_scale_e8m0);
+            }
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                r_scale_native[pass] = tile_scale_native;
+                r_scale_e8m0[pass]   = tile_scale_e8m0;
+            }
+        } else {
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                if (r_amax[pass] == 0.f) {
+                    r_scale_native[pass] = 1.0f;
+                    r_scale_e8m0[pass]   = E8M0_EXPONENT_BIAS;
+                } else {
+                    compute_tile_scale<OType>(r_amax[pass], r_scale_native[pass],
+                                              r_scale_e8m0[pass]);
+                }
+            }
+        }
+
+        {
+#pragma unroll
+            for (int pass = 0; pass < PASSES_PER_TILE; pass++) {
+                uint32_t fp8x4 =
+                    cvt_f32x4_to_fp8x4<OType>(r_vals[pass][0], r_vals[pass][1], r_vals[pass][2],
+                                              r_vals[pass][3], r_scale_native[pass]);
+
+                if constexpr (kIsRowwise) {
+                    const int col_base   = thread_in_row * ELEMS_PER_THREAD;
+                    const int global_col = tile_n + col_base;
+                    const int local_row  = pass * ROWS_PER_PASS + row_in_warp;
+                    const int global_row = tile_m + local_row;
+
+                    if (global_row < real_end_in_pad) {
+                        const int64_t row_out = group_offs_pad_out +
+                                                (static_cast<int64_t>(global_row) - group_offs_pad);
+                        if (global_col < N_pad) {
+                            if (shuffle_out) {
+                                int shuffled_index = compute_shuffled_index<OType>(
+                                    static_cast<int>(row_out), global_col, output_packed_stride);
+                                *reinterpret_cast<uint32_t *>(out_fp8 + shuffled_index) = fp8x4;
+                            } else {
+                                *reinterpret_cast<uint32_t *>(
+                                    out_fp8 + row_out * output_packed_stride + global_col) = fp8x4;
+                            }
+                        }
+
+                        if (thread_in_row == 0) {
+                            int scale_col = block_n * NUM_CHUNKS_N + chunk_n;
+                            if (shuffle_scale) {
+                                if (row_out < scale_M_pad && scale_col < scale_N_pad) {
+                                    int scale_index = compute_shuffle_scale_index(
+                                        static_cast<int>(row_out), scale_col, scale_N_pad);
+                                    out_scale[scale_index] = (scale_col < scale_N)
+                                                                 ? r_scale_e8m0[pass]
+                                                                 : static_cast<uint8_t>(0);
+                                }
+                            } else {
+                                if (scale_col < scale_N) {
+                                    out_scale[row_out * scale_stride + scale_col] =
+                                        r_scale_e8m0[pass];
+                                }
+                            }
+                        }
+                    }
+
+                } else {
+                    const int row_base        = thread_in_row * ELEMS_PER_THREAD;
+                    const int global_row_base = tile_m + row_base;
+                    const int local_col       = pass * ROWS_PER_PASS + row_in_warp;
+                    const int global_col      = tile_n + local_col;
+
+                    if (global_col < N) {
+                        if (global_row_base < M_pad) {
+                            if (shuffle_out) {
+                                int shuffled_index = compute_shuffled_index<OType>(
+                                    global_col, global_row_base, output_packed_stride);
+                                *reinterpret_cast<uint32_t *>(out_fp8 + shuffled_index) = fp8x4;
+                            } else {
+                                *reinterpret_cast<uint32_t *>(out_fp8 +
+                                                              static_cast<int64_t>(global_col) *
+                                                                  output_packed_stride +
+                                                              global_row_base) = fp8x4;
+                            }
+                        }
+
+                        if (thread_in_row == 0) {
+                            int scale_col = block_m * NUM_CHUNKS_M + chunk_m;
+                            if (shuffle_scale) {
+                                if (global_col < scale_M_pad && scale_col < scale_N_pad) {
+                                    int scale_index = compute_shuffle_scale_index(
+                                        global_col, scale_col, scale_N_pad);
+                                    out_scale[scale_index] = (scale_col < scale_N)
+                                                                 ? r_scale_e8m0[pass]
+                                                                 : static_cast<uint8_t>(0);
+                                }
+                            } else {
+                                if (scale_col < scale_N) {
+                                    out_scale[global_col * scale_stride + scale_col] =
+                                        r_scale_e8m0[pass];
+                                }
+                            }
+                        }
+                    }
+
+                    if (shuffle_scale && thread_in_row == 0 && global_col >= N &&
+                        global_col < scale_M_pad) {
+                        int scale_col = block_m * NUM_CHUNKS_M + chunk_m;
+                        if (scale_col < scale_N_pad) {
+                            int scale_index =
+                                compute_shuffle_scale_index(global_col, scale_col, scale_N_pad);
+                            out_scale[scale_index] = static_cast<uint8_t>(0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/*
  * MXFP8 Dual Quantization with per-group M-axis zero-padding (fused).
  * --------------------------------------------------------------------
  * Same as ``quantize_mxfp8_dual_kernel`` but each per-group region is
@@ -1351,7 +1671,7 @@ template <typename IType, typename OType>
 void grouped_quantize_mxfp8_dual_impl(
     const IType *input, OType *rowwise_output, uint8_t *rowwise_scale, OType *colwise_output,
     uint8_t *colwise_scale, const int64_t *group_offs, const int64_t *group_offs_padded_colwise,
-    const int64_t *group_offs_padded_rowwise, int G, int total_M_padded, int N, int N_pad,
+    const int64_t *group_offs_padded_rowwise, int G, int total_M, int N, int N_pad,
     int rowwise_scale_stride, int colwise_scale_stride, int rowwise_scale_N,
     int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M, int colwise_scale_N,
     int colwise_scale_M_pad, int colwise_scale_N_pad, ScalingRecipe rowwise_recipe,
@@ -1360,6 +1680,10 @@ void grouped_quantize_mxfp8_dual_impl(
     PRIMUS_TURBO_CHECK(colwise_recipe.use_rht == false, "MXFP8 not support RHT");
     PRIMUS_TURBO_CHECK(rowwise_recipe.use_sr == false, "MXFP8 not support SR");
     PRIMUS_TURBO_CHECK(colwise_recipe.use_sr == false, "MXFP8 not support SR");
+
+    // Colwise output / tile-iteration M extent is 128 (BLOCK_M) aligned per group;
+    // matches the M_pad_col the caller uses to size the colwise output tensor.
+    const int total_M_padded = (total_M + G * BLOCK_M + BLOCK_M - 1) / BLOCK_M * BLOCK_M;
 
     dim3 grid((total_M_padded + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
     dim3 block(THREADS_PER_BLOCK);
@@ -1426,6 +1750,64 @@ template void grouped_quantize_mxfp8_dual_impl<dtype::bfloat16, dtype::float8_e4
     int rowwise_scale_N, int rowwise_scale_M_pad, int rowwise_scale_N_pad, int colwise_scale_M,
     int colwise_scale_N, int colwise_scale_M_pad, int colwise_scale_N_pad,
     ScalingRecipe rowwise_recipe, ScalingRecipe colwise_recipe, hipStream_t stream);
+
+template <typename IType, typename OType>
+void grouped_quantize_mxfp8_impl(const IType *input, OType *output, uint8_t *scale,
+                                 const int64_t *group_offs, const int64_t *group_offs_padded,
+                                 QuantizeMode mode, int G, int total_M, int N, int N_pad,
+                                 int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
+                                 ScalingRecipe recipe, hipStream_t stream) {
+    PRIMUS_TURBO_CHECK(recipe.use_rht == false, "MXFP8 not support RHT");
+    PRIMUS_TURBO_CHECK(recipe.use_sr == false, "MXFP8 not support SR");
+
+    const int total_M_padded = (total_M + G * BLOCK_M + BLOCK_M - 1) / BLOCK_M * BLOCK_M;
+
+    dim3 grid((total_M_padded + BLOCK_M - 1) / BLOCK_M, (N_pad + BLOCK_N - 1) / BLOCK_N);
+    dim3 block(THREADS_PER_BLOCK);
+
+#define QUANTIZE_MXFP8_GROUPED_ARGS                                                                \
+    input, output, scale, group_offs, group_offs_padded, G, N, total_M_padded, N_pad,              \
+        scale_stride, scale_N, scale_M_pad, scale_N_pad, recipe.shuffle_out, recipe.shuffle_scale
+
+#define QUANTIZE_MXFP8_GROUPED_LAUNCH(USE_2D_BLOCK)                                                \
+    if (mode == QuantizeMode::ROWWISE) {                                                           \
+        grouped_quantize_mxfp8_kernel<IType, OType, QuantizeMode::ROWWISE, USE_2D_BLOCK>           \
+            <<<grid, block, 0, stream>>>(QUANTIZE_MXFP8_GROUPED_ARGS);                             \
+    } else {                                                                                       \
+        grouped_quantize_mxfp8_kernel<IType, OType, QuantizeMode::COLWISE, USE_2D_BLOCK>           \
+            <<<grid, block, 0, stream>>>(QUANTIZE_MXFP8_GROUPED_ARGS);                             \
+    }
+
+    if (recipe.use_2d_block) {
+        QUANTIZE_MXFP8_GROUPED_LAUNCH(true);
+    } else {
+        QUANTIZE_MXFP8_GROUPED_LAUNCH(false);
+    }
+
+#undef QUANTIZE_MXFP8_GROUPED_LAUNCH
+#undef QUANTIZE_MXFP8_GROUPED_ARGS
+}
+
+template void grouped_quantize_mxfp8_impl<dtype::float16, dtype::float8_e5m2>(
+    const dtype::float16 *x, dtype::float8_e5m2 *output, uint8_t *scale, const int64_t *group_offs,
+    const int64_t *group_offs_padded, QuantizeMode mode, int G, int total_M_padded, int N,
+    int N_pad, int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
+    ScalingRecipe recipe, hipStream_t stream);
+template void grouped_quantize_mxfp8_impl<dtype::bfloat16, dtype::float8_e5m2>(
+    const dtype::bfloat16 *x, dtype::float8_e5m2 *output, uint8_t *scale, const int64_t *group_offs,
+    const int64_t *group_offs_padded, QuantizeMode mode, int G, int total_M_padded, int N,
+    int N_pad, int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
+    ScalingRecipe recipe, hipStream_t stream);
+template void grouped_quantize_mxfp8_impl<dtype::float16, dtype::float8_e4m3>(
+    const dtype::float16 *x, dtype::float8_e4m3 *output, uint8_t *scale, const int64_t *group_offs,
+    const int64_t *group_offs_padded, QuantizeMode mode, int G, int total_M_padded, int N,
+    int N_pad, int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
+    ScalingRecipe recipe, hipStream_t stream);
+template void grouped_quantize_mxfp8_impl<dtype::bfloat16, dtype::float8_e4m3>(
+    const dtype::bfloat16 *x, dtype::float8_e4m3 *output, uint8_t *scale, const int64_t *group_offs,
+    const int64_t *group_offs_padded, QuantizeMode mode, int G, int total_M_padded, int N,
+    int N_pad, int scale_stride, int scale_N, int scale_M_pad, int scale_N_pad,
+    ScalingRecipe recipe, hipStream_t stream);
 
 template <typename IType, typename OType>
 void quantize_mxfp8_dual_impl(const IType *input, OType *rowwise_output, uint8_t *rowwise_scale,

--- a/csrc/pytorch/bindings_pytorch.cpp
+++ b/csrc/pytorch/bindings_pytorch.cpp
@@ -55,6 +55,10 @@ TORCH_LIBRARY(primus_turbo_cpp_extension, m) {
           "bool shuffle_scale=False, bool shuffle_out=False) -> Tensor[]");
     m.def("dequantize_mxfp4(Tensor input, Tensor scale_inv, int axis, int block_size, "
           "ScalarType dest_dtype) -> Tensor");
+    m.def("grouped_quantize_mxfp4_dual(Tensor input, Tensor group_lens, Tensor group_offs, "
+          "ScalarType dest_dtype, "
+          "bool rowwise_use_2d_block, bool rowwise_use_sr, bool rowwise_use_rht, "
+          "bool colwise_use_2d_block, bool colwise_use_sr, bool colwise_use_rht) -> Tensor[]");
 
     // ********* MXFP8 Quantization *********
     m.def("quantize_mxfp8_dual(Tensor input, ScalarType dest_dtype, "
@@ -67,15 +71,17 @@ TORCH_LIBRARY(primus_turbo_cpp_extension, m) {
           "bool rowwise_use_2d_block, bool colwise_use_2d_block, "
           "bool shuffle_rowwise_scale=False, bool shuffle_rowwise=False, "
           "bool shuffle_colwise_scale=False, bool shuffle_colwise=False) -> Tensor[]");
-    m.def("grouped_quantize_mxfp4_dual(Tensor input, Tensor group_lens, Tensor group_offs, "
-          "ScalarType dest_dtype, "
-          "bool rowwise_use_2d_block, bool rowwise_use_sr, bool rowwise_use_rht, "
-          "bool colwise_use_2d_block, bool colwise_use_sr, bool colwise_use_rht) -> Tensor[]");
+    m.def("grouped_quantize_mxfp8(Tensor input, Tensor group_lens, Tensor group_offs, "
+          "ScalarType dest_dtype, int axis, int padding_align_size, "
+          "bool use_2d_block, bool shuffle_scale=False, bool shuffle_out=False) -> Tensor[]");
     m.def("quantize_mxfp8(Tensor input, ScalarType dest_dtype, int axis, "
           "int padding_align_size, "
           "bool use_2d_block, bool shuffle_scale=False, bool shuffle_out=False) -> Tensor[]");
     m.def("dequantize_mxfp8(Tensor input, Tensor scale_inv, int axis, int block_size, "
           "ScalarType dest_dtype) -> Tensor");
+    m.def("grouped_dequantize_mxfp8(Tensor input, Tensor scale_inv, Tensor group_offs, "
+          "Tensor group_offs_padded, int axis, int block_size, ScalarType dest_dtype, "
+          "int? total_M=None) -> Tensor");
 
     // ********* Shuffle *********
     m.def("shuffle_scale(Tensor scale, int[] layout) -> Tensor");
@@ -134,13 +140,15 @@ TORCH_LIBRARY_IMPL(primus_turbo_cpp_extension, CUDA, m) {
     m.impl("quantize_mxfp4_dual", quantize_mxfp4_dual);
     m.impl("quantize_mxfp4", quantize_mxfp4);
     m.impl("dequantize_mxfp4", dequantize_mxfp4);
+    m.impl("grouped_quantize_mxfp4_dual", grouped_quantize_mxfp4_dual);
 
     // ********* MXFP8 Quantization *********
     m.impl("quantize_mxfp8_dual", quantize_mxfp8_dual);
     m.impl("grouped_quantize_mxfp8_dual", grouped_quantize_mxfp8_dual);
-    m.impl("grouped_quantize_mxfp4_dual", grouped_quantize_mxfp4_dual);
+    m.impl("grouped_quantize_mxfp8", grouped_quantize_mxfp8);
     m.impl("quantize_mxfp8", quantize_mxfp8);
     m.impl("dequantize_mxfp8", dequantize_mxfp8);
+    m.impl("grouped_dequantize_mxfp8", grouped_dequantize_mxfp8);
 
     // ********* Shuffle *********
     m.impl("shuffle_scale", shuffle_scale_impl);
@@ -181,13 +189,15 @@ TORCH_LIBRARY_IMPL(primus_turbo_cpp_extension, Meta, m) {
     m.impl("quantize_mxfp4_dual", quantize_mxfp4_dual_meta);
     m.impl("quantize_mxfp4", quantize_mxfp4_meta);
     m.impl("dequantize_mxfp4", dequantize_mxfp4_meta);
+    m.impl("grouped_quantize_mxfp4_dual", grouped_quantize_mxfp4_dual_meta);
 
     // ********* MXFP8 Quantization *********
     m.impl("quantize_mxfp8_dual", quantize_mxfp8_dual_meta);
     m.impl("grouped_quantize_mxfp8_dual", grouped_quantize_mxfp8_dual_meta);
-    m.impl("grouped_quantize_mxfp4_dual", grouped_quantize_mxfp4_dual_meta);
+    m.impl("grouped_quantize_mxfp8", grouped_quantize_mxfp8_meta);
     m.impl("quantize_mxfp8", quantize_mxfp8_meta);
     m.impl("dequantize_mxfp8", dequantize_mxfp8_meta);
+    m.impl("grouped_dequantize_mxfp8", grouped_dequantize_mxfp8_meta);
 
     // ********* Shuffle *********
     m.impl("shuffle_scale", shuffle_scale_impl_meta);

--- a/csrc/pytorch/extensions.h
+++ b/csrc/pytorch/extensions.h
@@ -86,6 +86,18 @@ at::Tensor dequantize_mxfp8_meta(const at::Tensor input, const at::Tensor scale_
                                  const int64_t axis, const int64_t block_size,
                                  const at::ScalarType dest_dtype);
 
+at::Tensor grouped_dequantize_mxfp8(const at::Tensor input, const at::Tensor scale_inv,
+                                    const at::Tensor group_offs, const at::Tensor group_offs_padded,
+                                    const int64_t axis, const int64_t block_size,
+                                    const at::ScalarType   dest_dtype,
+                                    c10::optional<int64_t> total_M = c10::nullopt);
+
+at::Tensor grouped_dequantize_mxfp8_meta(const at::Tensor input, const at::Tensor scale_inv,
+                                         const at::Tensor group_offs,
+                                         const at::Tensor group_offs_padded, const int64_t axis,
+                                         const int64_t block_size, const at::ScalarType dest_dtype,
+                                         c10::optional<int64_t> total_M = c10::nullopt);
+
 at::Tensor dequantize_mxfp4(const at::Tensor input, const at::Tensor scale_inv, const int64_t axis,
                             const int64_t block_size, const at::ScalarType dest_dtype);
 
@@ -125,6 +137,17 @@ std::vector<at::Tensor> quantize_mxfp8_dual_meta(
     const bool shuffle_rowwise_scale = false, const bool shuffle_rowwise = false,
     const bool shuffle_colwise_scale = false, const bool shuffle_colwise = false);
 
+std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarType dest_dtype,
+                                       const int64_t axis, const int64_t padding_align_size,
+                                       const bool use_2d_block, const bool shuffle_scale = false,
+                                       const bool shuffle_out = false);
+
+std::vector<at::Tensor> quantize_mxfp8_meta(const at::Tensor input, const at::ScalarType dest_dtype,
+                                            const int64_t axis, const int64_t padding_align_size,
+                                            const bool use_2d_block,
+                                            const bool shuffle_scale = false,
+                                            const bool shuffle_out   = false);
+
 std::vector<at::Tensor> grouped_quantize_mxfp8_dual(
     const at::Tensor input, const at::Tensor group_lens, const at::Tensor group_offs,
     const at::ScalarType dest_dtype, const bool rowwise_use_2d_block,
@@ -139,28 +162,29 @@ std::vector<at::Tensor> grouped_quantize_mxfp8_dual_meta(
     const bool shuffle_rowwise = false, const bool shuffle_colwise_scale = false,
     const bool shuffle_colwise = false);
 
-std::vector<at::Tensor> grouped_quantize_mxfp4_dual(
+std::vector<at::Tensor> grouped_quantize_mxfp8(
     const at::Tensor input, const at::Tensor group_lens, const at::Tensor group_offs,
-    const at::ScalarType dest_dtype, const bool rowwise_use_2d_block, const bool rowwise_use_sr,
-    const bool rowwise_use_rht, const bool colwise_use_2d_block, const bool colwise_use_sr,
-    const bool colwise_use_rht);
+    const at::ScalarType dest_dtype, const int64_t axis, const int64_t padding_align_size,
+    const bool use_2d_block, const bool shuffle_scale = false, const bool shuffle_out = false);
 
-std::vector<at::Tensor> grouped_quantize_mxfp4_dual_meta(
+std::vector<at::Tensor> grouped_quantize_mxfp8_meta(
     const at::Tensor input, const at::Tensor group_lens, const at::Tensor group_offs,
-    const at::ScalarType dest_dtype, const bool rowwise_use_2d_block, const bool rowwise_use_sr,
-    const bool rowwise_use_rht, const bool colwise_use_2d_block, const bool colwise_use_sr,
-    const bool colwise_use_rht);
+    const at::ScalarType dest_dtype, const int64_t axis, const int64_t padding_align_size,
+    const bool use_2d_block, const bool shuffle_scale = false, const bool shuffle_out = false);
 
-std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarType dest_dtype,
-                                       const int64_t axis, const int64_t padding_align_size,
-                                       const bool use_2d_block, const bool shuffle_scale = false,
-                                       const bool shuffle_out = false);
+std::vector<at::Tensor>
+grouped_quantize_mxfp4_dual(const at::Tensor input, const at::Tensor group_lens,
+                            const at::Tensor group_offs, const at::ScalarType dest_dtype,
+                            const bool rowwise_use_2d_block, const bool rowwise_use_sr,
+                            const bool rowwise_use_rht, const bool colwise_use_2d_block,
+                            const bool colwise_use_sr, const bool colwise_use_rht);
 
-std::vector<at::Tensor> quantize_mxfp8_meta(const at::Tensor input, const at::ScalarType dest_dtype,
-                                            const int64_t axis, const int64_t padding_align_size,
-                                            const bool use_2d_block,
-                                            const bool shuffle_scale = false,
-                                            const bool shuffle_out   = false);
+std::vector<at::Tensor>
+grouped_quantize_mxfp4_dual_meta(const at::Tensor input, const at::Tensor group_lens,
+                                 const at::Tensor group_offs, const at::ScalarType dest_dtype,
+                                 const bool rowwise_use_2d_block, const bool rowwise_use_sr,
+                                 const bool rowwise_use_rht, const bool colwise_use_2d_block,
+                                 const bool colwise_use_sr, const bool colwise_use_rht);
 
 //==================================================================
 //  Shuffle

--- a/csrc/pytorch/quantization/quantization.cpp
+++ b/csrc/pytorch/quantization/quantization.cpp
@@ -286,6 +286,86 @@ at::Tensor dequantize_mxfp8(const at::Tensor input, const at::Tensor scale_inv, 
 
     PRIMUS_TURBO_CHECK(input.is_cuda(), "Input must be a CUDA tensor");
     PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
+    PRIMUS_TURBO_CHECK(input.dim() == 2 || input.dim() == 3, "Input must be 2D or 3D");
+    PRIMUS_TURBO_CHECK(is_torch_fp8(input.scalar_type()), "Input must be FP8");
+    PRIMUS_TURBO_CHECK(scale_inv.is_cuda(), "scale_inv must be a CUDA tensor");
+    PRIMUS_TURBO_CHECK(scale_inv.dim() == input.dim(), "scale_inv rank must match input");
+    PRIMUS_TURBO_CHECK(scale_inv.is_contiguous(), "scale_inv must be contiguous");
+    PRIMUS_TURBO_CHECK(scale_inv.scalar_type() == at::kFloat8_e8m0fnu ||
+                           scale_inv.dtype() == at::kByte,
+                       "scale_inv must be Float8_e8m0fnu / uint8 tensor");
+    PRIMUS_TURBO_CHECK(dest_dtype == at::kBFloat16 || dest_dtype == at::kHalf ||
+                           dest_dtype == at::kFloat,
+                       "Output dtype must be bf16/fp16/fp32");
+    PRIMUS_TURBO_CHECK(block_size == MXFP8_BLOCK_SIZE, "block_size must be ", MXFP8_BLOCK_SIZE);
+
+    const bool is_batched = (input.dim() == 3);
+
+    bool    use_rowwise;
+    int64_t num_rows;
+    int64_t row_length;
+    if (input.dim() == 2) {
+        PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1 for 2D input");
+        use_rowwise = (axis == 1);
+        num_rows    = input.size(0);
+        row_length  = input.size(1);
+    } else {
+        PRIMUS_TURBO_CHECK(axis == 1 || axis == 2, "Axis must be 1 or 2 for 3D input");
+        use_rowwise = (axis == 2);
+        num_rows    = input.size(0) * input.size(1);
+        row_length  = input.size(2);
+    }
+
+    PRIMUS_TURBO_CHECK(row_length % block_size == 0,
+                       "The last dimension must be divisible by block_size");
+
+    at::Tensor input_2d = input.reshape({num_rows, row_length});
+    at::Tensor scale_2d =
+        is_batched ? scale_inv.reshape({scale_inv.size(0) * scale_inv.size(1), scale_inv.size(2)})
+                   : scale_inv;
+    const int64_t scale_m = scale_2d.size(0);
+    const int64_t scale_n = scale_2d.size(1);
+
+    auto       stream = at::cuda::getCurrentCUDAStream();
+    at::Tensor output_2d =
+        use_rowwise ? at::empty({num_rows, row_length}, input.options().dtype(dest_dtype))
+                    : at::empty({row_length, num_rows}, input.options().dtype(dest_dtype));
+
+    const uint8_t *scale_ptr = reinterpret_cast<const uint8_t *>(scale_2d.data_ptr());
+
+    TORCH_TYPE_SWITCH_FP16_BF16_FP32(output_2d.scalar_type(), OType, {
+        TORCH_TYPE_SWITCH_FP8(input.scalar_type(), QType, {
+            dequantize_mxfp8_impl<OType, QType>(
+                reinterpret_cast<const QType *>(input_2d.data_ptr()),
+                reinterpret_cast<OType *>(output_2d.data_ptr()), input_2d.stride(0),
+                input_2d.stride(1), output_2d.stride(0), output_2d.stride(1),
+                static_cast<int>(num_rows), static_cast<int>(row_length), scale_ptr,
+                scale_2d.stride(0), scale_2d.stride(1), static_cast<int>(scale_m),
+                static_cast<int>(scale_n), static_cast<int>(block_size), use_rowwise, stream);
+        });
+    });
+
+    if (is_batched) {
+        if (use_rowwise) {
+            return output_2d.reshape({input.size(0), input.size(1), row_length});
+        } else {
+            return output_2d.reshape({row_length, input.size(0), input.size(1)}).permute({1, 2, 0});
+        }
+    }
+
+    return output_2d;
+}
+
+// De-Quantize grouped MXFP8: fused dequant + compact gather to [total_M, N].
+at::Tensor grouped_dequantize_mxfp8(const at::Tensor input, const at::Tensor scale_inv,
+                                    const at::Tensor group_offs, const at::Tensor group_offs_padded,
+                                    const int64_t axis, const int64_t block_size,
+                                    const at::ScalarType   dest_dtype,
+                                    c10::optional<int64_t> total_M) {
+    using namespace primus_turbo::detail;
+
+    PRIMUS_TURBO_CHECK(input.is_cuda(), "Input must be a CUDA tensor");
+    PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
     PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
     PRIMUS_TURBO_CHECK(is_torch_fp8(input.scalar_type()), "Input must be FP8");
     PRIMUS_TURBO_CHECK(scale_inv.is_cuda(), "scale_inv must be a CUDA tensor");
@@ -294,6 +374,17 @@ at::Tensor dequantize_mxfp8(const at::Tensor input, const at::Tensor scale_inv, 
     PRIMUS_TURBO_CHECK(scale_inv.scalar_type() == at::kFloat8_e8m0fnu ||
                            scale_inv.dtype() == at::kByte,
                        "scale_inv must be Float8_e8m0fnu / uint8 tensor");
+    PRIMUS_TURBO_CHECK(group_offs.is_cuda() && group_offs_padded.is_cuda(),
+                       "group_offs / group_offs_padded must be CUDA tensors");
+    PRIMUS_TURBO_CHECK(group_offs.scalar_type() == at::kLong &&
+                           group_offs_padded.scalar_type() == at::kLong,
+                       "group tensors must be int64");
+    PRIMUS_TURBO_CHECK(group_offs.dim() == 1 && group_offs_padded.dim() == 1,
+                       "group tensors must be 1D");
+    PRIMUS_TURBO_CHECK(group_offs_padded.size(0) == group_offs.size(0),
+                       "group_offs_padded.size(0) must equal group_offs.size(0)");
+    PRIMUS_TURBO_CHECK(group_offs.size(0) >= 2,
+                       "group_offs must have length G+1 (at least one group)");
     PRIMUS_TURBO_CHECK(dest_dtype == at::kBFloat16 || dest_dtype == at::kHalf ||
                            dest_dtype == at::kFloat,
                        "Output dtype must be bf16/fp16/fp32");
@@ -301,30 +392,37 @@ at::Tensor dequantize_mxfp8(const at::Tensor input, const at::Tensor scale_inv, 
     PRIMUS_TURBO_CHECK(block_size == MXFP8_BLOCK_SIZE, "block_size must be ", MXFP8_BLOCK_SIZE);
 
     const bool    use_rowwise = (axis == 1);
-    const int64_t num_rows    = input.size(0);
-    const int64_t row_length  = input.size(1);
+    const int64_t G           = group_offs.size(0) - 1;
+    const int64_t total_M_val =
+        total_M.has_value() ? total_M.value() : group_offs.index({G}).item<int64_t>();
+    PRIMUS_TURBO_CHECK(total_M_val > 0, "total_M must be positive");
+
+    const int64_t num_rows   = input.size(0);
+    const int64_t row_length = input.size(1);
     PRIMUS_TURBO_CHECK(row_length % block_size == 0,
                        "The last dimension must be divisible by block_size");
+
+    const int64_t m_padded = use_rowwise ? num_rows : row_length;
+    const int64_t n_cols   = use_rowwise ? row_length : num_rows;
 
     const int64_t scale_m = scale_inv.size(0);
     const int64_t scale_n = scale_inv.size(1);
 
     auto       stream = at::cuda::getCurrentCUDAStream();
-    at::Tensor output = use_rowwise
-                            ? at::empty({num_rows, row_length}, input.options().dtype(dest_dtype))
-                            : at::empty({row_length, num_rows}, input.options().dtype(dest_dtype));
+    at::Tensor output = at::empty({total_M_val, n_cols}, input.options().dtype(dest_dtype));
 
     const uint8_t *scale_ptr = reinterpret_cast<const uint8_t *>(scale_inv.data_ptr());
 
     TORCH_TYPE_SWITCH_FP16_BF16_FP32(output.scalar_type(), OType, {
         TORCH_TYPE_SWITCH_FP8(input.scalar_type(), QType, {
-            dequantize_mxfp8_impl<OType, QType>(
+            grouped_dequantize_mxfp8_impl<OType, QType>(
                 reinterpret_cast<const QType *>(input.data_ptr()),
-                reinterpret_cast<OType *>(output.data_ptr()), input.stride(0), input.stride(1),
-                output.stride(0), output.stride(1), static_cast<int>(num_rows),
-                static_cast<int>(row_length), scale_ptr, scale_inv.stride(0), scale_inv.stride(1),
-                static_cast<int>(scale_m), static_cast<int>(scale_n), static_cast<int>(block_size),
-                use_rowwise, stream);
+                reinterpret_cast<OType *>(output.data_ptr()), input.stride(0), output.stride(0),
+                static_cast<int>(total_M_val), static_cast<int>(m_padded), static_cast<int>(n_cols),
+                scale_ptr, scale_inv.stride(0), scale_inv.stride(1), static_cast<int>(scale_m),
+                static_cast<int>(scale_n), group_offs.data_ptr<int64_t>(),
+                group_offs_padded.data_ptr<int64_t>(), static_cast<int>(G),
+                static_cast<int>(block_size), use_rowwise, stream);
         });
     });
 
@@ -729,7 +827,6 @@ std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarT
     PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
     PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat8_e4m3fn || dest_dtype == at::kFloat8_e5m2,
                        "Output must be Float8_e4m3fn or Float8_e5m2");
-    PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1");
     // Guard the public op argument against zero/negative values (would otherwise
     // divide-by-zero in cdiv below) and lock it to the expected MXFP8 constant.
     PRIMUS_TURBO_CHECK(padding_align_size == MXFP8_K_DIM_PADDING_ALIGN_SIZE,
@@ -740,12 +837,14 @@ std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarT
     QuantizeMode mode;
     int64_t      G, M, N;
     if (input.dim() == 2) {
+        PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1 for 2D input");
         mode       = (axis == 0) ? QuantizeMode::COLWISE : QuantizeMode::ROWWISE;
         is_rowwise = (mode == QuantizeMode::ROWWISE);
         G          = 1;
         M          = input.size(0);
         N          = input.size(1);
     } else if (input.dim() == 3) {
+        PRIMUS_TURBO_CHECK(axis == 1 || axis == 2, "Axis must be 1 or 2 for 3D input");
         mode       = (axis == 1) ? QuantizeMode::COLWISE : QuantizeMode::ROWWISE;
         is_rowwise = (mode == QuantizeMode::ROWWISE);
         G          = input.size(0);
@@ -823,6 +922,111 @@ std::vector<at::Tensor> quantize_mxfp8(const at::Tensor input, const at::ScalarT
     }
 
     return {output.view(dest_dtype), scale_tensor.view(at::kFloat8_e8m0fnu)};
+}
+
+std::vector<at::Tensor> grouped_quantize_mxfp8(const at::Tensor input, const at::Tensor group_lens,
+                                               const at::Tensor     group_offs,
+                                               const at::ScalarType dest_dtype, const int64_t axis,
+                                               const int64_t padding_align_size,
+                                               const bool use_2d_block, const bool shuffle_scale,
+                                               const bool shuffle_out) {
+    using namespace primus_turbo::detail;
+
+    PRIMUS_TURBO_CHECK(input.is_cuda(), "Input must be a CUDA tensor");
+    PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
+                       "Input must be BFloat16 or Half");
+    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
+    PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
+    PRIMUS_TURBO_CHECK(group_lens.is_cuda() && group_offs.is_cuda(),
+                       "group_lens / group_offs must be CUDA tensors");
+    PRIMUS_TURBO_CHECK(group_lens.scalar_type() == at::kLong &&
+                           group_offs.scalar_type() == at::kLong,
+                       "group_lens / group_offs must be int64");
+    PRIMUS_TURBO_CHECK(group_lens.dim() == 1 && group_offs.dim() == 1,
+                       "group_lens / group_offs must be 1D");
+    PRIMUS_TURBO_CHECK(group_offs.size(0) == group_lens.size(0) + 1,
+                       "group_offs.size(0) must equal group_lens.size(0) + 1");
+    PRIMUS_TURBO_CHECK(group_lens.size(0) >= 1, "must have at least one group");
+    PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat8_e4m3fn || dest_dtype == at::kFloat8_e5m2,
+                       "Output must be Float8_e4m3fn or Float8_e5m2");
+    PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1");
+    PRIMUS_TURBO_CHECK(padding_align_size == MXFP8_K_DIM_PADDING_ALIGN_SIZE,
+                       "padding_align_size must be ", MXFP8_K_DIM_PADDING_ALIGN_SIZE,
+                       " for MXFP8. But got padding_align_size=", padding_align_size);
+
+    const QuantizeMode mode       = (axis == 0) ? QuantizeMode::COLWISE : QuantizeMode::ROWWISE;
+    const bool         is_rowwise = (mode == QuantizeMode::ROWWISE);
+
+    constexpr int64_t ROW_ALIGN = MXFP8_GROUP_M_PADDING_ALIGN_SIZE; // = 32
+    constexpr int64_t COL_ALIGN = MXFP8_K_DIM_PADDING_ALIGN_SIZE;   // = 128
+
+    const int64_t G       = group_lens.size(0);
+    const int64_t total_M = input.size(0);
+    const int64_t N       = input.size(1);
+
+    const int64_t M_align_out = is_rowwise ? ROW_ALIGN : COL_ALIGN;
+    const int64_t M_pad_out   = cdiv(total_M + G * M_align_out, M_align_out) * M_align_out;
+    const int64_t N_pad       = cdiv(N, COL_ALIGN) * COL_ALIGN;
+
+    PRIMUS_TURBO_CHECK(N % MXFP8_BLOCK_SIZE == 0, "N must be divisible by ", MXFP8_BLOCK_SIZE);
+
+    if (shuffle_out) {
+        if (is_rowwise) {
+            PRIMUS_TURBO_CHECK(M_pad_out % MXFP8_SHUFFLE_BN == 0, "M_pad must be divisible by ",
+                               MXFP8_SHUFFLE_BN,
+                               " for shuffled rowwise FP8. But got M_pad=", M_pad_out);
+        } else {
+            PRIMUS_TURBO_CHECK(N % MXFP8_SHUFFLE_BN == 0, "N must be divisible by ",
+                               MXFP8_SHUFFLE_BN, " for shuffled colwise FP8. But got N=", N);
+        }
+    }
+
+    auto device = input.device();
+    auto stream = at::cuda::getCurrentCUDAStream();
+
+    auto group_lens_padded = at::empty_like(group_lens);
+    auto group_offs_padded = at::empty({G + 1}, group_offs.options());
+    primus_turbo::compute_padded_layout_gpu(
+        group_lens.data_ptr<int64_t>(), group_lens_padded.data_ptr<int64_t>(),
+        group_offs_padded.data_ptr<int64_t>(), static_cast<int>(G), M_align_out, stream);
+
+    int64_t scale_outer = is_rowwise ? M_pad_out : N;
+    int64_t scale_N =
+        is_rowwise ? cdiv(N_pad, MXFP8_BLOCK_SIZE) : cdiv(M_pad_out, MXFP8_BLOCK_SIZE);
+    int64_t scale_M_pad = cdiv(scale_outer, 256) * 256;
+    int64_t scale_N_pad = cdiv(scale_N, 8) * 8;
+
+    int64_t    scale_stride = 1;
+    at::Tensor scale_tensor;
+    if (shuffle_scale) {
+        scale_tensor = at::full({scale_M_pad, scale_N_pad}, /*scale pad=*/0,
+                                at::TensorOptions().dtype(at::kByte).device(device));
+        scale_stride = scale_tensor.stride(0);
+    } else {
+        scale_tensor =
+            at::empty({scale_outer, scale_N}, at::TensorOptions().dtype(at::kByte).device(device));
+        scale_stride = scale_N;
+    }
+
+    int64_t    output_rows = is_rowwise ? M_pad_out : N;
+    int64_t    output_cols = is_rowwise ? N_pad : M_pad_out;
+    at::Tensor output =
+        at::empty({output_rows, output_cols}, at::TensorOptions().dtype(at::kByte).device(device));
+
+    TORCH_TYPE_SWITCH_FP16_BF16(
+        input.scalar_type(), IType, {TORCH_TYPE_SWITCH_FP8(dest_dtype, OType, {
+            grouped_quantize_mxfp8_impl<IType, OType>(
+                reinterpret_cast<IType *>(input.data_ptr()),
+                reinterpret_cast<OType *>(output.data_ptr()), scale_tensor.data_ptr<uint8_t>(),
+                group_offs.data_ptr<int64_t>(), group_offs_padded.data_ptr<int64_t>(), mode,
+                static_cast<int>(G), static_cast<int>(total_M), static_cast<int>(N),
+                static_cast<int>(N_pad), scale_stride, static_cast<int>(scale_N),
+                static_cast<int>(scale_M_pad), static_cast<int>(scale_N_pad),
+                ScalingRecipe(use_2d_block, false, false, shuffle_scale, shuffle_out), stream);
+        })});
+
+    return {output.view(dest_dtype), scale_tensor.view(at::kFloat8_e8m0fnu), group_lens_padded,
+            group_offs_padded};
 }
 
 std::vector<at::Tensor>
@@ -940,7 +1144,7 @@ grouped_quantize_mxfp8_dual(const at::Tensor input, const at::Tensor group_lens,
                 colwise_scale.data_ptr<uint8_t>(), group_offs.data_ptr<int64_t>(),
                 group_offs_padded_colwise.data_ptr<int64_t>(),
                 group_offs_padded_rowwise.data_ptr<int64_t>(), static_cast<int>(G),
-                static_cast<int>(M_pad_col), static_cast<int>(N), static_cast<int>(N_pad),
+                static_cast<int>(total_M), static_cast<int>(N), static_cast<int>(N_pad),
                 rowwise_scale_stride, colwise_scale_stride, rowwise_scale_N, rowwise_scale_M_pad,
                 rowwise_scale_N_pad, N, colwise_scale_N, colwise_scale_M_pad, colwise_scale_N_pad,
                 ScalingRecipe(rowwise_use_2d_block, false, false, shuffle_rowwise_scale,
@@ -1045,9 +1249,9 @@ grouped_quantize_mxfp4_dual(const at::Tensor input, const at::Tensor group_lens,
             stream);
     });
 
-    return {rowwise_output.view(dest_dtype),  rowwise_scale.view(at::kFloat8_e8m0fnu),
-            colwise_output.view(dest_dtype),  colwise_scale.view(at::kFloat8_e8m0fnu),
-            group_lens_padded_colwise,        group_offs_padded_colwise};
+    return {rowwise_output.view(dest_dtype), rowwise_scale.view(at::kFloat8_e8m0fnu),
+            colwise_output.view(dest_dtype), colwise_scale.view(at::kFloat8_e8m0fnu),
+            group_lens_padded_colwise,       group_offs_padded_colwise};
 }
 
 // Fused single-pass row + segment-padded col blockwise FP8 quant for grouped GEMM.

--- a/csrc/pytorch/quantization/quantization_meta.cpp
+++ b/csrc/pytorch/quantization/quantization_meta.cpp
@@ -48,14 +48,37 @@ at::Tensor dequantize_fp8_rowwise_meta(const at::Tensor input, const at::Tensor 
 at::Tensor dequantize_mxfp8_meta(const at::Tensor input, const at::Tensor scale_inv,
                                  const int64_t axis, const int64_t block_size,
                                  const at::ScalarType dest_dtype) {
-    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
-    PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1");
-    const int64_t num_rows   = input.size(0);
-    const int64_t row_length = input.size(1);
-    at::Tensor    output =
-        (axis == 1) ? at::empty({num_rows, row_length}, at::dtype(dest_dtype).device(at::kMeta))
-                       : at::empty({row_length, num_rows}, at::dtype(dest_dtype).device(at::kMeta));
-    return output;
+    PRIMUS_TURBO_CHECK(input.dim() == 2 || input.dim() == 3, "Input must be 2D or 3D");
+    PRIMUS_TURBO_CHECK(scale_inv.dim() == input.dim(), "scale_inv rank must match input");
+
+    const bool is_batched = (input.dim() == 3);
+    bool       use_rowwise;
+    int64_t    num_rows;
+    int64_t    row_length;
+    if (input.dim() == 2) {
+        PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1 for 2D input");
+        use_rowwise = (axis == 1);
+        num_rows    = input.size(0);
+        row_length  = input.size(1);
+    } else {
+        PRIMUS_TURBO_CHECK(axis == 1 || axis == 2, "Axis must be 1 or 2 for 3D input");
+        use_rowwise = (axis == 2);
+        num_rows    = input.size(0) * input.size(1);
+        row_length  = input.size(2);
+    }
+
+    at::Tensor output_2d =
+        use_rowwise ? at::empty({num_rows, row_length}, at::dtype(dest_dtype).device(at::kMeta))
+                    : at::empty({row_length, num_rows}, at::dtype(dest_dtype).device(at::kMeta));
+
+    if (is_batched) {
+        if (use_rowwise) {
+            return output_2d.reshape({input.size(0), input.size(1), row_length});
+        }
+        return output_2d.reshape({row_length, input.size(0), input.size(1)}).permute({1, 2, 0});
+    }
+
+    return output_2d;
 }
 
 at::Tensor dequantize_mxfp4_meta(const at::Tensor input, const at::Tensor scale_inv,
@@ -70,6 +93,27 @@ at::Tensor dequantize_mxfp4_meta(const at::Tensor input, const at::Tensor scale_
         (axis == 1) ? at::empty({num_rows, row_length}, at::dtype(dest_dtype).device(at::kMeta))
                        : at::empty({row_length, num_rows}, at::dtype(dest_dtype).device(at::kMeta));
     return output;
+}
+
+at::Tensor grouped_dequantize_mxfp8_meta(const at::Tensor input, const at::Tensor scale_inv,
+                                         const at::Tensor group_offs,
+                                         const at::Tensor group_offs_padded, const int64_t axis,
+                                         const int64_t block_size, const at::ScalarType dest_dtype,
+                                         c10::optional<int64_t> total_M) {
+    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
+    PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1");
+    PRIMUS_TURBO_CHECK(group_offs_padded.size(0) == group_offs.size(0),
+                       "group_offs_padded.size(0) must equal group_offs.size(0)");
+    PRIMUS_TURBO_CHECK(group_offs.size(0) >= 2,
+                       "group_offs must have length G+1 (at least one group)");
+
+    at::Tensor padded_output =
+        dequantize_mxfp8_meta(input, scale_inv, axis, block_size, dest_dtype);
+    const int64_t G = group_offs.size(0) - 1;
+    const int64_t total_M_val =
+        total_M.has_value() ? total_M.value() : group_offs.index({G}).item<int64_t>();
+    const int64_t n_cols = padded_output.size(1);
+    return at::empty({total_M_val, n_cols}, at::dtype(dest_dtype).device(at::kMeta));
 }
 
 std::vector<at::Tensor> quantize_mxfp4_dual_meta(
@@ -324,6 +368,73 @@ quantize_mxfp8_dual_meta(const at::Tensor input, const at::ScalarType dest_dtype
             colwise_output.view(dest_dtype), colwise_scale.view(at::kFloat8_e8m0fnu)};
 }
 
+std::vector<at::Tensor> grouped_quantize_mxfp8_meta(
+    const at::Tensor input, const at::Tensor group_lens, const at::Tensor group_offs,
+    const at::ScalarType dest_dtype, const int64_t axis, const int64_t padding_align_size,
+    const bool use_2d_block, const bool shuffle_scale, const bool shuffle_out) {
+    using namespace primus_turbo::detail;
+    auto cdiv = [](int64_t a, int64_t b) -> int64_t { return (a + b - 1) / b; };
+
+    PRIMUS_TURBO_CHECK(input.scalar_type() == at::kBFloat16 || input.scalar_type() == at::kHalf,
+                       "Input must be BFloat16 or Half");
+    PRIMUS_TURBO_CHECK(input.dim() == 2, "Input must be 2D");
+    PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat8_e4m3fn || dest_dtype == at::kFloat8_e5m2,
+                       "Output must be Float8_e4m3fn or Float8_e5m2");
+    PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1");
+    PRIMUS_TURBO_CHECK(padding_align_size == MXFP8_K_DIM_PADDING_ALIGN_SIZE,
+                       "padding_align_size must be ", MXFP8_K_DIM_PADDING_ALIGN_SIZE,
+                       " for MXFP8. But got padding_align_size=", padding_align_size);
+
+    const bool is_rowwise = (axis != 0);
+
+    constexpr int64_t ROW_ALIGN = MXFP8_GROUP_M_PADDING_ALIGN_SIZE; // = 32
+    constexpr int64_t COL_ALIGN = MXFP8_K_DIM_PADDING_ALIGN_SIZE;   // = 128
+
+    const int64_t G       = group_lens.size(0);
+    const int64_t total_M = input.size(0);
+    const int64_t N       = input.size(1);
+    const int64_t M_align = is_rowwise ? ROW_ALIGN : COL_ALIGN;
+    const int64_t M_pad   = cdiv(total_M + G * M_align, M_align) * M_align;
+    const int64_t N_pad   = cdiv(N, COL_ALIGN) * COL_ALIGN;
+
+    PRIMUS_TURBO_CHECK(N % MXFP8_BLOCK_SIZE == 0, "N must be divisible by ", MXFP8_BLOCK_SIZE);
+
+    if (shuffle_out) {
+        if (is_rowwise) {
+            PRIMUS_TURBO_CHECK(M_pad % MXFP8_SHUFFLE_BN == 0, "M_pad must be divisible by ",
+                               MXFP8_SHUFFLE_BN, " for shuffled rowwise FP8");
+        } else {
+            PRIMUS_TURBO_CHECK(N % MXFP8_SHUFFLE_BN == 0, "N must be divisible by ",
+                               MXFP8_SHUFFLE_BN, " for shuffled colwise FP8");
+        }
+    }
+
+    int64_t scale_outer = is_rowwise ? M_pad : N;
+    int64_t scale_N = is_rowwise ? cdiv(N_pad, MXFP8_BLOCK_SIZE) : cdiv(M_pad, MXFP8_BLOCK_SIZE);
+    int64_t scale_M_pad = cdiv(scale_outer, 256) * 256;
+    int64_t scale_N_pad = cdiv(scale_N, 8) * 8;
+
+    at::Tensor scale_tensor;
+    if (shuffle_scale) {
+        scale_tensor = at::empty({scale_M_pad, scale_N_pad},
+                                 at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+    } else {
+        scale_tensor = at::empty({scale_outer, scale_N},
+                                 at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+    }
+
+    int64_t    output_rows = is_rowwise ? M_pad : N;
+    int64_t    output_cols = is_rowwise ? N_pad : M_pad;
+    at::Tensor output      = at::empty({output_rows, output_cols},
+                                       at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+
+    auto group_lens_padded = at::empty_like(group_lens, group_lens.options().device(at::kMeta));
+    auto group_offs_padded = at::empty({G + 1}, group_offs.options().device(at::kMeta));
+
+    return {output.view(dest_dtype), scale_tensor.view(at::kFloat8_e8m0fnu), group_lens_padded,
+            group_offs_padded};
+}
+
 std::vector<at::Tensor>
 grouped_quantize_mxfp8_dual_meta(const at::Tensor input, const at::Tensor group_lens,
                                  const at::Tensor group_offs, const at::ScalarType dest_dtype,
@@ -394,11 +505,12 @@ grouped_quantize_mxfp8_dual_meta(const at::Tensor input, const at::Tensor group_
             group_lens_padded_colwise,       group_offs_padded_colwise};
 }
 
-std::vector<at::Tensor> grouped_quantize_mxfp4_dual_meta(
-    const at::Tensor input, const at::Tensor group_lens, const at::Tensor group_offs,
-    const at::ScalarType dest_dtype, const bool rowwise_use_2d_block, const bool rowwise_use_sr,
-    const bool rowwise_use_rht, const bool colwise_use_2d_block, const bool colwise_use_sr,
-    const bool colwise_use_rht) {
+std::vector<at::Tensor>
+grouped_quantize_mxfp4_dual_meta(const at::Tensor input, const at::Tensor group_lens,
+                                 const at::Tensor group_offs, const at::ScalarType dest_dtype,
+                                 const bool rowwise_use_2d_block, const bool rowwise_use_sr,
+                                 const bool rowwise_use_rht, const bool colwise_use_2d_block,
+                                 const bool colwise_use_sr, const bool colwise_use_rht) {
     using namespace primus_turbo::detail;
     auto cdiv = [](int64_t a, int64_t b) -> int64_t { return (a + b - 1) / b; };
 
@@ -422,8 +534,8 @@ std::vector<at::Tensor> grouped_quantize_mxfp4_dual_meta(
         at::empty({total_M, N_pad / 2}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
 
     int64_t    colwise_scale_N = cdiv(M_pad_col, MXFP4_BLOCK_SIZE);
-    at::Tensor colwise_scale   = at::empty({N, colwise_scale_N},
-                                           at::TensorOptions().dtype(at::kByte).device(at::kMeta));
+    at::Tensor colwise_scale =
+        at::empty({N, colwise_scale_N}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
     at::Tensor colwise_output =
         at::empty({N, M_pad_col / 2}, at::TensorOptions().dtype(at::kByte).device(at::kMeta));
 
@@ -431,9 +543,12 @@ std::vector<at::Tensor> grouped_quantize_mxfp4_dual_meta(
         at::empty_like(group_lens, group_lens.options().device(at::kMeta));
     auto group_offs_padded_colwise = at::empty({G + 1}, group_offs.options().device(at::kMeta));
 
-    return {rowwise_output.view(at::kFloat4_e2m1fn_x2), rowwise_scale.view(at::kFloat8_e8m0fnu),
-            colwise_output.view(at::kFloat4_e2m1fn_x2), colwise_scale.view(at::kFloat8_e8m0fnu),
-            group_lens_padded_colwise,                  group_offs_padded_colwise};
+    return {rowwise_output.view(at::kFloat4_e2m1fn_x2),
+            rowwise_scale.view(at::kFloat8_e8m0fnu),
+            colwise_output.view(at::kFloat4_e2m1fn_x2),
+            colwise_scale.view(at::kFloat8_e8m0fnu),
+            group_lens_padded_colwise,
+            group_offs_padded_colwise};
 }
 
 std::vector<at::Tensor> quantize_mxfp8_meta(const at::Tensor input, const at::ScalarType dest_dtype,
@@ -448,7 +563,6 @@ std::vector<at::Tensor> quantize_mxfp8_meta(const at::Tensor input, const at::Sc
                        "Input must be BFloat16 or Half");
     PRIMUS_TURBO_CHECK(dest_dtype == at::kFloat8_e4m3fn || dest_dtype == at::kFloat8_e5m2,
                        "Output must be Float8_e4m3fn or Float8_e5m2");
-    PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1");
     PRIMUS_TURBO_CHECK(input.is_contiguous(), "Input must be contiguous");
     // Guard the public op argument against zero/negative values (would otherwise
     // divide-by-zero in cdiv below) and lock it to the expected MXFP8 constant.
@@ -456,18 +570,20 @@ std::vector<at::Tensor> quantize_mxfp8_meta(const at::Tensor input, const at::Sc
                        "padding_align_size must be ", MXFP8_K_DIM_PADDING_ALIGN_SIZE,
                        " for MXFP8. But got padding_align_size=", padding_align_size);
 
-    // Mirror the CUDA impl: ``axis`` is locked to {0, 1}. 2D maps axis==0 ->
-    // COLWISE / axis==1 -> ROWWISE; 3D maps axis==1 -> COLWISE, otherwise
-    // ROWWISE, with a leading group dim ``G`` and 3D views on the output.
+    // Mirror the CUDA impl: 2D uses axis in {0, 1}; 3D uses axis in {1, 2}.
+    // 2D maps axis==0 -> COLWISE / axis==1 -> ROWWISE; 3D maps axis==1 ->
+    // COLWISE / axis==2 -> ROWWISE, with a leading group dim ``G``.
     bool    is_rowwise;
     int64_t G, M, N;
     if (input.dim() == 2) {
+        PRIMUS_TURBO_CHECK(axis == 0 || axis == 1, "Axis must be 0 or 1 for 2D input");
         is_rowwise = (axis != 0); // axis==0 -> COLWISE, axis==1 -> ROWWISE
         G          = 1;
         M          = input.size(0);
         N          = input.size(1);
     } else if (input.dim() == 3) {
-        is_rowwise = (axis != 1); // axis==1 -> COLWISE, otherwise ROWWISE
+        PRIMUS_TURBO_CHECK(axis == 1 || axis == 2, "Axis must be 1 or 2 for 3D input");
+        is_rowwise = (axis != 1); // axis==1 -> COLWISE, axis==2 -> ROWWISE
         G          = input.size(0);
         M          = input.size(1);
         N          = input.size(2);

--- a/primus_turbo/pytorch/core/quantized_tensor.py
+++ b/primus_turbo/pytorch/core/quantized_tensor.py
@@ -32,7 +32,11 @@ _SUPPORTED_QUANTIZED_GRANS = [
     ScalingGranularity.TENSORWISE,
     ScalingGranularity.MX_BLOCKWISE,
 ]
-_SUPPORTED_GROUPED_QUANTIZED_GRANS = [ScalingGranularity.ROWWISE, ScalingGranularity.TENSORWISE]
+_SUPPORTED_GROUPED_QUANTIZED_GRANS = [
+    ScalingGranularity.ROWWISE,
+    ScalingGranularity.TENSORWISE,
+    ScalingGranularity.MX_BLOCKWISE,
+]
 
 
 def _pad_inner_dim(shape, align):
@@ -151,6 +155,8 @@ class QuantizedTensor(torch.Tensor):
         orig_dtype: torch.dtype,
         dest_dtype: torch.dtype,
         granularity: ScalingGranularity,
+        orig_group_lens: Optional[torch.Tensor] = None,
+        orig_group_offs: Optional[torch.Tensor] = None,
         group_lens: Optional[torch.Tensor] = None,
         group_offs: Optional[torch.Tensor] = None,
         is_grouped_tensor: bool = False,
@@ -162,20 +168,6 @@ class QuantizedTensor(torch.Tensor):
         assert dest_dtype in _SUPPORTED_QUANTIZED_DTYPES, "Unsupported quantized dtype"
         assert data.is_contiguous(), "data must be contiguous"
         assert scale_inv.is_contiguous(), "scale_inv must be contiguous"
-
-        if is_grouped_tensor:
-            assert group_lens is not None, "group_lens must be provided for grouped tensors"
-            assert group_lens.is_cuda, "group_lens must be on CUDA"
-
-            # Materialise ``group_offs`` from ``group_lens`` only if it was not
-            # supplied (e.g. by ``__tensor_unflatten__`` / ``_make_like`` which
-            # already carry a valid cached offsets tensor).
-            if group_offs is None:
-                from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
-                    group_offs_from_lens,
-                )
-
-                group_offs = group_offs_from_lens(group_lens)
 
         self = torch.Tensor._make_wrapper_subclass(
             cls,
@@ -194,6 +186,8 @@ class QuantizedTensor(torch.Tensor):
 
         self._group_lens = group_lens
         self._group_offs = group_offs
+        self._orig_group_lens = orig_group_lens
+        self._orig_group_offs = orig_group_offs
         self._is_grouped_tensor = is_grouped_tensor
         self._quantized_axis = quantized_axis
 
@@ -226,7 +220,11 @@ class QuantizedTensor(torch.Tensor):
         assert hp_tensor.ndim in (2, 3), f"data must be a 2D or 3D tensor, got {hp_tensor.ndim}D"
         assert dest_dtype in _SUPPORTED_QUANTIZED_DTYPES, "Unsupported quantized dtype"
 
-        is_grouped_tensor = group_lens is not None
+        # NOTE: we treat grouped tensors as non-grouped tensors when granularity is TENSORWISE or ROWWISE.
+        is_grouped_tensor = group_lens is not None and granularity not in [
+            ScalingGranularity.TENSORWISE,
+            ScalingGranularity.ROWWISE,
+        ]
         if is_grouped_tensor:
             assert granularity in _SUPPORTED_GROUPED_QUANTIZED_GRANS, (
                 f"Unsupported grouped granularity {granularity}"
@@ -237,6 +235,18 @@ class QuantizedTensor(torch.Tensor):
             assert dest_dtype in _SUPPORTED_QUANTIZED_DTYPES and dest_dtype != float4_e2m1fn_x2, (
                 "Unsupported quantized dtype (FP4 not supported for grouped activations)"
             )
+            if granularity == ScalingGranularity.MX_BLOCKWISE:
+                assert dest_dtype in [
+                    float8_e4m3,
+                    float8_e5m2,
+                ], "Unsupported quantized dtype for grouped MX_BLOCKWISE"
+
+                supported, reason = check_mxfp8_support()
+                assert block_size == MXFP8_BLOCK_SIZE, (
+                    "block_size must be MXFP8_BLOCK_SIZE for grouped MX_BLOCKWISE"
+                )
+                assert supported, reason
+                assert scaling_recipe is not None, "scaling_recipe must be provided for grouped MX_BLOCKWISE"
         else:
             assert granularity in _SUPPORTED_QUANTIZED_GRANS, f"Unsupported granularity {granularity}"
 
@@ -265,14 +275,37 @@ class QuantizedTensor(torch.Tensor):
         if granularity != ScalingGranularity.TENSORWISE:
             assert axis is not None, "axis must be provided for non-TENSORWISE granularity"
 
-        data, scale_inv = cls._quantize(
-            hp_tensor,
-            dest_dtype,
-            granularity,
-            block_size=block_size,
-            axis=axis,
-            scaling_recipe=scaling_recipe,
-        )
+        padded_group_lens = padded_group_offs = None
+        orig_group_lens = orig_group_offs = None
+        if is_grouped_tensor:
+            assert group_lens is not None, "group_lens must be provided for grouped tensors"
+            assert group_lens.is_cuda, "group_lens must be on CUDA"
+
+            from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
+                group_offs_from_lens,
+            )
+
+            orig_group_lens = group_lens
+            orig_group_offs = group_offs_from_lens(group_lens)
+            data, scale_inv, padded_group_lens, padded_group_offs = cls._grouped_quantize(
+                hp_tensor,
+                dest_dtype,
+                granularity,
+                group_lens=orig_group_lens,
+                group_offs=orig_group_offs,
+                block_size=block_size,
+                axis=axis,
+                scaling_recipe=scaling_recipe,
+            )
+        else:
+            data, scale_inv = cls._quantize(
+                hp_tensor,
+                dest_dtype,
+                granularity,
+                block_size=block_size,
+                axis=axis,
+                scaling_recipe=scaling_recipe,
+            )
 
         return cls(
             data,
@@ -287,8 +320,10 @@ class QuantizedTensor(torch.Tensor):
             scaling_recipe=scaling_recipe,
             requires_grad=hp_tensor.requires_grad,
             quantized_axis=axis,
-            # grouped tensor related
-            group_lens=group_lens,
+            orig_group_lens=orig_group_lens,
+            orig_group_offs=orig_group_offs,
+            group_lens=padded_group_lens,
+            group_offs=padded_group_offs,
             is_grouped_tensor=is_grouped_tensor,
         )
 
@@ -335,6 +370,38 @@ class QuantizedTensor(torch.Tensor):
             )
             return data_, scale_inv
 
+    @classmethod
+    @torch.no_grad()
+    def _grouped_quantize(
+        cls,
+        data: torch.Tensor,
+        dest_dtype: torch.dtype,
+        granularity: ScalingGranularity,
+        group_lens: torch.Tensor,
+        group_offs: torch.Tensor,
+        block_size: Optional[int] = None,
+        axis: Optional[int] = None,
+        scaling_recipe: Optional[ScalingRecipe] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        from primus_turbo.pytorch.ops.quantization import grouped_quantize_fp8
+
+        axis = _normalize_axis(axis, data.ndim)
+
+        if dest_dtype in [float8_e4m3, float8_e5m2]:
+            data_, scale_inv, group_lens_padded, group_offs_padded = grouped_quantize_fp8(
+                data,
+                dest_dtype,
+                granularity,
+                group_lens=group_lens,
+                group_offs=group_offs,
+                block_size=block_size,
+                axis=axis,
+                scaling_recipe=scaling_recipe,
+            )
+            return data_, scale_inv, group_lens_padded, group_offs_padded
+
+        raise ValueError(f"Unsupported dtype {dest_dtype} for grouped quantization")
+
     # ------------------------------------------------------------------
     # Public properties
     # ------------------------------------------------------------------
@@ -353,12 +420,14 @@ class QuantizedTensor(torch.Tensor):
 
     @property
     def group_lens(self) -> torch.Tensor:
+        """Padded per-group row counts used by the quantized layout."""
         assert self._is_grouped_tensor, "This is not a grouped tensor."
 
         return self._group_lens
 
     @property
     def group_offs(self) -> torch.Tensor:
+        """Padded prefix-sum offsets into the quantized M axis."""
         assert self._is_grouped_tensor, "This is not a grouped tensor."
 
         return self._group_offs
@@ -390,12 +459,37 @@ class QuantizedTensor(torch.Tensor):
     @torch.no_grad()
     def dequantize(self) -> torch.Tensor:
         """Dequantize back to the original high-precision dtype."""
-        from primus_turbo.pytorch.ops.quantization import dequantize_fp4, dequantize_fp8
+        from primus_turbo.pytorch.ops.quantization import (
+            dequantize_fp4,
+            dequantize_fp8,
+            grouped_dequantize_fp8,
+        )
 
         axis = _normalize_axis(self._quantized_axis, self._data.ndim)
 
-        # TODO(ruibi): add support for grouped dequantization
-        if self._dest_dtype in [float8_e4m3, float8_e5m2]:
+        if self._is_grouped_tensor:
+            if self._dest_dtype in [float8_e4m3, float8_e5m2]:
+                assert self._granularity == ScalingGranularity.MX_BLOCKWISE, (
+                    "Grouped dequantization is only supported for MX_BLOCKWISE FP8"
+                )
+                assert self._group_lens is not None, "group_lens is missing"
+                assert self._group_offs is not None, "group_offs is missing"
+                assert self._orig_group_offs is not None, "orig_group_offs is missing"
+                out = grouped_dequantize_fp8(
+                    self._data,
+                    self._orig_dtype,
+                    self._granularity,
+                    self._orig_group_offs,
+                    self._group_offs,
+                    block_size=self._block_size,
+                    axis=axis,
+                    scale_inv=self._scale_inv,
+                    scaling_recipe=self._scaling_recipe,
+                    total_M=self.shape[0],  # original shape
+                )
+            else:
+                raise ValueError(f"Grouped dequantization is not supported for dtype {self._dest_dtype}")
+        elif self._dest_dtype in [float8_e4m3, float8_e5m2]:
             out = dequantize_fp8(
                 self._data,
                 self._orig_dtype,
@@ -433,6 +527,10 @@ class QuantizedTensor(torch.Tensor):
     # ------------------------------------------------------------------
     def __tensor_flatten__(self):
         tensors = {"_data": self._data, "_scale_inv": self._scale_inv}
+        if self._orig_group_lens is not None:
+            tensors["_orig_group_lens"] = self._orig_group_lens
+        if self._orig_group_offs is not None:
+            tensors["_orig_group_offs"] = self._orig_group_offs
         if self._group_lens is not None:
             tensors["_group_lens"] = self._group_lens
         if self._group_offs is not None:
@@ -462,6 +560,8 @@ class QuantizedTensor(torch.Tensor):
             granularity=metadata["_granularity"],
             block_size=metadata["_block_size"],
             scaling_recipe=metadata["_scaling_recipe"],
+            orig_group_lens=inner_tensors.get("_orig_group_lens"),
+            orig_group_offs=inner_tensors.get("_orig_group_offs"),
             group_lens=inner_tensors.get("_group_lens"),
             group_offs=inner_tensors.get("_group_offs"),
             is_grouped_tensor=metadata["_is_grouped_tensor"],
@@ -484,9 +584,9 @@ class QuantizedTensor(torch.Tensor):
         but using the supplied *data*, *scale_inv* and *shape*.  Used by
         view / reshape dispatch to avoid a dequantize round-trip.
 
-        Grouped metadata (``group_lens`` / ``group_offs`` / ``is_grouped_tensor``)
-        is propagated unchanged so packed-M views/reshapes retain their
-        grouped identity.
+        Grouped metadata (``orig_group_lens`` / ``orig_group_offs`` /
+        ``group_lens`` / ``group_offs`` / ``is_grouped_tensor``) is propagated
+        unchanged so packed-M views/reshapes retain their grouped identity.
         """
         return cls(
             data,
@@ -497,6 +597,8 @@ class QuantizedTensor(torch.Tensor):
             granularity=tensor._granularity,
             block_size=tensor._block_size,
             scaling_recipe=tensor._scaling_recipe,
+            orig_group_lens=tensor._orig_group_lens,
+            orig_group_offs=tensor._orig_group_offs,
             group_lens=tensor._group_lens,
             group_offs=tensor._group_offs,
             is_grouped_tensor=tensor._is_grouped_tensor,

--- a/primus_turbo/pytorch/core/quantized_tensor.py
+++ b/primus_turbo/pytorch/core/quantized_tensor.py
@@ -221,10 +221,7 @@ class QuantizedTensor(torch.Tensor):
         assert dest_dtype in _SUPPORTED_QUANTIZED_DTYPES, "Unsupported quantized dtype"
 
         # NOTE: we treat grouped tensors as non-grouped tensors when granularity is TENSORWISE or ROWWISE.
-        is_grouped_tensor = group_lens is not None and granularity not in [
-            ScalingGranularity.TENSORWISE,
-            ScalingGranularity.ROWWISE,
-        ]
+        is_grouped_tensor = group_lens is not None
         if is_grouped_tensor:
             assert granularity in _SUPPORTED_GROUPED_QUANTIZED_GRANS, (
                 f"Unsupported grouped granularity {granularity}"
@@ -285,18 +282,33 @@ class QuantizedTensor(torch.Tensor):
                 group_offs_from_lens,
             )
 
-            orig_group_lens = group_lens
-            orig_group_offs = group_offs_from_lens(group_lens)
-            data, scale_inv, padded_group_lens, padded_group_offs = cls._grouped_quantize(
-                hp_tensor,
-                dest_dtype,
-                granularity,
-                group_lens=orig_group_lens,
-                group_offs=orig_group_offs,
-                block_size=block_size,
-                axis=axis,
-                scaling_recipe=scaling_recipe,
-            )
+            if granularity in [
+                ScalingGranularity.TENSORWISE,
+                ScalingGranularity.ROWWISE,
+            ]:
+                # NOTE: we treat grouped tensors as non-grouped tensors when granularity is TENSORWISE or ROWWISE.
+                orig_group_lens = padded_group_lens = group_lens
+                orig_group_offs = padded_group_offs = group_offs_from_lens(group_lens)
+
+                data, scale_inv = cls._quantize(
+                    hp_tensor,
+                    dest_dtype,
+                    granularity,
+                    block_size=block_size,
+                    axis=axis,
+                    scaling_recipe=scaling_recipe,
+                )
+            else:
+                data, scale_inv, padded_group_lens, padded_group_offs = cls._grouped_quantize(
+                    hp_tensor,
+                    dest_dtype,
+                    granularity,
+                    group_lens=orig_group_lens,
+                    group_offs=orig_group_offs,
+                    block_size=block_size,
+                    axis=axis,
+                    scaling_recipe=scaling_recipe,
+                )
         else:
             data, scale_inv = cls._quantize(
                 hp_tensor,
@@ -457,39 +469,47 @@ class QuantizedTensor(torch.Tensor):
         return _normalize_axis(self._quantized_axis, self._data.ndim)
 
     @torch.no_grad()
-    def dequantize(self) -> torch.Tensor:
-        """Dequantize back to the original high-precision dtype."""
+    def _grouped_dequantize(self) -> torch.Tensor:
         from primus_turbo.pytorch.ops.quantization import (
-            dequantize_fp4,
-            dequantize_fp8,
             grouped_dequantize_fp8,
         )
 
         axis = _normalize_axis(self._quantized_axis, self._data.ndim)
 
-        if self._is_grouped_tensor:
-            if self._dest_dtype in [float8_e4m3, float8_e5m2]:
-                assert self._granularity == ScalingGranularity.MX_BLOCKWISE, (
-                    "Grouped dequantization is only supported for MX_BLOCKWISE FP8"
-                )
-                assert self._group_lens is not None, "group_lens is missing"
-                assert self._group_offs is not None, "group_offs is missing"
-                assert self._orig_group_offs is not None, "orig_group_offs is missing"
-                out = grouped_dequantize_fp8(
-                    self._data,
-                    self._orig_dtype,
-                    self._granularity,
-                    self._orig_group_offs,
-                    self._group_offs,
-                    block_size=self._block_size,
-                    axis=axis,
-                    scale_inv=self._scale_inv,
-                    scaling_recipe=self._scaling_recipe,
-                    total_M=self.shape[0],  # original shape
-                )
-            else:
-                raise ValueError(f"Grouped dequantization is not supported for dtype {self._dest_dtype}")
-        elif self._dest_dtype in [float8_e4m3, float8_e5m2]:
+        if self._dest_dtype in [float8_e4m3, float8_e5m2]:
+            assert self._granularity == ScalingGranularity.MX_BLOCKWISE, (
+                "Grouped dequantization is only supported for MX_BLOCKWISE FP8"
+            )
+            assert self._group_lens is not None, "group_lens is missing"
+            assert self._group_offs is not None, "group_offs is missing"
+            assert self._orig_group_offs is not None, "orig_group_offs is missing"
+            out = grouped_dequantize_fp8(
+                self._data,
+                self._orig_dtype,
+                self._granularity,
+                self._orig_group_offs,
+                self._group_offs,
+                block_size=self._block_size,
+                axis=axis,
+                scale_inv=self._scale_inv,
+                scaling_recipe=self._scaling_recipe,
+                total_M=self.shape[0],  # original shape
+            )
+        else:
+            raise ValueError(f"Grouped dequantization is not supported for dtype {self._dest_dtype}")
+
+        return out
+
+    @torch.no_grad()
+    def _dequantize(self) -> torch.Tensor:
+        from primus_turbo.pytorch.ops.quantization import (
+            dequantize_fp4,
+            dequantize_fp8,
+        )
+
+        axis = _normalize_axis(self._quantized_axis, self._data.ndim)
+
+        if self._dest_dtype in [float8_e4m3, float8_e5m2]:
             out = dequantize_fp8(
                 self._data,
                 self._orig_dtype,
@@ -511,6 +531,20 @@ class QuantizedTensor(torch.Tensor):
             )
         else:
             raise AssertionError("Unsupported dtype")
+
+        return out
+
+    def dequantize(self) -> torch.Tensor:
+        """Dequantize back to the original high-precision dtype."""
+
+        if self._is_grouped_tensor:
+            # NOTE: we treat grouped tensors as non-grouped tensors when granularity is TENSORWISE or ROWWISE.
+            if self._granularity in [ScalingGranularity.TENSORWISE, ScalingGranularity.ROWWISE]:
+                out = self._dequantize()
+            else:
+                out = self._grouped_dequantize()
+        else:
+            out = self._dequantize()
 
         # TODO(ruibin): fused unpad in dequantize kernel
         if out.ndim == 2:

--- a/primus_turbo/pytorch/core/quantized_tensor.py
+++ b/primus_turbo/pytorch/core/quantized_tensor.py
@@ -299,6 +299,9 @@ class QuantizedTensor(torch.Tensor):
                     scaling_recipe=scaling_recipe,
                 )
             else:
+                orig_group_lens = group_lens
+                orig_group_offs = group_offs_from_lens(group_lens)
+
                 data, scale_inv, padded_group_lens, padded_group_offs = cls._grouped_quantize(
                     hp_tensor,
                     dest_dtype,

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -419,7 +419,12 @@ def quantize_mxfp8_impl(
         scaling_recipe_for_trans = scaling_recipe
 
     if not with_trans:
-        assert axis in (0, 1), "The axis must be 0 or 1 when with_trans is False."
+        if x.ndim == 2:
+            assert axis in (0, 1), "The axis must be 0 or 1 when with_trans is False and x is 2D."
+        elif x.ndim == 3:
+            assert axis in (1, 2), "The axis must be 1 or 2 when with_trans is False and x is 3D."
+        else:
+            raise ValueError(f"The input tensor must be 2D or 3D but got {x.ndim}D.")
     else:
         assert axis is None, "The axis must be None when with_trans is True."
 
@@ -450,20 +455,25 @@ def quantize_mxfp8_impl(
 def grouped_quantize_mxfp8_impl(
     x: torch.Tensor,
     out_dtype: torch.dtype,
+    axis: Optional[int],
     block_size: int,
     group_lens: torch.Tensor,
     group_offs: torch.Tensor,
+    with_trans: bool = False,
     scaling_recipe: Optional[ScalingRecipe] = None,
     scaling_recipe_for_trans: Optional[ScalingRecipe] = None,
-) -> Tuple[
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
+) -> Union[
+    Tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ],
+    Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
 ]:
     """MXFP8 dual (rowwise + colwise) quantization fused with per-group M-axis
     zero-padding.
@@ -478,22 +488,37 @@ def grouped_quantize_mxfp8_impl(
     assert block_size == MXFP8_BLOCK_SIZE, f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
 
     scaling_recipe = ScalingRecipe() if scaling_recipe is None else scaling_recipe
-    scaling_recipe_for_trans = (
-        ScalingRecipe() if scaling_recipe_for_trans is None else scaling_recipe_for_trans
-    )
 
-    return torch.ops.primus_turbo_cpp_extension.grouped_quantize_mxfp8_dual(
-        x,
-        group_lens,
-        group_offs,
-        out_dtype,
-        scaling_recipe.use_2d_block,
-        scaling_recipe_for_trans.use_2d_block,
-        scaling_recipe.shuffle_scale,
-        scaling_recipe.shuffle_out,
-        scaling_recipe_for_trans.shuffle_scale,
-        scaling_recipe_for_trans.shuffle_out,
-    )
+    if with_trans:
+        scaling_recipe_for_trans = (
+            ScalingRecipe() if scaling_recipe_for_trans is None else scaling_recipe_for_trans
+        )
+
+        return torch.ops.primus_turbo_cpp_extension.grouped_quantize_mxfp8_dual(
+            x,
+            group_lens,
+            group_offs,
+            out_dtype,
+            scaling_recipe.use_2d_block,
+            scaling_recipe_for_trans.use_2d_block,
+            scaling_recipe.shuffle_scale,
+            scaling_recipe.shuffle_out,
+            scaling_recipe_for_trans.shuffle_scale,
+            scaling_recipe_for_trans.shuffle_out,
+        )
+    else:
+        assert axis in (0, 1), "The axis must be 0 or 1 when with_trans is False."
+        return torch.ops.primus_turbo_cpp_extension.grouped_quantize_mxfp8(
+            x,
+            group_lens,
+            group_offs,
+            out_dtype,
+            axis,
+            MXFP8_PADDING_ALIGN_SIZE,
+            scaling_recipe.use_2d_block,
+            scaling_recipe.shuffle_scale,
+            scaling_recipe.shuffle_out,
+        )
 
 
 def grouped_quantize_mxfp4_impl(
@@ -557,6 +582,37 @@ def dequantize_mxfp8_impl(
     x: torch.Tensor, out_dtype: torch.dtype, axis: int, block_size: int, scale_inv: torch.Tensor
 ) -> torch.Tensor:
     assert x.is_contiguous(), "The x tensor must be contiguous."
+    assert x.dim() in (2, 3), "The x must be a 2D or 3D tensor."
+    assert scale_inv.dim() == x.dim(), "The scale_inv rank must match x."
+    assert scale_inv.is_contiguous(), "The scale_inv tensor must be contiguous."
+    if x.dim() == 2:
+        assert axis in (0, 1), "The axis must be 0 or 1 for 2D input."
+    else:
+        assert axis in (1, 2), "The axis must be 1 or 2 for 3D input."
+    SUPPORTED_OUT_DTYPES = [torch.float16, torch.bfloat16, torch.float32]
+    assert out_dtype in SUPPORTED_OUT_DTYPES, (
+        f"The out dtype must be one of {SUPPORTED_OUT_DTYPES} but got {out_dtype}."
+    )
+
+    row_length = x.size(-1)
+    assert row_length % block_size == 0, (
+        "The last dimension of the x tensor must be divisible by the block size."
+    )
+
+    return torch.ops.primus_turbo_cpp_extension.dequantize_mxfp8(x, scale_inv, axis, block_size, out_dtype)
+
+
+def grouped_dequantize_mxfp8_impl(
+    x: torch.Tensor,
+    out_dtype: torch.dtype,
+    axis: int,
+    block_size: int,
+    scale_inv: torch.Tensor,
+    group_offs: torch.Tensor,
+    group_offs_padded: torch.Tensor,
+    total_M: Optional[int] = None,
+) -> torch.Tensor:
+    assert x.is_contiguous(), "The x tensor must be contiguous."
     assert x.dim() == 2, "The x must be 2D tensor."
     assert scale_inv.dim() == 2, "The scale_inv must be 2D tensor."
     assert scale_inv.is_contiguous(), "The scale_inv tensor must be contiguous."
@@ -571,7 +627,9 @@ def dequantize_mxfp8_impl(
         "The last dimension of the x tensor must be divisible by the block size."
     )
 
-    return torch.ops.primus_turbo_cpp_extension.dequantize_mxfp8(x, scale_inv, axis, block_size, out_dtype)
+    return torch.ops.primus_turbo_cpp_extension.grouped_dequantize_mxfp8(
+        x, scale_inv, group_offs, group_offs_padded, axis, block_size, out_dtype, total_M
+    )
 
 
 def quantize_mxfp4_impl(

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -647,7 +647,7 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
             a_fp8_col = quantized_a_t.qdata
             a_scale_col = quantized_a_t.scale_inv
 
-            group_offs_padded_rowwise = quantized_a.group_offs_padded_rowwise
+            group_offs_padded_rowwise = quantized_a.group_offs
 
         b_scaling_recipe = ScalingRecipe(use_2d_block=True)
         if not isinstance(b, QuantizedTensor):

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -13,6 +13,7 @@ from primus_turbo.pytorch.core.low_precision import (
     Format,
     ScalingGranularity,
     ScalingRecipe,
+    check_mxfp8_support,
     float8_e4m3,
     float8_e5m2,
 )
@@ -579,44 +580,108 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(ctx, a, b, group_lens, group_offs, trans_b, out_dtype, config, num_cu):
+    def forward(
+        ctx,
+        a: Union[torch.Tensor, QuantizedTensor],
+        b: Union[torch.Tensor, QuantizedTensor],
+        a_t: Optional[QuantizedTensor],
+        b_t: Optional[QuantizedTensor],
+        group_lens: torch.Tensor,  # [B,] int64
+        group_offs: torch.Tensor,  # [B + 1,] int64
+        trans_b: bool,
+        out_dtype: torch.dtype,
+        config: Float8QuantConfig,
+        num_cu: int | None,
+    ):
+        supported_mxfp8_backend, reason = check_mxfp8_support()
+        assert supported_mxfp8_backend, reason
+
         assert config.granularity == ScalingGranularity.MX_BLOCKWISE
         assert a.ndim == 2 and b.ndim == 3
-        assert out_dtype in [torch.float16, torch.bfloat16]
         assert trans_b, "MXFP8 grouped GEMM only supports trans_b=True (NT layout)."
 
         a_dtype = b_dtype = _get_fp8_dtype(config.format, True)
 
-        # A: fused grouped dual-quant + per-group M zero-pad (rowwise 32 / colwise
-        # 128), padded layouts computed on GPU (no D2H sync).
-        (
-            a_fp8_row,
-            a_scale_row,
-            a_fp8_col,
-            a_scale_col,
-            _,
-            group_offs_padded_rowwise,
-            _,
-            _,
-        ) = grouped_quantize_fp8_with_trans(
-            a,
-            a_dtype,
-            config.granularity,
-            group_lens,
-            group_offs,
-            block_size=config.block_size,
-            scaling_recipe=ScalingRecipe(),
-            scaling_recipe_for_trans=ScalingRecipe(),
-        )
-        # B: per-group dual-quant (rowwise (G,N,K) for fwd, colwise (G,K,N) for dgrad).
-        b_fp8_row, b_scale_row, b_fp8_col, b_scale_col = quantize_fp8_with_trans(
-            b,
-            b_dtype,
-            config.granularity,
-            block_size=config.block_size,
-            scaling_recipe=ScalingRecipe(use_2d_block=True),
-            scaling_recipe_for_trans=ScalingRecipe(use_2d_block=True),
-        )
+        a_scaling_recipe = ScalingRecipe()
+        if not isinstance(a, QuantizedTensor):
+            # NOTE: If a is not a QuantizedTensor use grouped_quantize_fp8_with_trans to avoid call dequantize.
+            (
+                a_fp8_row,
+                a_scale_row,
+                a_fp8_col,
+                a_scale_col,
+                _,
+                group_offs_padded_rowwise,
+                _,
+                _,
+            ) = grouped_quantize_fp8_with_trans(
+                a,
+                a_dtype,
+                config.granularity,
+                group_lens,
+                group_offs,
+                block_size=config.block_size,
+                scaling_recipe=ScalingRecipe(),
+                scaling_recipe_for_trans=ScalingRecipe(),
+            )
+        else:
+            quantized_a = a
+            check_quantized_tensor(quantized_a, config, axis=-1, scaling_recipe=a_scaling_recipe)
+
+            if a_t is None:
+                quantized_a_t = QuantizedTensor.quantize(
+                    quantized_a.dequantize(),
+                    quantized_a.real_dtype,
+                    config.granularity,
+                    axis=-2,
+                    block_size=config.block_size,
+                    scaling_recipe=a_scaling_recipe,
+                    group_lens=group_lens,
+                )
+            else:
+                assert isinstance(a_t, QuantizedTensor)
+                quantized_a_t = a_t
+
+            a_fp8_row = quantized_a.qdata
+            a_scale_row = quantized_a.scale_inv
+            a_fp8_col = quantized_a_t.qdata
+            a_scale_col = quantized_a_t.scale_inv
+
+            group_offs_padded_rowwise = quantized_a.group_offs_padded_rowwise
+
+        b_scaling_recipe = ScalingRecipe(use_2d_block=True)
+        if not isinstance(b, QuantizedTensor):
+            # NOTE: If b is not a QuantizedTensor use quantize_fp8_with_trans to avoid call dequantize.
+
+            b_fp8_row, b_scale_row, b_fp8_col, b_scale_col = quantize_fp8_with_trans(
+                b,
+                b_dtype,
+                config.granularity,
+                block_size=config.block_size,
+                scaling_recipe=ScalingRecipe(use_2d_block=True),
+                scaling_recipe_for_trans=ScalingRecipe(use_2d_block=True),
+            )
+        else:
+            quantized_b = b
+            check_quantized_tensor(quantized_b, config, axis=-1, scaling_recipe=b_scaling_recipe)
+
+            if b_t is None:
+                quantized_b_t = QuantizedTensor.quantize(
+                    quantized_b.dequantize(),
+                    quantized_b.real_dtype,
+                    config.granularity,
+                    axis=-2,
+                    block_size=config.block_size,
+                    scaling_recipe=b_scaling_recipe,
+                )
+            else:
+                assert isinstance(b_t, QuantizedTensor)
+                quantized_b_t = b_t
+
+            b_fp8_row = quantized_b.qdata
+            b_scale_row = quantized_b.scale_inv
+            b_fp8_col = quantized_b_t.qdata
+            b_scale_col = quantized_b_t.scale_inv
 
         total_m = int(a.size(0))
         # fwd: read rowwise-padded layout (group_offs_padded_rowwise); the output
@@ -639,7 +704,14 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
         )
         out = out[:total_m]
 
-        ctx.save_for_backward(a_fp8_col, a_scale_col, b_fp8_col, b_scale_col, group_lens, group_offs)
+        ctx.save_for_backward(
+            a_fp8_col,
+            a_scale_col,
+            b_fp8_col,
+            b_scale_col,
+            group_lens,
+            group_offs,
+        )
         ctx.config = config
         ctx.out_dtype = out_dtype
         ctx.num_cu = num_cu
@@ -647,7 +719,7 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
         return out
 
     @staticmethod
-    def backward(ctx, grad_out):
+    def backward(ctx, grad_out: torch.Tensor):
         grad_out = _ensure_contiguous_grad_out(grad_out)
         (a_fp8_col, a_scale_col, b_fp8_col, b_scale_col, group_lens, group_offs) = ctx.saved_tensors
         grad_out_dtype = _get_fp8_dtype(ctx.config.format, False)
@@ -707,7 +779,7 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
             default_backend=BackendType.TRITON.value,
         )
         # NT-only: wgrad already produces grad_b as (G, N, K) matching b.
-        return grad_a, grad_b, None, None, None, None, None, None
+        return grad_a, grad_b, None, None, None, None, None, None, None, None
 
 
 @torch._dynamo.disable(
@@ -804,6 +876,17 @@ def grouped_gemm_fp8(
         return FP8GroupedGemmBlockFunc.apply(a, b, group_lens, group_offs, trans_b, out_dtype, config, num_cu)
     elif config.granularity == ScalingGranularity.MX_BLOCKWISE:
         # MXFP8: raw tensors; quant + grouped GEMM via the Triton MX backend.
-        return FP8GroupedGemmMXFunc.apply(a, b, group_lens, group_offs, trans_b, out_dtype, config, num_cu)
+        return FP8GroupedGemmMXFunc.apply(
+            a_data,
+            b_data,
+            a_data_t,
+            b_data_t,
+            group_lens,
+            group_offs,
+            trans_b,
+            out_dtype,
+            config,
+            num_cu,
+        )
     else:
         raise ValueError(f"Unsupported FP8 ScalingGranularity: {config.granularity}")

--- a/primus_turbo/pytorch/ops/quantization.py
+++ b/primus_turbo/pytorch/ops/quantization.py
@@ -19,6 +19,7 @@ from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
     dequantize_fp8_tensorwise_impl,
     dequantize_mxfp4_impl,
     dequantize_mxfp8_impl,
+    grouped_dequantize_mxfp8_impl,
     grouped_quantize_mxfp8_impl,
     quant_fp8_blockwise_for_weight_impl,
     quant_fp8_blockwise_impl,
@@ -28,7 +29,17 @@ from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
     quantize_mxfp8_impl,
 )
 
-__all__ = ["quantize_fp8", "dequantize_fp8", "quantize_fp4", "dequantize_fp4"]
+__all__ = [
+    "quantize_fp8",
+    "quantize_fp8_with_trans",
+    "dequantize_fp8",
+    "quantize_fp4",
+    "quantize_fp4_with_trans",
+    "dequantize_fp4",
+    "grouped_quantize_fp8",
+    "grouped_quantize_fp8_with_trans",
+    "grouped_dequantize_fp8",
+]
 
 
 def quantize_fp8(
@@ -121,6 +132,44 @@ def quantize_fp8_with_trans(
         raise NotImplementedError(f"Unknown granularity {granularity}")
 
 
+def grouped_quantize_fp8(
+    x: torch.Tensor,
+    out_dtype: torch.dtype,
+    granularity: ScalingGranularity,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    *,
+    block_size: Optional[int] = None,
+    axis: Optional[int] = None,
+    scaling_recipe: Optional[ScalingRecipe] = None,
+) -> Tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    """
+    FP8 Grouped Quantize with trans
+    """
+    if granularity == ScalingGranularity.MX_BLOCKWISE:
+        assert block_size == MXFP8_BLOCK_SIZE, (
+            f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
+        )
+
+        return grouped_quantize_mxfp8_impl(
+            x,
+            out_dtype,
+            axis,
+            block_size,
+            group_lens,
+            group_offs,
+            False,
+            scaling_recipe,
+        )
+    else:
+        raise NotImplementedError(f"Unknown granularity {granularity}")
+
+
 def grouped_quantize_fp8_with_trans(
     x: torch.Tensor,
     out_dtype: torch.dtype,
@@ -152,9 +201,11 @@ def grouped_quantize_fp8_with_trans(
         return grouped_quantize_mxfp8_impl(
             x,
             out_dtype,
+            None,
             block_size,
             group_lens,
             group_offs,
+            True,
             scaling_recipe,
             scaling_recipe_for_trans,
         )
@@ -197,6 +248,33 @@ def dequantize_fp8(
         )
 
         return dequantize_mxfp8_impl(x, out_dtype, axis, block_size, scale_inv)
+    else:
+        raise NotImplementedError(f"Unknown granularity {granularity}")
+
+
+def grouped_dequantize_fp8(
+    x: torch.Tensor,
+    out_dtype: torch.dtype,
+    granularity: ScalingGranularity,
+    group_offs: torch.Tensor,
+    group_offs_padded: torch.Tensor,
+    *,
+    block_size: Optional[int] = None,
+    axis: Optional[int] = None,
+    scale_inv: torch.Tensor,
+    scaling_recipe: Optional[ScalingRecipe] = None,
+    total_M: Optional[int] = None,
+) -> torch.Tensor:
+    """
+    FP8 Grouped DeQuantize
+    """
+    if granularity == ScalingGranularity.MX_BLOCKWISE:
+        assert block_size == MXFP8_BLOCK_SIZE, (
+            f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
+        )
+        return grouped_dequantize_mxfp8_impl(
+            x, out_dtype, axis, block_size, scale_inv, group_offs, group_offs_padded, total_M
+        )
     else:
         raise NotImplementedError(f"Unknown granularity {granularity}")
 

--- a/tests/pytorch/core/test_quantized_tensor.py
+++ b/tests/pytorch/core/test_quantized_tensor.py
@@ -452,7 +452,7 @@ class TestGroupSpecific:
 
     @pytest.mark.parametrize("granularity,block_size,dest_dtype", _GROUPED_GRAN_CASES)
     def test_group_lens_and_offs(self, granularity, block_size, dest_dtype):
-        """Compact ``orig_group_lens`` / ``orig_group_offs`` are preserved;
+        """Compact ``_orig_group_lens`` / ``_orig_group_offs`` are preserved;
         padded ``group_lens`` / ``group_offs`` come from the quantize kernel.
         """
         x = torch.randn(M, N, dtype=torch.bfloat16, device=DEVICE)
@@ -465,8 +465,8 @@ class TestGroupSpecific:
             group_lens=group_lens,
         )
 
-        assert torch.equal(qt.orig_group_lens, group_lens)
-        assert torch.equal(qt.orig_group_offs, group_offs_from_lens(group_lens))
+        assert torch.equal(qt._orig_group_lens, group_lens)
+        assert torch.equal(qt._orig_group_offs, group_offs_from_lens(group_lens))
         assert qt._orig_group_offs is not None
         assert qt._group_lens is not None
         assert qt._group_offs is not None
@@ -478,8 +478,8 @@ class TestGroupSpecific:
         assert int(lens.sum().item()) == M
         x = torch.randn(M, N, dtype=torch.bfloat16, device=DEVICE)
         qt = _make_quantized_tensor(x, granularity=ScalingGranularity.ROWWISE, group_lens=lens)
-        assert torch.equal(qt.orig_group_lens, lens)
-        assert torch.equal(qt.orig_group_offs, group_offs_from_lens(lens))
+        assert torch.equal(qt._orig_group_lens, lens)
+        assert torch.equal(qt._orig_group_offs, group_offs_from_lens(lens))
 
 
 # ---------------------------------------------------------------------
@@ -553,8 +553,8 @@ class TestGroupedSerialization:
         assert torch.equal(qt2._data, qt._data)
         assert torch.equal(qt2._scale_inv, qt._scale_inv)
         # group metadata round-trips: lens preserved and offs preserved.
-        assert torch.equal(qt2.orig_group_lens, qt.orig_group_lens)
-        assert torch.equal(qt2.orig_group_offs, qt.orig_group_offs)
+        assert torch.equal(qt2._orig_group_lens, qt._orig_group_lens)
+        assert torch.equal(qt2._orig_group_offs, qt._orig_group_offs)
         assert torch.equal(qt2.group_lens, qt.group_lens)
         assert torch.equal(qt2.group_offs, qt.group_offs)
 
@@ -621,7 +621,7 @@ class TestGroupedViewFunc:
 
         viewed = qt.view(M, N)
 
-        assert viewed.orig_group_lens.data_ptr() == qt.orig_group_lens.data_ptr()
-        assert viewed.orig_group_offs.data_ptr() == qt.orig_group_offs.data_ptr()
+        assert viewed._orig_group_lens.data_ptr() == qt._orig_group_lens.data_ptr()
+        assert viewed._orig_group_offs.data_ptr() == qt._orig_group_offs.data_ptr()
         assert viewed.group_lens.data_ptr() == qt.group_lens.data_ptr()
         assert viewed.group_offs.data_ptr() == qt.group_offs.data_ptr()

--- a/tests/pytorch/core/test_quantized_tensor.py
+++ b/tests/pytorch/core/test_quantized_tensor.py
@@ -452,9 +452,8 @@ class TestGroupSpecific:
 
     @pytest.mark.parametrize("granularity,block_size,dest_dtype", _GROUPED_GRAN_CASES)
     def test_group_lens_and_offs(self, granularity, block_size, dest_dtype):
-        """``group_lens`` is preserved; ``group_offs`` is derived as a
-        cumulative-sum (with a leading 0).  In the new implementation the
-        offsets are eagerly materialised inside ``__new__``.
+        """Compact ``orig_group_lens`` / ``orig_group_offs`` are preserved;
+        padded ``group_lens`` / ``group_offs`` come from the quantize kernel.
         """
         x = torch.randn(M, N, dtype=torch.bfloat16, device=DEVICE)
         group_lens = _make_group_lens()
@@ -466,10 +465,10 @@ class TestGroupSpecific:
             group_lens=group_lens,
         )
 
-        assert torch.equal(qt.group_lens, group_lens)
-        # ``group_offs`` matches a fresh prefix-sum.
-        assert torch.equal(qt.group_offs, group_offs_from_lens(group_lens))
-        # And it is already materialised (no lazy fallback needed).
+        assert torch.equal(qt.orig_group_lens, group_lens)
+        assert torch.equal(qt.orig_group_offs, group_offs_from_lens(group_lens))
+        assert qt._orig_group_offs is not None
+        assert qt._group_lens is not None
         assert qt._group_offs is not None
 
     def test_uneven_group_lens(self):
@@ -479,8 +478,8 @@ class TestGroupSpecific:
         assert int(lens.sum().item()) == M
         x = torch.randn(M, N, dtype=torch.bfloat16, device=DEVICE)
         qt = _make_quantized_tensor(x, granularity=ScalingGranularity.ROWWISE, group_lens=lens)
-        assert torch.equal(qt.group_lens, lens)
-        assert torch.equal(qt.group_offs, group_offs_from_lens(lens))
+        assert torch.equal(qt.orig_group_lens, lens)
+        assert torch.equal(qt.orig_group_offs, group_offs_from_lens(lens))
 
 
 # ---------------------------------------------------------------------
@@ -528,9 +527,9 @@ class TestGroupedSerialization:
         # Inner-tensor keys: data/scale + grouped buffers.
         assert "_data" in keys
         assert "_scale_inv" in keys
+        assert "_orig_group_lens" in keys
+        assert "_orig_group_offs" in keys
         assert "_group_lens" in keys
-        # ``_group_offs`` is eagerly materialised in ``__new__`` and must
-        # therefore be part of the flatten payload.
         assert "_group_offs" in keys
 
         # Metadata: includes scaling_recipe and the grouped predicate.
@@ -554,6 +553,8 @@ class TestGroupedSerialization:
         assert torch.equal(qt2._data, qt._data)
         assert torch.equal(qt2._scale_inv, qt._scale_inv)
         # group metadata round-trips: lens preserved and offs preserved.
+        assert torch.equal(qt2.orig_group_lens, qt.orig_group_lens)
+        assert torch.equal(qt2.orig_group_offs, qt.orig_group_offs)
         assert torch.equal(qt2.group_lens, qt.group_lens)
         assert torch.equal(qt2.group_offs, qt.group_offs)
 
@@ -606,13 +607,8 @@ class TestGroupedViewFunc:
 
     @pytest.mark.parametrize("granularity,block_size,dest_dtype", _GROUPED_GRAN_CASES)
     def test_view_group_metadata_propagated(self, granularity, block_size, dest_dtype):
-        """``group_lens`` / ``group_offs`` flow through ``_make_like`` —
-        the viewed wrapper shares the same tensors as the source.
-
-        Since ``__new__`` now eagerly materialises ``_group_offs``, both the
-        source and the viewed wrapper already hold the same offsets tensor
-        and pointer identity is preserved through ``_make_like``.
-        """
+        """Grouped metadata flows through ``_make_like`` — the viewed wrapper
+        shares the same compact / padded tensors as the source."""
         x = torch.randn(M, N, dtype=torch.bfloat16, device=DEVICE)
         group_lens = _make_group_lens()
         qt = _make_quantized_tensor(
@@ -625,5 +621,7 @@ class TestGroupedViewFunc:
 
         viewed = qt.view(M, N)
 
+        assert viewed.orig_group_lens.data_ptr() == qt.orig_group_lens.data_ptr()
+        assert viewed.orig_group_offs.data_ptr() == qt.orig_group_offs.data_ptr()
         assert viewed.group_lens.data_ptr() == qt.group_lens.data_ptr()
         assert viewed.group_offs.data_ptr() == qt.group_offs.data_ptr()

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -10,10 +10,12 @@ import torch
 
 from primus_turbo.pytorch.core.backend import BackendType, GlobalBackendManager
 from primus_turbo.pytorch.core.low_precision import (
+    MXFP8_BLOCK_SIZE,
     Float8QuantConfig,
     Format,
     ScaleDtype,
     ScalingGranularity,
+    ScalingRecipe,
     check_mxfp8_support,
     float8_e4m3,
     float8_e5m2,
@@ -591,12 +593,11 @@ def _run_grouped_gemm_fp8_quantized_tensor_test(
     if _check_hit_int32_limit(B, M, N, K):
         pytest.skip("Shape hits int32 indexing limit (numel >= 2**31).")
 
-    # Grouped QuantizedTensor only supports TENSORWISE and ROWWISE.
     assert granularity in (
         ScalingGranularity.TENSORWISE,
         ScalingGranularity.ROWWISE,
         ScalingGranularity.MX_BLOCKWISE,
-    ), "Grouped QuantizedTensor only supports TENSORWISE and ROWWISE"
+    ), "Grouped QuantizedTensor only supports TENSORWISE, ROWWISE and MX_BLOCKWISE"
 
     GlobalBackendManager.set_grouped_gemm_backend(backend)
     GlobalBackendManager.set_auto_tune(auto_tune)
@@ -619,12 +620,30 @@ def _run_grouped_gemm_fp8_quantized_tensor_test(
     # Externally construct quantized tensors.
     fwd_dtype = _get_fp8_dtype(format, is_fwd=True)
 
-    qt_a = QuantizedTensor.quantize(a, fwd_dtype, granularity, group_lens=group_lens, axis=-1)
+    block_size = None
+    a_scaling_recipe = None
+    b_scaling_recipe = None
+    if granularity == ScalingGranularity.MX_BLOCKWISE:
+        block_size = MXFP8_BLOCK_SIZE
+        a_scaling_recipe = ScalingRecipe()
+        b_scaling_recipe = ScalingRecipe(use_2d_block=True)
+
+    qt_a = QuantizedTensor.quantize(
+        a,
+        fwd_dtype,
+        granularity,
+        scaling_recipe=a_scaling_recipe,
+        block_size=block_size,
+        group_lens=group_lens,
+        axis=-1,
+    )
 
     qt_b = QuantizedTensor.quantize(
         b,
         fwd_dtype,
         granularity,
+        scaling_recipe=b_scaling_recipe,
+        block_size=block_size,
         axis=-1 if trans_b else -2,
     )
 
@@ -634,7 +653,12 @@ def _run_grouped_gemm_fp8_quantized_tensor_test(
     out_ref.backward(grad_out)
     torch.cuda.synchronize()
 
-    config = Float8QuantConfig(format=format, granularity=granularity)
+    config = Float8QuantConfig(
+        format=format,
+        granularity=granularity,
+        block_size=block_size,
+        scale_dtype=ScaleDtype.E8M0 if granularity == ScalingGranularity.MX_BLOCKWISE else ScaleDtype.FP32,
+    )
     out = grouped_gemm_fp8(qt_a, qt_b, group_lens, trans_b=trans_b, config=config)
     out.backward(grad_out)
     torch.cuda.synchronize()
@@ -679,8 +703,6 @@ def test_grouped_gemm_fp8_tensorwise_quantized_tensor(
     """TENSORWISE grouped_gemm with pre-quantized grouped/regular QuantizedTensor inputs."""
     if backend == BackendType.FLYDSL and get_device_compute_capability() < (9, 5):
         pytest.skip("FlyDSL fp8 grouped GEMM is gfx950-only")
-    if backend == BackendType.TRITON and format == Format.HYBRID:
-        pytest.skip("TRITON backend not support HYBRID format currently")
 
     # TODO(xiaobochen-amd): On gfx942, the hipBLASLt path can hang/flake when M <= 512.
     # This has been observed under pytest; root cause not yet identified. MI355 works normally.
@@ -730,6 +752,41 @@ def test_grouped_gemm_fp8_rowwise_quantized_tensor(
         ori_dtype=ori_dtype,
         format=format,
         granularity=ScalingGranularity.ROWWISE,
+        trans_b=trans_b,
+        balance=balance,
+        backend=backend,
+        auto_tune=auto_tune,
+    )
+
+
+@pytest.mark.parametrize("B", B_VALUES)
+@pytest.mark.parametrize("M", M_VALUES)
+@pytest.mark.parametrize("NK", NK_VALUES)
+@pytest.mark.parametrize("ori_dtype", ORI_DTYPE_VALUES)
+@pytest.mark.parametrize("format", FORMAT_VALUES + [Format.HYBRID])
+@pytest.mark.parametrize(
+    "trans_b",
+    [
+        True,
+    ],
+)
+@pytest.mark.parametrize("balance", BALANCE_VALUES)
+@pytest.mark.parametrize("backend", [None, BackendType.TRITON])
+@pytest.mark.parametrize("auto_tune", [False, True])
+def test_grouped_gemm_fp8_mx_blockwise_quantized_tensor(
+    B, M, NK, ori_dtype, format, trans_b, balance, backend, auto_tune
+):
+    """MX_BLOCKWISE grouped_gemm with pre-quantized grouped/regular QuantizedTensor inputs."""
+
+    N, K = NK
+    _run_grouped_gemm_fp8_quantized_tensor_test(
+        B=B,
+        M=M,
+        N=N,
+        K=K,
+        ori_dtype=ori_dtype,
+        format=format,
+        granularity=ScalingGranularity.MX_BLOCKWISE,
         trans_b=trans_b,
         balance=balance,
         backend=backend,

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -45,7 +45,7 @@ NK_VALUES = [
 ORI_DTYPE_VALUES = [torch.bfloat16, torch.float16]
 FORMAT_VALUES = [Format.E4M3, Format.E5M2]
 TRANS_B_VALUES = [True, False]
-BALANCE_VALUES = [True, False]
+BALANCE_VALUES = [False]
 
 
 def _check_hit_int32_limit(B, M, N, K):
@@ -595,6 +595,7 @@ def _run_grouped_gemm_fp8_quantized_tensor_test(
     assert granularity in (
         ScalingGranularity.TENSORWISE,
         ScalingGranularity.ROWWISE,
+        ScalingGranularity.MX_BLOCKWISE,
     ), "Grouped QuantizedTensor only supports TENSORWISE and ROWWISE"
 
     GlobalBackendManager.set_grouped_gemm_backend(backend)

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -777,6 +777,9 @@ def test_grouped_gemm_fp8_mx_blockwise_quantized_tensor(
     B, M, NK, ori_dtype, format, trans_b, balance, backend, auto_tune
 ):
     """MX_BLOCKWISE grouped_gemm with pre-quantized grouped/regular QuantizedTensor inputs."""
+    mxfp8_supported, reason = check_mxfp8_support()
+    if not mxfp8_supported:
+        pytest.skip(reason)
 
     N, K = NK
     _run_grouped_gemm_fp8_quantized_tensor_test(

--- a/tests/pytorch/ops/test_quantization.py
+++ b/tests/pytorch/ops/test_quantization.py
@@ -136,15 +136,42 @@ def padding_size(n: int, padding_align_size: int) -> int:
     return (n + padding_align_size - 1) // padding_align_size * padding_align_size - n
 
 
+def mxfp8_padded_ref(x: torch.Tensor, axis: int, padding_align_size: int, dtype: torch.dtype) -> torch.Tensor:
+    """Build zero-padded reference matching MXFP8 quantize/dequantize padding."""
+    if x.dim() == 2:
+        if axis == 0:
+            # Colwise: dequant output [M_pad, N].
+            pad_amt = padding_size(x.size(0), padding_align_size)
+            zeros = torch.zeros(pad_amt, x.size(1), device=x.device, dtype=dtype)
+            return torch.cat([x, zeros], dim=0)
+        # Rowwise: dequant output [M, N_pad].
+        pad_amt = padding_size(x.size(1), padding_align_size)
+        zeros = torch.zeros(x.size(0), pad_amt, device=x.device, dtype=dtype)
+        return torch.cat([x, zeros], dim=1)
+
+    # 3D batched [B, M, N]
+    if axis == 1:
+        # Colwise: quant/dequant layout [B, N, M_pad].
+        x_bn = x.transpose(1, 2).contiguous()
+        pad_amt = padding_size(x_bn.size(2), padding_align_size)
+        zeros = torch.zeros(x_bn.size(0), x_bn.size(1), pad_amt, device=x.device, dtype=dtype)
+        return torch.cat([x_bn, zeros], dim=2)
+    # Rowwise (axis == 2): dequant output [B, M, N_pad].
+    pad_amt = padding_size(x.size(2), padding_align_size)
+    zeros = torch.zeros(x.size(0), x.size(1), pad_amt, device=x.device, dtype=dtype)
+    return torch.cat([x, zeros], dim=2)
+
+
 @pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("dest_dtype", [turbo.float8_e4m3, turbo.float8_e5m2])
+@pytest.mark.parametrize("batched", [False, True])
 @pytest.mark.parametrize("B", [1, 4])
 @pytest.mark.parametrize("M", [32, 64, 256, 1024])
 @pytest.mark.parametrize("N", [32, 64, 256, 1024])
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("granularity", [ScalingGranularity.MX_BLOCKWISE])
 @pytest.mark.parametrize("use_2d_block", [True, False])
-def test_quantize_mxfp8(orig_dtype, dest_dtype, B, M, N, axis, granularity, use_2d_block):
+def test_quantize_mxfp8(orig_dtype, dest_dtype, batched, B, M, N, axis, granularity, use_2d_block):
     padding_align_size = 128
 
     # Skip unit test on gfx942.
@@ -155,49 +182,26 @@ def test_quantize_mxfp8(orig_dtype, dest_dtype, B, M, N, axis, granularity, use_
     MX_BLOCK_SIZE = 32
     torch.manual_seed(42)
 
-    x = torch.randn((B, M, N), device="cuda", dtype=orig_dtype)
-
-    row_length = x.size(-1)
-    x_2d = x.view(-1, row_length)
-    if padding_align_size is not None:
-        if axis == 0:
-            x_2d_ref = torch.cat(
-                [
-                    x_2d,
-                    torch.zeros(
-                        padding_size(x_2d.size(0), padding_align_size),
-                        x_2d.size(1),
-                        device=x.device,
-                        dtype=orig_dtype,
-                    ),
-                ],
-                dim=axis,
-            )
-        else:
-            x_2d_ref = torch.cat(
-                [
-                    x_2d,
-                    torch.zeros(
-                        x_2d.size(0),
-                        padding_size(x_2d.size(1), padding_align_size),
-                        device=x.device,
-                        dtype=orig_dtype,
-                    ),
-                ],
-                dim=axis,
-            )
+    if batched:
+        x = torch.randn((B, M, N), device="cuda", dtype=orig_dtype)
+        # 3D MXFP8: axis 1 = colwise, axis 2 = rowwise (inner-K).
+        quantize_axis = axis + 1
     else:
-        x_2d_ref = x_2d
+        x = torch.randn((M, N), device="cuda", dtype=orig_dtype)
+        # 2D MXFP8: axis 0 = colwise, axis 1 = rowwise.
+        quantize_axis = axis
+
+    x_ref = mxfp8_padded_ref(x, quantize_axis, padding_align_size, orig_dtype)
 
     scaling_recipe = ScalingRecipe(
         use_2d_block=use_2d_block,
     )
 
     x_fp8, x_scale_inv = quantize_fp8(
-        x_2d,
+        x,
         dest_dtype,
         granularity=granularity,
-        axis=axis,
+        axis=quantize_axis,
         block_size=MX_BLOCK_SIZE,
         scaling_recipe=scaling_recipe,
     )
@@ -208,12 +212,12 @@ def test_quantize_mxfp8(orig_dtype, dest_dtype, B, M, N, axis, granularity, use_
         orig_dtype,
         granularity=granularity,
         block_size=MX_BLOCK_SIZE,
-        axis=axis,
+        axis=quantize_axis,
         scale_inv=x_scale_inv,
         scaling_recipe=scaling_recipe,
     )
 
-    torch.testing.assert_close(x_2d_ref, out, **get_tolerances(dest_dtype))
+    torch.testing.assert_close(x_ref, out, **get_tolerances(dest_dtype))
 
 
 @pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16])


### PR DESCRIPTION
# Description

This PR adds end-to-end `QuantizedTensor` support for the MXFP8 grouped GEMM path.
Pre-quantized activations / weights can now be fed directly into `grouped_gemm_fp8` without an extra dequantize/requantize round-trip.

To make this possible, it introduces two new single-direction grouped MXFP8 kernels (quantize and dequantize) that operate on the per-group, M-axis zero-padded layout.
It also reworks `QuantizedTensor` to track both the compact (original) and padded group metadata.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add a single-direction grouped MXFP8 quantize kernel (`grouped_quantize_mxfp8_kernel` / `grouped_quantize_mxfp8_impl`) that fuses per-group M-axis zero-padding into the output without an intermediate padded copy of the input, supporting both rowwise and colwise modes plus the optional 2D-block and shuffle recipes.
- Add a grouped MXFP8 dequantize kernel (`grouped_dequantize_mxfp8_rowwise_kernel` / `..._colwise_kernel` / `grouped_dequantize_mxfp8_impl`) that fuses dequant with a compact gather, mapping the padded grouped layout back to a tight `[total_M, N]` output.
- Expose new PyTorch custom ops `grouped_quantize_mxfp8` and `grouped_dequantize_mxfp8` (CUDA + Meta implementations) and register them in the Torch library bindings.
- Extend `quantize_mxfp8` / `dequantize_mxfp8` to accept 2D and 3D inputs with the corresponding per-rank axis validation.
- Add Python wrappers `grouped_quantize_fp8` and `grouped_dequantize_fp8` in `ops/quantization.py`, and generalize `grouped_quantize_mxfp8_impl` to support a non-transposed (`with_trans=False`) single-direction path.
- Rework `QuantizedTensor` to store both compact metadata (`orig_group_lens` / `orig_group_offs`) and padded metadata (`group_lens` / `group_offs`), drive grouped quantization through the new `_grouped_quantize` classmethod, and implement grouped `dequantize()`; update flatten/unflatten and `_make_like` to propagate the new fields.
- Update `FP8GroupedGemmMXFunc` to accept pre-quantized `QuantizedTensor` inputs (with optional transposed counterparts `a_t` / `b_t`) and fall back to on-the-fly grouped quantization when raw tensors are passed.
- Refactor `FP8GemmMXFunction` backward to use `quantize_fp8_with_trans` instead of two separate `QuantizedTensor.quantize` calls.
- Update unit tests for the new grouped metadata, batched MXFP8 quantize/dequantize, and MX_BLOCKWISE grouped GEMM with `QuantizedTensor`.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
