### PR TITLE
feat: add quantized tensor support for blockwise gemm

### DIFF
--- a/primus_turbo/pytorch/core/low_precision.py
+++ b/primus_turbo/pytorch/core/low_precision.py
@@ -99,7 +99,7 @@ MXFP8_BLOCK_SIZE = 32
 # Padding align size for MXFP8
 MXFP8_PADDING_ALIGN_SIZE = 128
 # Block size for BLOCKWISE scaling
-BLOCKWISE_BLOCK_SIZE = 128
+DEFAULT_BLOCK_SIZE = 128
 
 
 class Format(Enum):

--- a/primus_turbo/pytorch/core/quantized_tensor.py
+++ b/primus_turbo/pytorch/core/quantized_tensor.py
@@ -30,11 +30,13 @@ _SUPPORTED_QUANTIZED_DTYPES = [float8_e4m3, float8_e5m2, float4_e2m1fn_x2]
 _SUPPORTED_QUANTIZED_GRANS = [
     ScalingGranularity.ROWWISE,
     ScalingGranularity.TENSORWISE,
+    ScalingGranularity.BLOCKWISE,
     ScalingGranularity.MX_BLOCKWISE,
 ]
 _SUPPORTED_GROUPED_QUANTIZED_GRANS = [
     ScalingGranularity.ROWWISE,
     ScalingGranularity.TENSORWISE,
+    ScalingGranularity.BLOCKWISE,
     ScalingGranularity.MX_BLOCKWISE,
 ]
 
@@ -62,6 +64,7 @@ def _get_padding_align_size(tensor: QuantizedTensor):
     if (
         tensor._granularity == ScalingGranularity.TENSORWISE
         or tensor._granularity == ScalingGranularity.ROWWISE
+        or tensor._granularity == ScalingGranularity.BLOCKWISE
     ):
         return 0
     else:
@@ -254,10 +257,22 @@ class QuantizedTensor(torch.Tensor):
                     )
                     assert supported, reason
                 assert scaling_recipe is not None, "scaling_recipe must be provided for grouped MX_BLOCKWISE"
+            elif granularity == ScalingGranularity.BLOCKWISE:
+                assert dest_dtype in [
+                    float8_e4m3,
+                    float8_e5m2,
+                ], "Unsupported quantized dtype for grouped BLOCKWISE quantization"
+                assert block_size is not None, "block_size must be provided for grouped BLOCKWISE"
         else:
             assert granularity in _SUPPORTED_QUANTIZED_GRANS, f"Unsupported granularity {granularity}"
 
-            if granularity == ScalingGranularity.MX_BLOCKWISE:
+            if granularity == ScalingGranularity.BLOCKWISE:
+                assert dest_dtype in [
+                    float8_e4m3,
+                    float8_e5m2,
+                ], "Unsupported quantized dtype for BLOCKWISE"
+                assert block_size is not None, "block_size must be provided for BLOCKWISE"
+            elif granularity == ScalingGranularity.MX_BLOCKWISE:
                 assert dest_dtype in [
                     float8_e4m3,
                     float8_e5m2,
@@ -517,9 +532,10 @@ class QuantizedTensor(torch.Tensor):
             )
 
         if self._dest_dtype in [float8_e4m3, float8_e5m2]:
