### PR TITLE
fix(triton): scope AMD gfx950 compiler knobs to GEMM kernel launches

### DIFF
--- a/primus_turbo/triton/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_fp8_kernel.py
@@ -50,7 +50,10 @@ from primus_turbo.triton.utils.origami import (
     origama_hardware_info,
     origama_select_params,
 )
-from primus_turbo.triton.utils.triton_knobs_helper import set_triton_knobs_gfx950
+from primus_turbo.triton.utils.triton_knobs_helper import (
+    scoped_amd_knobs,
+    set_triton_knobs_gfx950,
+)
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # AMD knobs helper (blockwise-specific)
@@ -255,6 +258,7 @@ def _fp8_persistent_gemm_kernel(
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
+@scoped_amd_knobs
 def gemm_fp8_tensorwise_triton_kernel(
     a: torch.Tensor,
     a_scale_inv: torch.Tensor,
@@ -554,6 +558,7 @@ def _fp8_rowwise_persistent_gemm_kernel(
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
+@scoped_amd_knobs
 def gemm_fp8_rowwise_triton_kernel(
     a: torch.Tensor,
     a_scale_inv: torch.Tensor,
@@ -1024,6 +1029,7 @@ _blockwise_fp8_tn_kernel = triton.autotune(
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
+@scoped_amd_knobs
 def gemm_fp8_blockwise_triton_kernel(
     a: torch.Tensor,
     a_scale_inv: torch.Tensor,

--- a/primus_turbo/triton/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_fp8_kernel.py
@@ -50,10 +50,7 @@ from primus_turbo.triton.utils.origami import (
     origama_hardware_info,
     origama_select_params,
 )
-from primus_turbo.triton.utils.triton_knobs_helper import (
-    scoped_amd_knobs,
-    set_triton_knobs_gfx950,
-)
+from primus_turbo.triton.utils.triton_knobs_helper import scoped_amd_knobs
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # AMD knobs helper (blockwise-specific)
@@ -324,8 +321,6 @@ def gemm_fp8_tensorwise_triton_kernel(
     s_bk = B_view.stride(0)
 
     if is_gfx950():
-        set_triton_knobs_gfx950()
-
         # gfx950 FP8: uniform 256×256×128 / stages=2 across all layouts (164-entry tuning).
         block_m, block_n, block_k = 256, 256, 128
         chunk_size, waves_per_eu = 32, 0
@@ -631,8 +626,6 @@ def gemm_fp8_rowwise_triton_kernel(
     s_bk = B_view.stride(0)
 
     if is_gfx950():
-        set_triton_knobs_gfx950()
-
         # gfx950 FP8: uniform 256×256×128 / stages=2 across all layouts.
         block_m, block_n, block_k = 256, 256, 128
         chunk_size, waves_per_eu = 32, 0
@@ -1083,12 +1076,11 @@ def gemm_fp8_blockwise_triton_kernel(
     M, K = A_view.shape
     _, N = B_view.shape
 
-    # AMD knobs: gfx950 always sets the gfx950 knobs; on gfx942 NT/NN benefit
-    # from use_async_copy/scalarize_packed_fops while TN/wgrad regresses 5-8%.
+    # AMD knobs: scoped_amd_knobs enables the gfx950 knobs on gfx950; on gfx942
+    # NT/NN benefit from use_async_copy/scalarize_packed_fops while TN/wgrad
+    # regresses 5-8%.
     is_tn = trans_a and not trans_b
-    if is_gfx950():
-        set_triton_knobs_gfx950()
-    else:
+    if not is_gfx950():
         _set_amd_knobs(enable=not is_tn)
 
     # ── Layout-specialised settings.

--- a/primus_turbo/triton/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_fp8_kernel.py
@@ -50,22 +50,10 @@ from primus_turbo.triton.utils.origami import (
     origama_hardware_info,
     origama_select_params,
 )
-from primus_turbo.triton.utils.triton_knobs_helper import scoped_amd_knobs
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# AMD knobs helper (blockwise-specific)
-# ═══════════════════════════════════════════════════════════════════════════════
-
-
-def _set_amd_knobs(enable: bool = True):
-    """Set AMD-specific Triton knobs.
-    NOTE: use_async_copy and scalarize_packed_fops HURT CRR/TN performance
-    by ~5-8% on MI300X. Only enable for NT/RCR and NN/RRR.
-    """
-    if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
-        triton.knobs.amd.use_async_copy = enable
-        triton.knobs.amd.scalarize_packed_fops = enable
-
+from primus_turbo.triton.utils.triton_knobs_helper import (
+    scoped_amd_knobs,
+    scoped_amd_triton_knobs,
+)
 
 # ###########################################################################
 #
@@ -1022,7 +1010,6 @@ _blockwise_fp8_tn_kernel = triton.autotune(
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-@scoped_amd_knobs
 def gemm_fp8_blockwise_triton_kernel(
     a: torch.Tensor,
     a_scale_inv: torch.Tensor,
@@ -1070,32 +1057,25 @@ def gemm_fp8_blockwise_triton_kernel(
     if (trans_a, trans_b) not in {(False, True), (False, False), (True, False)}:
         raise ValueError(f"Unsupported layout for blockwise FP8 Triton: trans_a={trans_a}, trans_b={trans_b}")
 
+    is_tn = trans_a and not trans_b
+
     # ── Operand views: always [M, K] @ [K, N] inside the kernel.
     A_view = a.T if trans_a else a
     B_view = b.T if trans_b else b
     M, K = A_view.shape
     _, N = B_view.shape
 
-    # AMD knobs: scoped_amd_knobs enables the gfx950 knobs on gfx950; on gfx942
-    # NT/NN benefit from use_async_copy/scalarize_packed_fops while TN/wgrad
-    # regresses 5-8%.
-    is_tn = trans_a and not trans_b
-    if not is_gfx950():
-        _set_amd_knobs(enable=not is_tn)
-
-    # ── Layout-specialised settings.
-    # The only true per-layout differences are: how A/B scales are laid out
-    # for the kernel, which autotune wrapper owns the search space/cache, and
-    # the three constexpr flags (SCALE_2D_B / EVEN_K / TRANS_C_STORE).
+    # ── Layout-specialised settings. The only true per-layout differences are:
+    # how A/B scales are laid out, which autotune wrapper owns the search
+    # space/cache, and the three constexpr flags (SCALE_2D_B/EVEN_K/TRANS_C_STORE).
     #
     # TN safety notes (Round-6 P2-#7.6):
-    #   * `TRANS_C_STORE=True` lets the BF16 epilogue coalesce into dwordx4
-    #     under the `(N, M)` output buffer; without it the wgrad path emits
+    #   * TRANS_C_STORE=True lets the BF16 epilogue coalesce into dwordx4 under
+    #     the (N, M) output buffer; without it the wgrad path emits
     #     64×buffer_store_short per tile.
-    #   * `EVEN_K=False` keeps the mask-load path for the dual strided-K
-    #     loads, the matched-pair safety net for the Triton 3.7
-    #     `Begin <= End` LLVM-backend assertion (the TN autotune wrapper
-    #     already drops `num_stages=3`).
+    #   * EVEN_K=False keeps the mask-load path for the dual strided-K loads, the
+    #     matched-pair safety net for the Triton 3.7 `Begin <= End` LLVM-backend
+    #     assertion (the TN autotune wrapper already drops num_stages=3).
     if not trans_a and trans_b:
         # NT
         A_scales_arg = a_scale_inv.T.contiguous()  # [K//128, M]
@@ -1140,31 +1120,35 @@ def gemm_fp8_blockwise_triton_kernel(
     num_k = (K + 127) // 128
     NUM_SMS = ((M + 127) // 128) * ((N + 127) // 128)
 
-    autotune_kernel[(NUM_SMS,)](
-        A_view,
-        B_view,
-        out,
-        A_scales_arg,
-        B_scales_arg,
-        M,
-        N,
-        K,
-        A_view.stride(0),
-        A_view.stride(1),
-        B_view.stride(0),
-        B_view.stride(1),
-        stride_cm,
-        stride_cn,
-        stride_as_k,
-        stride_as_m,
-        stride_bs_0,
-        stride_bs_1,
-        NUM_SMS,
-        num_k,
-        A_K_CONTIGUOUS=not trans_a,
-        B_K_CONTIGUOUS=trans_b,
-        SCALE_2D_B=SCALE_2D_B,
-        EVEN_K=EVEN_K,
-        TRANS_C_STORE=TRANS_C_STORE,
-    )
+    # gfx950 enables its full knob set for the scope; gfx942 enables
+    # use_async_copy/scalarize_packed_fops only for NT/NN (TN/wgrad regresses
+    # ~5-8%). The scope restores every knob on exit.
+    with scoped_amd_triton_knobs(gfx942_enable=not is_tn):
+        autotune_kernel[(NUM_SMS,)](
+            A_view,
+            B_view,
+            out,
+            A_scales_arg,
+            B_scales_arg,
+            M,
+            N,
+            K,
+            A_view.stride(0),
+            A_view.stride(1),
+            B_view.stride(0),
+            B_view.stride(1),
+            stride_cm,
+            stride_cn,
+            stride_as_k,
+            stride_as_m,
+            stride_bs_0,
+            stride_bs_1,
+            NUM_SMS,
+            num_k,
+            A_K_CONTIGUOUS=not trans_a,
+            B_K_CONTIGUOUS=trans_b,
+            SCALE_2D_B=SCALE_2D_B,
+            EVEN_K=EVEN_K,
+            TRANS_C_STORE=TRANS_C_STORE,
+        )
     return out

--- a/primus_turbo/triton/gemm/gemm_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_kernel.py
@@ -35,10 +35,7 @@ from primus_turbo.triton.utils.origami import (
     origama_hardware_info,
     origama_select_params,
 )
-from primus_turbo.triton.utils.triton_knobs_helper import (
-    scoped_amd_knobs,
-    set_triton_knobs_gfx950,
-)
+from primus_turbo.triton.utils.triton_knobs_helper import scoped_amd_knobs
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Hardware constants & chiplet transform
@@ -317,8 +314,6 @@ def gemm_triton_kernel(
     s_bk = B_view.stride(0)
 
     if is_gfx950():
-        set_triton_knobs_gfx950()
-
         # gfx950 BF16 config from 164-entry tuning data.
         # TN layout with large K → BLK_K=64, stages=2; all other cases → 32/3.
         # Small TN (K≤3584, dims≤16384, min dim≤4608) stays on 32/3.

--- a/primus_turbo/triton/gemm/gemm_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_kernel.py
@@ -35,7 +35,10 @@ from primus_turbo.triton.utils.origami import (
     origama_hardware_info,
     origama_select_params,
 )
-from primus_turbo.triton.utils.triton_knobs_helper import set_triton_knobs_gfx950
+from primus_turbo.triton.utils.triton_knobs_helper import (
+    scoped_amd_knobs,
+    set_triton_knobs_gfx950,
+)
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Hardware constants & chiplet transform
@@ -246,6 +249,7 @@ def _bf16_persistent_gemm_kernel(
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
+@scoped_amd_knobs
 def gemm_triton_kernel(
     a: torch.Tensor,
     b: torch.Tensor,

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp4_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp4_kernel.py
@@ -35,15 +35,11 @@ import torch
 import triton
 import triton.language as tl
 
-from primus_turbo.pytorch.core.utils import is_gfx950
 from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
     NUM_XCDS,
     _chiplet_transform_chunked,
 )
-from primus_turbo.triton.utils.triton_knobs_helper import (
-    scoped_amd_knobs,
-    set_triton_knobs_gfx950,
-)
+from primus_turbo.triton.utils.triton_knobs_helper import scoped_amd_knobs
 
 # E8M0 block size: one scale per 1x32 logical-element block (same as MXFP8).
 # tl.dot_scaled consumes the "e2m1" FP4 format string (inlined in the kernels;
@@ -197,8 +193,6 @@ def grouped_gemm_mxfp4_triton_kernel(
     """
     if group_offs_out is None:
         group_offs_out = group_offs
-    if is_gfx950():
-        set_triton_knobs_gfx950()
     G = b.shape[0]
     c = torch.empty((a.shape[0], N), dtype=out_dtype, device=a.device)
     a_s = a_scale.view(torch.uint8)
@@ -373,8 +367,6 @@ def grouped_gemm_mxfp4_variable_k_triton_kernel(
     lhs (OUT_M, M_total/2) fp4-packed, rhs (OUT_N, M_total/2) fp4-packed.
     go_pad: padded per-group offsets along M (each M_g a multiple of 128).
     """
-    if is_gfx950():
-        set_triton_knobs_gfx950()
     c = torch.empty((G, OUT_M, OUT_N), dtype=out_dtype, device=lhs.device)
     ls = lhs_scale.view(torch.uint8)
     rs = rhs_scale.view(torch.uint8)

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp4_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp4_kernel.py
@@ -40,7 +40,10 @@ from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
     NUM_XCDS,
     _chiplet_transform_chunked,
 )
-from primus_turbo.triton.utils.triton_knobs_helper import set_triton_knobs_gfx950
+from primus_turbo.triton.utils.triton_knobs_helper import (
+    scoped_amd_knobs,
+    set_triton_knobs_gfx950,
+)
 
 # E8M0 block size: one scale per 1x32 logical-element block (same as MXFP8).
 # tl.dot_scaled consumes the "e2m1" FP4 format string (inlined in the kernels;
@@ -173,6 +176,7 @@ def _grouped_mxfp4_persistent_gemm_kernel(
         tl.store(C_, c, c_mask)
 
 
+@scoped_amd_knobs
 def grouped_gemm_mxfp4_triton_kernel(
     a,
     a_scale,
@@ -360,6 +364,7 @@ def _grouped_mxfp4_variable_k_gemm_kernel(
         tl.store(C_, c, cmask)
 
 
+@scoped_amd_knobs
 def grouped_gemm_mxfp4_variable_k_triton_kernel(
     lhs, lhs_scale, rhs, rhs_scale, go_pad, OUT_M, OUT_N, G, out_dtype=torch.bfloat16, num_cu=None
 ):

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -54,10 +54,7 @@ from primus_turbo.triton.utils.origami import (
     origama_hardware_info,
     origama_select_params,
 )
-from primus_turbo.triton.utils.triton_knobs_helper import (
-    scoped_amd_knobs,
-    set_triton_knobs_gfx950,
-)
+from primus_turbo.triton.utils.triton_knobs_helper import scoped_amd_knobs
 
 _grouped_blockwise_warmed: set = set()
 _grouped_blockwise_vk_warmed: set = set()
@@ -557,8 +554,6 @@ def grouped_gemm_fp8_tensorwise_triton_kernel(
     # Kernel config (cached — origami + LDS check run only on first call per shape)
     num_sms = get_num_cus()
     avg_m = max(M_total // max(G, 1), 256)
-    if is_gfx950():
-        set_triton_knobs_gfx950()
     blk_m, blk_n, blk_k, group_m, cache_a, cache_b, num_stages_val, chunk_size, num_sms = (
         _get_gg_fp8_tw_fwd_config(
             avg_m,
@@ -650,8 +645,6 @@ def grouped_gemm_fp8_tensorwise_variable_k_triton_kernel(
     out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)
     num_sms = get_num_cus()
 
-    if is_gfx950():
-        set_triton_knobs_gfx950()
     avg_m_g = max(lhs.shape[0] // max(G, 1), 256)
     blk_m, blk_n, blk_k, group_m, cache_a, cache_b, num_stages_val, chunk_size = _get_gg_fp8_tw_vk_config(
         OUT_M, OUT_N, avg_m_g, lhs.dtype, rhs.dtype, G, num_sms
@@ -913,8 +906,6 @@ def grouped_gemm_fp8_rowwise_triton_kernel(
     # Kernel config (cached — origami + LDS check run only on first call per shape)
     num_sms = get_num_cus()
     avg_m = max(M_total // max(G, 1), 256)
-    if is_gfx950():
-        set_triton_knobs_gfx950()
     blk_m, blk_n, blk_k, group_m, cache_a, cache_b, num_stages_val, chunk_size = _get_gg_fp8_rw_fwd_config(
         avg_m,
         N,
@@ -1155,8 +1146,6 @@ def grouped_gemm_fp8_rowwise_variable_k_triton_kernel(
     out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)
     num_sms = get_num_cus()
 
-    if is_gfx950():
-        set_triton_knobs_gfx950()
     avg_m_g = max(lhs.shape[0] // max(G, 1), 256)
     blk_m, blk_n, blk_k, group_m, cache_a, cache_b, num_stages_val, chunk_size = _get_gg_fp8_rw_vk_config(
         OUT_M, OUT_N, avg_m_g, lhs.dtype, rhs.dtype, G, num_sms
@@ -1741,9 +1730,7 @@ def grouped_gemm_fp8_blockwise_triton_kernel(
     Returns:
         [M_total, N] output in out_dtype.
     """
-    if is_gfx950():
-        set_triton_knobs_gfx950()
-    else:
+    if not is_gfx950():
         _set_amd_knobs(enable=True)
 
     assert a.ndim == 2, f"a must be 2D, got {a.shape}"
@@ -1900,9 +1887,7 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
     Returns:
         [G, OUT_M, OUT_N] output.
     """
-    if is_gfx950():
-        set_triton_knobs_gfx950()
-    else:
+    if not is_gfx950():
         _set_amd_knobs(enable=False)
 
     assert lhs.ndim == 2 and rhs.ndim == 2
@@ -2190,8 +2175,6 @@ def grouped_gemm_mxfp8_triton_kernel(
     """
     if group_offs_out is None:
         group_offs_out = group_offs
-    if is_gfx950():
-        set_triton_knobs_gfx950()
     G = b.shape[0]
     c = torch.empty((a.shape[0], N), dtype=out_dtype, device=a.device)
     # scales come from the grouped MX quant in (free, K/VEC) layout:
@@ -2373,8 +2356,6 @@ def grouped_gemm_mxfp8_variable_k_triton_kernel(
     lhs, lhs_scale, rhs, rhs_scale, go_pad, OUT_M, OUT_N, G, out_dtype=torch.bfloat16, num_cu=None
 ):
     """C[g] (OUT_M,OUT_N) = lhs[:,g] @ rhs[:,g]^T. lhs (OUT_M,M_total), rhs (OUT_N,M_total)."""
-    if is_gfx950():
-        set_triton_knobs_gfx950()
     c = torch.empty((G, OUT_M, OUT_N), dtype=out_dtype, device=lhs.device)
     ls = lhs_scale.view(torch.uint8)
     rs = rhs_scale.view(torch.uint8)

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -54,7 +54,10 @@ from primus_turbo.triton.utils.origami import (
     origama_hardware_info,
     origama_select_params,
 )
-from primus_turbo.triton.utils.triton_knobs_helper import set_triton_knobs_gfx950
+from primus_turbo.triton.utils.triton_knobs_helper import (
+    scoped_amd_knobs,
+    set_triton_knobs_gfx950,
+)
 
 _grouped_blockwise_warmed: set = set()
 _grouped_blockwise_vk_warmed: set = set()
@@ -498,6 +501,7 @@ def _grouped_fp8_persistent_gemm_kernel(
         tl.store(C_, c, c_mask)
 
 
+@scoped_amd_knobs
 def grouped_gemm_fp8_tensorwise_triton_kernel(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -612,6 +616,7 @@ def grouped_gemm_fp8_tensorwise_triton_kernel(
 # ── Tensorwise FP8 Variable-K Backward ──
 
 
+@scoped_amd_knobs
 def grouped_gemm_fp8_tensorwise_variable_k_triton_kernel(
     lhs: torch.Tensor,
     rhs: torch.Tensor,
@@ -853,6 +858,7 @@ def _grouped_fp8_rowwise_persistent_gemm_kernel(
         tl.store(C_, c, c_mask)
 
 
+@scoped_amd_knobs
 def grouped_gemm_fp8_rowwise_triton_kernel(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -1111,6 +1117,7 @@ def _grouped_fp8_rowwise_variable_k_gemm_kernel(
         tl.store(C_, c, c_mask)
 
 
+@scoped_amd_knobs
 def grouped_gemm_fp8_rowwise_variable_k_triton_kernel(
     lhs: torch.Tensor,
     rhs: torch.Tensor,
@@ -1707,6 +1714,7 @@ def _grouped_blockwise_fp8_variable_k_gemm_kernel(
 # ── Blockwise FP8 Forward Public API ──
 
 
+@scoped_amd_knobs
 def grouped_gemm_fp8_blockwise_triton_kernel(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -1853,6 +1861,7 @@ def grouped_gemm_fp8_blockwise_triton_kernel(
 # ── Blockwise FP8 Variable-K Backward Public API ──
 
 
+@scoped_amd_knobs
 def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
     lhs: torch.Tensor,
     rhs: torch.Tensor,
@@ -2159,6 +2168,7 @@ def _grouped_mxfp8_persistent_gemm_kernel(
         tl.store(C_, c, c_mask)
 
 
+@scoped_amd_knobs
 def grouped_gemm_mxfp8_triton_kernel(
     a,
     a_scale,
@@ -2358,6 +2368,7 @@ def _grouped_mxfp8_variable_k_gemm_kernel(
         tl.store(C_, c, cmask)
 
 
+@scoped_amd_knobs
 def grouped_gemm_mxfp8_variable_k_triton_kernel(
     lhs, lhs_scale, rhs, rhs_scale, go_pad, OUT_M, OUT_N, G, out_dtype=torch.bfloat16, num_cu=None
 ):

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -59,17 +59,6 @@ from primus_turbo.triton.utils.triton_knobs_helper import scoped_amd_knobs
 _grouped_blockwise_warmed: set = set()
 _grouped_blockwise_vk_warmed: set = set()
 
-# ═══════════════════════════════════════════════════════════════════════════════
-# AMD knobs helper
-# ═══════════════════════════════════════════════════════════════════════════════
-
-
-def _set_amd_knobs(enable: bool = True):
-    """Set AMD-specific Triton knobs."""
-    if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
-        triton.knobs.amd.use_async_copy = enable
-        triton.knobs.amd.scalarize_packed_fops = enable
-
 
 def offline_select_gg_fp8(M_total, G, N, K, s_ak, s_bk):
     """FP8 grouped GEMM config from MI300X bench (out_gg_fp8_persistent_full.yaml).
@@ -1703,7 +1692,7 @@ def _grouped_blockwise_fp8_variable_k_gemm_kernel(
 # ── Blockwise FP8 Forward Public API ──
 
 
-@scoped_amd_knobs
+@scoped_amd_knobs(gfx942_enable=True)
 def grouped_gemm_fp8_blockwise_triton_kernel(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -1730,9 +1719,6 @@ def grouped_gemm_fp8_blockwise_triton_kernel(
     Returns:
         [M_total, N] output in out_dtype.
     """
-    if not is_gfx950():
-        _set_amd_knobs(enable=True)
-
     assert a.ndim == 2, f"a must be 2D, got {a.shape}"
     assert b.ndim == 3, f"b must be 3D, got {b.shape}"
     assert b_scales.ndim == 3, f"b_scales must be 3D, got {b_scales.shape}"
@@ -1848,7 +1834,7 @@ def grouped_gemm_fp8_blockwise_triton_kernel(
 # ── Blockwise FP8 Variable-K Backward Public API ──
 
 
-@scoped_amd_knobs
+@scoped_amd_knobs(gfx942_enable=False)
 def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
     lhs: torch.Tensor,
     rhs: torch.Tensor,
@@ -1887,9 +1873,6 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
     Returns:
         [G, OUT_M, OUT_N] output.
     """
-    if not is_gfx950():
-        _set_amd_knobs(enable=False)
-
     assert lhs.ndim == 2 and rhs.ndim == 2
     G = group_offs.shape[0] - 1
 

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
@@ -37,10 +37,7 @@ import triton.language as tl
 
 from primus_turbo.pytorch.core.utils import get_num_cus, is_gfx950
 from primus_turbo.triton.utils.origami import origama_select_params
-from primus_turbo.triton.utils.triton_knobs_helper import (
-    scoped_amd_knobs,
-    set_triton_knobs_gfx950,
-)
+from primus_turbo.triton.utils.triton_knobs_helper import scoped_amd_knobs
 
 # ===============================================================================
 # Hardware constants (lazy init)
@@ -642,8 +639,6 @@ def grouped_gemm_triton_kernel(
     device_num_cus = get_num_cus()
     num_sms = min(num_cu, device_num_cus) if num_cu is not None and num_cu > 0 else device_num_cus
     avg_m = max(M_total // max(G, 1), 256)
-    if is_gfx950():
-        set_triton_knobs_gfx950()
     BLOCK_M, BLOCK_N, BLOCK_K, group_m, cache_a, cache_b, num_stages_val, chunk_size = (
         _get_gg_bf16_fwd_config(avg_m, N, K, a.dtype, b.dtype, trans_b, G, num_sms)
     )
@@ -1132,8 +1127,6 @@ def grouped_gemm_variable_k_triton_kernel(
     num_sms = min(num_cu, device_num_cus) if num_cu is not None and num_cu > 0 else device_num_cus
     dummy_scale = torch.empty(1, device=lhs.device, dtype=torch.float32)
 
-    if is_gfx950():
-        set_triton_knobs_gfx950()
     avg_m_g = max(lhs.shape[0] // max(G, 1), 256)
     BLOCK_M, BLOCK_N, BLOCK_K, group_m, cache_a, cache_b, num_stages_val, chunk_size = _get_gg_bf16_vk_config(
         OUT_M, OUT_N, avg_m_g, lhs.dtype, rhs.dtype, G, num_sms

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
@@ -37,7 +37,10 @@ import triton.language as tl
 
 from primus_turbo.pytorch.core.utils import get_num_cus, is_gfx950
 from primus_turbo.triton.utils.origami import origama_select_params
-from primus_turbo.triton.utils.triton_knobs_helper import set_triton_knobs_gfx950
+from primus_turbo.triton.utils.triton_knobs_helper import (
+    scoped_amd_knobs,
+    set_triton_knobs_gfx950,
+)
 
 # ===============================================================================
 # Hardware constants (lazy init)
@@ -564,6 +567,7 @@ def _grouped_bf16_persistent_gemm_kernel_ws(
                 tile_id = xcd_id * per_xcd + local_idx
 
 
+@scoped_amd_knobs
 def grouped_gemm_triton_kernel(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -1085,6 +1089,7 @@ def _grouped_variable_k_gemm_kernel_ws(
 # -- Public API -- Variable-K BF16 grouped GEMM (backward) --
 
 
+@scoped_amd_knobs
 def grouped_gemm_variable_k_triton_kernel(
     lhs: torch.Tensor,
     rhs: torch.Tensor,

--- a/primus_turbo/triton/utils/triton_knobs_helper.py
+++ b/primus_turbo/triton/utils/triton_knobs_helper.py
@@ -4,28 +4,86 @@
 # See LICENSE for license information.
 ###############################################################################
 
-"""
-AMDGPU Triton compiler knob helpers (shared across GEMM / grouped-GEMM kernels).
-"""
+"""AMDGPU Triton compiler knob helpers (shared across GEMM / grouped-GEMM kernels)."""
 
+import contextlib
+import functools
 import os
 
 import triton
 
-_KNOBS_SET = False
+# Triton ``knobs.amd`` attributes touched by the turbo GEMM kernels.
+_AMD_KNOB_ATTRS = ("use_async_copy", "scalarize_packed_fops", "use_block_pingpong")
+
+# Env-var fallback (older Triton without ``triton.knobs``).
+_AMD_KNOB_ENVS = (
+    "TRITON_HIP_USE_ASYNC_COPY",
+    "AMDGCN_SCALARIZE_PACKED_FOPS",
+    "TRITON_HIP_USE_BLOCK_PINGPONG",
+)
+
+
+def _amd_knobs_available() -> bool:
+    return hasattr(triton, "knobs") and hasattr(triton.knobs, "amd")
 
 
 def set_triton_knobs_gfx950() -> None:
-    """Enable AMD compiler knobs for gfx950 (async_copy, block_pingpong, scalarize)."""
-    global _KNOBS_SET
-    if _KNOBS_SET:
-        return
-    _KNOBS_SET = True
-    if hasattr(triton, "knobs") and hasattr(triton.knobs, "amd"):
+    """Enable AMD compiler knobs for gfx950 (async_copy, block_pingpong, scalarize).
+
+    Must be called from inside a :func:`scoped_amd_knobs`-decorated entry point
+    so the change is reverted after the kernel compiles instead of leaking
+    process-wide.  Unlike the previous implementation this applies the knobs on
+    every call (the surrounding scope restores them afterwards).
+    """
+    if _amd_knobs_available():
         triton.knobs.amd.use_async_copy = True
         triton.knobs.amd.scalarize_packed_fops = True
         triton.knobs.amd.use_block_pingpong = True
     else:
-        os.environ.setdefault("TRITON_HIP_USE_ASYNC_COPY", "1")
-        os.environ.setdefault("AMDGCN_SCALARIZE_PACKED_FOPS", "1")
-        os.environ.setdefault("TRITON_HIP_USE_BLOCK_PINGPONG", "1")
+        os.environ["TRITON_HIP_USE_ASYNC_COPY"] = "1"
+        os.environ["AMDGCN_SCALARIZE_PACKED_FOPS"] = "1"
+        os.environ["TRITON_HIP_USE_BLOCK_PINGPONG"] = "1"
+
+
+@contextlib.contextmanager
+def scoped_amd_triton_knobs():
+    """Snapshot AMD Triton compiler knobs on entry, restore them on exit.
+
+    Any knob flipping done inside the ``with`` block (via
+    :func:`set_triton_knobs_gfx950` or a local ``_set_amd_knobs``) is undone on
+    exit, so turbo's GEMM knobs never leak into other Triton kernels.
+    """
+    saved_attrs = {}
+    if _amd_knobs_available():
+        amd = triton.knobs.amd
+        for name in _AMD_KNOB_ATTRS:
+            if hasattr(amd, name):
+                saved_attrs[name] = getattr(amd, name)
+    saved_env = {name: os.environ.get(name) for name in _AMD_KNOB_ENVS}
+    try:
+        yield
+    finally:
+        if saved_attrs:
+            amd = triton.knobs.amd
+            for name, val in saved_attrs.items():
+                setattr(amd, name, val)
+        for name, val in saved_env.items():
+            if val is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = val
+
+
+def scoped_amd_knobs(func):
+    """Decorator: run ``func`` under :func:`scoped_amd_triton_knobs`.
+
+    Apply to every turbo GEMM / grouped-GEMM entry point that toggles AMD knobs,
+    so the knobs are active only while that kernel compiles/launches.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        with scoped_amd_triton_knobs():
+            return func(*args, **kwargs)
+
+    return wrapper

--- a/primus_turbo/triton/utils/triton_knobs_helper.py
+++ b/primus_turbo/triton/utils/triton_knobs_helper.py
@@ -12,6 +12,8 @@ import os
 
 import triton
 
+from primus_turbo.pytorch.core.utils import is_gfx950
+
 # Triton ``knobs.amd`` attributes touched by the turbo GEMM kernels.
 _AMD_KNOB_ATTRS = ("use_async_copy", "scalarize_packed_fops", "use_block_pingpong")
 
@@ -27,31 +29,15 @@ def _amd_knobs_available() -> bool:
     return hasattr(triton, "knobs") and hasattr(triton.knobs, "amd")
 
 
-def set_triton_knobs_gfx950() -> None:
-    """Enable AMD compiler knobs for gfx950 (async_copy, block_pingpong, scalarize).
-
-    Must be called from inside a :func:`scoped_amd_knobs`-decorated entry point
-    so the change is reverted after the kernel compiles instead of leaking
-    process-wide.  Unlike the previous implementation this applies the knobs on
-    every call (the surrounding scope restores them afterwards).
-    """
-    if _amd_knobs_available():
-        triton.knobs.amd.use_async_copy = True
-        triton.knobs.amd.scalarize_packed_fops = True
-        triton.knobs.amd.use_block_pingpong = True
-    else:
-        os.environ["TRITON_HIP_USE_ASYNC_COPY"] = "1"
-        os.environ["AMDGCN_SCALARIZE_PACKED_FOPS"] = "1"
-        os.environ["TRITON_HIP_USE_BLOCK_PINGPONG"] = "1"
-
-
 @contextlib.contextmanager
 def scoped_amd_triton_knobs():
     """Snapshot AMD Triton compiler knobs on entry, restore them on exit.
 
-    Any knob flipping done inside the ``with`` block (via
-    :func:`set_triton_knobs_gfx950` or a local ``_set_amd_knobs``) is undone on
-    exit, so turbo's GEMM knobs never leak into other Triton kernels.
+    On gfx950 the gfx950 knobs (async_copy, scalarize_packed_fops,
+    block_pingpong) are enabled for the duration of the scope. Any further knob
+    flipping done inside the ``with`` block (e.g. a local ``_set_amd_knobs`` on
+    gfx942) is likewise undone on exit, so turbo's GEMM knobs never leak into
+    other Triton kernels.
     """
     saved_attrs = {}
     if _amd_knobs_available():
@@ -61,6 +47,15 @@ def scoped_amd_triton_knobs():
                 saved_attrs[name] = getattr(amd, name)
     saved_env = {name: os.environ.get(name) for name in _AMD_KNOB_ENVS}
     try:
+        if is_gfx950():
+            if _amd_knobs_available():
+                triton.knobs.amd.use_async_copy = True
+                triton.knobs.amd.scalarize_packed_fops = True
+                triton.knobs.amd.use_block_pingpong = True
+            else:
+                os.environ["TRITON_HIP_USE_ASYNC_COPY"] = "1"
+                os.environ["AMDGCN_SCALARIZE_PACKED_FOPS"] = "1"
+                os.environ["TRITON_HIP_USE_BLOCK_PINGPONG"] = "1"
         yield
     finally:
         if saved_attrs:

--- a/primus_turbo/triton/utils/triton_knobs_helper.py
+++ b/primus_turbo/triton/utils/triton_knobs_helper.py
@@ -9,6 +9,7 @@
 import contextlib
 import functools
 import os
+from typing import Optional
 
 import triton
 
@@ -30,13 +31,19 @@ def _amd_knobs_available() -> bool:
 
 
 @contextlib.contextmanager
-def scoped_amd_triton_knobs():
+def scoped_amd_triton_knobs(gfx942_enable: Optional[bool] = None):
     """Snapshot AMD Triton compiler knobs on entry, restore them on exit.
 
-    On gfx950 the gfx950 knobs (async_copy, scalarize_packed_fops,
-    block_pingpong) are enabled for the duration of the scope. Any further knob
-    flipping done inside the ``with`` block (e.g. a local ``_set_amd_knobs`` on
-    gfx942) is likewise undone on exit, so turbo's GEMM knobs never leak into
+    On gfx950 the full gfx950 knob set (async_copy, scalarize_packed_fops,
+    block_pingpong) is enabled for the duration of the scope.
+
+    On gfx942, when ``gfx942_enable`` is not None, use_async_copy /
+    scalarize_packed_fops are set to that value for the scope (NT/NN GEMMs
+    benefit, but TN/wgrad regresses ~5-8% on MI300X so those callers pass
+    ``False``); ``None`` leaves the gfx942 knobs at their defaults.
+    block_pingpong is never touched on gfx942.
+
+    All changes are restored on exit, so turbo's GEMM knobs never leak into
     other Triton kernels.
     """
     saved_attrs = {}
@@ -56,6 +63,9 @@ def scoped_amd_triton_knobs():
                 os.environ["TRITON_HIP_USE_ASYNC_COPY"] = "1"
                 os.environ["AMDGCN_SCALARIZE_PACKED_FOPS"] = "1"
                 os.environ["TRITON_HIP_USE_BLOCK_PINGPONG"] = "1"
+        elif gfx942_enable is not None and _amd_knobs_available():
+            triton.knobs.amd.use_async_copy = gfx942_enable
+            triton.knobs.amd.scalarize_packed_fops = gfx942_enable
         yield
     finally:
         if saved_attrs:
@@ -69,16 +79,24 @@ def scoped_amd_triton_knobs():
                 os.environ[name] = val
 
 
-def scoped_amd_knobs(func):
+def scoped_amd_knobs(func=None, *, gfx942_enable: Optional[bool] = None):
     """Decorator: run ``func`` under :func:`scoped_amd_triton_knobs`.
 
     Apply to every turbo GEMM / grouped-GEMM entry point that toggles AMD knobs,
     so the knobs are active only while that kernel compiles/launches.
+
+    Usable bare (``@scoped_amd_knobs``) or parametrised
+    (``@scoped_amd_knobs(gfx942_enable=True)``) to pin a fixed gfx942 per-layout
+    policy. For entry points whose layout is only known at call time (e.g. the
+    unified dense blockwise kernel that dispatches NT/NN/TN internally), use the
+    :func:`scoped_amd_triton_knobs` context manager directly instead.
     """
+    if func is None:
+        return functools.partial(scoped_amd_knobs, gfx942_enable=gfx942_enable)
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        with scoped_amd_triton_knobs():
+        with scoped_amd_triton_knobs(gfx942_enable=gfx942_enable):
             return func(*args, **kwargs)
 
     return wrapper

--- a/primus_turbo/triton/utils/triton_knobs_helper.py
+++ b/primus_turbo/triton/utils/triton_knobs_helper.py
@@ -56,16 +56,22 @@ def scoped_amd_triton_knobs(gfx942_enable: Optional[bool] = None):
     try:
         if is_gfx950():
             if _amd_knobs_available():
-                triton.knobs.amd.use_async_copy = True
-                triton.knobs.amd.scalarize_packed_fops = True
-                triton.knobs.amd.use_block_pingpong = True
+                # Only touch knobs that exist, so snapshot/restore stays
+                # symmetric and we never AttributeError on a Triton build
+                # missing one.
+                amd = triton.knobs.amd
+                for name in _AMD_KNOB_ATTRS:
+                    if hasattr(amd, name):
+                        setattr(amd, name, True)
             else:
-                os.environ["TRITON_HIP_USE_ASYNC_COPY"] = "1"
-                os.environ["AMDGCN_SCALARIZE_PACKED_FOPS"] = "1"
-                os.environ["TRITON_HIP_USE_BLOCK_PINGPONG"] = "1"
+                for name in _AMD_KNOB_ENVS:
+                    os.environ[name] = "1"
         elif gfx942_enable is not None and _amd_knobs_available():
-            triton.knobs.amd.use_async_copy = gfx942_enable
-            triton.knobs.amd.scalarize_packed_fops = gfx942_enable
+            # gfx942 touches only async_copy + scalarize (not block_pingpong).
+            amd = triton.knobs.amd
+            for name in ("use_async_copy", "scalarize_packed_fops"):
+                if hasattr(amd, name):
+                    setattr(amd, name, gfx942_enable)
         yield
     finally:
         if saved_attrs:


### PR DESCRIPTION
# Description

The AMD Triton knobs (`use_async_copy` / `scalarize_packed_fops` /
`use_block_pingpong`) were set process-globally once (guarded by a
`_KNOBS_SET` flag) and never reverted. After any turbo GEMM / grouped-GEMM ran,
these knobs leaked into **unrelated** Triton kernels running in the same
process (e.g. the training loop): they raise shared-memory (LDS) usage — fine
for a standalone op, but enough to OOM during training — and regress some other
Triton kernels.

These knobs are **compile-time only**: they affect codegen and only need to be
active while a kernel is JIT-compiled on its first launch (Triton caches the
compiled binary, so later launches are unaffected). This PR keeps the knob
flipping inside the GEMM / grouped-GEMM entry points but wraps every entry
point with a new `scoped_amd_knobs` decorator that snapshots the knob state on
entry and restores it on exit.

Net effect: the default state is now **off**; turbo turns these knobs on only
while its own GEMM / grouped-GEMM kernels compile, so nothing else in the
process inherits them.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- `primus_turbo/triton/utils/triton_knobs_helper.py`: drop the one-shot
  `_KNOBS_SET` global guard (knobs are now re-applied per call and restored by
  the surrounding scope); add `scoped_amd_triton_knobs()` context manager that
  snapshots/restores the AMD knobs (with `triton.knobs.amd` and env-var
  fallback), and a `scoped_amd_knobs` decorator wrapping it.
- Decorate all 16 GEMM / grouped-GEMM entry points with `@scoped_amd_knobs`:
  - `primus_turbo/triton/gemm/gemm_kernel.py` (1)
  - `primus_turbo/triton/gemm/gemm_fp8_kernel.py` (3)
  - `primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py` (2)
  - `primus_turbo/triton/grouped_gemm/grouped_gemm_fp4_kernel.py` (2)
  - `primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py` (8)
- The existing gfx942 layout-dependent `_set_amd_knobs(...)` calls are kept
  verbatim; they are now scoped (restored on function exit) too.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
