### PR TITLE
fix(grouped_gemm): zero uncovered padding tail of grouped GEMM outputs

### DIFF
--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
@@ -36,6 +36,9 @@ from primus_turbo.triton.grouped_gemm.grouped_gemm_fp4_kernel import (
     grouped_gemm_mxfp4_triton_kernel,
     grouped_gemm_mxfp4_variable_k_triton_kernel,
 )
+from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
+    grouped_gemm_output_tail_kernel,
+)
 
 
 class GroupedGEMMFP4TritonBackend(KernelBackend):
@@ -284,7 +287,12 @@ def grouped_gemm_fp4_impl(
         group_offs_out=group_offs_out,
     )
 
-    return GroupedGEMMFP4KernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    out = GroupedGEMMFP4KernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    # Over-allocated output: zero the unwritten tail past the tight write bound
+    # (group_offs_out for MX; group_offs otherwise) so the caller's [:total_m]
+    # slice never exposes uninitialized rows.
+    out = grouped_gemm_output_tail_kernel(out, group_offs_out if group_offs_out is not None else group_offs)
+    return out
 
 
 @_torch_custom_op_wrapper(

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -34,6 +34,9 @@ from primus_turbo.triton.grouped_gemm.grouped_gemm_fp8_kernel import (
     grouped_gemm_mxfp8_triton_kernel,
     grouped_gemm_mxfp8_variable_k_triton_kernel,
 )
+from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
+    grouped_gemm_output_tail_kernel,
+)
 
 _COMMON_SUPPORTED_DTYPES = (
     (float8_e4m3, float8_e4m3, torch.float16),
@@ -848,7 +851,10 @@ def grouped_gemm_fp8_impl(
         group_offs_out=group_offs_out,
     )
 
-    return GroupedGEMMFP8KernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    out = GroupedGEMMFP8KernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    if group_offs_out is None:
+        out = grouped_gemm_output_tail_kernel(out, group_offs)
+    return out
 
 
 @_torch_custom_op_wrapper(

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -852,8 +852,10 @@ def grouped_gemm_fp8_impl(
     )
 
     out = GroupedGEMMFP8KernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
-    if group_offs_out is None:
-        out = grouped_gemm_output_tail_kernel(out, group_offs)
+    # Over-allocated output: zero the unwritten tail past the tight write bound
+    # (group_offs_out for MX; group_offs otherwise) so the caller's [:total_m]
+    # slice never exposes uninitialized rows.
+    out = grouped_gemm_output_tail_kernel(out, group_offs_out if group_offs_out is not None else group_offs)
     return out
 
 

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
@@ -40,6 +40,7 @@ from primus_turbo.pytorch.kernels.grouped_gemm.ws_ck_heuristic import (
     resolve_ck_ws_local_per_xcd,
 )
 from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
+    grouped_gemm_output_tail_kernel,
     grouped_gemm_triton_kernel,
     grouped_gemm_variable_k_triton_kernel,
 )
@@ -495,7 +496,9 @@ def grouped_gemm_impl(
         schedule=schedule,
     )
 
-    return GroupedGEMMKernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    out = GroupedGEMMKernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    out = grouped_gemm_output_tail_kernel(out, group_offs)
+    return out
 
 
 @_torch_custom_op_wrapper("primus_turbo::grouped_gemm_variable_k_impl", mutates_args=(), device_types="cuda")

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
@@ -1235,3 +1235,80 @@ def grouped_gemm_variable_k_triton_kernel(
         kpack=1,
     )
     return out
+
+
+@triton.jit
+def _grouped_gemm_output_tail_kernel(
+    C,
+    group_offs_ptr,
+    G,
+    M_total,
+    N,
+    stride_cm,
+    stride_cn,
+    NUM_SMS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+):
+    covered = tl.load(group_offs_ptr + G).to(tl.int64)
+    m_total = tl.cast(M_total, tl.int64)
+    num_pad = m_total - covered
+    if num_pad <= 0:
+        return
+
+    num_m_blocks = tl.cdiv(num_pad, BLOCK_SIZE_M)
+    num_n_blocks = tl.cdiv(N, BLOCK_SIZE_N)
+    total_tiles = num_m_blocks * num_n_blocks
+
+    zeros = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=C.dtype.element_ty)
+
+    pid = tl.program_id(0)
+    for tile in range(pid, total_tiles, NUM_SMS):
+        bm = tile // num_n_blocks
+        bn = tile % num_n_blocks
+        rows = covered + bm * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+        cols = bn * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        mask = (rows[:, None] < m_total) & (cols[None, :] < N)
+        C_ = C + rows[:, None] * stride_cm + cols[None, :] * stride_cn
+        tl.store(C_, zeros, mask)
+
+
+def grouped_gemm_output_tail_kernel(
+    out: torch.Tensor,
+    group_offs: torch.Tensor,
+) -> torch.Tensor:
+    """Zero the uncovered padding tail of a grouped GEMM output, in place.
+
+    Clears rows ``[group_offs[-1], out.shape[0])`` -- the rows the persistent
+    forward/dgrad kernel never writes when the output is over-allocated to
+    padded token counts. CPU-sync-free (the covered boundary is read on device)
+    and a no-op when there is no padding.
+
+    Args:
+        out: [M_total, N] grouped GEMM output.
+        group_offs: [G+1] int64 prefix sum the kernel used to write ``out``.
+
+    Returns:
+        The same ``out`` tensor.
+    """
+    assert out.ndim == 2, f"expected 2D grouped GEMM output, got {tuple(out.shape)}"
+    M_total, N = out.shape
+    G = group_offs.shape[0] - 1
+    if G <= 0 or M_total == 0 or N == 0:
+        return out
+
+    num_sms = get_num_cus()
+    _grouped_gemm_output_tail_kernel[(num_sms,)](
+        out,
+        group_offs,
+        G,
+        M_total,
+        N,
+        out.stride(0),
+        out.stride(1),
+        NUM_SMS=num_sms,
+        BLOCK_SIZE_M=64,
+        BLOCK_SIZE_N=256,
+        num_warps=4,
+    )
+    return out