-            assert self._granularity == ScalingGranularity.MX_BLOCKWISE, (
-                "Grouped dequantization is only supported for MX_BLOCKWISE FP8"
-            )
+            assert self._granularity in (
+                ScalingGranularity.MX_BLOCKWISE,
+                ScalingGranularity.BLOCKWISE,
+            ), "Grouped dequantization is only supported for MX_BLOCKWISE / BLOCKWISE FP8"
             assert self._group_lens is not None, "group_lens is missing"
             assert self._group_offs is not None, "group_offs is missing"
             assert self._orig_group_offs is not None, "orig_group_offs is missing"

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -19,6 +19,8 @@ from primus_turbo.pytorch.core.low_precision import (
     check_mxfp8_support,
 )
 from primus_turbo.triton.quantization.quant_blockwise import (
+    dequant_fp8_blockwise_for_weight_kernel,
+    dequant_fp8_blockwise_kernel,
     quant_fp8_blockwise_dual_kernel,
     quant_fp8_blockwise_for_weight_kernel,
     quant_fp8_blockwise_kernel,
@@ -132,6 +134,96 @@ def quant_fp8_blockwise_impl_meta(
     scales_shape = (M, triton.cdiv(N, block_size)) if axis == 1 else (triton.cdiv(M, block_size), N)
     x_scales = torch.empty(scales_shape, dtype=torch.float32, device=x.device)
     return x_fp8, x_scales
+
+
+@torch.library.custom_op("primus_turbo::dequant_fp8_blockwise_impl", mutates_args=())
+def dequant_fp8_blockwise_impl(
+    x_fp8: torch.Tensor,
+    scale_inv: torch.Tensor,
+    out_dtype: torch.dtype,
+    axis: int,
+    block_size: int = 128,
+) -> torch.Tensor:
+    """Dequantize a 2D 1D-block (row/col) blockwise-quantized tensor."""
+    assert x_fp8.is_contiguous() and x_fp8.dim() == 2, "Input must be 2D and contiguous"
+    assert axis in (-2, -1, 0, 1), f"axis must be 0 or 1 (or -1, -2), got {axis}"
+    axis = axis % 2
+
+    M, N = x_fp8.shape
+    out = torch.empty((M, N), dtype=out_dtype, device=x_fp8.device)
+    grid = (triton.cdiv(M, block_size), triton.cdiv(N, block_size))
+    dequant_fp8_blockwise_kernel[grid](
+        x_fp8,
+        scale_inv,
+        out,
+        M,
+        N,
+        block_size,
+        axis,
+    )
+    return out
+
+
+@dequant_fp8_blockwise_impl.register_fake
+def dequant_fp8_blockwise_impl_meta(
+    x_fp8: torch.Tensor,
+    scale_inv: torch.Tensor,
+    out_dtype: torch.dtype,
+    axis: int,
+    block_size: int = 128,
+) -> torch.Tensor:
+    assert x_fp8.dim() == 2, "Input must be 2D"
+    M, N = x_fp8.shape
+    return torch.empty((M, N), dtype=out_dtype, device=x_fp8.device)
+
+
+@torch.library.custom_op("primus_turbo::dequant_fp8_blockwise_for_weight_impl", mutates_args=())
+def dequant_fp8_blockwise_for_weight_impl(
+    w_fp8: torch.Tensor,
+    scale_inv: torch.Tensor,
+    out_dtype: torch.dtype,
+    block_size: int = 128,
+) -> torch.Tensor:
+    """Dequantize a 2D/3D 2D-block (``[..., cdiv(M,BS), cdiv(N,BS)]`` scale) weight.
+
+    Inverse of :func:`quant_fp8_blockwise_for_weight_impl`.
+    """
+    assert w_fp8.dim() in (2, 3)
+    if not w_fp8.is_contiguous():
+        w_fp8 = w_fp8.contiguous()
+
+    ori_dims = w_fp8.dim()
+    if ori_dims == 2:
+        B, M, N = 1, *w_fp8.shape
+        w_fp8 = w_fp8.unsqueeze(0)
+        scale_inv = scale_inv.unsqueeze(0)
+    else:
+        B, M, N = w_fp8.shape
+
+    out = torch.empty((B, M, N), dtype=out_dtype, device=w_fp8.device)
+    grid = (B, triton.cdiv(M, block_size), triton.cdiv(N, block_size))
+    dequant_fp8_blockwise_for_weight_kernel[grid](
+        w_fp8,
+        scale_inv,
+        out,
+        M,
+        N,
+        block_size,
+    )
+    if ori_dims == 2:
+        out = out.squeeze(0)
+    return out
+
+
+@dequant_fp8_blockwise_for_weight_impl.register_fake
+def dequant_fp8_blockwise_for_weight_impl_meta(
+    w_fp8: torch.Tensor,
+    scale_inv: torch.Tensor,
+    out_dtype: torch.dtype,
+    block_size: int = 128,
+) -> torch.Tensor:
+    assert w_fp8.dim() in (2, 3)
+    return torch.empty(w_fp8.shape, dtype=out_dtype, device=w_fp8.device)
 
 
 @torch.library.custom_op("primus_turbo::quant_fp8_blockwise_dual_impl", mutates_args=())

--- a/primus_turbo/pytorch/ops/gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/gemm_fp8.py
@@ -27,10 +27,10 @@ from primus_turbo.pytorch.core.quantized_tensor import (
 )
 from primus_turbo.pytorch.core.utils import is_gfx942
 from primus_turbo.pytorch.kernels.gemm.gemm_fp8_impl import gemm_fp8_impl
-from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
-    quant_fp8_blockwise_dual_impl,
+from primus_turbo.pytorch.ops.quantization import (
+    quantize_fp8,
+    quantize_fp8_with_trans,
 )
-from primus_turbo.pytorch.ops.quantization import quantize_fp8_with_trans
 
 __all__ = ["gemm_fp8"]
 
@@ -379,133 +379,126 @@ class FP8GemmRowFunction(torch.autograd.Function):
         )
 
 
-# TODO(ruibin): Add support for quantized tensor
 class FP8GemmBlockFunction(torch.autograd.Function):
     @staticmethod
     def forward(
         ctx,
-        a: torch.Tensor,
-        b: torch.Tensor,
+        a: Union[torch.Tensor, QuantizedTensor],
+        b: Union[torch.Tensor, QuantizedTensor],
+        a_t: Optional[QuantizedTensor],
+        b_t: Optional[QuantizedTensor],  # not used
         trans_a: bool,
         trans_b: bool,
         out_dtype: torch.dtype,
         config: Float8QuantConfig,
     ):
-        from primus_turbo.pytorch.ops.quantization import (
-            quant_fp8_blockwise_for_weight_impl,
-            quant_fp8_blockwise_impl,
-        )
-
-        assert isinstance(a, torch.Tensor) and isinstance(b, torch.Tensor), "a and b must be torch.Tensor"
         assert trans_a == False, "trans_a has to be False"
         a_dtype = _get_fp8_dtype(config.format, True)
         b_dtype = _get_fp8_dtype(config.format, True)
-        a_dtype_bwd = _get_fp8_dtype(config.format, False)
 
-        # When forward and backward share the same FP8 dtype (i.e. non-HYBRID
-        # formats), fuse forward row-quant with column-quant of the same
-        # activation in a single dual kernel pass and save the column result
-        # into ctx so the backward can skip its own column-quant launch.
-        # This is a kernel fusion (single tensor `a` is read once instead of
-        # twice) and does NOT depend on tensor identity across iterations.
-        fuse_a_dual = a_dtype == a_dtype_bwd and a.is_contiguous()
+        if isinstance(a, QuantizedTensor):
+            check_quantized_tensor(a, config, axis=-1)
+            a_row, a_row_scale = a.qdata, a.scale_inv
+            if a_t is None:
+                a_t = QuantizedTensor.quantize(
+                    a.dequantize(),
+                    a_dtype,
+                    config.granularity,
+                    axis=-2,
+                    block_size=config.block_size,
+                )
 
-        if fuse_a_dual:
-            (
-                a_fp8_row,
-                a_scale_inv_row,
-                a_fp8_col,
-                a_scale_inv_col,
-            ) = quant_fp8_blockwise_dual_impl(a, a_dtype, config.block_size)
+            a_col, a_col_scale = a_t.qdata, a_t.scale_inv
         else:
-            a_fp8_row, a_scale_inv_row = quant_fp8_blockwise_impl(
-                a, a_dtype, axis=1, block_size=config.block_size
-            )
-            a_fp8_col = None
-            a_scale_inv_col = None
+            (
+                a_row,
+                a_row_scale,
+                a_col,
+                a_col_scale,
+            ) = quantize_fp8_with_trans(a, a_dtype, config.block_size)
 
-        b_fp8, b_scale_inv = quant_fp8_blockwise_for_weight_impl(b, b_dtype, block_size=config.block_size)
+        # --- B side: 2D-block weight, reused unchanged in fwd + bwd. ---
+        b_scaling_recipe = ScalingRecipe(use_2d_block=True)
+        if isinstance(b, QuantizedTensor):
+            check_quantized_tensor(b, config, scaling_recipe=b_scaling_recipe)
+            b_row, b_row_scale = b.qdata, b.scale_inv
+        else:
+            b_row, b_row_scale = quantize_fp8(
+                b, b_dtype, block_size=config.block_size, scaling_recipe=b_scaling_recipe
+            )
+        b_col, b_col_scale = b_row, b_row_scale
 
         out = gemm_fp8_impl(
-            a_fp8_row,
-            a_scale_inv_row,
+            a_row,
+            a_row_scale,
             trans_a,
-            b_fp8,
-            b_scale_inv,
+            b_row,
+            b_row_scale,
             trans_b,
             out_dtype,
             False,
             granularity=config.granularity.value,
-            default_backend=BackendType.CK.value,
+            default_backend=BackendType.TRITON.value,
         )
-        if fuse_a_dual:
-            ctx.save_for_backward(b_fp8, b_scale_inv, a_fp8_col, a_scale_inv_col)
-            ctx.has_prequantized_a_col = True
-        else:
-            ctx.save_for_backward(a, b_fp8, b_scale_inv)
-            ctx.has_prequantized_a_col = False
+        ctx.save_for_backward(a_col, a_col_scale, b_col, b_col_scale)
+
         ctx.trans_a = trans_a
         ctx.trans_b = trans_b
         ctx.out_dtype = out_dtype
         ctx.config = config
+
         return out
 
     @staticmethod
     def backward(ctx, grad_out: torch.Tensor):
-        from primus_turbo.pytorch.ops.quantization import quant_fp8_blockwise_impl
+        a_col, a_col_scale, b_col, b_col_scale = ctx.saved_tensors
 
-        if not grad_out.is_contiguous():
-            grad_out = grad_out.contiguous()
-
-        if ctx.has_prequantized_a_col:
-            b_fp8, b_scale_inv, a_fp8_col, a_scale_inv_col = ctx.saved_tensors
-        else:
-            a, b_fp8, b_scale_inv = ctx.saved_tensors
-            a_dtype = _get_fp8_dtype(ctx.config.format, False)
-            a_fp8_col, a_scale_inv_col = quant_fp8_blockwise_impl(
-                a, a_dtype, axis=0, block_size=ctx.config.block_size
-            )
         grad_out_dtype = _get_fp8_dtype(ctx.config.format, False)
+        grad_out = grad_out.contiguous()
 
         # Quantize grad_out in both row-wise and column-wise directions:
         # - row-wise: for dgrad (grad_x)
         # - col-wise: for wgrad (grad_w)
         (
-            grad_out_fp8_row,
-            grad_out_scale_inv_row,
-            grad_out_fp8_col,
-            grad_out_scale_inv_col,
-        ) = quant_fp8_blockwise_dual_impl(grad_out, grad_out_dtype, ctx.config.block_size)
+            g_row,
+            g_row_scale,
+            g_col,
+            g_col_scale,
+        ) = quantize_fp8_with_trans(
+            grad_out, grad_out_dtype, ctx.config.granularity, block_size=ctx.config.block_size
+        )
 
