### PR TITLE
feat: adapt rocm_sdk_devel build for v26.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 import os
 import platform
 import subprocess
@@ -13,7 +12,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from tools.build_ext import TurboBuildExt, _join_rocm_home
-from tools.build_utils import HIPExtension, find_rocshmem_library, get_gpu_arch
+from tools.build_utils import HIPExtension, find_rocshmem_library, get_gpu_arch, is_package_installed
 
 # -------- Framework Switches ---------
 # PRIMUS_TURBO_FRAMEWORK="PYTORCH;JAX"
@@ -72,20 +71,6 @@ def check_submodules():
                 sys.exit(1)
             return
     print("[Primus-Turbo] Submodules already initialized.")
-
-
-def is_package_installed(package_name):
-    """Check if a package is properly installed (not just a namespace ghost).
-
-    Uses importlib.metadata to verify the package has real distribution
-    metadata registered with pip, avoiding false positives from leftover
-    empty directories that Python treats as implicit namespace packages.
-    """
-    try:
-        importlib.metadata.distribution(package_name)
-        return True
-    except importlib.metadata.PackageNotFoundError:
-        return False
 
 
 def get_extras_require():
@@ -226,9 +211,11 @@ def check_hip_compiler_flag(flag):
 
 
 def get_common_flags():
+    from tools.build_utils import HIP_LIBRARY_PATH
+
     arch = platform.machine().lower()
     extra_link_args = [
-        "-Wl,-rpath,/opt/rocm/lib",
+        f"-Wl,-rpath,{HIP_LIBRARY_PATH}",
         f"-L/usr/lib/{arch}-linux-gnu",
         "-fgpu-rdc",
         "--hip-link",

--- a/tools/build_utils.py
+++ b/tools/build_utils.py
@@ -4,6 +4,7 @@
 # See LICENSE for license information.
 ###############################################################################
 
+import importlib.metadata
 import os
 import re
 import shutil
@@ -42,7 +43,41 @@ else:
     patch_torch_extension()
 
 
-TURBO_FALLBACK_LIBRARY_HOME = "/opt/rocm"
+def is_package_installed(package_name):
+    """Check if a package is properly installed (not just a namespace ghost).
+
+    Uses importlib.metadata to verify the package has real distribution
+    metadata registered with pip, avoiding false positives from leftover
+    empty directories that Python treats as implicit namespace packages.
+    """
+    try:
+        importlib.metadata.distribution(package_name)
+        return True
+    except importlib.metadata.PackageNotFoundError:
+        return False
+
+
+def is_rocm_sdk_devel_installed():
+    return is_package_installed("rocm_sdk_devel")
+
+
+def rocm_sdk_devel_library_home():
+    if is_package_installed("rocm_sdk_devel"):
+        from rocm_sdk._devel import get_devel_root
+
+        return get_devel_root()
+
+    else:
+        return None
+
+
+def _rocm_fallback_library_home():
+    rocm_library_home = rocm_sdk_devel_library_home()
+
+    return rocm_library_home if rocm_library_home is not None else "/opt/rocm"
+
+
+ROCM_FALLBACK_LIBRARY_HOME = _rocm_fallback_library_home()
 
 
 @dataclass
@@ -106,14 +141,16 @@ def find_rocm_home() -> Optional[str]:
         if os.path.basename(rocm_home) == "hip":
             rocm_home = os.path.dirname(rocm_home)
     else:
-        fallback_path = TURBO_FALLBACK_LIBRARY_HOME
+        fallback_path = ROCM_FALLBACK_LIBRARY_HOME
         if os.path.exists(fallback_path):
             rocm_home = fallback_path
     return rocm_home
 
 
 def find_hip_home() -> str:
-    return _find_library_home(["HIP_HOME", "HIP_PATH", "HIP_DIR"], ["hipcc"], fallback_path="/opt/rocm")
+    return _find_library_home(
+        ["HIP_HOME", "HIP_PATH", "HIP_DIR"], ["hipcc"], fallback_path=ROCM_FALLBACK_LIBRARY_HOME
+    )
 
 
 HIP_HOME: Path = find_hip_home()
@@ -188,8 +225,14 @@ def find_mpi_home():
 
 
 def find_rocshmem_home():
+
+    def _rocshmem_fallback_library_home():
+        rocshmem_library_home = rocm_sdk_devel_library_home()
+
+        return rocshmem_library_home if rocshmem_library_home is not None else "/opt/rocm/rocshmem"
+
     return _find_library_home(
-        ["ROCSHMEM_HOME", "ROCSHMEM_PATH", "ROCSHMEM_DIR"], fallback_path="/opt/rocm/rocshmem"
+        ["ROCSHMEM_HOME", "ROCSHMEM_PATH", "ROCSHMEM_DIR"], fallback_path=_rocshmem_fallback_library_home()
     )
 
 


### PR DESCRIPTION
# Description

This PR adapts the Primus-Turbo build system to support ROCm SDK v26.4, which distributes development libraries via the `rocm_sdk_devel` Python package instead of relying solely on a system-wide `/opt/rocm` installation.

When `rocm_sdk_devel` is installed, the build now resolves ROCm, HIP, and rocSHMEM library paths through `rocm_sdk._devel.get_devel_root()`.
When it is not present, the existing `/opt/rocm` fallback behavior is preserved for backward compatibility.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `is_rocm_sdk_devel_installed()` and `rocm_sdk_devel_library_home()` helpers in `tools/build_utils.py` to detect and resolve the ROCm SDK devel root via `rocm_sdk._devel.get_devel_root()`
- Introduce `ROCM_FALLBACK_LIBRARY_HOME` (replacing the hardcoded `TURBO_FALLBACK_LIBRARY_HOME`) that dynamically selects the `rocm_sdk_devel` root or falls back to `/opt/rocm`
- Update `find_rocm_home()`, `find_hip_home()`, and `find_rocshmem_home()` to use the new dynamic fallback paths instead of hardcoded `/opt/rocm` locations
- Move `is_package_installed()` from `setup.py` into `tools/build_utils.py` for centralized reuse across build utilities
- Update `get_common_flags()` in `setup.py` to set the linker rpath using `HIP_LIBRARY_PATH` instead of the hardcoded `/opt/rocm/lib`

# Checklist:

- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