--- a/tests/pytorch/ops/test_grouped_gemm.py
+++ b/tests/pytorch/ops/test_grouped_gemm.py
@@ -484,3 +484,63 @@ def test_ck_grouped_gemm_op_ws_num_cu_below_num_xcds(num_cu):
         a, b, group_lens, group_offs, False, True, num_cu, True, counter, local_per_xcd
     )
     torch.testing.assert_close(out_ref, out_ws, rtol=0.0, atol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Over-allocated output tail must be zeroed (mirrors the FP8/FP4 sibling tests).
+# ---------------------------------------------------------------------------
+def _poison_alloc_pool(shape, dtype, device, sentinel, n=24):
+    """Fill and free caching-allocator blocks of ``shape`` with ``sentinel`` so a
+    subsequent same-shape allocation reuses a dirty (non-zero) block instead of a
+    fresh, driver-zeroed page. Lets us detect output regions the kernel never wrote."""
+    blocks = [torch.full(shape, sentinel, dtype=dtype, device=device) for _ in range(n)]
+    for x in blocks:
+        x.add_(0.0)
+    del blocks
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("trans_b", [True, False])
+@pytest.mark.parametrize("backend", [BackendType.CK, BackendType.HIPBLASLT, BackendType.TRITON])
+def test_grouped_gemm_padded_tail_zeroed(dtype, trans_b, backend):
+    """Over-allocated output tail [sum(group_lens):M_total] must be zeroed, not left as
+    caching-allocator garbage."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    torch.manual_seed(42)
+    device = "cuda:0"
+    G, K, N = 8, 2048, 2880
+    group_lens = torch.tensor([4096, 0, 3072, 0, 0, 5120, 0, 0], dtype=torch.int64, device=device)
+    S = int(group_lens.sum())
+    PAD = 224
+    M_total = S + PAD  # simulate over-allocated (fixed-capacity permute) activation rows
+    sentinel = 12288.0  # exactly representable in bf16 and fp16
+    print(f"\ndtype={dtype}, trans_b={trans_b}, backend={backend}, S={S}, M_total={M_total}")
+
+    GlobalBackendManager.set_grouped_gemm_backend(backend)
+
+    b_shape = (G, N, K) if trans_b else (G, K, N)
+    a = torch.randn((M_total, K), dtype=dtype, device=device)
+    b = torch.randn(b_shape, dtype=dtype, device=device)
+
+    # Warm up (JIT/autotune), then poison the pool so any unwritten padding rows
+    # surface the sentinel instead of a fresh zeroed page.
+    grouped_gemm(a, b, group_lens, trans_b=trans_b)
+    torch.cuda.synchronize()
+    _poison_alloc_pool((M_total, N), dtype, device, sentinel)
+
+    out = grouped_gemm(a, b, group_lens, trans_b=trans_b)
+    torch.cuda.synchronize()
+
+    pad_tail = out[S:M_total]
+    assert torch.isfinite(pad_tail).all(), f"{backend.name}: padding tail non-finite"
+    torch.testing.assert_close(
+        pad_tail,
+        torch.zeros_like(pad_tail),
+        rtol=0.0,
+        atol=0.0,
+        msg=f"{backend.name}: padding tail [{S}:{M_total}] must be zeroed",
+    )
+
+    GlobalBackendManager.reset()

--- a/tests/pytorch/ops/test_grouped_gemm_fp4.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp4.py
@@ -337,3 +337,58 @@ def test_grouped_gemm_fp4_mx_blockwise_deterministic(B, M, NK, dtype, balance):
     """fwd + dgrad + wgrad are bit-exact across 10 repeats (SR off)."""
     N, K = NK
     _run_grouped_gemm_fp4_deterministic_test(B, M, N, K, dtype, balance, repeats=10)
+
+
+# ----------------------------------------------------------------------------
+# Over-allocated output tail must be zeroed (mirrors the FP8 sibling test).
+# ----------------------------------------------------------------------------
+def _poison_alloc_pool(shape, dtype, device, sentinel, n=24):
+    """Fill and free caching-allocator blocks of ``shape`` with ``sentinel`` so a
+    subsequent same-shape allocation reuses a dirty (non-zero) block instead of a
+    fresh, driver-zeroed page. Lets us detect output regions the kernel never wrote."""
+    blocks = [torch.full(shape, sentinel, dtype=dtype, device=device) for _ in range(n)]
+    for x in blocks:
+        x.add_(0.0)
+    del blocks
+
+
+@pytest.mark.parametrize("dtype", DTYPE_VALUES)
+def test_grouped_gemm_fp4_padded_tail_zeroed(dtype):
+    """Over-allocated output tail [sum(group_lens):M_total] must be zeroed, not left as
+    caching-allocator garbage."""
+    supported, reason = check_mxfp4_support()
+    if not supported:
+        pytest.skip(reason)
+
+    torch.manual_seed(42)
+    device = "cuda:0"
+    G, K, N = 8, 2048, 2880
+    group_lens = torch.tensor([4096, 0, 3072, 0, 0, 5120, 0, 0], dtype=torch.int64, device=device)
+    S = int(group_lens.sum())
+    PAD = 224
+    M_total = S + PAD  # simulate over-allocated (fixed-capacity permute) activation rows
+    sentinel = 12288.0  # exactly representable in bf16 and fp16
+    print(f"\ndtype={dtype}, S={S}, M_total={M_total}")
+
+    config = _make_config()
+    a = torch.randn((M_total, K), dtype=dtype, device=device)
+    b = torch.randn((G, N, K), dtype=dtype, device=device)
+
+    # Warm up (JIT/autotune), then poison the pool so any unwritten padding rows
+    # surface the sentinel instead of a fresh zeroed page.
+    grouped_gemm_fp4(a, b, group_lens, trans_b=True, config=config)
+    torch.cuda.synchronize()
+    _poison_alloc_pool((M_total, N), dtype, device, sentinel)
+
+    out = grouped_gemm_fp4(a, b, group_lens, trans_b=True, config=config)
+    torch.cuda.synchronize()
+
+    pad_tail = out[S:M_total]
+    assert torch.isfinite(pad_tail).all(), "padding tail non-finite"
+    torch.testing.assert_close(
+        pad_tail,
+        torch.zeros_like(pad_tail),
+        rtol=0.0,
+        atol=0.0,
+        msg=f"padding tail [{S}:{M_total}] must be zeroed",
+    )

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -1068,3 +1068,78 @@ def test_grouped_gemm_fp8_blockwise_zero_group_lens():
     b_grad_snr = compute_snr(b_ref.grad, b.grad)
     print(f"BGrad-SNR: {b_grad_snr:.2f} dB")
     assert b_grad_snr > snr_threshold, "b_grad_snr too low"
+
+
+def _poison_alloc_pool(shape, dtype, device, sentinel, n=24):
+    """Fill and free caching-allocator blocks of ``shape`` with ``sentinel`` so a
+    subsequent same-shape allocation reuses a dirty (non-zero) block instead of a
+    fresh, driver-zeroed page. Lets us detect output regions the kernel never wrote."""
+    blocks = [torch.full(shape, sentinel, dtype=dtype, device=device) for _ in range(n)]
+    for x in blocks:
+        x.add_(0.0)
+    del blocks
+
+
+@pytest.mark.parametrize("ori_dtype", ORI_DTYPE_VALUES)
+@pytest.mark.parametrize("trans_b", TRANS_B_VALUES)
+@pytest.mark.parametrize(
+    "backend", [BackendType.CK, BackendType.HIPBLASLT, BackendType.TRITON, BackendType.FLYDSL]
+)
+def test_grouped_gemm_fp8_padded_rows_zero_init(ori_dtype, trans_b, backend):
+    """issue #397: the FP8 grouped-GEMM forward only writes output rows
+    ``[0, sum(group_lens))``. When ``M_total = a.size(0) > sum(group_lens)`` the
+    trailing rows must be zero-initialized, not leftover caching-allocator garbage
+    (frequently NaN/Inf, which non-deterministically corrupts MoE gradients).
+
+    This is not hypothetical: the MoE token dispatcher run with
+    ``permute_max_token_num > 0`` (fixed-capacity permute, used to drop the
+    device->host sync for CUDA-graph / static-shape capture) over-allocates the
+    permuted activation buffer to a fixed capacity, so the real token count
+    ``sum(group_lens)`` is strictly less than ``a.size(0)`` (see
+    ``moe_permute``: ``permuted_tokens = torch.empty((num_permuted_tokens, H))``).
+
+    All four backends skip the trailing rows (each writes only ``[0, sum)``), so
+    all four must zero-init the output; this test covers every one.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    if backend == BackendType.FLYDSL and get_device_compute_capability() < (9, 5):
+        pytest.skip("FlyDSL fp8 grouped GEMM is gfx950-only")
+
+    torch.manual_seed(42)
+    device = "cuda:0"
+    G, K, N = 8, 2048, 2880
+    group_lens = torch.tensor([4096, 0, 3072, 0, 0, 5120, 0, 0], dtype=torch.int64, device=device)
+    S = int(group_lens.sum())
+    PAD = 224
+    M_total = S + PAD  # simulate FP8-padded activation rows
+    sentinel = 12288.0  # exactly representable in bf16 and fp16
+    print(f"\nori_dtype={ori_dtype}, trans_b={trans_b}, backend={backend}, S={S}, M_total={M_total}")
+
+    GlobalBackendManager.set_grouped_gemm_backend(backend)
+    config = Float8QuantConfig(format=Format.E4M3, granularity=ScalingGranularity.TENSORWISE)
+
+    b_shape = (G, N, K) if trans_b else (G, K, N)
+    a = torch.randn((M_total, K), dtype=ori_dtype, device=device)
+    b = torch.randn(b_shape, dtype=ori_dtype, device=device)
+
+    # Warm up (JIT/autotune), then poison the pool so any unwritten padding rows
+    # surface the sentinel instead of a fresh zeroed page.
+    grouped_gemm_fp8(a, b, group_lens, trans_b=trans_b, config=config)
+    torch.cuda.synchronize()
+    _poison_alloc_pool((M_total, N), ori_dtype, device, sentinel)
+
+    out = grouped_gemm_fp8(a, b, group_lens, trans_b=trans_b, config=config)
+    torch.cuda.synchronize()
+
+    pad_rows = out[S:M_total]
+    assert torch.isfinite(pad_rows).all(), f"{backend.name}: padding rows non-finite (#397)"
+    torch.testing.assert_close(
+        pad_rows,
+        torch.zeros_like(pad_rows),
+        rtol=0.0,
+        atol=0.0,
+        msg=f"{backend.name}: padding rows [{S}:{M_total}] must be zero-initialized (#397)",
+    )
+
+    GlobalBackendManager.reset()

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -1086,21 +1086,8 @@ def _poison_alloc_pool(shape, dtype, device, sentinel, n=24):
     "backend", [BackendType.CK, BackendType.HIPBLASLT, BackendType.TRITON, BackendType.FLYDSL]
 )
 def test_grouped_gemm_fp8_padded_tail_zeroed(ori_dtype, trans_b, backend):