-        a_grad = gemm_fp8_impl(
-            grad_out_fp8_row,
-            grad_out_scale_inv_row,
+        grad_a = gemm_fp8_impl(
+            g_row,
+            g_row_scale,
             False,
-            b_fp8,
-            b_scale_inv,
+            b_col,
+            b_col_scale,
             not ctx.trans_b,
             ctx.out_dtype,
             False,
             granularity=ctx.config.granularity.value,
-            default_backend=BackendType.CK.value,
+            default_backend=BackendType.TRITON.value,
         )
 
-        b_grad = gemm_fp8_impl(
-            a_fp8_col,
-            a_scale_inv_col,
+        grad_b = gemm_fp8_impl(
+            a_col,
+            a_col_scale,
             not ctx.trans_a,
-            grad_out_fp8_col,
-            grad_out_scale_inv_col,
+            g_col,
+            g_col_scale,
             False,
             ctx.out_dtype,
             ctx.trans_b,
             granularity=ctx.config.granularity.value,
-            default_backend=BackendType.CK.value,
+            default_backend=BackendType.TRITON.value,
         )
 
         return (
-            a_grad,  # a
-            b_grad,  # b
+            grad_a,  # a
+            grad_b,  # b
+            None,  # a_t
+            None,  # b_t
             None,  # trans_a
             None,  # trans_b
             None,  # out_dtype
@@ -739,9 +732,9 @@ def gemm_fp8(
             a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config
         )
     elif config.granularity == ScalingGranularity.BLOCKWISE:
-        # BLOCKWISE does not yet support pre-quantized inputs; preserve the
-        # existing assertion behaviour in ``FP8GemmBlockFunction.forward``.
-        return FP8GemmBlockFunction.apply(a, b, trans_a, trans_b, out_dtype, config)
+        return FP8GemmBlockFunction.apply(
+            a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config
+        )
     elif config.granularity == ScalingGranularity.MX_BLOCKWISE:
         return FP8GemmMXFunction.apply(
             a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config

--- a/primus_turbo/pytorch/ops/gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/gemm_fp8.py
@@ -415,7 +415,7 @@ class FP8GemmBlockFunction(torch.autograd.Function):
                 a_row_scale,
                 a_col,
                 a_col_scale,
-            ) = quantize_fp8_with_trans(a, a_dtype, config.block_size)
+            ) = quantize_fp8_with_trans(a, a_dtype, config.granularity, block_size=config.block_size)
 
         # --- B side: 2D-block weight, reused unchanged in fwd + bwd. ---
         b_scaling_recipe = ScalingRecipe(use_2d_block=True)
@@ -424,7 +424,7 @@ class FP8GemmBlockFunction(torch.autograd.Function):
             b_row, b_row_scale = b.qdata, b.scale_inv
         else:
             b_row, b_row_scale = quantize_fp8(
-                b, b_dtype, block_size=config.block_size, scaling_recipe=b_scaling_recipe
+                b, b_dtype, config.granularity, block_size=config.block_size, scaling_recipe=b_scaling_recipe
             )
         b_col, b_col_scale = b_row, b_row_scale
 

--- a/primus_turbo/pytorch/ops/quantization.py
+++ b/primus_turbo/pytorch/ops/quantization.py
@@ -16,6 +16,8 @@ from primus_turbo.pytorch.core.low_precision import (
     float4_e2m1fn_x2,
 )
 from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
+    dequant_fp8_blockwise_for_weight_impl,
+    dequant_fp8_blockwise_impl,
     dequantize_fp8_rowwise_impl,
     dequantize_fp8_tensorwise_impl,
     dequantize_mxfp4_impl,
@@ -23,6 +25,7 @@ from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
     grouped_dequantize_mxfp8_impl,
     grouped_quantize_mxfp4_impl,
     grouped_quantize_mxfp8_impl,
+    quant_fp8_blockwise_dual_impl,
     quant_fp8_blockwise_for_weight_impl,
     quant_fp8_blockwise_impl,
     quantize_fp8_rowwise_impl,
@@ -132,6 +135,8 @@ def quantize_fp8_with_trans(
             scaling_recipe,
             scaling_recipe_for_trans,
         )
+    elif granularity == ScalingGranularity.BLOCKWISE:
+        return quant_fp8_blockwise_dual_impl(x, out_dtype, block_size=block_size)
     else:
         raise NotImplementedError(f"Unknown granularity {granularity}")
 
@@ -246,6 +251,14 @@ def dequantize_fp8(
             raise ValueError("axis must be specified for rowwise FP8 de-quantization")
 
         return dequantize_fp8_rowwise_impl(x, out_dtype, axis, scale_inv)
+    elif granularity == ScalingGranularity.BLOCKWISE:
+        assert block_size is not None, "block_size must be specified for BLOCKWISE de-quantization"
+        # 2D-block (weight) scales along both dims; 1D-block (activation) scales
+        # along a single ``axis`` (row: -1/1, col: -2/0).
+        if scaling_recipe is not None and scaling_recipe.use_2d_block:
+            return dequant_fp8_blockwise_for_weight_impl(x, scale_inv, out_dtype, block_size)
+        assert axis is not None, "axis must be specified for 1D BLOCKWISE de-quantization"
+        return dequant_fp8_blockwise_impl(x, scale_inv, out_dtype, axis, block_size)
     elif granularity == ScalingGranularity.MX_BLOCKWISE:
         assert block_size == MXFP8_BLOCK_SIZE, (
             f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"

--- a/primus_turbo/triton/quantization/quant_blockwise.py
+++ b/primus_turbo/triton/quantization/quant_blockwise.py
@@ -156,6 +156,84 @@ def quant_fp8_blockwise_for_weight_kernel(
     tl.store(w_scales_ptr + scale_offs, w_scales_inv)
 
 
+# ---------------------------------------------------------------------------
+# Blockwise dequantize kernels (inverse of the quantize kernels above).
+# ---------------------------------------------------------------------------
+@triton.jit
+def dequant_fp8_blockwise_kernel(
+    x_fp8_ptr,
+    x_scales_ptr,
+    out_ptr,
+    M,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+    AXIS: tl.constexpr,
+):
+    """Dequantize a 2D blockwise-quantized tensor along ``AXIS``.
+
+    * ``AXIS == 1`` (row): one scale value per (row, N-block), stored as
+      ``[M, cdiv(N, BLOCK_SIZE)]``.
+    * ``AXIS == 0`` (col): one scale value per (M-block, col), stored as
+      ``[cdiv(M, BLOCK_SIZE), N]``.
+    """
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    offs_m = tl.cast(pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE), tl.int64)
+    offs_n = tl.cast(pid_n * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE), tl.int64)
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    x_ptrs = x_fp8_ptr + offs_m[:, None] * N + offs_n[None, :]
+    x_tile = tl.load(x_ptrs, mask=mask, other=0.0).to(tl.float32)
+
+    if AXIS == 1:
+        # One scale per row for this N-block.
+        scale_offs = offs_m * tl.cdiv(N, BLOCK_SIZE) + pid_n
+        scale_mask = offs_m < M
+        scale = tl.load(x_scales_ptr + scale_offs, mask=scale_mask, other=0.0)
+        out_tile = x_tile * scale[:, None]
+    else:
+        # One scale per col for this M-block.
+        scale_offs = pid_m * N + offs_n
+        scale_mask = offs_n < N
+        scale = tl.load(x_scales_ptr + scale_offs, mask=scale_mask, other=0.0)
+        out_tile = x_tile * scale[None, :]
+
+    out_ptrs = out_ptr + offs_m[:, None] * N + offs_n[None, :]
+    tl.store(out_ptrs, out_tile.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+@triton.jit
+def dequant_fp8_blockwise_for_weight_kernel(
+    w_fp8_ptr,
+    w_scales_ptr,
+    out_ptr,
+    M,
+    N,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Dequantize a 2D-block (``[cdiv(M,BS), cdiv(N,BS)]`` scale) weight tile."""
+    bid = tl.program_id(axis=0)
+    pid_m = tl.program_id(axis=1)
+    pid_n = tl.program_id(axis=2)
+
+    batch_offset_w = bid * M * N
+    batch_offset_scales = bid * tl.cdiv(M, BLOCK_SIZE) * tl.cdiv(N, BLOCK_SIZE)
+
+    offs_m = pid_m * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    offs_n = pid_n * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+
+    w_ptrs = w_fp8_ptr + batch_offset_w + offs_m[:, None] * N + offs_n[None, :]
+    w_tile = tl.load(w_ptrs, mask=mask, other=0.0).to(tl.float32)
+
+    scale_offs = batch_offset_scales + pid_m * tl.cdiv(N, BLOCK_SIZE) + pid_n
+    scale = tl.load(w_scales_ptr + scale_offs)
+    out_tile = w_tile * scale
+
+    out_ptrs = out_ptr + batch_offset_w + offs_m[:, None] * N + offs_n[None, :]
+    tl.store(out_ptrs, out_tile.to(out_ptr.dtype.element_ty), mask=mask)
+
+
 @triton.jit
 def quant_fp8_blockwise_segment_m_row_col_kernel(
     x_ptr,

--- a/tests/pytorch/ops/test_gemm_fp8.py
+++ b/tests/pytorch/ops/test_gemm_fp8.py
@@ -415,8 +415,8 @@ def _run_gemm_fp8_quantized_tensor_test(
     )
 
     b_kwargs = dict()
-    if granularity == ScalingGranularity.MX_BLOCKWISE:
-        # MX uses fused dual-direction kernel; cache both directions at construction time.
+    if granularity in (ScalingGranularity.MX_BLOCKWISE, ScalingGranularity.BLOCKWISE):
+        # MX / BLOCKWISE weights use a 2D block scale.
         b_kwargs["scaling_recipe"] = ScalingRecipe(use_2d_block=True)
 
     qt_b = QuantizedTensor.quantize(
@@ -545,6 +545,29 @@ def test_gemm_fp8_mx_blockwise_quantized_tensor(m, n, k, layout, format, dtype, 
         granularity=ScalingGranularity.MX_BLOCKWISE,
         backend=backend,
         block_size=32,
+    )
+
+
+@pytest.mark.parametrize("m", [256, 512, 1024])
+@pytest.mark.parametrize("n", [256, 512, 4096])
+@pytest.mark.parametrize("k", [256, 1024])
+@pytest.mark.parametrize("layout", ["NT", "NN"])
+@pytest.mark.parametrize("format", [Format.E4M3, Format.E5M2])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("backend", [None, BackendType.CK, BackendType.TRITON])
+def test_gemm_fp8_blockwise_quantized_tensor(m, n, k, layout, format, dtype, backend):
+    """BLOCKWISE gemm with pre-quantized QuantizedTensor inputs."""
+
+    _run_gemm_fp8_quantized_tensor_test(
+        m=m,
+        n=n,
+        k=k,
+        layout=layout,
+        format=format,
+        dtype=dtype,
+        granularity=ScalingGranularity.BLOCKWISE,
+        backend=backend,
+        block_size=128,
     )
 
 

--- a/tests/pytorch/ops/test_quantization.py
+++ b/tests/pytorch/ops/test_quantization.py
@@ -10,6 +10,7 @@ import torch
 
 import primus_turbo.pytorch as turbo
 from primus_turbo.pytorch.core.low_precision import (
+    DEFAULT_BLOCK_SIZE,
     MXFP4_BLOCK_SIZE,
     MXFP8_BLOCK_SIZE,
     ScalingGranularity,
@@ -130,6 +131,118 @@ def test_quantize_fp8_rowwise(orig_dtype, dest_dtype, axis, B, M, N, torch_compi
     x_dq = dequantize_fp8(x_fp8, orig_dtype, granularity, axis=axis, scale_inv=x_scale_inv)
     x_dq_ref = dequantize_fp8_ref(x_fp8_ref, orig_dtype, granularity, axis=axis, scale_inv=x_scale_inv_ref)
     torch.testing.assert_close(x_dq, x_dq_ref, **get_tolerances(dest_dtype))
+
+
+@pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dest_dtype", [turbo.float8_e4m3, turbo.float8_e5m2])
+@pytest.mark.parametrize("M", [128, 256, 320])
+@pytest.mark.parametrize("N", [128, 256, 320])
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("granularity", [ScalingGranularity.BLOCKWISE])
+def test_quantize_fp8_blockwise(orig_dtype, dest_dtype, M, N, axis, granularity):
+    """1D-block (activation) blockwise FP8 quant/dequant round-trip."""
+    torch.manual_seed(42)
+
+    x = torch.randn((M, N), device="cuda", dtype=orig_dtype)
+
+    x_fp8, x_scale_inv = quantize_fp8(
+        x,
+        dest_dtype,
+        granularity=granularity,
+        axis=axis,
+        block_size=DEFAULT_BLOCK_SIZE,
+    )
+
+    out = dequantize_fp8(
+        x_fp8,
+        orig_dtype,
+        granularity=granularity,
+        block_size=DEFAULT_BLOCK_SIZE,
+        axis=axis,
+        scale_inv=x_scale_inv,
+    )
+
+    torch.testing.assert_close(x, out, **get_tolerances(dest_dtype))
+
+
+@pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dest_dtype", [turbo.float8_e4m3, turbo.float8_e5m2])
+@pytest.mark.parametrize("M", [128, 256, 320])
+@pytest.mark.parametrize("N", [128, 256, 320])
+@pytest.mark.parametrize("granularity", [ScalingGranularity.BLOCKWISE])
+def test_quantize_fp8_blockwise_with_trans(orig_dtype, dest_dtype, M, N, granularity):
+    """Fused row + col blockwise FP8 quant, dequantized in both directions."""
+    torch.manual_seed(42)
+
+    x = torch.randn((M, N), device="cuda", dtype=orig_dtype)
+
+    x_fp8_row, x_scale_inv_row, x_fp8_col, x_scale_inv_col = quantize_fp8_with_trans(
+        x,
+        dest_dtype,
+        granularity=granularity,
+        block_size=DEFAULT_BLOCK_SIZE,
+    )
+
+    # Rowwise (axis == 1) dequantize.
+    out_row = dequantize_fp8(
+        x_fp8_row,
+        orig_dtype,
+        granularity=granularity,
+        block_size=DEFAULT_BLOCK_SIZE,
+        axis=1,
+        scale_inv=x_scale_inv_row,
+    )
+    torch.testing.assert_close(x, out_row, **get_tolerances(dest_dtype))
+
+    # Colwise (axis == 0) dequantize.
+    out_col = dequantize_fp8(
+        x_fp8_col,
+        orig_dtype,
+        granularity=granularity,
+        block_size=DEFAULT_BLOCK_SIZE,
+        axis=0,
+        scale_inv=x_scale_inv_col,
+    )
+    torch.testing.assert_close(x, out_col, **get_tolerances(dest_dtype))
+
+
+@pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dest_dtype", [turbo.float8_e4m3, turbo.float8_e5m2])
+@pytest.mark.parametrize("batched", [False, True])
+@pytest.mark.parametrize("B", [1, 4])
+@pytest.mark.parametrize("M", [128, 256, 320])
+@pytest.mark.parametrize("N", [128, 256, 320])
+@pytest.mark.parametrize("granularity", [ScalingGranularity.BLOCKWISE])
+def test_quantize_fp8_blockwise_for_weight(orig_dtype, dest_dtype, batched, B, M, N, granularity):
+    """2D-block (weight) blockwise FP8 quant/dequant round-trip for 2D/3D weights."""
+    torch.manual_seed(42)
+
+    if batched:
+        x = torch.randn((B, M, N), device="cuda", dtype=orig_dtype)
+    else:
+        x = torch.randn((M, N), device="cuda", dtype=orig_dtype)
+
+    # use_2d_block ignores axis; scales along both dims.
+    scaling_recipe = ScalingRecipe(use_2d_block=True)
+
+    x_fp8, x_scale_inv = quantize_fp8(
+        x,
+        dest_dtype,
+        granularity=granularity,
+        block_size=DEFAULT_BLOCK_SIZE,
+        scaling_recipe=scaling_recipe,
+    )
+
+    out = dequantize_fp8(
+        x_fp8,
+        orig_dtype,
+        granularity=granularity,
+        block_size=DEFAULT_BLOCK_SIZE,
+        scale_inv=x_scale_inv,
+        scaling_recipe=scaling_recipe,
+    )
+
+    torch.testing.assert_close(x, out, **get_tolerances(dest_dtype))
 
 
 def padding_size(n: int, padding_align_size: int) -> int:


### PR DESCRIPTION
# Description

This PR adds full `QuantizedTensor` support to the BLOCKWISE FP8 GEMM path, bringing it in line with the ROWWISE and MX_BLOCKWISE granularities that already accept pre-quantized inputs.

Previously `FP8GemmBlockFunction` only accepted plain `torch.Tensor` inputs and re-quantized activations and weights on every call, with a `TODO` noting that quantized-tensor support was missing. This change lets callers pass in `QuantizedTensor` activations/weights (and an optional pre-quantized transposed activation), reuses their cached qdata/scales, and avoids redundant quantization launches in the forward and backward passes.

To make round-tripping possible, this PR also introduces the missing BLOCKWISE dequantization kernels and wires them through the public `quantize_fp8` / `quantize_fp8_with_trans` / `dequantize_fp8` ops.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `QuantizedTensor` support to `FP8GemmBlockFunction`:
  forward/backward now accept `Union[torch.Tensor, QuantizedTensor]` activations
  and weights plus an optional pre-quantized transposed activation `a_t`,
  reusing cached qdata/scales instead of always re-quantizing.
- Enable the BLOCKWISE branch of `gemm_fp8` to forward pre-quantized inputs
  (`a_data`, `b_data`, `a_data_t`, `b_data_t`) to `FP8GemmBlockFunction`,
  removing the previous "not yet supported" assertion path.
- Register BLOCKWISE granularity in `_SUPPORTED_QUANTIZED_GRANS` and
  `_SUPPORTED_GROUPED_QUANTIZED_GRANS`, add its validation
  (dtype / `block_size` checks) in `QuantizedTensor.quantize`, treat it as
  needing no padding alignment, and allow BLOCKWISE grouped dequantization.
- Add Triton dequant kernels `dequant_fp8_blockwise_kernel`
  (1D-block activation, row/col) and `dequant_fp8_blockwise_for_weight_kernel`
  (2D-block weight, 2D/3D) as inverses of the existing quantize kernels.
- Add the corresponding custom ops `dequant_fp8_blockwise_impl` and
  `dequant_fp8_blockwise_for_weight_impl` (with fake/meta registrations).
- Route BLOCKWISE through the public ops: `quantize_fp8_with_trans` now uses
  the fused dual kernel, and `dequantize_fp8` dispatches to the 1D-block or
  2D-block dequant path based on `ScalingRecipe.use_2d_block`.
- Rename `BLOCKWISE_BLOCK_SIZE` to `DEFAULT_BLOCK_SIZE` in `low_precision.py`.
- Switch the BLOCKWISE GEMM default backend from CK to TRITON in the
  forward and backward passes.
- Add tests: BLOCKWISE quant/dequant round-trips (activation 1D-block,
  fused row+col, weight 2D-block) in `test_quantization.py`, and a BLOCKWISE
  `QuantizedTensor` GEMM test in `test_gemm_fp8.py`.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
