### PR TITLE
fix(dsv4 sparse-MLA): three cr=4 correctness bugs (fwd NaN, bwd dQ race, bwd dkv misdispatch)

### DIFF
--- a/primus_turbo/flydsl/attention/kernels/sparse_mla_v2/dsa_bwd.py
+++ b/primus_turbo/flydsl/attention/kernels/sparse_mla_v2/dsa_bwd.py
@@ -2386,7 +2386,11 @@ def _get_dq(topk_len, scale, num_heads=None):
         # PV-K32: per-16 QK/softmax kept, PV batches 2 tiles into mfma_16x16x32 with direct-v8
         # operands. Gated to large-topk (topk>=512, even tile count); small-topk pair-batch's
         # per-pair WAR barrier overhead loses. Both dQ kernels pin dq_acc in AGPR via inline-asm.
-        if topk_len >= 512 and topk_len % 32 == 0:
+        # FIX (dsv4 cr=4 bwd dQ race): gate lowered 512 -> 384. build_bwd_dq (topk<512,
+        # single-tile + delta-fold) has a nondeterministic cross-wave race corrupting dq
+        # d-tile 0 at TOPK=384 (cr=4 S=1024). build_bwd_dq_pvk32 (per-pair WAR barrier) is
+        # race-free and handles any even tile count; the 512 gate was perf-only.
+        if topk_len >= 384 and topk_len % 32 == 0:
             fn = build_bwd_dq_pvk32(topk_len, float(scale), num_heads=num_heads)
         else:
             fn = build_bwd_dq(topk_len, float(scale), num_heads=num_heads)