-    """The FP8 grouped-GEMM forward only writes output rows ``[0, sum(group_lens))``.
-    When ``M_total = a.size(0) > sum(group_lens)`` the uncovered tail must be zeroed
-    by the post-op, not left as caching-allocator garbage (frequently NaN/Inf,
-    which non-deterministically corrupts MoE gradients).
-
-    This is not hypothetical: the MoE token dispatcher run with
-    ``permute_max_token_num > 0`` (fixed-capacity permute, used to drop the
-    device->host sync for CUDA-graph / static-shape capture) over-allocates the
-    permuted activation buffer to a fixed capacity, so the real token count
-    ``sum(group_lens)`` is strictly less than ``a.size(0)`` (see
-    ``moe_permute``: ``permuted_tokens = torch.empty((num_permuted_tokens, H))``).
-
-    All four backends skip the trailing rows (each writes only ``[0, sum)``), so
-    the shared post-op must zero the tail; this test covers every backend.
-    """
+    """Over-allocated output tail [sum(group_lens):M_total] must be zeroed, not left as
+    caching-allocator garbage."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
     if backend == BackendType.FLYDSL and get_device_compute_capability() < (9, 5):

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -1085,11 +1085,11 @@ def _poison_alloc_pool(shape, dtype, device, sentinel, n=24):
 @pytest.mark.parametrize(
     "backend", [BackendType.CK, BackendType.HIPBLASLT, BackendType.TRITON, BackendType.FLYDSL]
 )
-def test_grouped_gemm_fp8_padded_rows_zero_init(ori_dtype, trans_b, backend):
-    """issue #397: the FP8 grouped-GEMM forward only writes output rows
-    ``[0, sum(group_lens))``. When ``M_total = a.size(0) > sum(group_lens)`` the
-    trailing rows must be zero-initialized, not leftover caching-allocator garbage
-    (frequently NaN/Inf, which non-deterministically corrupts MoE gradients).
+def test_grouped_gemm_fp8_padded_tail_zeroed(ori_dtype, trans_b, backend):
+    """The FP8 grouped-GEMM forward only writes output rows ``[0, sum(group_lens))``.
+    When ``M_total = a.size(0) > sum(group_lens)`` the uncovered tail must be zeroed
+    by the post-op, not left as caching-allocator garbage (frequently NaN/Inf,
+    which non-deterministically corrupts MoE gradients).
 
     This is not hypothetical: the MoE token dispatcher run with
     ``permute_max_token_num > 0`` (fixed-capacity permute, used to drop the
@@ -1099,7 +1099,7 @@ def test_grouped_gemm_fp8_padded_rows_zero_init(ori_dtype, trans_b, backend):
     ``moe_permute``: ``permuted_tokens = torch.empty((num_permuted_tokens, H))``).
 
     All four backends skip the trailing rows (each writes only ``[0, sum)``), so
-    all four must zero-init the output; this test covers every one.
+    the shared post-op must zero the tail; this test covers every backend.
     """
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
@@ -1132,14 +1132,14 @@ def test_grouped_gemm_fp8_padded_rows_zero_init(ori_dtype, trans_b, backend):
     out = grouped_gemm_fp8(a, b, group_lens, trans_b=trans_b, config=config)
     torch.cuda.synchronize()
 
