### PR TITLE
feat: add quantized tensor support for blockwise grouped gemm

### DIFF
--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -33,10 +33,12 @@ from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
     group_offs_from_lens,
 )
 from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
-    grouped_quantize_mxfp8_flydsl_impl,
     quant_fp8_blockwise_for_weight_impl,
     quant_fp8_blockwise_segment_m_row_col_impl,
-    quantize_mxfp8_flydsl_impl,
+)
+from primus_turbo.pytorch.ops.quantization import (
+    grouped_quantize_fp8_with_trans,
+    quantize_fp8_with_trans,
 )
 
 __all__ = [
@@ -71,11 +73,15 @@ def _deter_use_nt_layout_gemm_in_bwd(trans_a: bool, trans_b: bool):
 
 
 class FP8GroupedGemmBlockFunc(torch.autograd.Function):
+    """BLOCKWISE grouped GEMM autograd"""
+
     @staticmethod
     def forward(
         ctx,
-        a: torch.Tensor,
-        b: torch.Tensor,
+        a: Union[torch.Tensor, QuantizedTensor],
+        b: Union[torch.Tensor, QuantizedTensor],
+        a_t: Optional[QuantizedTensor],  # not used
+        b_t: Optional[QuantizedTensor],  # not used
         group_lens: torch.Tensor,  # [B,] int64
         group_offs: torch.Tensor,  # [B + 1,] int64
         trans_b: bool,
@@ -85,6 +91,11 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
     ):
         assert config.granularity == ScalingGranularity.BLOCKWISE
         assert config.block_size in [128], "Only block_size 128 is supported currently."
+        if isinstance(a, QuantizedTensor):
+            # TODO(ruibin): grouped BLOCKWISE emits fused pre-shuffled row / segment-padded col scales, from the quant kernel, it is not compatible with the QuantizedTensor."
+            raise NotImplementedError(
+                "FP8GroupedGemmBlockFunc does not support a pre-quantized activation `a`"
+            )
         assert a.ndim == 2, "Input tensor must be 2-dimensional."
         assert b.ndim == 3, "Weight tensor must be 3-dimensional."
         assert group_lens.size(0) == b.size(0), "group_lens size must match b size(0)."
@@ -93,23 +104,26 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
         a_dtype = _get_fp8_dtype(config.format, True)
         b_dtype = _get_fp8_dtype(config.format, True)
 
-        # One bf16 read of `a` → row-wise (fwd) + segment-padded col-wise (bwd wgrad).
-        # Row scales are pre-shuffled to the persistent GEMM's scale order. gemm_other_dim
-        # = fwd-GEMM N lets the quant pick the HIP fast path on small GEMMs.
+        # --- A side: fused row + segment-padded col grouped quant in one bf16 read.
         gemm_n = b.size(-2) if trans_b else b.size(-1)
-        a_fp8_row, a_fp8_col, a_scale_inv_row, a_scale_inv_col, _, _ = (
-            quant_fp8_blockwise_segment_m_row_col_impl(
-                a, a_dtype, config.block_size, group_lens, group_offs, gemm_other_dim=gemm_n
-            )
+        a_fp8_row, a_fp8_col, a_scale_row, a_scale_col, _, _ = quant_fp8_blockwise_segment_m_row_col_impl(
+            a, a_dtype, config.block_size, group_lens, group_offs, gemm_other_dim=gemm_n
         )
 
-        b_fp8, b_scale_inv = quant_fp8_blockwise_for_weight_impl(b, b_dtype, block_size=config.block_size)
+        # --- B side: 2D-block weight, reused unchanged in fwd + bwd. If the caller
+        # pre-quantized it as a QuantizedTensor, reuse its buffers directly. ---
+        b_scaling_recipe = ScalingRecipe(use_2d_block=True)
+        if isinstance(b, QuantizedTensor):
+            check_quantized_tensor(b, config, scaling_recipe=b_scaling_recipe)
+            b_fp8, b_scale = b.qdata, b.scale_inv
+        else:
+            b_fp8, b_scale = quant_fp8_blockwise_for_weight_impl(b, b_dtype, block_size=config.block_size)
 
         out = grouped_gemm_fp8_impl(
             a_fp8_row,
             b_fp8,
-            a_scale_inv_row,
-            b_scale_inv,
+            a_scale_row,
+            b_scale,
             group_lens,
             group_offs,
             trans_a=False,
@@ -122,9 +136,9 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
 
         ctx.save_for_backward(
             a_fp8_col,
-            a_scale_inv_col,
+            a_scale_col,
             b_fp8,
-            b_scale_inv,
+            b_scale,
             group_lens,
             group_offs,
         )
@@ -142,23 +156,22 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
 
         (
             a_fp8_col,
-            a_scale_inv_col,
+            a_scale_col,
             b_fp8,
-            b_scale_inv,
+            b_scale,
             group_lens,
             group_offs,
         ) = ctx.saved_tensors
         block_size = ctx.config.block_size
         grad_out_dtype = _get_fp8_dtype(ctx.config.format, False)
 
-        # One bf16 read of grad_out → row-wise (dgrad) + segment-padded col-wise (wgrad).
-        # gemm_other_dim = bwd-GEMM K lets the quant pick the HIP fast path on small GEMMs.
+        # --- grad_out: fused row + segment-padded col grouped quant in one bf16 read.
         gemm_k = b_fp8.size(-1) if ctx.trans_b else b_fp8.size(-2)
         (
             grad_out_fp8_row,
             grad_out_fp8_col,
-            grad_out_scale_inv_row,
-            grad_out_scale_inv_col,
+            grad_out_scale_row,
+            grad_out_scale_col,
             var_k_group_lens,
             var_k_group_offs,
         ) = quant_fp8_blockwise_segment_m_row_col_impl(
@@ -169,8 +182,8 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
         grad_a = grouped_gemm_fp8_impl(
             grad_out_fp8_row,
             b_fp8,
-            grad_out_scale_inv_row,
-            b_scale_inv,
+            grad_out_scale_row,
+            b_scale,
             group_lens,
             group_offs,
             trans_a=False,
@@ -184,8 +197,8 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
         grad_b = grouped_gemm_fp8_variable_k_impl(
             a_fp8_col,
             grad_out_fp8_col,
-            a_scale_inv_col,
-            grad_out_scale_inv_col,
+            a_scale_col,
+            grad_out_scale_col,
             var_k_group_lens,
             var_k_group_offs,
             trans_a=not ctx.trans_a,
@@ -200,6 +213,8 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
         return (
             grad_a,  # a
             grad_b,  # b
+            None,  # a_t
+            None,  # b_t
             None,  # group_lens
             None,  # group_offs
             None,  # trans_b
@@ -604,7 +619,7 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
 
         a_scaling_recipe = ScalingRecipe()
         if not isinstance(a, QuantizedTensor):
-            # NOTE: If a is not a QuantizedTensor use grouped_quantize_mxfp8_flydsl_impl to avoid call dequantize.
+            # NOTE: If a is not a QuantizedTensor use grouped_quantize_fp8_with_trans to avoid call dequantize.
             (
                 a_fp8_row,
                 a_scale_row,
@@ -614,9 +629,10 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
                 group_offs_padded_rowwise,
                 _,
                 _,
-            ) = grouped_quantize_mxfp8_flydsl_impl(
+            ) = grouped_quantize_fp8_with_trans(
                 a,
                 a_dtype,
+                config.granularity,
                 group_lens,
                 group_offs,
                 block_size=config.block_size,
@@ -650,13 +666,15 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
 
         b_scaling_recipe = ScalingRecipe(use_2d_block=True)
         if not isinstance(b, QuantizedTensor):
-            # NOTE: If b is not a QuantizedTensor use quantize_mxfp8_flydsl_impl to avoid call dequantize.
-            b_fp8_row, b_scale_row, b_fp8_col, b_scale_col = quantize_mxfp8_flydsl_impl(
+            # NOTE: If b is not a QuantizedTensor use quantize_fp8_with_trans to avoid call dequantize.
+
+            b_fp8_row, b_scale_row, b_fp8_col, b_scale_col = quantize_fp8_with_trans(
                 b,
                 b_dtype,
+                config.granularity,
                 block_size=config.block_size,
-                scaling_recipe=b_scaling_recipe,
-                scaling_recipe_for_trans=b_scaling_recipe,
+                scaling_recipe=ScalingRecipe(use_2d_block=True),
+                scaling_recipe_for_trans=ScalingRecipe(use_2d_block=True),
             )
         else:
             quantized_b = b
@@ -730,9 +748,10 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
             group_offs_padded_rowwise,
             group_lens_padded_colwise,
             group_offs_padded_colwise,
-        ) = grouped_quantize_mxfp8_flydsl_impl(
+        ) = grouped_quantize_fp8_with_trans(
             grad_out,
             grad_out_dtype,
+            ctx.config.granularity,
             group_lens,
             group_offs,
             block_size=ctx.config.block_size,
@@ -878,9 +897,21 @@ def grouped_gemm_fp8(
             num_cu,
         )
     elif config.granularity == ScalingGranularity.BLOCKWISE:
-        # BLOCKWISE only accepts raw tensors today; preserve existing assertion
-        # behaviour in ``FP8GroupedGemmBlockFunc.forward``.
-        return FP8GroupedGemmBlockFunc.apply(a, b, group_lens, group_offs, trans_b, out_dtype, config, num_cu)
+        # BLOCKWISE accepts a pre-quantized 2D-block weight (``b``); the activation
+        # ``a`` must stay a raw tensor (fused pre-shuffled quant). ``a_data_t`` /
+        # ``b_data_t`` are unused by ``FP8GroupedGemmBlockFunc``.
+        return FP8GroupedGemmBlockFunc.apply(
+            a_data,
+            b_data,
+            a_data_t,
+            b_data_t,
+            group_lens,
+            group_offs,
+            trans_b,
+            out_dtype,
+            config,
+            num_cu,
+        )
     elif config.granularity == ScalingGranularity.MX_BLOCKWISE:
         return FP8GroupedGemmMXFunc.apply(
             a_data,

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -799,6 +799,102 @@ def test_grouped_gemm_fp8_mx_blockwise_quantized_tensor(
     )
 
 
+@pytest.mark.parametrize("B", B_VALUES)
+@pytest.mark.parametrize("M", M_VALUES)
+@pytest.mark.parametrize("NK", NK_VALUES)
+@pytest.mark.parametrize("ori_dtype", ORI_DTYPE_VALUES)
+@pytest.mark.parametrize("format", FORMAT_VALUES)
+@pytest.mark.parametrize("block_size", [128])
+@pytest.mark.parametrize("trans_b", TRANS_B_VALUES)
+@pytest.mark.parametrize("balance", BALANCE_VALUES)
+@pytest.mark.parametrize("backend", [None, BackendType.TRITON])
+@pytest.mark.parametrize("auto_tune", [False, True])
+def test_grouped_gemm_fp8_blockwise_weight_quantized_tensor(
+    B, M, NK, ori_dtype, format, block_size, trans_b, balance, backend, auto_tune
+):
+    """BLOCKWISE grouped_gemm with a pre-quantized 2D-block weight (``b``); ``a`` raw.
+
+    NOTE: Grouped BLOCKWISE only supports the weight side as a QuantizedTensor: the
+    activation ``a`` must stay a raw tensor. So ``a`` is kept high-precision and
+    only ``b`` is externally quantized.
+    """
+    N, K = NK
+    seed = 42
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    # Skip redundant test: auto_tune is ignored when backend is explicitly specified
+    if backend is not None and auto_tune:
+        pytest.skip("auto_tune is ignored when backend is explicitly specified")
+
+    if _check_hit_int32_limit(B, M, N, K):
+        pytest.skip("Shape hits int32 indexing limit (numel >= 2**31).")
+
+    GlobalBackendManager.set_grouped_gemm_backend(backend)
+    GlobalBackendManager.set_auto_tune(auto_tune)
+
+    device = "cuda:0"
+    group_lens = generate_grouped_gemm_group_lens(B, M, balance=balance).to(device)
+    print(
+        f"\n[QT-BLOCKWISE-weight] B={B}, M={M}, N={N}, K={K}, ori_dtype={ori_dtype}, "
+        f"format={format}, block_size={block_size}, trans_b={trans_b}, balance={balance}, "
+        f"backend={backend}, auto_tune={auto_tune}"
+    )
+
+    b_shape = (B, N, K) if trans_b else (B, K, N)
+    a = torch.randn((B * M, K), dtype=ori_dtype, device=device, requires_grad=True)
+    b = torch.randn(b_shape, dtype=ori_dtype, device=device, requires_grad=True)
+    a_ref = a.detach().clone().requires_grad_(True)
+    b_ref = b.detach().clone().requires_grad_(True)
+    torch.cuda.synchronize()
+
+    # Externally quantize only the weight as a 2D-block QuantizedTensor.
+    fwd_dtype = _get_fp8_dtype(format, is_fwd=True)
+    b_scaling_recipe = ScalingRecipe(use_2d_block=True)
+    qt_b = QuantizedTensor.quantize(
+        b,
+        fwd_dtype,
+        ScalingGranularity.BLOCKWISE,
+        axis=-1 if trans_b else -2,
+        block_size=block_size,
+        scaling_recipe=b_scaling_recipe,
+    )
+
+    # Reference
+    out_ref = grouped_gemm_ref(a_ref, b_ref, group_lens, trans_b)
+    grad_out = torch.randn_like(out_ref)
+    out_ref.backward(grad_out)
+    torch.cuda.synchronize()
+
+    config = Float8QuantConfig(format=format, granularity=ScalingGranularity.BLOCKWISE, block_size=block_size)
+    out = grouped_gemm_fp8(a, qt_b, group_lens, trans_b=trans_b, config=config)
+    out.backward(grad_out)
+    torch.cuda.synchronize()
+
+    # Check Shape
+    assert out.shape == out_ref.shape
+    assert a.grad is not None and a.grad.shape == a_ref.grad.shape
+    assert qt_b.grad is not None and qt_b.grad.shape == b.shape
+
+    # Check Results
+    snr_threshold = 25 if format == Format.E4M3 else 20
+
+    out_snr = compute_snr(out_ref, out)
+    a_grad_snr = compute_snr(a_ref.grad, a.grad)
+    b_grad_snr = compute_snr(b_ref.grad, qt_b.grad)
+    print(
+        f"[QT-BLOCKWISE-weight] Out-SNR={out_snr:.2f} dB, "
+        f"AGrad-SNR={a_grad_snr:.2f} dB, BGrad-SNR={b_grad_snr:.2f} dB"
+    )
+    assert out_snr > snr_threshold, f"out_snr={out_snr:.2f} too low"
+    assert a_grad_snr > snr_threshold, f"a_grad_snr={a_grad_snr:.2f} too low"
+    assert b_grad_snr > snr_threshold, f"b_grad_snr={b_grad_snr:.2f} too low"
+
+    # Reset config and caches
+    GlobalBackendManager.reset()
+
+
 def _test_grouped_gemm_fp8_hipgraph_test(
     B: int,
     M: int,


### PR DESCRIPTION
# Description

This PR adds `QuantizedTensor` support to the **BLOCKWISE** FP8 grouped GEMM path, so a pre-quantized 2D-block weight can be passed directly into `grouped_gemm_fp8` without going through an internal dequantize/re-quantize round trip.

Previously the BLOCKWISE grouped GEMM only accepted raw high-precision tensors and asserted on anything else.
It now accepts a `QuantizedTensor` weight (`b`) and reuses its `qdata` / `scale_inv` buffers directly in both forward and backward.
The activation (`a`) must remain a raw tensor, because the grouped BLOCKWISE quant kernel emits fused pre-shuffled row scales plus segment-padded column scales that are not compatible with the standard `QuantizedTensor` layout.

As part of this change the MX_BLOCKWISE path is migrated onto the unified, granularity-aware quant entry points (`quantize_fp8_with_trans` / `grouped_quantize_fp8_with_trans`), replacing the MX-specific `*_mxfp8_flydsl_impl` helpers so both granularities share one quant interface.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Extend `FP8GroupedGemmBlockFunc` to accept a pre-quantized 2D-block weight `b` as a `QuantizedTensor`, reusing its `qdata` / `scale_inv` in forward and backward instead of re-quantizing.
- Add `a_t` / `b_t` placeholder arguments (currently unused) to the `FP8GroupedGemmBlockFunc.forward` signature and update the backward return tuple and the `grouped_gemm_fp8` dispatch accordingly, aligning the API with the other grouped GEMM functions.
- Raise a clear `NotImplementedError` when a pre-quantized activation `a` is supplied to the BLOCKWISE path, since the fused pre-shuffled row / segment-padded col scales from the grouped quant kernel are not compatible with `QuantizedTensor`.
- Validate the incoming weight `QuantizedTensor` via `check_quantized_tensor` against the `ScalingRecipe(use_2d_block=True)` recipe.
- Rename the internal scale variables from `*_scale_inv_*` to `*_scale_*` for consistency across the forward/backward code paths.
- Migrate the MX_BLOCKWISE path to the unified, granularity-aware quant helpers `quantize_fp8_with_trans` / `grouped_quantize_fp8_with_trans` (passing `config.granularity`) in place of the MX-specific `*_mxfp8_flydsl_impl` functions.
- Add `test_grouped_gemm_fp8_blockwise_weight_quantized_tensor` covering a pre-quantized 2D-block weight with a raw activation, checking output and gradient SNR across formats, backends, auto-tune, and transpose configurations.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
