### PR TITLE
opt(grouped_gemm): improve fp8 dgrad & wgrad performance

### DIFF
--- a/primus_turbo/flydsl/grouped_gemm/gemm_fp8_grouped_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/gemm_fp8_grouped_kernel.py
@@ -35,8 +35,10 @@ import os
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 import torch
+from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm as _llvm
 from flydsl.expr import arith, const_expr, range_constexpr, rocdl
+from flydsl.expr import buffer_ops as _buffer_ops
 from flydsl.expr.typing import T
 from flydsl.expr.typing import Vector as Vec
 
@@ -63,9 +65,10 @@ from primus_turbo.flydsl.utils.gemm_helper import (
 # Baked NT super-block tile swizzle width (0 = row-major; the autotune sweeps group_m
 # per shape for B[g] N-stripe L2 reuse).
 _GROUPED_NT_GROUPM = 0
-_WG_INTERLEAVE = bool(
-    int(os.environ.get("WG_INTERLEAVE", "1"))
-)  # band-cyclic group interleave: skew load-balance, balanced-neutral (env=0 to disable)
+# Band-cyclic group interleave (skew load-balance, keeps group_m B-stripe L2 reuse); a
+# balanced-neutral rebalance so it is always on. One-M-row fallback when group_m doesn't
+# tile N_BLOCKS_M (see _wgrad_block_mn).
+_WG_INTERLEAVE = True
 
 
 def _load_i32(div, idx):
@@ -281,7 +284,7 @@ def _compile_grouped_nn(
             b_base = arith.index_cast(T.index, group_idx) * arith.index(K) * cn_i + arith.index_cast(
                 T.index, block_n * BLOCK_N
             )
-            m_total = _load_go(go_div, G)
+            m_total = _readfirstlane_i32(_load_go(go_div, G))
             a_nrec = (arith.index_cast(T.index, m_total) - arith.index_cast(T.index, m_row)) * arith.index(K)
             b_nrec = (arith.index(G) - arith.index_cast(T.index, group_idx)) * arith.index(
                 K
@@ -296,8 +299,9 @@ def _compile_grouped_nn(
             a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
             b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
 
+            _nnwz = os.environ.get("PT_NN_WSWZ", "1") == "1"  # wave-swizzle dgrad B, default on
             gl_off_a = compute_global_swizzle(lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=False)
-            gl_off_b = compute_global_swizzle_nn(lane_id, wave_id, c_n, N_LDS_ROUNDS)
+            gl_off_b = compute_global_swizzle_nn(lane_id, wave_id, c_n, N_LDS_ROUNDS, wswz=_nnwz)
 
             # AGPR in-place accum (mode 2) when agpr_inplace -> off the VGPR file (spill-free).
             mfma = _build_mfma(
@@ -317,7 +321,9 @@ def _compile_grouped_nn(
             # B transpose-load via inline-asm ds_read_b64_tr_b8: the opaque asm hides the
             # wave-coop transpose reads from the backend so it keeps load/mfma overlap
             # (the intrinsic would force a vmcnt(0) drain). Inline path needs agpr_alloc>0.
-            b_s2r = S2RLoaderTr(wave_n, N_TILES_B, 32, inline_asm=(agpr_inplace and acc_mode == "agpr"))
+            b_s2r = S2RLoaderTr(
+                wave_n, N_TILES_B, 32, inline_asm=(agpr_inplace and acc_mode == "agpr"), wswz=_nnwz
+            )
             if const_expr(store_cshuffle):
                 store_c = StoreCPerTensorCShuffle(
                     A_scale,
@@ -677,7 +683,7 @@ def _compile_grouped_nt(
             b_base = (
                 arith.index_cast(T.index, group_idx) * cn_i + arith.index_cast(T.index, block_n * BLOCK_N)
             ) * arith.index(K)
-            m_total = _load_go(go_div, G)
+            m_total = _readfirstlane_i32(_load_go(go_div, G))
             a_nrec = (arith.index_cast(T.index, m_total) - arith.index_cast(T.index, m_row)) * arith.index(K)
             b_nrec = arith.index(G) * cn_i * arith.index(K) - b_base
             A0_gl_offset = 0
@@ -1479,10 +1485,21 @@ def _balanced_targs(args, m_total, G):
     return args[:5] + (bal,) + args[6:]
 
 
+# Fixed 8-wave candidates shared by NT (fwd) and NN (dgrad): (BLOCK_M, num_xcd, group_m,
+# group_n). Chosen from measured per-shape winners across m_total/G in 1024..8192, 7
+# production shapes, 28 combos each op: these 3 are the winner in ~26/28 rows across both
+# ops (a 4th xcd1 candidate is added below only for the op/shape that needs it). Autotune
+# candidate count is capped at 4 per shape (NT: 4 of these; NN: 3 of these + 1 4-wave).
+_NP_8WAVE_CANDS = ((256, 8, 4, 0), (256, 8, 8, 0), (256, 8, 4, 4))
+# xcd1 (group-major, B[g] L2-resident) only pays off once B[g] is large; K>=4096 is the
+# observed crossover (deepseek-up K=7168 wins with this at large M, nothing smaller does).
+_NP_LARGE_K = 4096
+
+
 def _autotune_np_dispatch(trans_b, K, G, out_fp16, cbsz, blgp, args):
     """Per-shape autotune of the non-persistent NT/NN kernel, balanced-timed (1.5% hysteresis,
-    cached per static shape). NN small-M (G*ceil(pm/128)*ceil(N/256)<=num_cus, underfilled):
-    single BLOCK_M=128; else 3 bm256 swizzles (8,4,0)/(1,0,0)/(8,8,0), cand[0] = ref."""
+    cached per static shape, <=4 candidates raced). NN small-M (G*ceil(pm/128)*ceil(N/256)
+    <=num_cus, underfilled): single BLOCK_M=128, no autotune."""
     out_view = args[2]
     # time on a balanced group_offs (args[6] = M_total) so a skewed first call cannot
     # bias the config pick.
@@ -1537,7 +1554,12 @@ def _autotune_np_dispatch(trans_b, K, G, out_fp16, cbsz, blgp, args):
         # (boundary sweep +5..31%, never loses) -> single config, no autotune.
         return mk(128, 1, 0, 0)
 
-    cands = [(256, 8, 4, 0), (256, 1, 0, 0), (256, 8, 8, 0)]  # large-M / NT swizzles
+    # NT gets a 4th (xcd1) 8-wave candidate since it has no 4-wave to race; NN keeps 3
+    # 8-wave candidates and spends its 4th slot on a single rule-picked 4-wave candidate
+    # below, so both ops stay at <=4 total.
+    cands = list(_NP_8WAVE_CANDS)
+    if trans_b and K >= _NP_LARGE_K:
+        cands.append((256, 1, 4, 0))
     base = mk(*cands[0])
     base(*targs)
     torch.cuda.synchronize()
@@ -1559,6 +1581,45 @@ def _autotune_np_dispatch(trans_b, K, G, out_fp16, cbsz, blgp, args):
         t = _robust_time(l, targs)
         if t < bt * 0.985:  # adopt only if >=1.5% faster (robust timing -> reliable)
             best, bt = l, t
+
+    # Race one 4-wave (occ=1) candidate against the 8-wave winner, dgrad (NN) only (fwd
+    # NT 4-wave never wins). Config is a fixed rule on K, not a sweep: large-K -> xcd1
+    # group-major, else xcd8. Keeps NN at 3 8-wave + 1 4-wave = 4 candidates. Any K (the
+    # group-bounded B SRD zeros the K%128 tail); PT_NO_G4W=1 disables.
+    if (not trans_b) and os.environ.get("PT_NO_G4W", "0") != "1":
+        xcd4, gm4, gn4, vm4h = (1, 4, 8, 2) if K >= _NP_LARGE_K else (8, 4, 0, 2)
+        try:
+            l4 = _compile_grouped_nn_4wave(
+                K=K,
+                G=G,
+                num_xcd=xcd4,
+                group_m=gm4,
+                group_n=gn4,
+                cbsz=cbsz,
+                blgp=blgp,
+                out_fp16=out_fp16,
+                vmcnt_hint=vm4h,
+            )
+        except Exception as _e4w:
+            if os.environ.get("PT_QUIET_G4W", "0") != "1":
+                import warnings as _warnings_g4w
+
+                _warnings_g4w.warn(
+                    f"4-wave joint candidate compile failed (trans_b={trans_b}, K={K}, G={G}, "
+                    f"xcd={xcd4}, gm={gm4}, gn={gn4}): {_e4w!r}"
+                )
+                l4 = None
+        else:
+            l4(*targs)
+            torch.cuda.synchronize()
+            if not _ok():
+                l4 = None
+        if l4 is not None:
+            t = _robust_time(l4, targs)
+            # Re-time `best` right next to it to cancel thermal drift between candidates.
+            tb_now = _robust_time(best, targs)
+            if t < tb_now * 0.985:
+                best, bt = l4, t
     return best
 
 
@@ -1754,14 +1815,12 @@ def _compile_grouped_tn_wgrad_persistent(
     asm_acc_mode: str = "vgpr",
     s2r_inline: bool = False,
     nt_vmcnt: int = 3,
-    grid_mul: int = 1,  # grid = grid_mul * num_cus (more WGs -> HW hides per-tile prologue latency)
     unroll_n: int = -1,  # >=2: continuous-N chunk-unroll (dense-pipeline, capacity-free); -1 = use module env default
-    persistent: bool = True,  # False = TRUE non-persistent: NO outer scf.for tile loop (one tile/WG, grid=TOTAL, straight-line outer; the runtime K-loop stays). Avoids the outer tile-loop scheduling penalty.
-    cap_cu: int = -1,  # persistent only: >0 caps grid to this many WGs (reserve CUs for comm overlap)
+    cap_cu: int = -1,  # >0 caps grid to this many WGs (reserve CUs for comm overlap)
     i64_traverse: bool = False,  # A[m,OUT_M] & B[m,OUT_N] traversal via per-load i64 SRD re-base (lifts mg*OUT < 2^32 cap)
 ):
     """PERSISTENT grouped TN wgrad (the production wgrad; fwd/dgrad are persistent
-    so wgrad must be too). grid = min(G*TILES_PER_GROUP, grid_mul*num_cus); each WG
+    so wgrad must be too). grid = min(G*TILES_PER_GROUP, num_cus); each WG
     strides `for t in range(pid, TOTAL, nsms)` over the tile space in XCD-remapped +
     band order. TOTAL is compile-time (OUT dims fixed) -> no device scan. Per-group
     SRD num_records clamp handles the K-tail; rmem accs reset per tile."""
@@ -2002,14 +2061,9 @@ def _compile_grouped_tn_wgrad_persistent(
             base_col = block_n * BLOCK_N + wave_n_offset
             _store_quadrants(store_c, c00, c01, c10, c11, base_row, base_col, LDS_BLOCK_M, LDS_BLOCK_N)
 
-        if const_expr(persistent):
-            # persistent: fixed grid strides over the tile space (scf.for).
-            for t in range(pid, TOTAL, nsms):
-                _do_tile(t)
-        else:
-            # TRUE non-persistent: one tile per WG, NO outer scf.for. grid=TOTAL
-            # (compile-time, so block_idx is always a valid tile -> no scan/guard).
-            _do_tile(pid)
+        # Persistent: a fixed grid of <=ncus WGs strides the tile space (scf.for).
+        for t in range(pid, TOTAL, nsms):
+            _do_tile(t)
 
     @flyc.jit
     def launch_grouped_tn_persist(
@@ -2022,11 +2076,9 @@ def _compile_grouped_tn_wgrad_persistent(
         stream: fx.Stream,
     ):
         ncus = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
-        # persistent: cap to grid_mul*ncus (or cap_cu for comm overlap); non-persistent:
-        # exactly TOTAL WGs. Python-ternary (@flyc.jit rewrites if-statements into scf.if).
-        cap = (grid_mul * ncus) if cap_cu <= 0 else min(int(cap_cu), ncus)
-        _capg = arith.select(fx.Int32(TOTAL) < cap, fx.Int32(TOTAL), fx.Int32(cap))
-        grid_x = _capg if persistent else fx.Int32(TOTAL)
+        # Cap the grid to ncus WGs (or cap_cu when reserving CUs for comm overlap).
+        cap = ncus if cap_cu <= 0 else min(int(cap_cu), ncus)
+        grid_x = arith.select(fx.Int32(TOTAL) < cap, fx.Int32(TOTAL), fx.Int32(cap))
         _ag = 128 if (asm_mma and asm_acc_mode == "agpr") else 0
         attrs = make_value_attrs(waves_per_eu, _ag, "512,512")
         kernel_grouped_tn_persist(
@@ -2042,6 +2094,830 @@ def _compile_grouped_tn_wgrad_persistent(
     return launch_grouped_tn_persist
 
 
+# 3-buffer whole-loop: one pool gets prefetch depth 3, the rest depth 2. n_phases =
+# lcm(nbuf per pool), statically unrolled so each pool's write/refill buf index is a
+# compile-time constant per phase. PT_WL_VMCNT_MODE="partial" (default) skips the next
+# barrier's drain for the 3-buf pool's just-issued write, relying on buffer_load_lds FIFO
+# order -- verify with a bit-exact repeated-run race test, SNR alone won't catch it.
+_WL_ASM_CACHE_3BUF = {}
+
+
+def _wgrad_wholeloop_asm_3buf(
+    *,
+    nta,
+    ntb,
+    bases,  # [4][nbuf_p][2*tiles] -- nbuf_p = len(bases[p]), 2 or 3 per pool
+    gbases,  # [4][nbuf_p]
+    gl_a,
+    gl_b,
+    rsrc_a,
+    rsrc_b,
+    soff0,  # [4] initial gmem soffset for the first in-loop write (targets K-block nbuf_p[p])
+    kstep,
+    kstep_b,
+    nval,  # runtime trip count, must be a multiple of n_phases = lcm(nbuf_p)
+    acc,
+    nsa,
+    nsb,
+    rs,
+    cs,
+    nw,
+    cbsz=0,
+    blgp=0,
+    tail_nval=None,  # SGPR i32: count of extra single-block passes (0..5) appended after
+    # the main do-while, fused into the same inline-asm block so accumulator state
+    # carries over natively.
+    a_plain=False,  # see _wgrad_wholeloop_asm's a_plain
+):
+    from functools import reduce
+    from math import gcd
+
+    nq = nta * ntb
+    NT = 4 * nq
+    PIN = 8
+    QUADS = ((0, 2), (0, 3), (1, 2), (1, 3))
+    tiles = (nta, nta, ntb, ntb)
+    ntmp = sum(tiles)
+    nbase = [2 * tiles[p] for p in range(4)]
+    nbuf_p = tuple(len(bases[p]) for p in range(4))
+    n_phases = reduce(lambda a, b: a * b // gcd(a, b), nbuf_p, 1)
+    mods = f" cbsz:{cbsz} blgp:{blgp}" if (cbsz or blgp) else ""
+    _vmcnt_mode = os.environ.get("PT_WL_VMCNT_MODE", "partial")  # partial-drain is the default
+    _has_tail = tail_nval is not None
+    _cs_t = tuple(cs) if isinstance(cs, (list, tuple)) else (cs, cs, cs, cs)
+    key = ("3buf", nta, ntb, nsa, nsb, nbuf_p, mods, rs, _cs_t, nw, _vmcnt_mode, _has_tail, a_plain)
+    if key not in _WL_ASM_CACHE_3BUF:
+        o_acc = list(range(NT))
+        t_pool = [NT]
+        for p in range(4):
+            t_pool.append(t_pool[-1] + tiles[p])
+        o_cnt = NT + ntmp
+        o_wsoff = [o_cnt + 1 + p for p in range(4)]  # per-pool running gmem write soffset
+        # The tail is 5 statically unrolled gated phases (s_cmp/s_cbranch skip), not a
+        # runtime counter loop -- no extra scratch SGPR needed. Do not add an "=&s" output
+        # register here unless an instruction actually writes it: an unwritten "=&s"
+        # output is an uninitialized-output hazard that can corrupt register allocation.
+
+        i = o_cnt + 5
+        i_base = []  # i_base[p][b] = [input idx, ...] (len nbase[p])
+        for p in range(4):
+            row = []
+            for _b in range(nbuf_p[p]):
+                row.append([i + j for j in range(nbase[p])])
+                i += nbase[p]
+            i_base.append(row)
+        i_gbase = []
+        for p in range(4):
+            i_gbase.append([i + b for b in range(nbuf_p[p])])
+            i += nbuf_p[p]
+        i_gla = [i + s for s in range(nsa)]
+        i += nsa
+        i_glb = [i + s for s in range(nsb)]
+        i += nsb
+        i_rsa = i
+        i += 1
+        i_rsb = i
+        i += 1
+        i_kstep = i
+        i += 1
+        i_kstepb = i
+        i += 1
+        i_nval = i
+        i += 1
+        if _has_tail:
+            i_tailval = i
+            i += 1
+        i_soff0 = [i + p for p in range(4)]
+        i_ks = [i_kstep, i_kstep, i_kstepb, i_kstepb]
+
+        def pool_of(tt):
+            for p in range(4):
+                if t_pool[p] <= tt < t_pool[p + 1]:
+                    return p, tt - t_pool[p]
+            raise AssertionError
+
+        def ds_line(buf_per_pool, tt):
+            p, ti = pool_of(tt)
+            buf = buf_per_pool[p]
+            vb = PIN + (tt - NT) * 8
+            p0, p1 = i_base[p][buf][2 * ti], i_base[p][buf][2 * ti + 1]
+            if a_plain and p < 2:
+                # plain (no-transpose) read -- see _wgrad_wholeloop_asm's a_plain.
+                return (
+                    f"ds_read_b128 v[{vb}:{vb + 3}], ${p0} offset:0\n"
+                    f"ds_read_b128 v[{vb + 4}:{vb + 7}], ${p1} offset:0"
+                )
+            return (
+                f"ds_read_b64_tr_b8 v[{vb}:{vb + 1}], ${p0} offset:0\n"
+                f"ds_read_b64_tr_b8 v[{vb + 2}:{vb + 3}], ${p1} offset:0\n"
+                f"ds_read_b64_tr_b8 v[{vb + 4}:{vb + 5}], ${p0} offset:{rs}\n"
+                f"ds_read_b64_tr_b8 v[{vb + 6}:{vb + 7}], ${p1} offset:{rs}"
+            )
+
+        def emit_g2s(write_buf_per_pool):
+            r = []
+            for p in range(4):
+                rsrc = i_rsa if p < 2 else i_rsb
+                gl = i_gla if p < 2 else i_glb
+                nst = nsa if p < 2 else nsb
+                buf = write_buf_per_pool[p]
+                for st in range(nst):
+                    r.append(
+                        f"s_add_u32 m0, ${i_gbase[p][buf]}, {st * nw * _cs_t[p]}\n"
+                        f"buffer_load_dwordx4 ${gl[st]}, ${rsrc}, ${o_wsoff[p]} offen lds"
+                    )
+            return r
+
+        def _mfma_line(qi, ii, ji):
+            ap, bp = QUADS[qi]
+            q = qi * nq + ii * ntb + ji
+            at = t_pool[ap] + ii
+            bt = t_pool[bp] + ji
+            return (f"v_mfma_f32_16x16x128_f8f6f4 ${q}, ${at}, ${bt}, ${q}{mods}", at, bt)
+
+        def _diag_cells():
+            bm, bn = 2, 4
+            ncol = 2 * ntb
+            nib, ncb = nta // bm, ncol // bn
+            cells = []
+            for D in range(nib + ncb - 1):
+                for iib in range(nib):
+                    cb = D - iib
+                    if 0 <= cb < ncb:
+                        for di in range(bm):
+                            for dj in range(bn):
+                                ii = iib * bm + di
+                                col = cb * bn + dj
+                                cells.append((ii, col // ntb, col % ntb))
+            return cells
+
+        def emit_quadrant_mfmas():
+            seq = []
+            for ii, bh, ji in _diag_cells():
+                for ah in range(2):
+                    qi = ah * 2 + bh
+                    seq.append(_mfma_line(qi, ii, ji))
+            return seq
+
+        def emit_phase(refill_bp, write_bp):
+            g2sl = emit_g2s(write_bp)
+            mlist = emit_quadrant_mfmas()
+            last = {}
+            for mi, (_ml, at, bt) in enumerate(mlist):
+                last[at] = mi
+                last[bt] = mi
+            _gset = {}
+            if g2sl:
+                rfslot, rf = set(), set()
+                for mi, (_ml, at, bt) in enumerate(mlist):
+                    for rt in (at, bt):
+                        if last[rt] == mi and rt not in rf:
+                            rfslot.add(mi)
+                            rf.add(rt)
+                free = [mi for mi in range(len(mlist)) if mi not in rfslot]
+                fgap = max(len(free) // max(len(g2sl), 1), 1)
+                for k, fi in enumerate(free):
+                    if (k % fgap == 0) and len(_gset) < len(g2sl):
+                        _gset[fi] = len(_gset)
+            out, gi, refilled = [], 0, set()
+            for mi, (ml, at, bt) in enumerate(mlist):
+                out.append(ml)
+                for rt in (at, bt):
+                    if last[rt] == mi and rt not in refilled:
+                        out.append(ds_line(refill_bp, rt))
+                        refilled.add(rt)
+                if g2sl and mi in _gset and gi < len(g2sl):
+                    out.append(g2sl[gi])
+                    gi += 1
+            while gi < len(g2sl):
+                out.append(g2sl[gi])
+                gi += 1
+            for tt in range(NT, NT + ntmp):
+                if tt not in refilled:
+                    out.append(ds_line(refill_bp, tt))
+            return out
+
+        _3buf_pools = [p for p in range(4) if nbuf_p[p] == 3]
+        _3buf_pool = _3buf_pools[0] if _3buf_pools else None
+        if _vmcnt_mode == "partial" and _3buf_pool is not None:
+            # Partial drain must leave in flight the writes of ALL 3-buffered pools, not
+            # just the first. Emit order (pools 0,1,2,3) issues the 3-buf pools last, so
+            # vmcnt(sum of their write counts) leaves exactly those writes outstanding.
+            _n_outstanding = sum((nsa if p < 2 else nsb) for p in _3buf_pools)
+            _ipend = f"s_waitcnt vmcnt({_n_outstanding}) lgkmcnt(0)\ns_barrier"
+        else:
+            _ipend = "s_waitcnt vmcnt(0) lgkmcnt(0)\ns_barrier"
+
+        refill0 = [(-1 + 1) % nbuf_p[p] for p in range(4)]
+        L = [f"s_mov_b32 ${o_cnt}, 0"]
+        for p in range(4):
+            L.append(f"s_mov_b32 ${o_wsoff[p]}, ${i_soff0[p]}")
+        L += [ds_line(refill0, tt) for tt in range(NT, NT + ntmp)]
+        L.append("s_waitcnt lgkmcnt(0)")
+        L.append("1:")
+        for ph in range(n_phases):
+            refill_bp = [(ph + 1) % nbuf_p[p] for p in range(4)]
+            write_bp = [ph % nbuf_p[p] for p in range(4)]
+            L += emit_phase(refill_bp, write_bp)
+            L.append(_ipend)
+            for p in range(4):
+                L.append(f"s_add_u32 ${o_wsoff[p]}, ${o_wsoff[p]}, ${i_ks[p]}")
+        L.append(f"s_add_u32 ${o_cnt}, ${o_cnt}, {n_phases}")
+        L.append(f"s_cmp_lt_u32 ${o_cnt}, ${i_nval}")
+        L.append("s_cbranch_scc1 1b")
+
+        if _has_tail and _vmcnt_mode == "partial" and _3buf_pool is not None:
+            # The main loop's per-phase partial drain assumes there's always a next
+            # phase to finish draining outstanding loads; that breaks once the do-while
+            # exits into the tail. Force one full drain+barrier here before the tail
+            # reuses the main loop's LDS/register state. Skipped when tail_nval==0 since
+            # no tail phase runs and nothing reads the in-flight buffers.
+            L.append(f"s_cmp_eq_u32 ${i_tailval}, 0")
+            L.append("s_cbranch_scc1 3f")
+            L.append("s_waitcnt vmcnt(0) lgkmcnt(0)")
+            L.append("s_barrier")
+            L.append("3:")
+
+        if _has_tail:
+            # In-asm tail: up to 5 extra single-block phases fused into this asm block so
+            # accumulator state carries over natively. n_phases=6 is a multiple of every
+            # pool's nbuf_p, so the do-while exits aligned to phase j=0; these reuse the
+            # same write_bp/refill_bp formula, each gated by s_cmp/s_cbranch on tail_nval.
+            for j in range(5):
+                refill_bp = [(j + 1) % nbuf_p[p] for p in range(4)]
+                write_bp = [j % nbuf_p[p] for p in range(4)]
+                skip_lbl = f"{j + 4}"  # distinct numeric local labels, unused elsewhere
+                L.append(f"s_cmp_le_u32 ${i_tailval}, {j}")  # tail_nval<=j -> no phase j
+                L.append(f"s_cbranch_scc1 {skip_lbl}f")
+                L += emit_phase(refill_bp, write_bp)
+                L.append("s_waitcnt vmcnt(0) lgkmcnt(0)\ns_barrier")
+                for p in range(4):
+                    L.append(f"s_add_u32 ${o_wsoff[p]}, ${o_wsoff[p]}, ${i_ks[p]}")
+                L.append(f"{skip_lbl}:")
+
+        L.append("s_waitcnt vmcnt(0) lgkmcnt(0)")
+        asm = "\n".join(L)
+
+        vtmp = [f"=&{{v[{PIN + f * 8}:{PIN + f * 8 + 7}]}}" for f in range(ntmp)]
+        cons = ",".join(
+            ["=a"] * NT
+            + vtmp
+            + ["=&s"] * 5
+            + ["v"] * sum(nbase[p] * nbuf_p[p] for p in range(4))
+            + ["s"] * sum(nbuf_p)
+            + ["v"] * nsa
+            + ["v"] * nsb
+            + (["s", "s", "s", "s", "s", "s"] if _has_tail else ["s", "s", "s", "s", "s"])
+            + ["s", "s", "s", "s"]
+            + [str(q) for q in o_acc]
+        )
+        st = (
+            "!llvm.struct<("
+            + ", ".join(["vector<4xf32>"] * NT + ["vector<8xi32>"] * ntmp + ["i32"] * 5)
+            + ")>"
+        )
+        _WL_ASM_CACHE_3BUF[key] = (asm, cons, st)
+    asm, cons, st = _WL_ASM_CACHE_3BUF[key]
+
+    ins = []
+    for p in range(4):
+        for buf in bases[p]:
+            ins += list(buf)
+    for p in range(4):
+        ins += list(gbases[p])
+    ins += list(gl_a) + list(gl_b)
+    ins += [rsrc_a, rsrc_b, kstep, kstep_b, nval]
+    if _has_tail:
+        ins += [tail_nval]
+    ins += list(soff0)
+    for qi in range_constexpr(4):
+        ins += [acc[qi][q] for q in range_constexpr(nq)]
+    ins = [arith._to_raw(v) for v in ins]
+
+    r = _llvm.inline_asm(ir.Type.parse(st), ins, asm, cons, has_side_effects=True)
+    o = [Vec(_llvm.extractvalue(ir.Type.parse("vector<4xf32>"), r, [q])) for q in range_constexpr(NT)]
+    return [o[qi * nq : (qi + 1) * nq] for qi in range(4)]
+
+
+def _wgrad_wholeloop_tile_3buf(
+    *,
+    a_g2s,
+    b_g2s,
+    a_s2r,
+    b_s2r,
+    lds,
+    gl_off_a,
+    gl_off_b,
+    A,
+    B,
+    a_base,
+    b_base,
+    a_nrec,
+    b_nrec,
+    c_n,
+    c_m,
+    wave_id,
+    mfma,
+    store_c,
+    nta,
+    ntb,
+    n_accums,
+    nsa,
+    nsb,
+    block_k,
+    cs,
+    nw,
+    cbsz,
+    blgp,
+    base_row,
+    base_col,
+    lds_block_m,
+    lds_block_n,
+    nval,
+    do_store=True,  # False = return res, caller stores after the tail
+    tail_nval=None,  # pass through to _wgrad_wholeloop_asm_3buf
+    a_plain=False,  # see _wgrad_wholeloop_tile's a_plain/a_row_stride
+    a_row_stride=None,
+    b0_extra_buf=None,  # optional 3rd buffer for pool2 (B0), giving both B pools 3-deep
+    # buffering instead of just pool3 (B1). None = 1-pool-3buf behavior.
+):
+    assert not a_plain or a_row_stride is not None, "a_plain=True requires a_row_stride"
+    a_cur0, a_cur1 = lds.A_lds_cur_0, lds.A_lds_cur_1
+    a_next0, a_next1 = lds.A_lds_next_0, lds.A_lds_next_1
+    b_cur0, b_cur1 = lds.B_lds_cur_0, lds.B_lds_cur_1
+    b_next0, b_next1 = lds.B_lds_next_0, lds.B_lds_next_1
+    b_extra1 = lds.B_lds_extra_1  # pool3's 3rd buffer
+    if a_plain:
+        A0_gl_offset = 0
+        A1_gl_offset = fx.Int32(lds_block_m) * a_row_stride
+    else:
+        A0_gl_offset, A1_gl_offset = 0, lds_block_m
+    B0_gl_offset, B1_gl_offset = 0, lds_block_n
+    cm_i = arith.index_cast(T.index, c_m)
+    cn_i = arith.index_cast(T.index, c_n)
+    A_K_STEP = arith.index(block_k) * cm_i
+    B_K_STEP = arith.index(block_k) * cn_i
+
+    # Prologue: pools 0-2 prime 2 K-blocks (cur,next); pool3 (B1) primes 3 (cur,next,extra).
+    a_g2s.load(a_cur0, A0_gl_offset + 0 * A_K_STEP)
+    b_g2s.load(b_cur0, B0_gl_offset + 0 * B_K_STEP)
+    b_g2s.load(b_cur1, B1_gl_offset + 0 * B_K_STEP)
+    a_g2s.load(a_cur1, A1_gl_offset + 0 * A_K_STEP)
+    a_g2s.load(a_next0, A0_gl_offset + 1 * A_K_STEP)
+    b_g2s.load(b_next0, B0_gl_offset + 1 * B_K_STEP)
+    b_g2s.load(b_next1, B1_gl_offset + 1 * B_K_STEP)
+    a_g2s.load(a_next1, A1_gl_offset + 1 * A_K_STEP)
+    b_g2s.load(b_extra1, B1_gl_offset + 2 * B_K_STEP)  # pool3's 3rd prime (K-block 2)
+    if b0_extra_buf is not None:
+        b_g2s.load(b0_extra_buf, B0_gl_offset + 2 * B_K_STEP)  # pool2's 3rd prime
+    wait_barrier(0)
+
+    # pools[p] = (buf_tuple, s2r); 3buf pools' buf_tuple has 3 entries, others 2.
+    pool2_bufs = (b_cur0, b_next0) if b0_extra_buf is None else (b_cur0, b_next0, b0_extra_buf)
+    pools = [
+        ((a_cur0, a_next0), a_s2r),
+        ((a_cur1, a_next1), a_s2r),
+        (pool2_bufs, b_s2r),
+        ((b_cur1, b_next1, b_extra1), b_s2r),
+    ]
+    bases = [
+        [[v for pair in s2r.base_addr(buf) for v in pair] for buf in buf_tuple] for buf_tuple, s2r in pools
+    ]
+    _cs_p = list(cs) if isinstance(cs, (list, tuple)) else [cs] * 4
+    gbases = [
+        [
+            rocdl.readfirstlane(
+                T.i32, fx.Int32(fx.ptrtoint(buf.ptr)) + fx.Int32(wave_id) * fx.Int32(_cs_p[p])
+            )
+            for buf in buf_tuple
+        ]
+        for p, (buf_tuple, _s2r) in enumerate(pools)
+    ]
+    gl_a6 = [fx.Int32(gl_off_a[st]) for st in range_constexpr(nsa)]
+    gl_b6 = [fx.Int32(gl_off_b[st]) for st in range_constexpr(nsb)]
+    rsrc_a = _buffer_ops.create_buffer_resource(
+        A, max_size=False, num_records_bytes=a_nrec, base_byte_offset=a_base
+    )
+    rsrc_b = _buffer_ops.create_buffer_resource(
+        B, max_size=False, num_records_bytes=b_nrec, base_byte_offset=b_base
+    )
+    kstep_a = rocdl.readfirstlane(T.i32, fx.Int32(block_k) * c_m)
+    kstep_b = rocdl.readfirstlane(T.i32, fx.Int32(block_k) * c_n)
+    # soff0[p] = the gmem offset for the FIRST in-loop write, targeting K-block nbuf[p]
+    # (2 for pools 0-2, 3 for pool3 -- matches W(0)=nbuf[p] in the asm's schedule).
+    soff0_a = [
+        rocdl.readfirstlane(T.i32, fx.Int32(A0_gl_offset) + fx.Int32(2) * kstep_a),
+        rocdl.readfirstlane(T.i32, fx.Int32(A1_gl_offset) + fx.Int32(2) * kstep_a),
+    ]
+    soff0_b = [
+        rocdl.readfirstlane(
+            T.i32, fx.Int32(B0_gl_offset) + fx.Int32(3 if b0_extra_buf is not None else 2) * kstep_b
+        ),
+        rocdl.readfirstlane(T.i32, fx.Int32(B1_gl_offset) + fx.Int32(3) * kstep_b),
+    ]
+    acc0 = [[mfma.zero_value] * n_accums for _ in range_constexpr(4)]
+    res = _wgrad_wholeloop_asm_3buf(
+        nta=nta,
+        ntb=ntb,
+        bases=bases,
+        gbases=gbases,
+        gl_a=gl_a6,
+        gl_b=gl_b6,
+        rsrc_a=rsrc_a,
+        rsrc_b=rsrc_b,
+        soff0=soff0_a + soff0_b,
+        kstep=kstep_a,
+        kstep_b=kstep_b,
+        nval=nval,
+        acc=acc0,
+        nsa=nsa,
+        nsb=nsb,
+        # see the other call site's comment: general formula = chunks*chunk_stride.
+        rs=(b_s2r.width // 16) * b_s2r.chunk_stride,
+        cs=_cs_p,
+        nw=nw,
+        cbsz=cbsz,
+        blgp=blgp,
+        tail_nval=tail_nval,
+        a_plain=a_plain,
+    )
+    if not do_store:
+        return res
+    store_c.store(res[0], base_row + 0, base_col + 0)
+    store_c.store(res[1], base_row + 0, base_col + lds_block_n)
+    store_c.store(res[2], base_row + lds_block_m, base_col + 0)
+    store_c.store(res[3], base_row + lds_block_m, base_col + lds_block_n)
+    return res
+
+
+# Must stay top-level, not nested inside kernel_grouped_tn_wgrad_4wave's body: FlyDSL's
+# @flyc.kernel tracer processes any def nested in the traced function's own source, and
+# nesting this here previously tripped @flyc.jit's global-drift check on an unrelated
+# cache the moment the launch function was invoked more than once in one process.
+def _wgrad_do_tile_3buf(
+    t,
+    *,
+    TOTAL,
+    num_xcd,
+    G,
+    TILES_PER_GROUP,
+    N_BLOCKS_M,
+    N_BLOCKS_N,
+    group_m,
+    group_n,
+    go_div,
+    BLOCK_K,
+    BLOCK_M,
+    BLOCK_N,
+    OUT_M,
+    OUT_N,
+    F8_IR_t,
+    N_TILES_A,
+    N_TILES_B,
+    N_ACCUMS,
+    N_LDS_STEPS_A,
+    N_LDS_STEPS_B,
+    _CS,
+    N_WAVES,
+    cbsz,
+    blgp,
+    LDS_BLOCK_M,
+    LDS_BLOCK_N,
+    vmcnt_hint,
+    _out_ty,
+    gl_off_a,
+    gl_off_b,
+    A,
+    B,
+    C,
+    A_scale,
+    B_scale,
+    wave_id,
+    wave_m,
+    wave_n,
+    lds,
+    _cm,
+    _cn,
+):
+    tt = xcd_remap_pid(t, TOTAL, num_xcd)
+    group_idx, block_m, block_n = _wgrad_block_mn(
+        tt, G, TILES_PER_GROUP, N_BLOCKS_M, N_BLOCKS_N, group_m, group_n, False
+    )
+    group_idx = _readfirstlane_i32(group_idx)
+    block_m = _readfirstlane_i32(block_m)
+    block_n = _readfirstlane_i32(block_n)
+    m_start = _readfirstlane_i32(_load_go(go_div, group_idx))
+    m_end = _readfirstlane_i32(_load_go(go_div, group_idx + 1))
+    mg = _readfirstlane_i32(m_end - m_start)
+    k_iters = ceildiv(mg, BLOCK_K)
+    # main loop takes the largest multiple of 6; the remainder (0..5) is the in-asm fused tail.
+    n6 = (k_iters // 6) * 6
+    consumed = arith.select(n6 < fx.Int32(6), fx.Int32(6), n6)
+    nval_main = _readfirstlane_i32(n6)
+    tail_k = arith.select(k_iters < consumed, fx.Int32(0), k_iters - consumed)
+    tail_k_u = _readfirstlane_i32(tail_k)  # raw 0..5, for the in-asm fused tail
+
+    bm_off = block_m * BLOCK_M
+    bn_off = block_n * BLOCK_N
+    a_base = arith.index_cast(T.index, m_start) * arith.index(OUT_M) + arith.index_cast(T.index, bm_off)
+    a_nrec = arith.index_cast(T.index, mg) * arith.index(OUT_M) - arith.index_cast(T.index, bm_off)
+    b_base = arith.index_cast(T.index, m_start) * arith.index(OUT_N) + arith.index_cast(T.index, bn_off)
+    b_nrec = arith.index_cast(T.index, mg) * arith.index(OUT_N) - arith.index_cast(T.index, bn_off)
+
+    gA = make_fp8_buffer_tensor_rebased(A, F8_IR_t, a_base, a_nrec)
+    gB = make_fp8_buffer_tensor_rebased(B, F8_IR_t, b_base, b_nrec)
+    a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
+    b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
+
+    mfma = Mfma16x16x128(N_TILES_A, N_TILES_B)
+    mfma._do_mma = lambda _a, _b, _c: asm_mma_do(_a, _b, _c, mode="2", cbsz=cbsz, blgp=blgp)
+
+    # wave bank-swizzle on iff 2-pool (matches gl_off_a/b wswz in the kernel body).
+    _wswz = os.environ.get("PT_WL_2BPOOL", "1") == "1"
+    a_g2s = G2SLoader(a_div, gl_off_a, N_LDS_STEPS_A, F8_IR_t, wave_id, chunk_stride=_CS)
+    b_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_B, F8_IR_t, wave_id, chunk_stride=_CS)
+    a_s2r = S2RLoaderTr(
+        wave_m,
+        N_TILES_A,
+        N_TILES_A * 16,
+        inline_asm=True,
+        vmcnt_hint=vmcnt_hint,
+        n_waves=N_WAVES,
+        chunk_stride=_CS,
+        width=LDS_BLOCK_M,
+        wswz=_wswz,
+    )
+    b_s2r = S2RLoaderTr(
+        wave_n,
+        N_TILES_B,
+        N_TILES_B * 16,
+        inline_asm=True,
+        vmcnt_hint=vmcnt_hint,
+        n_waves=N_WAVES,
+        chunk_stride=_CS,
+        width=LDS_BLOCK_N,
+        wswz=_wswz,
+    )
+
+    if (
+        os.environ.get("PT_EPI_PLAIN", "0") == "1"
+        or os.environ.get("PT_WL_2BPOOL", "1") == "1"  # 2bpool forces scalar store
+    ):
+        store_c = StoreCPerTensor(
+            A_scale,
+            B_scale,
+            C,
+            (group_idx + 1) * OUT_M,
+            _cn,
+            mfma.idx,
+            N_TILES_A,
+            N_TILES_B,
+            _out_ty,
+        )
+    else:
+        store_c = StoreCPerTensorCShuffle(
+            A_scale,
+            B_scale,
+            C,
+            (group_idx + 1) * OUT_M,
+            _cn,
+            mfma.idx,
+            N_TILES_A,
+            N_TILES_B,
+            _out_ty,
+            lds.C_lds_shuffle,
+            wave_id,
+            row_pad=4,  # must match _EPI_PAD in _compile_grouped_tn_wgrad_4wave's C_lds_shuffle sizing
+        )
+    _common = dict(
+        a_g2s=a_g2s,
+        b_g2s=b_g2s,
+        a_s2r=a_s2r,
+        b_s2r=b_s2r,
+        lds=lds,
+        gl_off_a=gl_off_a,
+        gl_off_b=gl_off_b,
+        A=A,
+        B=B,
+        a_base=a_base,
+        b_base=b_base,
+        a_nrec=a_nrec,
+        b_nrec=b_nrec,
+        c_n=_cn,
+        c_m=_cm,
+        wave_id=wave_id,
+        mfma=mfma,
+        store_c=store_c,
+        nta=N_TILES_A,
+        ntb=N_TILES_B,
+        n_accums=N_ACCUMS,
+        nsa=N_LDS_STEPS_A,
+        nsb=N_LDS_STEPS_B,
+        block_k=BLOCK_K,
+        cs=_CS,
+        nw=N_WAVES,
+        cbsz=cbsz,
+        blgp=blgp,
+        base_row=group_idx * OUT_M + bm_off + wave_m * (N_TILES_A * 16),
+        base_col=bn_off + wave_n * (N_TILES_B * 16),
+        lds_block_m=LDS_BLOCK_M,
+        lds_block_n=LDS_BLOCK_N,
+    )
+
+    _b0x = lds.B_lds_extra_0 if os.environ.get("PT_WL_2BPOOL", "1") == "1" else None
+    _wgrad_wholeloop_tile_3buf(
+        **_common,
+        nval=nval_main,
+        do_store=True,
+        tail_nval=tail_k_u,
+        b0_extra_buf=_b0x,
+    )
+
+
+def _compile_grouped_tn_wgrad_4wave(
+    *,
+    OUT_M: int,
+    OUT_N: int,
+    G: int,
+    BLOCK_M: int = 256,
+    BLOCK_N: int = 256,
+    num_xcd: int = 8,
+    cbsz: int = 0,
+    blgp: int = 0,
+    out_fp16: bool = False,
+    group_m: int = 0,
+    group_n: int = 0,
+    vmcnt_hint: int = 2,
+    cap_cu: int = -1,
+):
+    """4-wave (occ=1) grouped TN wgrad dW[g]=A[g]^T@B[g], variable-K over per-group token
+    rows. 256x256 2x2-wave whole-loop bare-asm body drives the runtime nval (floored to a
+    multiple of 6) + in-asm fused tail; partial/over-run K-blocks are zeroed by per-group
+    SRD num_records clamp (no K-tail mask). C is [G*OUT_M, OUT_N], store clamps per group."""
+
+    # 2-pool (both B pools 3-buffered) is default-on; needs _CS=1024 (fit 10 buffers)
+    # + scalar store. PT_WL_2BPOOL=0 falls back to 1-pool @1056.
+    _2BPOOL = os.environ.get("PT_WL_2BPOOL", "1") == "1"
+    BLOCK_K = 128
+    # BLOCK_N=128 is not supported: ds_read_b64_tr_b8's hardware transpose semantics at
+    # that width produce a wrong (but finite) result despite the addressing plumbing
+    # below being width-parameterized. Keep this assert at 256.
+    assert BLOCK_M == 256 and BLOCK_N == 256, "4-wave grouped wgrad is 256x256-only"
+    assert G >= 1
+    N_WAVES = 4
+    N_TILES_A = BLOCK_M // 64
+    N_TILES_B = BLOCK_N // 64
+    N_ACCUMS = N_TILES_A * N_TILES_B
+    LDS_BLOCK_M = BLOCK_M // 2
+    LDS_BLOCK_N = BLOCK_N // 2
+    # 2-pool needs _CS=1024 (fit 10 buffers); 1-pool/2-buffer keep 1056 (0 bank conflict).
+    _CS = int(os.environ.get("PT_CS", "1024" if _2BPOOL else "1056"))
+    N_LDS_STEPS_A = (LDS_BLOCK_M * BLOCK_K) // (256 * 16)
+    N_LDS_STEPS_B = (LDS_BLOCK_N * BLOCK_K) // (256 * 16)
+    N_LDS_ROUNDS = max(N_LDS_STEPS_A, N_LDS_STEPS_B)
+    a_lds_size = (LDS_BLOCK_M * BLOCK_K) // 1024 * _CS
+    b_lds_size = (LDS_BLOCK_N * BLOCK_K) // 1024 * _CS
+    N_BLOCKS_M = (OUT_M + BLOCK_M - 1) // BLOCK_M
+    N_BLOCKS_N = (OUT_N + BLOCK_N - 1) // BLOCK_N
+    TILES_PER_GROUP = N_BLOCKS_M * N_BLOCKS_N
+    TOTAL = G * TILES_PER_GROUP
+    _cshuf_ty = fx.Float16 if out_fp16 else fx.BFloat16
+    # row_pad=4 drives StoreCPerTensorCShuffle's epilogue LDS bank conflict to exactly
+    # 0.0% (rocprofv3 LDSBankConflict, measured; see StoreCPerTensorCShuffle's
+    # docstring). C_lds_shuffle's allocation must grow to match (n_tiles_b*16+_EPI_PAD
+    # per row, not just n_tiles_b*16) -- this constant MUST stay in sync with the
+    # row_pad= value passed to both StoreCPerTensorCShuffle(...) call sites below.
+    _EPI_PAD = 4
+    _cshuf_n = N_WAVES * 16 * (N_TILES_B * 16 + _EPI_PAD)
+
+    @fx.struct
+    class SharedStorage:
+        A_lds_cur_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_cur_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        B_lds_cur_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_cur_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        # 2bpool mode forces scalar store (no CShuffle) to free C_lds space, so
+        # C_lds_shuffle shrinks to a stub; otherwise full size.
+        C_lds_shuffle: fx.Array[_cshuf_ty, (16 if _2BPOOL else _cshuf_n), 16]
+        B_lds_extra_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        if _2BPOOL:
+            # 2nd B-pool 3rd buffer (defer 1/2 the writes). Only fits at _CS=1024 + scalar store.
+            B_lds_extra_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+
+    @flyc.kernel(known_block_size=[256, 1, 1])
+    def kernel_grouped_tn_wgrad_4wave(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+        group_offs: fx.Tensor,
+    ):
+        _ = str(fx.thread_idx.x)
+        F8_IR_t = fx.Float8E4M3FN.ir_type
+        _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
+        go = fx.rocdl.make_buffer_tensor(group_offs, max_size=False, num_records_bytes=(G + 1) * 8)
+        go_div = fx.logical_divide(go, fx.make_layout(1, 1))
+
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        pid = fx.block_idx.x
+        nsms = fx.grid_dim.x
+
+        lane_id = fx.thread_idx.x % 64
+        wave_id = fx.thread_idx.x // 64
+        wave_m = wave_id // 2
+        wave_n = wave_id % 2
+        # wave bank-swizzle on iff 2-pool (write side; matches S2RLoaderTr wswz).
+        gl_off_a = compute_global_swizzle_nn(
+            lane_id, wave_id, OUT_M, N_LDS_ROUNDS, width=LDS_BLOCK_M, wswz=_2BPOOL
+        )
+        gl_off_b = compute_global_swizzle_nn(
+            lane_id, wave_id, OUT_N, N_LDS_ROUNDS, width=LDS_BLOCK_N, wswz=_2BPOOL
+        )
+        _cm = fx.Int32(OUT_M)
+        _cn = fx.Int32(OUT_N)
+
+        def _do_tile_3buf(t):
+            _wgrad_do_tile_3buf(
+                t,
+                TOTAL=TOTAL,
+                num_xcd=num_xcd,
+                G=G,
+                TILES_PER_GROUP=TILES_PER_GROUP,
+                N_BLOCKS_M=N_BLOCKS_M,
+                N_BLOCKS_N=N_BLOCKS_N,
+                group_m=group_m,
+                group_n=group_n,
+                go_div=go_div,
+                BLOCK_K=BLOCK_K,
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+                OUT_M=OUT_M,
+                OUT_N=OUT_N,
+                F8_IR_t=F8_IR_t,
+                N_TILES_A=N_TILES_A,
+                N_TILES_B=N_TILES_B,
+                N_ACCUMS=N_ACCUMS,
+                N_LDS_STEPS_A=N_LDS_STEPS_A,
+                N_LDS_STEPS_B=N_LDS_STEPS_B,
+                _CS=_CS,
+                N_WAVES=N_WAVES,
+                cbsz=cbsz,
+                blgp=blgp,
+                LDS_BLOCK_M=LDS_BLOCK_M,
+                LDS_BLOCK_N=LDS_BLOCK_N,
+                vmcnt_hint=vmcnt_hint,
+                _out_ty=_out_ty,
+                gl_off_a=gl_off_a,
+                gl_off_b=gl_off_b,
+                A=A,
+                B=B,
+                C=C,
+                A_scale=A_scale,
+                B_scale=B_scale,
+                wave_id=wave_id,
+                wave_m=wave_m,
+                wave_n=wave_n,
+                lds=lds,
+                _cm=_cm,
+                _cn=_cn,
+            )
+
+        # Persistent: a fixed grid of <=ncus WGs strides the tile space (scf.for).
+        for t in range(pid, TOTAL, nsms):
+            _do_tile_3buf(t)
+
+    @flyc.jit
+    def launch_grouped_tn_wgrad_4wave(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+        group_offs: fx.Tensor,
+        stream: fx.Stream,
+    ):
+        ncus = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+        cap = ncus if cap_cu <= 0 else min(int(cap_cu), ncus)
+        grid_x = arith.select(fx.Int32(TOTAL) < cap, fx.Int32(TOTAL), fx.Int32(cap))
+        attrs = make_value_attrs(1, 0, "256,256")
+        kernel_grouped_tn_wgrad_4wave(
+            A,
+            B,
+            C,
+            A_scale,
+            B_scale,
+            group_offs,
+            value_attrs=attrs,
+        ).launch(grid=(grid_x, 1, 1), block=(256, 1, 1), stream=stream)
+
+    return launch_grouped_tn_wgrad_4wave
+
+
 def _wgrad_compile_cfg(
     OUT_M,
     OUT_N,
@@ -2053,12 +2929,10 @@ def _wgrad_compile_cfg(
     group_m,
     group_n=0,
     unroll_n=-1,
-    persistent=True,
     cap_cu=-1,
     i64_traverse=False,
 ):
-    """Compile (or cache-hit) an asm_mma wgrad for one config. persistent=False ->
-    TRUE non-persistent (no outer scf.for tile loop)."""
+    """Compile (or cache-hit) an asm_mma wgrad for one config."""
     ck = (
         OUT_M,
         OUT_N,
@@ -2067,7 +2941,6 @@ def _wgrad_compile_cfg(
         cbsz,
         blgp,
         num_xcd,
-        "persist" if persistent else "nonpersist",
         group_m,
         group_n,
         unroll_n,
@@ -2091,7 +2964,6 @@ def _wgrad_compile_cfg(
             asm_acc_mode="vgpr",
             s2r_inline=False,
             unroll_n=unroll_n,
-            persistent=persistent,
             cap_cu=cap_cu,
             i64_traverse=i64_traverse,
         )
@@ -2123,15 +2995,25 @@ def _wgrad_masked_cfg(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, chunk, group_m, num
     return l
 
 
+# 4-wave (group_m, group_n, num_xcd) candidates raced alongside 8-wave. (8,4,4)/(4,4,8)
+# cover most shapes; long contraction (m_total/G>1536) adds a 3rd picked by larger output
+# dim ((0,0,2) when OUT_M>OUT_N, else (4,16,8)) -- a no-op extra try on square shapes.
+_WGRAD_4WAVE_CANDS_SHORT = ((8, 4, 4), (4, 4, 8))  # m_total/G<=1536
+_WGRAD_4WAVE_CANDS_LONG_BASE = ((8, 4, 4), (4, 4, 8))  # m_total/G>1536
+
+
 def _autotune_wgrad_dispatch(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, args, m_total, i64_traverse=False):
-    """Per-shape wgrad autotune, balanced-timed (1.5% hysteresis). Branched on per-group
-    contraction m_total/G (not m_total, so high-G MoE keeps persist): <=1536 -> 2 persistent
-    candidates; else 3 masked chunked (8,4,8)/(8,0,8)/(4,4,8)."""
+    """Per-shape wgrad autotune, balanced-timed, <=4 candidates raced. Races a same-family
+    8-wave pool first (persistent for short contraction m_total/G<=1536, masked-chunked
+    otherwise -- the two kernels tuned for their respective regimes), then joins the
+    occ=1 4-wave whole-loop against the winner. cands[0] is the correctness reference +
+    fallback if a candidate produces NaN/Inf or drifts."""
     out_view = args[2]
     # time on a balanced group_offs (m_total split over G) so a skewed call can't bias it.
     targs = _balanced_targs(args, m_total, G)
 
-    if m_total // G <= 1536:
+    short = m_total // G <= 1536
+    if short:
         cands = [
             _wgrad_compile_cfg(
                 OUT_M, OUT_N, G, out_fp16, cbsz, blgp, 8, 4, 0, unroll_n=4, i64_traverse=i64_traverse
@@ -2141,21 +3023,53 @@ def _autotune_wgrad_dispatch(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, args, m_tota
             ),
         ]
     else:
-        cands = [
-            _wgrad_masked_cfg(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, 8, 4, 8, i64_traverse=i64_traverse),
-            _wgrad_masked_cfg(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, 8, 0, 8, i64_traverse=i64_traverse),
-            _wgrad_masked_cfg(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, 4, 4, 8, i64_traverse=i64_traverse),
-        ]
+        # Single masked candidate: 4-wave wins essentially every long-contraction shape
+        # in the measured grid, so the masked pool's only real job here is the
+        # correctness reference + fallback, not winning the race. chunk=8/group_m=4 is
+        # the stronger of the two previously-raced masked configs.
+        cands = [_wgrad_masked_cfg(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, 8, 4, 8, i64_traverse=i64_traverse)]
 
     prod = cands[0]  # correctness reference + fallback
     prod(*targs)
     torch.cuda.synchronize()
     if not torch.isfinite(out_view.view(-1)[:1024].float()).all().item():
         return prod  # numeric guard: prod produced NaN/Inf -> don't time alts
+    _ref = out_view.detach().clone().float()
+    _rn = float((_ref * _ref).sum().item()) or 1.0
+
+    def _ok():
+        o = out_view.detach().float()
+        e = float(((o - _ref) * (o - _ref)).sum().item())
+        return (e / _rn) < (2e-2**2) and torch.isfinite(o.view(-1)[:1024]).all().item()
+
     best_l, best_t = prod, _robust_time(prod, targs)
-    for l in cands[1:]:
+    for l in cands[1:]:  # same-family pool: 1.5% hysteresis
         t = _robust_time(l, targs)
-        if t < best_t * 0.985:  # hysteresis: adopt only if >=1.5% faster (robust timing)
+        if t < best_t * 0.985:
+            best_l, best_t = l, t
+
+    if short:
+        wave4_cands = _WGRAD_4WAVE_CANDS_SHORT
+    else:
+        wave4_cands = _WGRAD_4WAVE_CANDS_LONG_BASE + ((0, 0, 2) if OUT_M > OUT_N else (4, 16, 8),)
+    for gm, gn, xcd in wave4_cands:
+        l = _compile_grouped_tn_wgrad_4wave(
+            OUT_M=OUT_M,
+            OUT_N=OUT_N,
+            G=G,
+            out_fp16=out_fp16,
+            cbsz=cbsz,
+            blgp=blgp,
+            num_xcd=xcd,
+            group_m=gm,
+            group_n=gn,
+        )
+        l(*targs)
+        torch.cuda.synchronize()
+        if not _ok():
+            continue
+        t = _robust_time(l, targs)
+        if t < best_t * 0.985:
             best_l, best_t = l, t
     return best_l
 
@@ -2199,27 +3113,228 @@ def grouped_gemm_fp8_variable_k_tensorwise_flydsl_kernel(
     rsf = rhs_scale.float().reshape(1)
     stream = torch.cuda.current_stream()
 
-    # NOTE: no cap-fed masked wgrad path — a general dropless operator must not assume
-    # a host-fed per-expert token capacity. Only the capacity-free chunked-masked variant
-    # (reads group_offs, SRD-clamped over-run) is used, as an autotune candidate below.
-
-    # ── Per-shape online autotune (wgrad): time 3 masked configs on a balanced token
-    #    distribution, cache the winner. Keyed on static dims (OUT_M,OUT_N,G,dtype,M_total);
-    #    M_total is in the key because the best config depends on the contraction length.
-    #    num_cu is ignored: the masked kernel uses a full G*tiles grid (it isn't
-    #    persistent-strided), so it can't reserve CUs for comm-overlap.
     M_total = lhs.shape[0]
     at_key = (OUT_M, OUT_N, G, out_fp16, cbsz, blgp, M_total)
     # out as 2D [G*OUT_M, OUT_N] (the kernel's stacked-group view).
     wargs = (lhs_i8, rhs_i8, out.view(G * OUT_M, OUT_N), lsf, rsf, go32, stream)
     launch = _GROUPED_WGRAD_AT_CACHE.get(at_key)
     if launch is None:
-        # wgrad A[m,OUT_M] / B[m,OUT_N] stride the per-group token dim (contraction);
-        # the per-group span mg*OUT rides the 32-bit soffset. mg is runtime and one
-        # group can hold all tokens, so bound by M_total: re-base in i64 if M_total*OUT
-        # could reach 2^32 fp8.
         i64_tr = (M_total * OUT_M >= 2**32) or (M_total * OUT_N >= 2**32)
         launch = _autotune_wgrad_dispatch(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, wargs, M_total, i64_tr)
         _GROUPED_WGRAD_AT_CACHE[at_key] = launch
     launch(*wargs)
     return out
+
+
+def _wholeloop_tail_split_3buf(K, block_k):
+    """3buf FUSED tail split (n_phases=6): main loop takes the largest multiple of 6,
+    remainder (0..5) goes to tail_nval."""
+    k_iters = (K + block_k - 1) // block_k
+    return k_iters, (k_iters // 6) * 6, k_iters % 6
+
+
+def _grouped_4wave_tile_scan(
+    t, num_xcd, total_tiles, go_div, G, BLOCK_M, BLOCK_N, n_blocks, group_m, group_n, K
+):
+    """Resolve tile -> (group, block_m, block_n) + A addressing.
+    Returns (gi, m_row, m_end, block_n, a_base, a_nrec)."""
+    tt = xcd_remap_pid(t, total_tiles, num_xcd)
+    cum = fx.Int32(0)
+    gi = fx.Int32(0)
+    tstart = fx.Int32(0)
+    p2 = _load_go(go_div, 0)
+    for g in range_constexpr(G):
+        nx = _load_go(go_div, g + 1)
+        mg = nx - p2
+        tg = ceildiv(mg, BLOCK_M) * n_blocks
+        nc = cum + tg
+        inq = (tt >= cum) & (tt < nc)
+        gi = arith.select(inq, fx.Int32(g), gi)
+        tstart = arith.select(inq, cum, tstart)
+        cum = nc
+        p2 = nx
+    gi = _readfirstlane_i32(gi)
+    m_start = _readfirstlane_i32(_load_go(go_div, gi))
+    m_end = _readfirstlane_i32(_load_go(go_div, gi + 1))
+    local = tt - tstart
+    lbm, block_n = _grouped_block_mn(local, m_start, m_end, n_blocks, BLOCK_M, group_m, group_n)
+    lbm = _readfirstlane_i32(lbm)
+    block_n = _readfirstlane_i32(block_n)
+    m_row = _readfirstlane_i32(m_start + lbm * BLOCK_M)
+    a_base = arith.index_cast(T.index, m_row) * arith.index(K)
+    m_total = _readfirstlane_i32(_load_go(go_div, G))
+    a_nrec = (arith.index_cast(T.index, m_total) - arith.index_cast(T.index, m_row)) * arith.index(K)
+    return gi, m_row, m_end, block_n, a_base, a_nrec
+
+
+def _compile_grouped_nn_4wave(
+    *, K, G, num_xcd=8, group_m=0, group_n=0, cbsz=0, blgp=0, out_fp16=False, cap_cu=-1, vmcnt_hint=2
+):
+    """4-wave (occ=1) grouped NN dgrad: out[Mt,Nout]=A[Mt,K]@B[G,K,Nout], contract K
+    (compile-time). Reuses the wgrad 4-wave whole-loop with a_plain=True (A read plain,
+    NN's natural [M,K] layout -- not a pre-transpose). B transpose-read like wgrad."""
+    BLOCK_M = 256
+    BLOCK_N = 256
+    BLOCK_K = 128
+    N_WAVES = 4
+    N_TILES_A = BLOCK_M // 64
+    N_TILES_B = BLOCK_N // 64
+    N_ACCUMS = N_TILES_A * N_TILES_B
+    LDS_BLOCK_M = BLOCK_M // 2
+    LDS_BLOCK_N = BLOCK_N // 2
+    _CS = 1024
+    _CSA = 1024
+    N_LDS_STEPS_A = (LDS_BLOCK_M * BLOCK_K) // (256 * 16)
+    N_LDS_STEPS_B = (LDS_BLOCK_N * BLOCK_K) // (256 * 16)
+    N_LDS_ROUNDS = max(N_LDS_STEPS_A, N_LDS_STEPS_B)
+    a_lds_size = (LDS_BLOCK_M * BLOCK_K) // 1024 * _CSA
+    b_lds_size = (LDS_BLOCK_N * BLOCK_K) // 1024 * _CS
+    _, NVAL, TAIL = _wholeloop_tail_split_3buf(
+        K, BLOCK_K
+    )  # 3buf FUSED: main loop in multiples of 6 + tail remainder
+    _EPI_PAD = 4
+    _cshuf_n = N_WAVES * 16 * (N_TILES_B * 16 + _EPI_PAD)
+    _cshuf_ty = fx.Float16 if out_fp16 else fx.BFloat16
+
+    @fx.struct
+    class SharedStorage:
+        A_lds_cur_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_cur_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        A_lds_next_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
+        B_lds_cur_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_cur_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_next_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_extra_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        B_lds_extra_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+        C_lds_shuffle: fx.Array[_cshuf_ty, 16, 16]
+
+    @flyc.kernel(known_block_size=[256, 1, 1])
+    def kernel_grouped_nn_4wave(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+        group_offs: fx.Tensor,
+        c_n: fx.Int32,
+    ):
+        _ = str(fx.thread_idx.x)
+        F8_IR_t = fx.Float8E4M3FN.ir_type
+        _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
+        go = fx.rocdl.make_buffer_tensor(group_offs, max_size=False, num_records_bytes=(G + 1) * 8)
+        go_div = fx.logical_divide(go, fx.make_layout(1, 1))
+        n_blocks = ceildiv(c_n, BLOCK_N)
+        total_tiles = fx.Int32(0)
+        prev = _load_go(go_div, 0)
+        for g in range_constexpr(G):
+            nx = _load_go(go_div, g + 1)
+            total_tiles = total_tiles + ceildiv(nx - prev, BLOCK_M) * n_blocks
+            prev = nx
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        pid = fx.block_idx.x
+        nsms = fx.grid_dim.x
+        lane_id = fx.thread_idx.x % 64
+        wave_id = fx.thread_idx.x // 64
+        wave_m = wave_id // 2
+        wave_n = wave_id % 2
+        gl_off_a = compute_global_swizzle(lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=False)
+        gl_off_b = compute_global_swizzle_nn(lane_id, wave_id, c_n, N_LDS_ROUNDS, wswz=False)
+
+        def _do_tile(t):
+            gi, m_row, m_end, block_n, a_base, a_nrec = _grouped_4wave_tile_scan(
+                t, num_xcd, total_tiles, go_div, G, BLOCK_M, BLOCK_N, n_blocks, group_m, group_n, K
+            )
+            cn_i = arith.index_cast(T.index, c_n)
+            b_base = arith.index_cast(T.index, gi) * arith.index(K) * cn_i + arith.index_cast(
+                T.index, block_n * BLOCK_N
+            )
+            b_nrec = arith.index(K) * cn_i - arith.index_cast(T.index, block_n * BLOCK_N)
+            gA = make_fp8_buffer_tensor_rebased(A, F8_IR_t, a_base, a_nrec)
+            gB = make_fp8_buffer_tensor_rebased(B, F8_IR_t, b_base, b_nrec)
+            a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
+            b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
+            mfma = Mfma16x16x128(N_TILES_A, N_TILES_B)
+            mfma._do_mma = lambda _a, _b, _c: asm_mma_do(_a, _b, _c, mode="2", cbsz=cbsz, blgp=blgp)
+            a_g2s = G2SLoader(a_div, gl_off_a, N_LDS_STEPS_A, F8_IR_t, wave_id, chunk_stride=_CSA)
+            b_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_B, F8_IR_t, wave_id, chunk_stride=_CS)
+            a_s2r = S2RLoader(wave_m, N_TILES_A)
+            b_s2r = S2RLoaderTr(
+                wave_n,
+                N_TILES_B,
+                N_TILES_B * 16,
+                inline_asm=True,
+                vmcnt_hint=vmcnt_hint,
+                n_waves=N_WAVES,
+                chunk_stride=_CS,
+                width=LDS_BLOCK_N,
+            )
+            store_c = StoreCPerTensor(
+                A_scale, B_scale, C, m_end, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty
+            )
+            _wgrad_wholeloop_tile_3buf(
+                a_g2s=a_g2s,
+                b_g2s=b_g2s,
+                a_s2r=a_s2r,
+                b_s2r=b_s2r,
+                lds=lds,
+                gl_off_a=gl_off_a,
+                gl_off_b=gl_off_b,
+                A=A,
+                B=B,
+                a_base=a_base,
+                b_base=b_base,
+                a_nrec=a_nrec,
+                b_nrec=b_nrec,
+                c_n=c_n,
+                c_m=fx.Int32(1),
+                wave_id=wave_id,
+                mfma=mfma,
+                store_c=store_c,
+                nta=N_TILES_A,
+                ntb=N_TILES_B,
+                n_accums=N_ACCUMS,
+                nsa=N_LDS_STEPS_A,
+                nsb=N_LDS_STEPS_B,
+                block_k=BLOCK_K,
+                cs=[_CSA, _CSA, _CS, _CS],
+                nw=N_WAVES,
+                cbsz=cbsz,
+                blgp=blgp,
+                base_row=m_row + wave_m * (N_TILES_A * 16),
+                base_col=block_n * BLOCK_N + wave_n * (N_TILES_B * 16),
+                lds_block_m=LDS_BLOCK_M,
+                lds_block_n=LDS_BLOCK_N,
+                nval=fx.Int32(NVAL),
+                tail_nval=fx.Int32(TAIL),
+                a_plain=True,
+                a_row_stride=fx.Int32(K),
+                b0_extra_buf=lds.B_lds_extra_0,
+            )
+
+        for t in range(pid, total_tiles, nsms):
+            _do_tile(t)
+
+    @flyc.jit
+    def launch_grouped_nn_4wave(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+        group_offs: fx.Tensor,
+        M_total: fx.Int32,
+        c_n: fx.Int32,
+        stream: fx.Stream,
+    ):
+        # M_total is a placeholder to line up with the 8-wave dispatch's arg order
+        # (the kernel scans total_tiles from group_offs itself).
+        ncus = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+        cap = ncus if cap_cu <= 0 else min(int(cap_cu), ncus)
+        attrs = make_value_attrs(1, 0, "256,256")
+        kernel_grouped_nn_4wave(A, B, C, A_scale, B_scale, group_offs, c_n, value_attrs=attrs).launch(
+            grid=(cap, 1, 1), block=(256, 1, 1), stream=stream
+        )
+
+    return launch_grouped_nn_4wave

--- a/primus_turbo/flydsl/grouped_gemm/gemm_fp8_grouped_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/gemm_fp8_grouped_kernel.py
@@ -31,6 +31,7 @@ K-tail / barrier rationale (identical here).
 """
 
 import os
+from collections import namedtuple
 
 import flydsl.compiler as flyc
 import flydsl.expr as fx
@@ -2102,7 +2103,7 @@ def _compile_grouped_tn_wgrad_persistent(
 _WL_ASM_CACHE_3BUF = {}
 
 
-def _wgrad_wholeloop_asm_3buf(
+def _wholeloop_asm_3buf(
     *,
     nta,
     ntb,
@@ -2124,10 +2125,8 @@ def _wgrad_wholeloop_asm_3buf(
     nw,
     cbsz=0,
     blgp=0,
-    tail_nval=None,  # SGPR i32: count of extra single-block passes (0..5) appended after
-    # the main do-while, fused into the same inline-asm block so accumulator state
-    # carries over natively.
-    a_plain=False,  # see _wgrad_wholeloop_asm's a_plain
+    tail_nval=None,  # SGPR i32: 0..5 extra single-block passes fused into this asm block.
+    a_plain=False,  # see _wholeloop_asm_3buf's a_plain
 ):
     from functools import reduce
     from math import gcd
@@ -2153,41 +2152,35 @@ def _wgrad_wholeloop_asm_3buf(
             t_pool.append(t_pool[-1] + tiles[p])
         o_cnt = NT + ntmp
         o_wsoff = [o_cnt + 1 + p for p in range(4)]  # per-pool running gmem write soffset
-        # The tail is 5 statically unrolled gated phases (s_cmp/s_cbranch skip), not a
-        # runtime counter loop -- no extra scratch SGPR needed. Do not add an "=&s" output
-        # register here unless an instruction actually writes it: an unwritten "=&s"
-        # output is an uninitialized-output hazard that can corrupt register allocation.
+        # Tail = 5 statically-unrolled gated phases, so no extra scratch SGPR. Never add an
+        # unwritten "=&s" output here: it is an uninitialized-output hazard for regalloc.
 
+        # Ordered input-operand schema (name, width): one left-to-right walk assigns
+        # every operand index above the NT+ntmp+5 output base, in the exact order the
+        # cons input segment and the ins list are built.
         i = o_cnt + 5
-        i_base = []  # i_base[p][b] = [input idx, ...] (len nbase[p])
-        for p in range(4):
-            row = []
-            for _b in range(nbuf_p[p]):
-                row.append([i + j for j in range(nbase[p])])
-                i += nbase[p]
-            i_base.append(row)
-        i_gbase = []
-        for p in range(4):
-            i_gbase.append([i + b for b in range(nbuf_p[p])])
-            i += nbuf_p[p]
-        i_gla = [i + s for s in range(nsa)]
-        i += nsa
-        i_glb = [i + s for s in range(nsb)]
-        i += nsb
-        i_rsa = i
-        i += 1
-        i_rsb = i
-        i += 1
-        i_kstep = i
-        i += 1
-        i_kstepb = i
-        i += 1
-        i_nval = i
-        i += 1
+        _in_schema = (
+            [("base", nbase[p]) for p in range(4) for _b in range(nbuf_p[p])]
+            + [("gbase", nbuf_p[p]) for p in range(4)]
+            + [("gl_a", nsa), ("gl_b", nsb)]
+            + [("rsrc_a", 1), ("rsrc_b", 1), ("kstep", 1), ("kstep_b", 1), ("nval", 1)]
+            + ([("tail_nval", 1)] if _has_tail else [])
+            + [("soff0", 4)]
+        )
+        _blocks = []
+        for _name, _w in _in_schema:
+            _blocks.append(list(range(i, i + _w)))
+            i += _w
+        _it = iter(_blocks)
+        i_base = [[next(_it) for _b in range(nbuf_p[p])] for p in range(4)]
+        i_gbase = [next(_it) for _p in range(4)]
+        i_gla = next(_it)
+        i_glb = next(_it)
+        i_rsa, i_rsb = next(_it)[0], next(_it)[0]
+        i_kstep, i_kstepb, i_nval = next(_it)[0], next(_it)[0], next(_it)[0]
         if _has_tail:
-            i_tailval = i
-            i += 1
-        i_soff0 = [i + p for p in range(4)]
+            i_tailval = next(_it)[0]
+        i_soff0 = next(_it)
         i_ks = [i_kstep, i_kstep, i_kstepb, i_kstepb]
 
         def pool_of(tt):
@@ -2202,7 +2195,7 @@ def _wgrad_wholeloop_asm_3buf(
             vb = PIN + (tt - NT) * 8
             p0, p1 = i_base[p][buf][2 * ti], i_base[p][buf][2 * ti + 1]
             if a_plain and p < 2:
-                # plain (no-transpose) read -- see _wgrad_wholeloop_asm's a_plain.
+                # plain (no-transpose) read -- see _wholeloop_asm_3buf's a_plain.
                 return (
                     f"ds_read_b128 v[{vb}:{vb + 3}], ${p0} offset:0\n"
                     f"ds_read_b128 v[{vb + 4}:{vb + 7}], ${p1} offset:0"
@@ -2300,13 +2293,22 @@ def _wgrad_wholeloop_asm_3buf(
         _3buf_pools = [p for p in range(4) if nbuf_p[p] == 3]
         _3buf_pool = _3buf_pools[0] if _3buf_pools else None
         if _vmcnt_mode == "partial" and _3buf_pool is not None:
-            # Partial drain must leave in flight the writes of ALL 3-buffered pools, not
-            # just the first. Emit order (pools 0,1,2,3) issues the 3-buf pools last, so
-            # vmcnt(sum of their write counts) leaves exactly those writes outstanding.
+            # Partial drain keeps ALL 3-buffered pools' writes in flight; emit order
+            # (0,1,2,3) issues them last so vmcnt(sum) leaves exactly those outstanding.
             _n_outstanding = sum((nsa if p < 2 else nsb) for p in _3buf_pools)
             _ipend = f"s_waitcnt vmcnt({_n_outstanding}) lgkmcnt(0)\ns_barrier"
         else:
             _ipend = "s_waitcnt vmcnt(0) lgkmcnt(0)\ns_barrier"
+
+        def _emit_phase_block(ph, drain_line):
+            # One whole-loop phase: mfma+refill+g2s, then drain and bump each pool's soffset.
+            refill_bp = [(ph + 1) % nbuf_p[p] for p in range(4)]
+            write_bp = [ph % nbuf_p[p] for p in range(4)]
+            blk = emit_phase(refill_bp, write_bp)
+            blk.append(drain_line)
+            for p in range(4):
+                blk.append(f"s_add_u32 ${o_wsoff[p]}, ${o_wsoff[p]}, ${i_ks[p]}")
+            return blk
 
         refill0 = [(-1 + 1) % nbuf_p[p] for p in range(4)]
         L = [f"s_mov_b32 ${o_cnt}, 0"]
@@ -2316,22 +2318,14 @@ def _wgrad_wholeloop_asm_3buf(
         L.append("s_waitcnt lgkmcnt(0)")
         L.append("1:")
         for ph in range(n_phases):
-            refill_bp = [(ph + 1) % nbuf_p[p] for p in range(4)]
-            write_bp = [ph % nbuf_p[p] for p in range(4)]
-            L += emit_phase(refill_bp, write_bp)
-            L.append(_ipend)
-            for p in range(4):
-                L.append(f"s_add_u32 ${o_wsoff[p]}, ${o_wsoff[p]}, ${i_ks[p]}")
+            L += _emit_phase_block(ph, _ipend)
         L.append(f"s_add_u32 ${o_cnt}, ${o_cnt}, {n_phases}")
         L.append(f"s_cmp_lt_u32 ${o_cnt}, ${i_nval}")
         L.append("s_cbranch_scc1 1b")
 
         if _has_tail and _vmcnt_mode == "partial" and _3buf_pool is not None:
-            # The main loop's per-phase partial drain assumes there's always a next
-            # phase to finish draining outstanding loads; that breaks once the do-while
-            # exits into the tail. Force one full drain+barrier here before the tail
-            # reuses the main loop's LDS/register state. Skipped when tail_nval==0 since
-            # no tail phase runs and nothing reads the in-flight buffers.
+            # Full drain before the tail reuses the loop's LDS/regs: partial drain relies
+            # on a next phase, which is gone after loop exit. Skipped when tail_nval==0.
             L.append(f"s_cmp_eq_u32 ${i_tailval}, 0")
             L.append("s_cbranch_scc1 3f")
             L.append("s_waitcnt vmcnt(0) lgkmcnt(0)")
@@ -2339,20 +2333,13 @@ def _wgrad_wholeloop_asm_3buf(
             L.append("3:")
 
         if _has_tail:
-            # In-asm tail: up to 5 extra single-block phases fused into this asm block so
-            # accumulator state carries over natively. n_phases=6 is a multiple of every
-            # pool's nbuf_p, so the do-while exits aligned to phase j=0; these reuse the
-            # same write_bp/refill_bp formula, each gated by s_cmp/s_cbranch on tail_nval.
+            # In-asm tail: up to 5 gated single-block phases (loop exits aligned to j=0
+            # since n_phases=6), reusing the main-loop phase block, gated on tail_nval.
             for j in range(5):
-                refill_bp = [(j + 1) % nbuf_p[p] for p in range(4)]
-                write_bp = [j % nbuf_p[p] for p in range(4)]
                 skip_lbl = f"{j + 4}"  # distinct numeric local labels, unused elsewhere
                 L.append(f"s_cmp_le_u32 ${i_tailval}, {j}")  # tail_nval<=j -> no phase j
                 L.append(f"s_cbranch_scc1 {skip_lbl}f")
-                L += emit_phase(refill_bp, write_bp)
-                L.append("s_waitcnt vmcnt(0) lgkmcnt(0)\ns_barrier")
-                for p in range(4):
-                    L.append(f"s_add_u32 ${o_wsoff[p]}, ${o_wsoff[p]}, ${i_ks[p]}")
+                L += _emit_phase_block(j, "s_waitcnt vmcnt(0) lgkmcnt(0)\ns_barrier")
                 L.append(f"{skip_lbl}:")
 
         L.append("s_waitcnt vmcnt(0) lgkmcnt(0)")
@@ -2399,7 +2386,7 @@ def _wgrad_wholeloop_asm_3buf(
     return [o[qi * nq : (qi + 1) * nq] for qi in range(4)]
 
 
-def _wgrad_wholeloop_tile_3buf(
+def _wholeloop_tile_3buf(
     *,
     a_g2s,
     b_g2s,
@@ -2435,8 +2422,8 @@ def _wgrad_wholeloop_tile_3buf(
     lds_block_n,
     nval,
     do_store=True,  # False = return res, caller stores after the tail
-    tail_nval=None,  # pass through to _wgrad_wholeloop_asm_3buf
-    a_plain=False,  # see _wgrad_wholeloop_tile's a_plain/a_row_stride
+    tail_nval=None,  # pass through to _wholeloop_asm_3buf
+    a_plain=False,  # see _wholeloop_tile_3buf's a_plain/a_row_stride
     a_row_stride=None,
     b0_extra_buf=None,  # optional 3rd buffer for pool2 (B0), giving both B pools 3-deep
     # buffering instead of just pool3 (B1). None = 1-pool-3buf behavior.
@@ -2516,7 +2503,7 @@ def _wgrad_wholeloop_tile_3buf(
         rocdl.readfirstlane(T.i32, fx.Int32(B1_gl_offset) + fx.Int32(3) * kstep_b),
     ]
     acc0 = [[mfma.zero_value] * n_accums for _ in range_constexpr(4)]
-    res = _wgrad_wholeloop_asm_3buf(
+    res = _wholeloop_asm_3buf(
         nta=nta,
         ntb=ntb,
         bases=bases,
@@ -2543,10 +2530,7 @@ def _wgrad_wholeloop_tile_3buf(
     )
     if not do_store:
         return res
-    store_c.store(res[0], base_row + 0, base_col + 0)
-    store_c.store(res[1], base_row + 0, base_col + lds_block_n)
-    store_c.store(res[2], base_row + lds_block_m, base_col + 0)
-    store_c.store(res[3], base_row + lds_block_m, base_col + lds_block_n)
+    _store_quadrants(store_c, res[0], res[1], res[2], res[3], base_row, base_col, lds_block_m, lds_block_n)
     return res
 
 
@@ -2554,7 +2538,7 @@ def _wgrad_wholeloop_tile_3buf(
 # @flyc.kernel tracer processes any def nested in the traced function's own source, and
 # nesting this here previously tripped @flyc.jit's global-drift check on an unrelated
 # cache the moment the launch function was invoked more than once in one process.
-def _wgrad_do_tile_3buf(
+def _wave4_do_tile_tn(
     t,
     *,
     TOTAL,
@@ -2687,7 +2671,7 @@ def _wgrad_do_tile_3buf(
             _out_ty,
             lds.C_lds_shuffle,
             wave_id,
-            row_pad=4,  # must match _EPI_PAD in _compile_grouped_tn_wgrad_4wave's C_lds_shuffle sizing
+            row_pad=4,  # must match epi_pad in _wave4_geometry's C_lds_shuffle sizing (cshuf_n)
         )
     _common = dict(
         a_g2s=a_g2s,
@@ -2725,12 +2709,75 @@ def _wgrad_do_tile_3buf(
     )
 
     _b0x = lds.B_lds_extra_0 if os.environ.get("PT_WL_2BPOOL", "1") == "1" else None
-    _wgrad_wholeloop_tile_3buf(
+    _wholeloop_tile_3buf(
         **_common,
         nval=nval_main,
         do_store=True,
         tail_nval=tail_k_u,
         b0_extra_buf=_b0x,
+    )
+
+
+def _make_wave4_smem(*, a_lds_size, b_lds_size, cshuf_ty, cshuf_n, tail):
+    """Build the 4-wave SharedStorage @fx.struct: 8 fixed A/B triple-buffer fields then an
+    ordered tail. Field ORDER fixes LDS offsets, so each kernel passes its own tail
+    ("C"=C_lds_shuffle, "B_extra_1"/"B_extra_0"=deferred-write B buffers)."""
+    F8 = fx.Float8E4M3FN
+    ann = {
+        "A_lds_cur_0": fx.Array[F8, a_lds_size, 16],
+        "A_lds_cur_1": fx.Array[F8, a_lds_size, 16],
+        "A_lds_next_0": fx.Array[F8, a_lds_size, 16],
+        "A_lds_next_1": fx.Array[F8, a_lds_size, 16],
+        "B_lds_cur_0": fx.Array[F8, b_lds_size, 16],
+        "B_lds_cur_1": fx.Array[F8, b_lds_size, 16],
+        "B_lds_next_0": fx.Array[F8, b_lds_size, 16],
+        "B_lds_next_1": fx.Array[F8, b_lds_size, 16],
+    }
+    tail_field = {
+        "C": ("C_lds_shuffle", fx.Array[cshuf_ty, cshuf_n, 16]),
+        "B_extra_1": ("B_lds_extra_1", fx.Array[F8, b_lds_size, 16]),
+        "B_extra_0": ("B_lds_extra_0", fx.Array[F8, b_lds_size, 16]),
+    }
+    for key in tail:
+        name, ty = tail_field[key]
+        ann[name] = ty
+    return fx.struct(type("SharedStorage", (), {"__annotations__": ann}))
+
+
+_Wave4Geometry = namedtuple(
+    "_Wave4Geometry",
+    "N_WAVES N_TILES_A N_TILES_B N_ACCUMS LDS_BLOCK_M LDS_BLOCK_N "
+    "N_LDS_STEPS_A N_LDS_STEPS_B N_LDS_ROUNDS a_lds_size b_lds_size EPI_PAD cshuf_n cshuf_ty",
+)
+
+
+def _wave4_geometry(*, block_m, block_n, block_k, cs, csa, out_fp16):
+    """Derived 4-wave tile/LDS geometry shared by both grouped factories (trans_b-agnostic,
+    factory-scope Python). ``csa``/``cs`` are the A/B LDS column strides (wgrad shares one
+    _CS, dgrad uses _CSA/_CS); EPI_PAD keeps the CShuffle epilogue at 0% LDS bank conflict."""
+    n_waves = 4
+    n_tiles_a = block_m // 64
+    n_tiles_b = block_n // 64
+    lds_block_m = block_m // 2
+    lds_block_n = block_n // 2
+    n_lds_steps_a = (lds_block_m * block_k) // (256 * 16)
+    n_lds_steps_b = (lds_block_n * block_k) // (256 * 16)
+    epi_pad = 4
+    return _Wave4Geometry(
+        N_WAVES=n_waves,
+        N_TILES_A=n_tiles_a,
+        N_TILES_B=n_tiles_b,
+        N_ACCUMS=n_tiles_a * n_tiles_b,
+        LDS_BLOCK_M=lds_block_m,
+        LDS_BLOCK_N=lds_block_n,
+        N_LDS_STEPS_A=n_lds_steps_a,
+        N_LDS_STEPS_B=n_lds_steps_b,
+        N_LDS_ROUNDS=max(n_lds_steps_a, n_lds_steps_b),
+        a_lds_size=(lds_block_m * block_k) // 1024 * csa,
+        b_lds_size=(lds_block_n * block_k) // 1024 * cs,
+        EPI_PAD=epi_pad,
+        cshuf_n=n_waves * 16 * (n_tiles_b * 16 + epi_pad),
+        cshuf_ty=fx.Float16 if out_fp16 else fx.BFloat16,
     )
 
 
@@ -2750,10 +2797,9 @@ def _compile_grouped_tn_wgrad_4wave(
     vmcnt_hint: int = 2,
     cap_cu: int = -1,
 ):
-    """4-wave (occ=1) grouped TN wgrad dW[g]=A[g]^T@B[g], variable-K over per-group token
-    rows. 256x256 2x2-wave whole-loop bare-asm body drives the runtime nval (floored to a
-    multiple of 6) + in-asm fused tail; partial/over-run K-blocks are zeroed by per-group
-    SRD num_records clamp (no K-tail mask). C is [G*OUT_M, OUT_N], store clamps per group."""
+    """4-wave (occ=1) grouped TN wgrad dW[g]=A[g]^T@B[g], variable-K per group. 256x256
+    whole-loop bare-asm body: runtime nval (floored to x6) + in-asm fused tail; partial
+    K-blocks zeroed by per-group SRD num_records clamp. C=[G*OUT_M, OUT_N]."""
 
     # 2-pool (both B pools 3-buffered) is default-on; needs _CS=1024 (fit 10 buffers)
     # + scalar store. PT_WL_2BPOOL=0 falls back to 1-pool @1056.
@@ -2764,49 +2810,39 @@ def _compile_grouped_tn_wgrad_4wave(
     # below being width-parameterized. Keep this assert at 256.
     assert BLOCK_M == 256 and BLOCK_N == 256, "4-wave grouped wgrad is 256x256-only"
     assert G >= 1
-    N_WAVES = 4
-    N_TILES_A = BLOCK_M // 64
-    N_TILES_B = BLOCK_N // 64
-    N_ACCUMS = N_TILES_A * N_TILES_B
-    LDS_BLOCK_M = BLOCK_M // 2
-    LDS_BLOCK_N = BLOCK_N // 2
     # 2-pool needs _CS=1024 (fit 10 buffers); 1-pool/2-buffer keep 1056 (0 bank conflict).
     _CS = int(os.environ.get("PT_CS", "1024" if _2BPOOL else "1056"))
-    N_LDS_STEPS_A = (LDS_BLOCK_M * BLOCK_K) // (256 * 16)
-    N_LDS_STEPS_B = (LDS_BLOCK_N * BLOCK_K) // (256 * 16)
-    N_LDS_ROUNDS = max(N_LDS_STEPS_A, N_LDS_STEPS_B)
-    a_lds_size = (LDS_BLOCK_M * BLOCK_K) // 1024 * _CS
-    b_lds_size = (LDS_BLOCK_N * BLOCK_K) // 1024 * _CS
+    # geo.cshuf_n bakes EPI_PAD=4 (row_pad=4 at the StoreCPerTensorCShuffle call sites).
+    _geo = _wave4_geometry(
+        block_m=BLOCK_M, block_n=BLOCK_N, block_k=BLOCK_K, cs=_CS, csa=_CS, out_fp16=out_fp16
+    )
+    N_WAVES = _geo.N_WAVES
+    N_TILES_A = _geo.N_TILES_A
+    N_TILES_B = _geo.N_TILES_B
+    N_ACCUMS = _geo.N_ACCUMS
+    LDS_BLOCK_M = _geo.LDS_BLOCK_M
+    LDS_BLOCK_N = _geo.LDS_BLOCK_N
+    N_LDS_STEPS_A = _geo.N_LDS_STEPS_A
+    N_LDS_STEPS_B = _geo.N_LDS_STEPS_B
+    N_LDS_ROUNDS = _geo.N_LDS_ROUNDS
+    a_lds_size = _geo.a_lds_size
+    b_lds_size = _geo.b_lds_size
+    _cshuf_n = _geo.cshuf_n
+    _cshuf_ty = _geo.cshuf_ty
     N_BLOCKS_M = (OUT_M + BLOCK_M - 1) // BLOCK_M
     N_BLOCKS_N = (OUT_N + BLOCK_N - 1) // BLOCK_N
     TILES_PER_GROUP = N_BLOCKS_M * N_BLOCKS_N
     TOTAL = G * TILES_PER_GROUP
-    _cshuf_ty = fx.Float16 if out_fp16 else fx.BFloat16
-    # row_pad=4 drives StoreCPerTensorCShuffle's epilogue LDS bank conflict to exactly
-    # 0.0% (rocprofv3 LDSBankConflict, measured; see StoreCPerTensorCShuffle's
-    # docstring). C_lds_shuffle's allocation must grow to match (n_tiles_b*16+_EPI_PAD
-    # per row, not just n_tiles_b*16) -- this constant MUST stay in sync with the
-    # row_pad= value passed to both StoreCPerTensorCShuffle(...) call sites below.
-    _EPI_PAD = 4
-    _cshuf_n = N_WAVES * 16 * (N_TILES_B * 16 + _EPI_PAD)
 
-    @fx.struct
-    class SharedStorage:
-        A_lds_cur_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
-        A_lds_cur_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
-        A_lds_next_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
-        A_lds_next_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
-        B_lds_cur_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
-        B_lds_cur_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
-        B_lds_next_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
-        B_lds_next_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
-        # 2bpool mode forces scalar store (no CShuffle) to free C_lds space, so
-        # C_lds_shuffle shrinks to a stub; otherwise full size.
-        C_lds_shuffle: fx.Array[_cshuf_ty, (16 if _2BPOOL else _cshuf_n), 16]
-        B_lds_extra_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
-        if _2BPOOL:
-            # 2nd B-pool 3rd buffer (defer 1/2 the writes). Only fits at _CS=1024 + scalar store.
-            B_lds_extra_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
+    # 2bpool forces scalar store (no CShuffle) so C_lds_shuffle shrinks to a stub and a
+    # 2nd deferred-write B buffer (B_lds_extra_0) fits (only at _CS=1024 + scalar store).
+    SharedStorage = _make_wave4_smem(
+        a_lds_size=a_lds_size,
+        b_lds_size=b_lds_size,
+        cshuf_ty=_cshuf_ty,
+        cshuf_n=(16 if _2BPOOL else _cshuf_n),
+        tail=["C", "B_extra_1"] + (["B_extra_0"] if _2BPOOL else []),
+    )
 
     @flyc.kernel(known_block_size=[256, 1, 1])
     def kernel_grouped_tn_wgrad_4wave(
@@ -2842,7 +2878,7 @@ def _compile_grouped_tn_wgrad_4wave(
         _cn = fx.Int32(OUT_N)
 
         def _do_tile_3buf(t):
-            _wgrad_do_tile_3buf(
+            _wave4_do_tile_tn(
                 t,
                 TOTAL=TOTAL,
                 num_xcd=num_xcd,
@@ -3167,6 +3203,122 @@ def _grouped_4wave_tile_scan(
     return gi, m_row, m_end, block_n, a_base, a_nrec
 
 
+# Module-level (not nested in kernel_grouped_nn_4wave's body) for the same reason as
+# _wave4_do_tile_tn: the @flyc.kernel tracer would otherwise re-trace it and trip the
+# global-drift check on repeat launches. Symmetric to the wgrad (TN) tile body.
+def _wave4_do_tile_nn(
+    t,
+    *,
+    num_xcd,
+    total_tiles,
+    go_div,
+    G,
+    BLOCK_M,
+    BLOCK_N,
+    BLOCK_K,
+    n_blocks,
+    group_m,
+    group_n,
+    K,
+    c_n,
+    F8_IR_t,
+    _out_ty,
+    N_TILES_A,
+    N_TILES_B,
+    N_ACCUMS,
+    N_LDS_STEPS_A,
+    N_LDS_STEPS_B,
+    _CS,
+    _CSA,
+    N_WAVES,
+    vmcnt_hint,
+    cbsz,
+    blgp,
+    LDS_BLOCK_M,
+    LDS_BLOCK_N,
+    NVAL,
+    TAIL,
+    A,
+    B,
+    C,
+    A_scale,
+    B_scale,
+    gl_off_a,
+    gl_off_b,
+    wave_id,
+    wave_m,
+    wave_n,
+    lds,
+):
+    gi, m_row, m_end, block_n, a_base, a_nrec = _grouped_4wave_tile_scan(
+        t, num_xcd, total_tiles, go_div, G, BLOCK_M, BLOCK_N, n_blocks, group_m, group_n, K
+    )
+    cn_i = arith.index_cast(T.index, c_n)
+    b_base = arith.index_cast(T.index, gi) * arith.index(K) * cn_i + arith.index_cast(
+        T.index, block_n * BLOCK_N
+    )
+    b_nrec = arith.index(K) * cn_i - arith.index_cast(T.index, block_n * BLOCK_N)
+    gA = make_fp8_buffer_tensor_rebased(A, F8_IR_t, a_base, a_nrec)
+    gB = make_fp8_buffer_tensor_rebased(B, F8_IR_t, b_base, b_nrec)
+    a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
+    b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
+    mfma = Mfma16x16x128(N_TILES_A, N_TILES_B)
+    mfma._do_mma = lambda _a, _b, _c: asm_mma_do(_a, _b, _c, mode="2", cbsz=cbsz, blgp=blgp)
+    a_g2s = G2SLoader(a_div, gl_off_a, N_LDS_STEPS_A, F8_IR_t, wave_id, chunk_stride=_CSA)
+    b_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_B, F8_IR_t, wave_id, chunk_stride=_CS)
+    a_s2r = S2RLoader(wave_m, N_TILES_A)
+    b_s2r = S2RLoaderTr(
+        wave_n,
+        N_TILES_B,
+        N_TILES_B * 16,
+        inline_asm=True,
+        vmcnt_hint=vmcnt_hint,
+        n_waves=N_WAVES,
+        chunk_stride=_CS,
+        width=LDS_BLOCK_N,
+    )
+    store_c = StoreCPerTensor(A_scale, B_scale, C, m_end, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty)
+    _wholeloop_tile_3buf(
+        a_g2s=a_g2s,
+        b_g2s=b_g2s,
+        a_s2r=a_s2r,
+        b_s2r=b_s2r,
+        lds=lds,
+        gl_off_a=gl_off_a,
+        gl_off_b=gl_off_b,
+        A=A,
+        B=B,
+        a_base=a_base,
+        b_base=b_base,
+        a_nrec=a_nrec,
+        b_nrec=b_nrec,
+        c_n=c_n,
+        c_m=fx.Int32(1),
+        wave_id=wave_id,
+        mfma=mfma,
+        store_c=store_c,
+        nta=N_TILES_A,
+        ntb=N_TILES_B,
+        n_accums=N_ACCUMS,
+        nsa=N_LDS_STEPS_A,
+        nsb=N_LDS_STEPS_B,
+        block_k=BLOCK_K,
+        cs=[_CSA, _CSA, _CS, _CS],
+        nw=N_WAVES,
+        cbsz=cbsz,
+        blgp=blgp,
+        base_row=m_row + wave_m * (N_TILES_A * 16),
+        base_col=block_n * BLOCK_N + wave_n * (N_TILES_B * 16),
+        lds_block_m=LDS_BLOCK_M,
+        lds_block_n=LDS_BLOCK_N,
+        nval=fx.Int32(NVAL),
+        tail_nval=fx.Int32(TAIL),
+        a_plain=True,
+        a_row_stride=fx.Int32(K),
+        b0_extra_buf=lds.B_lds_extra_0,
+    )
+
+
 def _compile_grouped_nn_4wave(
     *, K, G, num_xcd=8, group_m=0, group_n=0, cbsz=0, blgp=0, out_fp16=False, cap_cu=-1, vmcnt_hint=2
 ):
@@ -3176,39 +3328,35 @@ def _compile_grouped_nn_4wave(
     BLOCK_M = 256
     BLOCK_N = 256
     BLOCK_K = 128
-    N_WAVES = 4
-    N_TILES_A = BLOCK_M // 64
-    N_TILES_B = BLOCK_N // 64
-    N_ACCUMS = N_TILES_A * N_TILES_B
-    LDS_BLOCK_M = BLOCK_M // 2
-    LDS_BLOCK_N = BLOCK_N // 2
     _CS = 1024
     _CSA = 1024
-    N_LDS_STEPS_A = (LDS_BLOCK_M * BLOCK_K) // (256 * 16)
-    N_LDS_STEPS_B = (LDS_BLOCK_N * BLOCK_K) // (256 * 16)
-    N_LDS_ROUNDS = max(N_LDS_STEPS_A, N_LDS_STEPS_B)
-    a_lds_size = (LDS_BLOCK_M * BLOCK_K) // 1024 * _CSA
-    b_lds_size = (LDS_BLOCK_N * BLOCK_K) // 1024 * _CS
+    _geo = _wave4_geometry(
+        block_m=BLOCK_M, block_n=BLOCK_N, block_k=BLOCK_K, cs=_CS, csa=_CSA, out_fp16=out_fp16
+    )
+    N_WAVES = _geo.N_WAVES
+    N_TILES_A = _geo.N_TILES_A
+    N_TILES_B = _geo.N_TILES_B
+    N_ACCUMS = _geo.N_ACCUMS
+    LDS_BLOCK_M = _geo.LDS_BLOCK_M
+    LDS_BLOCK_N = _geo.LDS_BLOCK_N
+    N_LDS_STEPS_A = _geo.N_LDS_STEPS_A
+    N_LDS_STEPS_B = _geo.N_LDS_STEPS_B
+    N_LDS_ROUNDS = _geo.N_LDS_ROUNDS
+    a_lds_size = _geo.a_lds_size
+    b_lds_size = _geo.b_lds_size
+    _cshuf_ty = _geo.cshuf_ty
     _, NVAL, TAIL = _wholeloop_tail_split_3buf(
         K, BLOCK_K
     )  # 3buf FUSED: main loop in multiples of 6 + tail remainder
-    _EPI_PAD = 4
-    _cshuf_n = N_WAVES * 16 * (N_TILES_B * 16 + _EPI_PAD)
-    _cshuf_ty = fx.Float16 if out_fp16 else fx.BFloat16
 
-    @fx.struct
-    class SharedStorage:
-        A_lds_cur_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
-        A_lds_cur_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
-        A_lds_next_0: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
-        A_lds_next_1: fx.Array[fx.Float8E4M3FN, a_lds_size, 16]
-        B_lds_cur_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
-        B_lds_cur_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
-        B_lds_next_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
-        B_lds_next_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
-        B_lds_extra_1: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
-        B_lds_extra_0: fx.Array[fx.Float8E4M3FN, b_lds_size, 16]
-        C_lds_shuffle: fx.Array[_cshuf_ty, 16, 16]
+    # dgrad tail order differs from wgrad (B extras before C); order fixes LDS offsets.
+    SharedStorage = _make_wave4_smem(
+        a_lds_size=a_lds_size,
+        b_lds_size=b_lds_size,
+        cshuf_ty=_cshuf_ty,
+        cshuf_n=16,
+        tail=["B_extra_1", "B_extra_0", "C"],
+    )
 
     @flyc.kernel(known_block_size=[256, 1, 1])
     def kernel_grouped_nn_4wave(
@@ -3243,74 +3391,48 @@ def _compile_grouped_nn_4wave(
         gl_off_b = compute_global_swizzle_nn(lane_id, wave_id, c_n, N_LDS_ROUNDS, wswz=False)
 
         def _do_tile(t):
-            gi, m_row, m_end, block_n, a_base, a_nrec = _grouped_4wave_tile_scan(
-                t, num_xcd, total_tiles, go_div, G, BLOCK_M, BLOCK_N, n_blocks, group_m, group_n, K
-            )
-            cn_i = arith.index_cast(T.index, c_n)
-            b_base = arith.index_cast(T.index, gi) * arith.index(K) * cn_i + arith.index_cast(
-                T.index, block_n * BLOCK_N
-            )
-            b_nrec = arith.index(K) * cn_i - arith.index_cast(T.index, block_n * BLOCK_N)
-            gA = make_fp8_buffer_tensor_rebased(A, F8_IR_t, a_base, a_nrec)
-            gB = make_fp8_buffer_tensor_rebased(B, F8_IR_t, b_base, b_nrec)
-            a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
-            b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
-            mfma = Mfma16x16x128(N_TILES_A, N_TILES_B)
-            mfma._do_mma = lambda _a, _b, _c: asm_mma_do(_a, _b, _c, mode="2", cbsz=cbsz, blgp=blgp)
-            a_g2s = G2SLoader(a_div, gl_off_a, N_LDS_STEPS_A, F8_IR_t, wave_id, chunk_stride=_CSA)
-            b_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_B, F8_IR_t, wave_id, chunk_stride=_CS)
-            a_s2r = S2RLoader(wave_m, N_TILES_A)
-            b_s2r = S2RLoaderTr(
-                wave_n,
-                N_TILES_B,
-                N_TILES_B * 16,
-                inline_asm=True,
-                vmcnt_hint=vmcnt_hint,
-                n_waves=N_WAVES,
-                chunk_stride=_CS,
-                width=LDS_BLOCK_N,
-            )
-            store_c = StoreCPerTensor(
-                A_scale, B_scale, C, m_end, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty
-            )
-            _wgrad_wholeloop_tile_3buf(
-                a_g2s=a_g2s,
-                b_g2s=b_g2s,
-                a_s2r=a_s2r,
-                b_s2r=b_s2r,
-                lds=lds,
-                gl_off_a=gl_off_a,
-                gl_off_b=gl_off_b,
-                A=A,
-                B=B,
-                a_base=a_base,
-                b_base=b_base,
-                a_nrec=a_nrec,
-                b_nrec=b_nrec,
+            _wave4_do_tile_nn(
+                t,
+                num_xcd=num_xcd,
+                total_tiles=total_tiles,
+                go_div=go_div,
+                G=G,
+                BLOCK_M=BLOCK_M,
+                BLOCK_N=BLOCK_N,
+                BLOCK_K=BLOCK_K,
+                n_blocks=n_blocks,
+                group_m=group_m,
+                group_n=group_n,
+                K=K,
                 c_n=c_n,
-                c_m=fx.Int32(1),
-                wave_id=wave_id,
-                mfma=mfma,
-                store_c=store_c,
-                nta=N_TILES_A,
-                ntb=N_TILES_B,
-                n_accums=N_ACCUMS,
-                nsa=N_LDS_STEPS_A,
-                nsb=N_LDS_STEPS_B,
-                block_k=BLOCK_K,
-                cs=[_CSA, _CSA, _CS, _CS],
-                nw=N_WAVES,
+                F8_IR_t=F8_IR_t,
+                _out_ty=_out_ty,
+                N_TILES_A=N_TILES_A,
+                N_TILES_B=N_TILES_B,
+                N_ACCUMS=N_ACCUMS,
+                N_LDS_STEPS_A=N_LDS_STEPS_A,
+                N_LDS_STEPS_B=N_LDS_STEPS_B,
+                _CS=_CS,
+                _CSA=_CSA,
+                N_WAVES=N_WAVES,
+                vmcnt_hint=vmcnt_hint,
                 cbsz=cbsz,
                 blgp=blgp,
-                base_row=m_row + wave_m * (N_TILES_A * 16),
-                base_col=block_n * BLOCK_N + wave_n * (N_TILES_B * 16),
-                lds_block_m=LDS_BLOCK_M,
-                lds_block_n=LDS_BLOCK_N,
-                nval=fx.Int32(NVAL),
-                tail_nval=fx.Int32(TAIL),
-                a_plain=True,
-                a_row_stride=fx.Int32(K),
-                b0_extra_buf=lds.B_lds_extra_0,
+                LDS_BLOCK_M=LDS_BLOCK_M,
+                LDS_BLOCK_N=LDS_BLOCK_N,
+                NVAL=NVAL,
+                TAIL=TAIL,
+                A=A,
+                B=B,
+                C=C,
+                A_scale=A_scale,
+                B_scale=B_scale,
+                gl_off_a=gl_off_a,
+                gl_off_b=gl_off_b,
+                wave_id=wave_id,
+                wave_m=wave_m,
+                wave_n=wave_n,
+                lds=lds,
             )
 
         for t in range(pid, total_tiles, nsms):

--- a/primus_turbo/flydsl/utils/gemm_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_helper.py
@@ -73,11 +73,19 @@ def make_fp8_buffer_tensor_rebased(arg_i8, fp8_ir_t, base_elems, num_records_byt
     return fx.Tensor(fx.make_view(iter_f8, lay))
 
 
-def swizzle_128(row, col):
-    offset = row * 128 + col
-    swizzle = ((offset % (16 * 128)) >> 8) << 4
+def swizzle_128(row, col, width=128):
+    """XOR bank-swizzle over a `width`=2**k logical row (width=128 is byte-identical to
+    the original fixed-128 form). The swizzle must stay within col's bits [0,k); for k<7
+    we extract fewer bits (k-4) from the `row%16` window so the result is always < width."""
+    k = width.bit_length() - 1
+    period = 16 * width
+    offset = row * width + col
+    nbits = k - 4
+    mask = (1 << nbits) - 1
+    extracted = (offset % period) >> (k + 1)
+    swizzle = (extracted & mask) << 4
     swizzled_offset = offset ^ swizzle
-    return swizzled_offset // 128, swizzled_offset % 128
+    return swizzled_offset // width, swizzled_offset % width
 
 
 def compute_global_swizzle(lane_id, wave_id, K, n_rounds, preshuffled):
@@ -193,6 +201,28 @@ class S2RLoader:
                 halves.append(v.bitcast(fx.Int32))
             frag.append(pack_i32x4_i32x8(halves[0], halves[1]))
         return frag
+
+    def base_addr(self, lds_src, preshuffled=False):
+        """Per-lane LDS byte address pairs for the bare-asm whole-loop: mirrors `load()`'s
+        addressing but returns addresses so `ds_line` can emit 2x ds_read_b128 (no HW
+        transpose) for an already-M/N-major operand. Same [[p0,p1]]*n_tiles shape as
+        `S2RLoaderTr.base_addr` (interchangeable); p0/p1 are the two 16B halves of one
+        32-elem fragment, not two lane-group bases."""
+        base = fx.Int32(fx.ptrtoint(lds_src.ptr))
+        out = []
+        for i in range_constexpr(self.n_tiles):
+            row = self.wave_idx * (self.n_tiles * 16) + i * 16 + self.lane_id % 16
+            addrs = []
+            for step in range_constexpr(2):
+                col = (self.lane_id // 16) * 16 + step * 64
+                if const_expr(preshuffled):
+                    offset = (row // 8) * 1024 + (row % 8) * 16 + (col // 16) * 128
+                else:
+                    row_swz, col_swz = swizzle_128(row, col)
+                    offset = row_swz * 128 + col_swz
+                addrs.append(base + fx.Int32(offset))
+            out.append(addrs)
+        return out
 
 
 def wait_barrier(count):
@@ -447,7 +477,19 @@ class StoreCPerTensorCShuffle:
     invalid runs clamp to an OOB element index (HW SRD drop), as the scalar path does."""
 
     def __init__(
-        self, A_scale, B_scale, C, c_rows, c_cols, c_idx_fn, n_tiles_a, n_tiles_b, out_ty, c_lds, wave_id
+        self,
+        A_scale,
+        B_scale,
+        C,
+        c_rows,
+        c_cols,
+        c_idx_fn,
+        n_tiles_a,
+        n_tiles_b,
+        out_ty,
+        c_lds,
+        wave_id,
+        row_pad=0,
     ):
         self.c_rows = c_rows
         self.c_cols = c_cols
@@ -457,13 +499,22 @@ class StoreCPerTensorCShuffle:
         self.n_tiles_a = n_tiles_a
         self.n_tiles_b = n_tiles_b
         self.out_ty = out_ty
-        self.Cc = n_tiles_b * 16
-        self.EPL = (16 * self.Cc) // 64  # out_ty elements per lane on re-read
-        assert self.EPL * 2 == 16, f"CShuffle expects a 128b store (EPL=8 bf16); got EPL={self.EPL}"
-        # The ds_write_b16 staging + 128b re-read aliases LDS banks, but the epilogue
-        # store stall is hidden behind the MMA pipeline / next-tile prologue, so anti-
-        # conflict row padding is perf-neutral here and is not used.
-        self.row_stride = self.Cc  # logical == physical (no anti-conflict padding)
+        self.Cc = n_tiles_b * 16  # columns in one 16-row shuffle tile
+        self.EPL = (16 * self.Cc) // 64  # out_ty elements each lane re-reads (16*Cc rows/cols / 64 lanes)
+        # One coalesced global store is 128 bits = 8 x 16b (buffer_store_dwordx4). If a
+        # lane re-reads more than that (EPL > 8 -- e.g. the 4-wave 2x2 geometry has
+        # n_tiles_b=4 -> Cc=64 -> EPL=16), emit EPL//8 back-to-back 128b stores; EPL==8
+        # (the 8-wave path) is a single store. EPL must be a multiple of 8 and fit in one row.
+        self.elems_per_store = 8  # 16b elements packed into one 128b vector store
+        assert self.EPL % self.elems_per_store == 0 and self.EPL <= self.Cc, (
+            f"CShuffle expects EPL a multiple of 8 within Cc={self.Cc}; got EPL={self.EPL}"
+        )
+        # The ds_write_b16 staging + 128b re-read aliases LDS banks. row_pad=0 (default)
+        # keeps the historical behavior. row_pad is an explicit opt-in: the caller must
+        # size its own C_lds_shuffle allocation as n_waves*16*(n_tiles_b*16 + row_pad)
+        # (not just n_tiles_b*16), or this overflows the buffer.
+        self.row_stride = self.Cc + row_pad
+        self.row_pad = row_pad
         self.wave_lds_elems = 16 * self.row_stride  # per-wave staging (one 16-row tile)
         self.c_lds = c_lds
         # C addressed via i64 per-band re-basing (handles OUT_M*OUT_N > 2^31 / >4GB);
@@ -513,14 +564,16 @@ class StoreCPerTensorCShuffle:
             nrec_pinned = arith.index_cast(T.index, _readfirstlane_i32(arith.index_cast(T.i64, nrec)))
             rsrc = _buffer_ops.create_buffer_resource_from_addr(band_base_i64, num_records_bytes=nrec_pinned)
             row_in = (self.lane_id * self.EPL) // self.Cc
-            col_in = (self.lane_id * self.EPL) % self.Cc
-            lane_e = wave_off + row_in * self.row_stride + col_in
-            rptr = fx.inttoptr(self._read_ptr_t, lds_base + lane_e * 2)
-            vec = fx.make_view(rptr, fx.make_layout(self.EPL, 1)).load()
-            gcol = base_col + col_in
-            valid = (gcol + fx.Int32(self.EPL)) <= self.c_cols
-            off = (row_in * self.c_cols + gcol) * out_b  # i32-small within band
-            _buffer_ops.buffer_store(vec, rsrc, off, mask=valid, offset_is_bytes=True)
+            col0 = (self.lane_id * self.EPL) % self.Cc
+            for sub in range_constexpr(self.EPL // self.elems_per_store):
+                col_in = col0 + sub * self.elems_per_store
+                lane_e = wave_off + row_in * self.row_stride + col_in
+                rptr = fx.inttoptr(self._read_ptr_t, lds_base + lane_e * 2)
+                vec = fx.make_view(rptr, fx.make_layout(self.elems_per_store, 1)).load()
+                gcol = base_col + col_in
+                valid = (gcol + fx.Int32(self.elems_per_store)) <= self.c_cols
+                off = (row_in * self.c_cols + gcol) * out_b  # i32-small within band
+                _buffer_ops.buffer_store(vec, rsrc, off, mask=valid, offset_is_bytes=True)
             S2RLoaderTr._wait_lgkmcnt(0)  # drain re-read before next ti overwrites LDS
 
 
@@ -645,16 +698,24 @@ def _packed_ds_read_tr_offsets(base_ptr, byte_offsets, vmcnt_hint=None):
     return [_llvm.extractvalue(v2i32, asm_op.result, [k]) for k in range(N)]
 
 
-def compute_global_swizzle_nn(lane_id, wave_id, N_out, n_rounds):
-    """Per-lane global-load offsets for NN B [K_inner, N_out] row-major: each
-    round loads 64 K-rows x 128 N-bytes via swizzle_128(k_row, n_col) over the
-    flat [K, N] byte view with N_out element stride."""
+def compute_global_swizzle_nn(lane_id, wave_id, N_out, n_rounds, width=128, wswz=False):
+    """Per-lane global-load offsets for NN B [K_inner, N_out] row-major, via
+    swizzle_128(k_row, n_col, width) over the flat [K, N] byte view. `width` must equal
+    the destination buffer's LDS column span (e.g. LDS_BLOCK_N; defaults to 128,
+    byte-identical there) or reads overlap. chunks=width//16 lanes cooperate per K-row,
+    the remaining 64/chunks lanes per wave span distinct K-rows."""
     offsets = []
     n_waves = fx.block_dim.x // 64
+    chunks = width // 16
+    rows_per_wave = 64 // chunks
     for r in range_constexpr(n_rounds):
-        k_row = lane_id // 8 + wave_id * 8 + r * (n_waves * 8)
-        n_col = (lane_id % 8) * 16
-        rs, cs = swizzle_128(k_row, n_col)
+        k_row = lane_id // chunks + wave_id * rows_per_wave + r * (n_waves * rows_per_wave)
+        n_col = (lane_id % chunks) * 16
+        rs, cs = swizzle_128(k_row, n_col, width=width)
+        if wswz:
+            # Matching write for the read-side j_chunk^(W<<1) bank-spread swizzle:
+            # XOR (wave_id<<1) into the column chunk so it lands where the read looks.
+            cs = cs ^ (((wave_id << 1) & (chunks - 1)) * 16)
         offsets.append(rs * N_out + cs)
     return offsets
 
@@ -677,11 +738,14 @@ class S2RLoaderTr:
         vmcnt_hint=2,
         chunk_stride=1024,
         n_waves=8,
+        width=128,
+        wswz=False,
     ):
-        """wave_idx: this wave's index along the transposed coordinate (wave_n
-        for B, wave_m for A). tile_stride: per-wave coverage on that axis.
-        chunk_stride must match the G2S writer. inline_asm issues the reads as
-        opaque asm (caller drains via vmcnt_hint) and requires agpr_alloc>0."""
+        """wave_idx: this wave's index along the transposed coord (wave_n for B, wave_m for
+        A). tile_stride: per-wave coverage. chunk_stride must match the G2S writer.
+        inline_asm issues opaque-asm reads (caller drains via vmcnt_hint, needs
+        agpr_alloc>0). width: this buffer's LDS column span (defaults 128) -- MUST match the
+        paired compute_global_swizzle_nn `width` (see swz_K for why it scales with width)."""
         self.wave_idx = wave_idx
         self.n_tiles = n_tiles
         self.tile_stride = tile_stride
@@ -691,20 +755,33 @@ class S2RLoaderTr:
         self.chunk_stride = chunk_stride
         self.n_waves = n_waves
         self.round_stride = n_waves * chunk_stride
+        self.width = width
+        self.wswz = wswz  # wave bank-swizzle (j_chunk^(W<<1)); scoped to 2-pool@1024
 
     def _ptr_off(self, c, tile_i, I, L_in_sg):
-        KW = self.n_waves * 8
+        # rows_per_wave = 64/chunks must match compute_global_swizzle_nn's own
+        # rows_per_wave (the write side's local K-row count per wave per round).
+        chunks = self.width // 16
+        rows_per_wave = 64 // chunks
+        KW = self.n_waves * rows_per_wave
         K_log = I * 16 + S2RLoaderTr._K_BASE[c] + (L_in_sg // 2)
         r_step = K_log // KW
-        W = (K_log % KW) // 8
-        K_mod_8 = K_log % 8
-        swz_K = ((K_log % 16) // 2) * 16
+        W = (K_log % KW) // rows_per_wave
+        K_local_row = K_log % rows_per_wave
+        # swz_K reproduces swizzle_128's own (extracted & mask) term: extracted =
+        # (K_log%16)//2 is width-independent; only the mask narrows with width.
+        swz_K = (((K_log % 16) // 2) & (chunks - 1)) * 16
         coord_start = self.wave_idx * self.tile_stride + tile_i * 16
         j_chunk = (coord_start // 16) ^ (swz_K // 16)
+        if self.wswz:
+            # XOR (W<<1) into j_chunk: address bit shift W*32, matching the write
+            # side's compute_global_swizzle_nn(wswz=True) -- drops LDSBankConflict
+            # 14% -> 0% at _CS=1024 (2-pool).
+            j_chunk = j_chunk ^ ((W << 1) & (chunks - 1))
         return (
             W * self.chunk_stride
             + r_step * self.round_stride
-            + K_mod_8 * 128
+            + K_local_row * self.width
             + j_chunk * 16
             + (L_in_sg % 2) * 8
         )
@@ -766,6 +843,21 @@ class S2RLoaderTr:
                 self._wait_lgkmcnt(0)
             return [self._assemble(c) for c in all_calls]
         return [self._assemble(self._issue_one(lds_src, t, base_off)) for t in range_constexpr(self.n_tiles)]
+
+    def base_addr(self, lds_src):
+        """Per-lane LDS address pairs [[p0,p1]]*n_tiles for the whole-loop transpose reads:
+        tile i's 4 ds_read_b64_tr_b8 are p0[i]+0, p1[i]+0, p0[i]+RS, p1[i]+RS (RS =
+        8*chunk_stride). p0/p1 are not tile-strided (j_chunk carries an XOR), so each tile
+        needs its own pair."""
+        base = fx.Int32(fx.ptrtoint(lds_src.ptr))
+        I = self.lane_id // 16
+        L_in_sg = self.lane_id % 16
+        out = []
+        for t in range_constexpr(self.n_tiles):
+            p0 = base + fx.Int32(self._ptr_off(0, t, I, L_in_sg))
+            p1 = base + fx.Int32(self._ptr_off(1, t, I, L_in_sg))
+            out.append([p0, p1])
+        return out
 
 
 def block_mn(pid, num_pid_m, n_blocks, GM, GN):


### PR DESCRIPTION
# Description

Add occ=1 4-wave whole-loop FP8 grouped kernels for both **wgrad** (variable-K) and **dgrad** (NN), and let the respective dispatches autotune them against the existing 8-wave paths, improving grouped wgrad/dgrad performance on MI355X (gfx950).

Motivation: main's grouped wgrad only had the 8-wave masked+persistent path, and grouped dgrad (NN) only the 8-wave candidates. wgrad (variable-K) is **not** DVFS power-limited (runs at ~266W, MfmaUtil ~54%), so kernel-efficiency gains show up strongly; dgrad (NN) is closer to the power wall so its 4-wave gains are more modest but still positive where applicable.

Fixes # (N/A)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Add an occ=1 4-wave whole-loop FP8 grouped wgrad (variable-K) kernel.
- Add an occ=1 4-wave whole-loop FP8 grouped dgrad (NN) kernel (`_compile_grouped_nn_4wave`).
- Large-contraction wgrad dispatch now serially times the masked 8-wave pool `(8,4,8)/(8,0,8)/(4,4,8)` against the 4-wave candidates (`_robust_time`) and picks the fastest, with best-8w as a 1.5%-hysteresis fallback — instead of unconditionally returning on the first numerically-passing 4-wave.
- dgrad (NN) non-persistent dispatch keeps its 3 8-wave candidates and spends a 4th slot on a single rule-picked 4-wave candidate (K≥large → xcd1 group-major, else xcd8), raced with the same 1.5% hysteresis; `PT_NO_G4W=1` disables. Total candidates stay ≤4 per op.
- NN 4-wave now supports any K (dropped the `K % 128 == 0` gate): the whole-loop bounds B's buffer SRD to the current group (`K*N`, not `gi..G`), so the K%128 tail over-reads rows `k>=K` clamp to 0. A's contiguous `[M,K]` cross-row bleed in that tail then multiplies B=0 and vanishes — no explicit K-tail mask needed.
- Drain the whole-loop phase barrier (`vmcnt(0) lgkmcnt(0)`) so the ping-pong `ds_read` cannot race a still-pending `buffer_load_lds` (see Correctness).
- fwd (NT) path unchanged.

# Correctness (race verification)

The 4-wave whole-loop phase barrier originally kept loads in flight across the ping-pong `s_barrier`, letting `ds_read` race the pending LDS write — run-to-run bit-nondeterministic output that aggregate SNR hides. Fixed by draining the barrier and verified with a bit-exact run-to-run test (fixed input, N iters, `atol=rtol=0`):

- **wgrad: 0 / 140,000** mismatches across all 7 MoE shapes (20K iters each), matching the deterministic 8-wave baseline. Before the fix the same test showed up to 100% run-to-run diff (rel err ~10–14%).
- **dgrad (NN): 0 / 140,000** mismatches (same 7 shapes × 20K iters, m2048, production-rule 4-wave config), including the `K%128≠0` group-bounded-SRD tail shapes (`gpt_oss-down` K=2880, `synth-oddtail` K=3008). NN reuses the same drained whole-loop barrier.

# Performance

MI355X gfx950, kernel-only TFLOPS, `PT_WARMUP=250`, real MoE shapes (G=8),
same-session A/B on a dedicated GPU. 4-wave vs 8-wave-only (main); SNR all 56.

## wgrad (variable-K, `dW = Aᵀ@B`)

| shape (OUT N×K) | m2048 main→PR | m4096 main→PR |
|---|---|---|
| deepseek-up 4096×7168 | 2139→2297 (+7.4%) | 2480→2665 (+7.5%) |
| deepseek-down 7168×2048 | 2052→2218 (+8.1%) | 2466→2627 (+6.5%) |
| qwen235b-up 3072×4096 | 2201→2370 (+7.7%) | 2431→2650 (+9.0%) |
| qwen235b-down 4096×1536 | 2054→2303 (+12.1%) | 2369→2676 (+13.0%) |
| gpt_oss-up 5760×2880 | 1984→2070 (+4.3%) | 2120→2356 (+11.1%) |
| gpt_oss-down 2880×2880 | 1782→1910 (+7.2%) | 2084→2215 (+6.3%) |
| synth-oddtail 3008×3008 | 1953→2090 (+7.0%) | 2248→2397 (+6.6%) |

- **4-wave wins every shape at both M (+4.3~13.0%)** and is the autotune pick; no
  regression anywhere.

## dgrad (NN, `dX = dY@Wᵀ`)

NN contracts the forward out-dim, so its `K×N` is the wgrad `(OUT_M, OUT_N)` swapped.
4-wave now covers **all** K incl. `K%128≠0` (`gpt_oss-down` K=2880, `synth-oddtail`
K=3008); SNR 56 across the whole tuning grid for those tails:

| shape (dgrad K×N) | m2048 main→PR | m4096 main→PR |
|---|---|---|
| deepseek-up 4096×7168 | 2501→2593 (+3.7%) | 2551→2627 (+2.9%) |
| deepseek-down 7168×2048 | 2723→2799 (+2.8%) | 2704→2761 (+2.1%) |
| qwen235b-up 3072×4096 | 2483→2560 (+3.1%) | 2396→2431 (+1.5%) |
| qwen235b-down 4096×1536 | 2246→2236 (−0.5%) | 2626→2641 (+0.6%) |
| gpt_oss-up 5760×2880 | 2449→2532 (+3.4%) | 2384→2486 (+4.2%) |
| gpt_oss-down 2880×2880 | 2163→2205 (+1.9%) | 2199→2206 (+0.3%) |
| synth-oddtail 3008×3008 | 2294→2347 (+2.3%) | 2324→2328 (+0.2%) |

- 4-wave leads on nearly every shape (up to +4.2%); where it's within the 1.5%
  hysteresis (qwen235b-down m2048) the autotune keeps 8-wave, so there is **no
  regression**.
- Numbers are per-shape best-of-grid 4-wave vs best-of-pool 8-wave, measured in one
  session on an idle GPU (rules out cross-session thermal/clock drift).

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