-    pad_rows = out[S:M_total]
-    assert torch.isfinite(pad_rows).all(), f"{backend.name}: padding rows non-finite (#397)"
+    pad_tail = out[S:M_total]
+    assert torch.isfinite(pad_tail).all(), f"{backend.name}: padding tail non-finite"
     torch.testing.assert_close(
-        pad_rows,
-        torch.zeros_like(pad_rows),
+        pad_tail,
+        torch.zeros_like(pad_tail),
         rtol=0.0,
         atol=0.0,
-        msg=f"{backend.name}: padding rows [{S}:{M_total}] must be zero-initialized (#397)",
+        msg=f"{backend.name}: padding tail [{S}:{M_total}] must be zeroed",
     )
 
     GlobalBackendManager.reset()


### PR DESCRIPTION
<!-- ============ PR TITLE (copy into the title field) ============ -->

fix(grouped_gemm): zero only the uncovered padding tail of grouped GEMM outputs

<!-- ============ PR DESCRIPTION (copy everything below) ============ -->

# Description

Grouped GEMM allocates its `forward`/`dgrad` output with `empty` and only writes
the covered rows `[0, sum(group_lens))`. When the input is over-allocated
(`M_total = a.size(0) > sum(group_lens)`, e.g. the fixed-capacity `moe_permute`
buffer), the trailing rows are left uninitialized and read back as stale memory
(`NaN`/`Inf`), non-deterministically corrupting MoE gradients.

Fix: keep the `empty` allocation (no full-tensor memset) and add a lightweight
Triton post-op `grouped_gemm_output_tail_kernel` that zeros only the uncovered
`[sum(group_lens), M_total)` tail after the GEMM. It reads the boundary on device
(no CPU sync) and is a no-op when there is no padding. Runs in the shared impl
layer after dispatch, so it covers all four backends (Triton, FlyDSL, CK,
hipBLASLt) at once. Variable-K wgrad already writes its full output, so it is
skipped.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Add `grouped_gemm_output_tail_kernel` (Triton) that zeros only the uncovered
  output tail; wire it into `grouped_gemm_impl` and `grouped_gemm_fp8_impl`
  (non-MX path) after backend dispatch.
- Add regression test `test_grouped_gemm_fp8_padded_tail_zeroed` (poisons the
  allocator, checks the padded tail is zero) across all four backends × dtype ×
  `trans_b`.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