@@ -2533,7 +2537,9 @@ def sparse_mla_bwd_v4_flydsl(q, kv, o, do, topk_indices, lse, attn_sink=None, kv
     # The fused kernel (flash small-topk) AND build_bwd_dq (pro cr0/cr128, topk<512) both fold the
     # delta compute inline (dO already resident), dropping the standalone delta off the wall. Only
     # the pvk32 dQ path (cr4, topk>=512) still needs the standalone kernel.
-    dq_folds_delta = (not use_fused) and (int(topk) < 512)
+    # FIX (dsv4 cr=4 bwd dQ race): threshold 512 -> 384, coupled with `_get_dq` so TOPK=384
+    # routes through the race-free pvk32 path (+ standalone delta / no-O args).
+    dq_folds_delta = (not use_fused) and (int(topk) < 384)
     if not (use_fused or dq_folds_delta):
         # flydsl delta = rowsum(O*dO), fp32 (replaces the triton _bwd_delta_kernel).
         _dstream = torch.cuda.current_stream()
@@ -2651,7 +2657,20 @@ def sparse_mla_bwd_v4_flydsl(q, kv, o, do, topk_indices, lse, attn_sink=None, kv
     # (skips the CSR argsort/bincount/cumsum + InvPtr/InvData buffers entirely; the
     # inverse window map is closed-form). Bit-exact vs the CSR path.
     is_cr0 = (num_kv == total_tokens) and (topk == 128)
-    is_cr128 = (num_kv > total_tokens) and (topk <= 256)
+    # FIX (dsv4 cr=4 small-seq dkv): the cr=128 (HCA) closed-form pool gather assumes a
+    # DETERMINISTIC causal pool (pool_cr = T/npool = 128). The bare `topk <= 256` test also
+    # catches cr=4 (CSA, RANDOM pool) at small seq (S<=512 -> topk<=256), routing its random
+    # pool through the closed-form gather -> wrong dkv/dpool. Guard with the same
+    # deterministic-pool condition the forward uses (T % npool == 0 and T // npool >= 64) so
+    # cr=4 (pool_cr=4) always falls through to the CSR gather. Production S=4096 (topk>256)
+    # was already CSR; this only rescues the small-seq cr=4 shapes.
+    _npool_bwd = num_kv - total_tokens
+    is_cr128 = (
+        _npool_bwd > 0
+        and topk <= 256
+        and total_tokens % _npool_bwd == 0
+        and (total_tokens // _npool_bwd) >= 64
+    )
     if is_cr0:
         _gargs = (interm.reshape(-1, D), dkv, int(num_kv), int(total_tokens), stream)
         _gc = _GATHER_CACHE.get("cb")

--- a/primus_turbo/flydsl/attention/kernels/sparse_mla_v2/dsa_fwd.py
+++ b/primus_turbo/flydsl/attention/kernels/sparse_mla_v2/dsa_fwd.py
@@ -497,7 +497,11 @@ def build_fwd(topk_len, scale, has_sink=True, banded=False, qk2=False, pool_P=0,
                     lm_f0 = fx.Float32(arith.MaxNumFOp(_raw(lm_f0), _raw(sa_f0[i] + fx.Float32(_raw(Vec(ma_f0)[i])))).result)
                 for i in range_constexpr(4):
                     lm_f0 = fx.Float32(arith.MaxNumFOp(_raw(lm_f0), _raw(sb_f0[i] + fx.Float32(_raw(Vec(mb_f0)[i])))).result)
-                _mb[0] = crossgrp_max(lm_f0)
+                # FIX (dsv4 cr=4 fwd NaN): floor the first-pair fixed-max bound to finite. A
+                # fully-masked first key-pair (query t<96 -> SWA slots all -1 -> -inf) makes
+                # crossgrp_max=-inf -> exp2(score-(-inf))=+inf -> NaN. maxnumf(.,0) floors it;
+                # fp_max>0 unchanged, bf16 rel-precision magnitude-independent -> speed-neutral.
+                _mb[0] = fx.Float32(arith.MaxNumFOp(_raw(crossgrp_max(lm_f0)), _raw(c_zero)).result)
             idx2 = load_topk(TWO * MK)
             idx3 = load_topk(fx.Index(3) * MK)
             xinit = [c_big_neg, c_zero] + [c_zero_v4 for _ in range_constexpr(DT)] + [idx2, idx3]
@@ -551,7 +555,8 @@ def build_fwd(topk_len, scale, has_sink=True, banded=False, qk2=False, pool_P=0,
                     lm_f0 = fx.Float32(arith.MaxNumFOp(_raw(lm_f0), _raw(sa_f0[i] + fx.Float32(_raw(Vec(ma_f0)[i])))).result)
                 for i in range_constexpr(4):
                     lm_f0 = fx.Float32(arith.MaxNumFOp(_raw(lm_f0), _raw(sb_f0[i] + fx.Float32(_raw(Vec(mb_f0)[i])))).result)
-                _mb[0] = crossgrp_max(lm_f0)
+                # FIX (dsv4 cr=4 fwd NaN): floor the fixed-max bound to finite (see pstore path).
+                _mb[0] = fx.Float32(arith.MaxNumFOp(_raw(crossgrp_max(lm_f0)), _raw(c_zero)).result)
                 gpu.barrier()
             # 2-tile-batch PV K=32 (non-banded)
             idx2 = load_topk(fx.Index(2) * fx.Index(TILE_K))


### PR DESCRIPTION
> ## Summary
> The native-FlyDSL DeepSeek-V4 sparse-MLA v2 attention (`primus_turbo/flydsl/attention/kernels/sparse_mla_v2`) produced **wrong results for the CSA (cr=4) layer**. Three independent, cr=4-only bugs, found by comparing fwd+bwd against an fp32 eager reference (and the `triton_v2` / `gluon_v2` bf16 anchors):
>
> **1. Forward `fast_path` NaN (`dsa_fwd.py`).** The first-pair fixed-max softmax bound `_mb[0] = crossgrp_max(...)` is `-inf` when the first key-pair is fully masked (query token `t<96` → SWA slots `[t-127..t-96]` all `-1` → `-inf`), so `exp2(score-(-inf)) = +inf` → **NaN on the first 96 query tokens** (all seq lengths, flash+pro). Fix: floor the bound to finite, `maxnumf(crossgrp_max, 0.0)`. The common case (`fp_max>0`) is unchanged and bf16 relative precision is magnitude-independent, so the `alpha≡1` fold is preserved → **speed-neutral**.
>
> **2. Backward dQ nondeterministic cross-wave race (`dsa_bwd.py::_get_dq`).** `build_bwd_dq` (the `topk<512` single-tile + inline-delta dQ kernel) corrupts `dq` d-tile 0 on scattered query tokens at TOPK=384 (cr=4 @ S=1024); the NaN count varies run-to-run. `build_bwd_dq_pvk32` (K=32 pair-batch, explicit per-pair WAR barrier) is race-free. Fix: lower the pvk32 dispatch gate `512 → 384` (coupled with the wrapper's `dq_folds_delta` threshold so the standalone-delta / no-O args stay consistent). The 512 gate was perf-only; at TOPK=384 the rerouted pvk32 bwd is actually slightly **faster**. Production S=4096 (topk≥512) already used pvk32 → unaffected.
>
> **3. Backward dkv small-seq misdispatch (`dsa_bwd.py`).** `is_cr128 = (num_kv>total_tokens) and (topk<=256)` also catches cr=4 (CSA, **random** pool) at small seq (`S≤512` → `topk≤256`), routing its random pool through the cr=128 (HCA) **closed-form causal-pool** gather → wrong `dkv`/`dpool` (e.g. S=256 relL2=0.83 vs eager/triton/gluon). Fix: guard `is_cr128` with the same deterministic-pool condition the forward uses (`T % npool == 0 and T // npool >= 64`) so cr=4 (`pool_cr=4`) falls through to the CSR gather. Production S=4096 (topk>256) already used CSR → unaffected.
>
> ## Test plan
> - [x] fp32-eager accuracy suite: flash+pro × cr{0,4,128}, fwd (o, lse) + bwd (dq, dkv, d_sink) at S ∈ {256, 512, 1024, 4096} → goes from **SOME FAILED → ALL PASS**; cr=4 bwd dq clean over 6/6 repeated runs (race gone).
> - [x] Cross-checked vs `triton_v2` / `gluon_v2` bf16 anchors.
> - [x] All three fixes speed-neutral (bug 2 slightly faster at the rerouted small-seq shape); S=4096 benchmark unchanged.
>
> Note: dense/HCA `banded` path is still single-sequence (B=1); multi-batch (mbs>1) dense/HCA is a separate known limitation (the closed-form SWA window crosses batch boundaries) and is out of scope for this correctness PR.