### PR TITLE
fix(grouped_gemm): guard work_steal + num_cu; harden WS per-XCD layout

### DIFF
--- a/primus_turbo/pytorch/ops/grouped_gemm.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm.py
@@ -131,6 +131,10 @@ def grouped_gemm(
                                           If None, it will be computed internally.
         trans_b (bool): If True, treat each b[g] as transposed.
         num_cu (int | None): Limit the number of CUs to use. None = default.
+            Must be None when ``schedule="work_steal"`` -- the work-stealing
+            kernel was designed and tested for full-device launches, and the
+            heuristic / per-XCD slot layout assume the persistent grid spans
+            every XCD. Mixing the two raises ``ValueError``.
         schedule (str): Persistent-loop scheduling. One of:
             * ``"static"`` (default): static-stride persistent kernel.
             * ``"work_steal"``: work-stealing persistent kernel with a kernel-
@@ -139,7 +143,7 @@ def grouped_gemm(
               selection of a non-Triton backend together with ``"work_steal"``
               is rejected at dispatch. Internal WS sub-modes are not exposed
               at this layer; tune via ``grouped_gemm_triton_kernel`` directly
-              when needed.
+              when needed. Requires ``num_cu=None`` (see ``num_cu`` above).
 
     Returns:
         torch.Tensor: Output of shape [sum(group_lens), N], same dtype/device as `a`.
@@ -153,6 +157,14 @@ def grouped_gemm(
         >>> out.shape
         torch.Size([96, 64])
     """
+    if schedule == "work_steal" and num_cu is not None:
+        raise ValueError(
+            f'schedule="work_steal" requires num_cu=None, got num_cu={num_cu}. '
+            "Work-stealing is designed and tested for full-device launches; the "
+            "heuristic and per-XCD slot layout assume the persistent grid spans "
+            'every XCD. Pass num_cu=None, or use schedule="static".'
+        )
+
     if group_offs is None:
         group_offs = group_offs_from_lens(group_lens)
 

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
@@ -497,11 +497,20 @@ def _grouped_bf16_persistent_gemm_kernel_ws(
     tl.assume(stride_cm > 0)
     tl.assume(stride_cn > 0)
 
-    # AMD pid -> XCD mapping is round-robin.
-    xcd_id = pid % NUM_XCDS
+    # AMD pid -> XCD mapping is round-robin. When the persistent grid is
+    # capped to fewer CUs than there are XCDs (NUM_SMS < NUM_XCDS), only
+    # XCD ids [0, NUM_SMS) ever issue phase-1 claims, so both the per-XCD
+    # slot count AND the phase-1 ID span must use min(NUM_SMS, NUM_XCDS).
+    # Otherwise phase 2 starts past where phase 1 actually ended and the
+    # tiles in the gap are silently dropped. The public ``grouped_gemm``
+    # API rejects num_cu != None + schedule="work_steal" so callers should
+    # never hit this branch from the high-level op, but the kernel-level
+    # entry point exposes num_cu directly -- belt-and-braces.
+    ACTIVE_XCDS: tl.constexpr = min(NUM_SMS, NUM_XCDS)
+    xcd_id = pid % ACTIVE_XCDS
     local_counter = tile_counter_ptr + xcd_id * COUNTER_STRIDE
     per_xcd = local_per_xcd.to(tl.int32)
-    phase1_total = (per_xcd * NUM_XCDS).to(tl.int32)
+    phase1_total = (per_xcd * ACTIVE_XCDS).to(tl.int32)
 
     # Single unified loop with one call site for the per-tile body.
     # (Inlining the per-tile body twice -- once per phase -- produced phase-2
@@ -1013,10 +1022,15 @@ def _grouped_variable_k_gemm_kernel_ws(
     if IS_FP8:
         scale = tl.load(LHS_scale_ptr) * tl.load(RHS_scale_ptr)
 
-    xcd_id = pid % NUM_XCDS
+    # See the forward WS kernel for the ACTIVE_XCDS rationale: when
+    # NUM_SMS < NUM_XCDS, both the per-XCD slot count and the phase-1 ID
+    # span must be capped at the active XCD count, or phase 2 skips past
+    # the gap and silently drops tiles.
+    ACTIVE_XCDS: tl.constexpr = min(NUM_SMS, NUM_XCDS)
+    xcd_id = pid % ACTIVE_XCDS
     local_counter = tile_counter_ptr + xcd_id * COUNTER_STRIDE
     per_xcd = local_per_xcd.to(tl.int32)
-    phase1_total = (per_xcd * NUM_XCDS).to(tl.int32)
+    phase1_total = (per_xcd * ACTIVE_XCDS).to(tl.int32)
 
     local_idx = tl.atomic_add(local_counter, 1, sem="relaxed", scope="gpu")
     in_phase2 = local_idx >= per_xcd

--- a/tests/pytorch/ops/test_grouped_gemm.py
+++ b/tests/pytorch/ops/test_grouped_gemm.py
@@ -349,6 +349,25 @@ def test_grouped_gemm_schedule_work_steal_rejects_non_triton_backend(non_triton_
     GlobalBackendManager.reset()
 
 
+@pytest.mark.parametrize("num_cu", [64, 128, 240, 256])
+def test_grouped_gemm_schedule_work_steal_rejects_num_cu(num_cu):
+    """``schedule="work_steal"`` combined with an explicit ``num_cu`` must
+    raise: the WS heuristic and per-XCD slot layout assume the persistent
+    grid spans every XCD, so partial-grid launches are unsupported at the
+    public op layer."""
+    GlobalBackendManager.set_grouped_gemm_backend(BackendType.TRITON)
+    device = "cuda"
+    torch.manual_seed(0)
+    B, M, K, N = 4, 1024, 1280, 2560
+    a = torch.randn(B * M, K, device=device, dtype=torch.bfloat16)
+    b = torch.randn(B, N, K, device=device, dtype=torch.bfloat16)
+    group_lens = torch.full((B,), M, dtype=torch.int64, device=device)
+
+    with pytest.raises(ValueError, match="num_cu=None"):
+        grouped_gemm(a, b, group_lens, trans_b=True, num_cu=num_cu, schedule="work_steal")
+    GlobalBackendManager.reset()
+
+
 # ---------------------------------------------------------------------------
 # Kernel-level WS test: cover each ws_mode (the internal tuning knob) at the
 # low-level ``grouped_gemm_triton_kernel`` entry point. Not reachable from

--- a/tests/pytorch/ops/test_grouped_gemm.py
+++ b/tests/pytorch/ops/test_grouped_gemm.py
@@ -397,3 +397,33 @@ def test_grouped_gemm_triton_kernel_ws_modes(ws_mode, trans_b):
     out_ref = grouped_gemm_triton_kernel(a, b, group_offs, trans_b=trans_b, work_steal=False)
     out_ws = grouped_gemm_triton_kernel(a, b, group_offs, trans_b=trans_b, work_steal=True, ws_mode=ws_mode)
     torch.testing.assert_close(out_ref, out_ws, rtol=0.0, atol=0.0)
+
+
+@pytest.mark.parametrize("num_cu", [4, 6, 7, 8, 16])
+@pytest.mark.parametrize("ws_mode", ["per-xcd", "hierarchical"])
+def test_grouped_gemm_triton_kernel_ws_num_cu_below_num_xcds(num_cu, ws_mode):
+    """Regression: ``num_cu < NUM_XCDS`` (=8) on a per-XCD-style ws_mode used
+    to silently drop tiles in the gap between ``num_cu * per_xcd`` and
+    ``NUM_XCDS * per_xcd`` (phase-2 started past where phase-1 actually
+    ended). With the ``ACTIVE_XCDS = min(NUM_SMS, NUM_XCDS)`` fix the kernel
+    matches static at any grid size. (The public API now blocks num_cu
+    together with schedule="work_steal", but the low-level kernel entry
+    point still accepts the combination -- belt-and-braces defense.)"""
+    from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
+        grouped_gemm_triton_kernel,
+    )
+
+    device = "cuda"
+    torch.manual_seed(0)
+    B, M, N, K = 4, 1024, 2048, 1408
+    a = torch.randn((B * M, K), dtype=torch.bfloat16, device=device)
+    b = torch.randn((B, N, K), dtype=torch.bfloat16, device=device)
+    group_lens = torch.full((B,), M, dtype=torch.int64, device=device)
+    group_offs = torch.zeros(B + 1, dtype=torch.int64, device=device)
+    group_offs[1:] = torch.cumsum(group_lens, dim=0)
+
+    out_ref = grouped_gemm_triton_kernel(a, b, group_offs, trans_b=True, work_steal=False)
+    out_ws = grouped_gemm_triton_kernel(
+        a, b, group_offs, trans_b=True, num_cu=num_cu, work_steal=True, ws_mode=ws_mode
+    )
+    torch.testing.assert_close(out_ref, out_ws, rtol=0.0, atol=0.0)


### PR DESCRIPTION
## Summary

Two-commit follow-up to PR #353. Both target a single class of bugs: the WS
forward / variable-K kernels assume the persistent grid spans every XCD, but
the public op and the low-level kernel entry both accept `num_cu` and never
checked.

- **Commit 1 — public API guard.** `grouped_gemm(..., schedule="work_steal", num_cu=N)`
  with `N ≠ None` now raises `ValueError` early, before dispatch. WS was
  designed and characterized for full-device launches; the heuristic, the
  per-XCD slot layout, and the 288-shape MoE perf sweep all assume that. The
  guard makes the supported combination explicit instead of silently running
  WS on a partial grid where edge cases drop tiles.
- **Commit 2 — kernel-level fix (defense in depth).** `_grouped_bf16_persistent_gemm_kernel_ws`
  and `_grouped_variable_k_gemm_kernel_ws` now use
  `ACTIVE_XCDS = min(NUM_SMS, NUM_XCDS)` for both `xcd_id` and `phase1_total`.
  The kernel-level entry `grouped_gemm_triton_kernel(..., num_cu=...)` is still
  public and exposes the bug; this hardens it.

## The bug

`xcd_id = pid % NUM_XCDS` populates only XCD ids in `[0, NUM_SMS)`, so when
`NUM_SMS < NUM_XCDS=8` only those slots receive atomic claims. But
`phase1_total = per_xcd * NUM_XCDS` reserves the full `[0, 8 * per_xcd)` range
for phase 1, so phase 2 starts at `phase1_total` — past where phase 1 actually
ended — and the tiles in `[NUM_SMS * per_xcd, NUM_XCDS * per_xcd)` are never
claimed by any CTA. Silent wrong output.

Repro before the fix (B=4, M=1024, N=2048, K=1408, ws_mode="per-xcd"):

| `num_cu` | output zeros | unfilled XCDs |
|---|---:|---:|
| 4 | **50.00%** | 4 of 8 |
| 6 | 12.50% | 2 of 8 |
| 7 | 12.50% | 1 of 8 |
| 8 | 0% (clean) | 0 |

The bug stayed hidden in practice because the `auto` heuristic returns
`per_xcd=0` (global-only, phase 1 empty) whenever `tpc ≥ 16`, and `num_cu < 8`
always yields a very high tpc. Explicit `ws_mode="per-xcd"` /
`"hierarchical"` with small `num_cu` did trip it. Originally reported by
Copilot review on PR #353.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Infra/Build
- [ ] Code refactoring

The `ValueError` on `schedule="work_steal" + num_cu != None` is technically a
behavior change, but the combination was never validated — no caller is known
to rely on the silently-broken behavior.

## Changes

- `primus_turbo/pytorch/ops/grouped_gemm.py`: raise `ValueError` when
  `schedule="work_steal"` is paired with non-`None` `num_cu`; update docstring
  to spell out the constraint.
- `primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py`: introduce
  `ACTIVE_XCDS: tl.constexpr = min(NUM_SMS, NUM_XCDS)` in both
  `_grouped_bf16_persistent_gemm_kernel_ws` and
  `_grouped_variable_k_gemm_kernel_ws`. Use it for `xcd_id` and `phase1_total`.
  No-op codegen when `NUM_SMS >= NUM_XCDS` (the common case).
- `tests/pytorch/ops/test_grouped_gemm.py`:
  - `test_grouped_gemm_schedule_work_steal_rejects_num_cu` — 4 cases
    confirming the public API rejection.
  - `test_grouped_gemm_triton_kernel_ws_num_cu_below_num_xcds` — 10 cases
    (`num_cu ∈ {4, 6, 7, 8, 16} × ws_mode ∈ {per-xcd, hierarchical}`) asserting
    bit-equal output against the static-stride kernel at small grid sizes.

## Checklist

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes