### PR TITLE
[flydsl][mxfp4] Pad grouped scale workspace to 256 rows

### DIFF
--- a/primus_turbo/flydsl/grouped_gemm/mxfp4_grouped_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/mxfp4_grouped_kernel.py
@@ -91,8 +91,13 @@ def _build_grouped_mxfp4_ab_preshuffle(K128: int, G: int, N: int, k128_rd: int =
     select) -- no per-thread divergence. ``k128_rd`` real read + 256-block mask = zero pad,
     no host F.pad."""
     _KRD = K128 if k128_rd is None else k128_rd
+    # ScaleS2RPacked interleaves four 64-row groups at a time, so its physical
+    # row extent must be a 256-multiple even though the FP4 operand keeps the
+    # real N row stride. Without this padding, the last partial quartet leaves
+    # holes in one expert's workspace and spills stores into the next expert.
+    N_SCALE = ceildiv(N, 256) * 256
     n_sub, nd, KK = 2, 4, K128 // 2
-    b_dwords_pe = N * K128 // _PRESHUF_NG
+    b_dwords_pe = N_SCALE * K128 // _PRESHUF_NG
 
     @flyc.kernel(known_block_size=[_PRESHUF_BLK, 1, 1])
     def kern(
@@ -116,7 +121,7 @@ def _build_grouped_mxfp4_ab_preshuffle(K128: int, G: int, N: int, k128_rd: int =
             b_raw, max_size=False, num_records_bytes=I32(G * N * _KRD) * 4
         )
         b_rout = buffer_ops.create_buffer_resource(
-            b_out, max_size=False, num_records_bytes=I32(G * N * K128) * 4
+            b_out, max_size=False, num_records_bytes=I32(G * N_SCALE * K128) * 4
         )
         bid = rocdl.readfirstlane(T.i32, fx.block_idx.x)
         is_b = bid >= a_grid
@@ -141,7 +146,7 @@ def _build_grouped_mxfp4_ab_preshuffle(K128: int, G: int, N: int, k128_rd: int =
         grp_a = _mxfp4_grp_from(wi, r_region, 0)
         grp_b = _mxfp4_grp_from(wi, r_region, 1)
         _blk = ((wi * I32(KK) + kk) * I32(64) + r) * I32(nd) + last
-        base = arith.select(is_b, b_expert * I32(N * K128) + _blk, _blk)
+        base = arith.select(is_b, b_expert * I32(N_SCALE * K128) + _blk, _blk)
 
         # A: inline a_pre scan (owning group -> tight source rows rd0..rd_end)
         go_t = rocdl.make_buffer_tensor(go_out, max_size=False, num_records_bytes=(G + 1) * 8)
@@ -220,6 +225,7 @@ def _build_grouped_mxfp4_nt_kernel(
     N_LDS_STEPS_BH = LDS_BN_HALF // _ROWS_PER_STEP
     _PRELL, _NSCBUF = 2, 2
     K128 = K // 128
+    N_SCALE = ceildiv(N, 256) * 256
     _SCBUF = 4 * 4 * (BLOCK_K // 128) * 64
     _SCW = 4 * N_SUB * 64
     NBK = ceildiv(N, BLOCK_N)  # n_blocks
@@ -265,9 +271,8 @@ def _build_grouped_mxfp4_nt_kernel(
         gl_off_b = fp4_g2s_offsets(lane_id, wave_id, _KR, N_LDS_STEPS_BH, BPR, swizzle=swizzle)
         a_s2r = S2RLoaderFp4(wave_m, N_TILES_A, LDS_ROW_STRIDE, swizzle=swizzle)
         b_s2r = S2RLoaderFp4(wave_n, N_TILES_BH, LDS_ROW_STRIDE, swizzle=swizzle)
-        _qn = ((c_n + 63) // 64) * 64
         sa_s2r = ScaleS2RPacked(A_scale, slab_rows, K, 4)
-        sb_s2r = ScaleS2RPacked(B_scale, _qn * I32(G), K, 4)
+        sb_s2r = ScaleS2RPacked(B_scale, I32(N_SCALE * G), K, 4)
         wave_m_off = wave_m * (N_TILES_A * 16)
         wave_n_off = wave_n * (N_TILES_BH * 16)
 
@@ -387,7 +392,7 @@ def _build_grouped_mxfp4_nt_kernel(
         sa_b = a_pre_g * I32(64) + bm * I32(BLOCK_M) + I32(wave_m_off)
         sbl_b = bn * I32(BLOCK_N) + I32(wave_n_off)
         sbr_b = bn * I32(BLOCK_N) + I32(LDS_BN_HALF) + I32(wave_n_off)
-        b_exp_bytes = group_idx * c_n * I32(K128) * I32(4)  # per-expert B-scale base (bytes)
+        b_exp_bytes = group_idx * I32(N_SCALE * K128 * 4)  # padded per-expert B-scale base (bytes)
 
         # ---- fill operand buffers ----
         for _pp in range_constexpr(0, _PRELL):
@@ -484,12 +489,13 @@ def _bound_caches(*caches):
 
 def _compile_grouped_mxfp4_nt_fused(K, G, N, gm, xcd, gn, wlv, elgk, out_fp16, k_real=None):
     K128 = K // 128
+    N_SCALE = ceildiv(N, 256) * 256
     k128_rd = (K if k_real is None else k_real) // 128  # real raw K128 (scale not host-padded)
     ab_pre_shuf = _build_grouped_mxfp4_ab_preshuffle(K128, G, N, k128_rd)  # merged A+B, 1 launch
     gemm_k, attrs, NBK = _build_grouped_mxfp4_nt_kernel(
         K, G, N, group_m=gm, num_xcds=xcd, group_n=gn, wlv=wlv, elgk=elgk, out_fp16=out_fp16, k_real=k_real
     )
-    b_pre_grid = ceildiv(G * N * K128, _PRESHUF_NG * _PRESHUF_BLK)
+    b_pre_grid = ceildiv(G * N_SCALE * K128, _PRESHUF_NG * _PRESHUF_BLK)
 
     @flyc.jit
     def launch(
@@ -525,11 +531,14 @@ def _get_grouped_mxfp4_ws(total_M, N, K128, G, device):
     # prefix is written/read. Keeping total_M out of the key stops per-total_M churn from
     # tripping _bound_caches and evicting the compiled kernels (mirrors #419 for mxfp8).
     slab_rows = (ceildiv(total_M, 256) + G) * 256  # padded A-slab upper bound for this call
+    n_scale = ceildiv(N, 256) * 256
     key = (N, K128, G, device)
     e = _GMXFP4_WS_CACHE.get(key)
     if e is None or e[2] < slab_rows:
         a_sp = torch.empty(slab_rows * K128, dtype=torch.int32, device=device)
-        b_sp = e[1] if e is not None else torch.empty(G * N * K128, dtype=torch.int32, device=device)
+        b_sp = (
+            e[1] if e is not None else torch.empty(G * n_scale * K128, dtype=torch.int32, device=device)
+        )
         e = (a_sp, b_sp, slab_rows)
         _GMXFP4_WS_CACHE[key] = e
     return e[0], e[1], slab_rows

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
@@ -116,7 +116,8 @@ class GroupedGEMMFP4FlyDSLBackend(KernelBackend):
 
     MX_BLOCKWISE, NT (trans_b=True). Reuses the dense mxfp4 whole-loop compute
     (mfma_scale_f32_16x16x128_f8f6f4) with the fp8-grouped addressing; the host
-    wrapper zero-pads K/N to 256 so every shape runs natively.
+    wrapper zero-pads K scales and the packed N-scale workspace to 256 while
+    retaining the real FP4 operand strides.
     """
 
     SUPPORTED_GRANULARITIES = {ScalingGranularity.MX_BLOCKWISE}
@@ -142,8 +143,9 @@ class GroupedGEMMFP4FlyDSLBackend(KernelBackend):
         supported &= a.dtype == float4_e2m1fn_x2 and b.dtype == float4_e2m1fn_x2
         supported &= out_dtype in (torch.float16, torch.bfloat16)
         supported &= trans_b and not trans_a
-        # Free dim N must be a 64-multiple (the packed-scale preshuffle groups 64 rows);
-        # non-64 N (tiny 32-mult test shapes) falls back to Triton. MoE dims are 64-mult.
+        # Free dim N must be a 64-multiple (the packed-scale preshuffle groups 64 rows).
+        # Its physical scale workspace is padded to 256 by the FlyDSL wrapper.
+        # Non-64 N (tiny 32-mult test shapes) falls back to Triton.
         supported &= b.shape[-2] % 64 == 0
         supported &= get_device_compute_capability() >= (9, 5)
         return supported

--- a/tests/pytorch/ops/test_grouped_gemm_fp4.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp4.py
@@ -7,6 +7,7 @@
 import pytest
 import torch
 
+from primus_turbo.pytorch.core.backend import BackendType, GlobalBackendManager
 from primus_turbo.pytorch.core.low_precision import (
     MXFP4_BLOCK_SIZE,
     Float4QuantConfig,
@@ -135,6 +136,58 @@ def test_grouped_gemm_fp4_mx_blockwise(B, M, NK, dtype, balance):
     """MXFP4 grouped GEMM fwd + dgrad + wgrad on the Triton backend."""
     N, K = NK
     _run(B, M, N, K, dtype, balance)
+
+
+# ----------------------------------------------------------------------------
+# FlyDSL packed-scale workspace regression.
+# ----------------------------------------------------------------------------
+def test_grouped_gemm_fp4_flydsl_non_256_free_dim_scale_workspace():
+    """FlyDSL dgrad must fully overwrite packed scales when free-N is not 256-aligned."""
+    supported, reason = check_mxfp4_support()
+    if not supported:
+        pytest.skip(reason)
+
+    from primus_turbo.flydsl.grouped_gemm import mxfp4_grouped_kernel
+
+    device = "cuda:0"
+    groups, n, k = 2, 256, 320
+    group_lens = torch.tensor([0, 128], dtype=torch.int64, device=device)
+
+    torch.manual_seed(42)
+    torch.cuda.manual_seed_all(42)
+    a = torch.randn((128, k), dtype=torch.bfloat16, device=device, requires_grad=True)
+    b = torch.randn((groups, n, k), dtype=torch.bfloat16, device=device)
+    a_ref = a.detach().clone().requires_grad_(True)
+    b_ref = b.detach().clone()
+    grad_out = torch.randn((128, n), dtype=torch.bfloat16, device=device)
+
+    out_ref = grouped_gemm_ref(a_ref, b_ref, group_lens, trans_b=True)
+    out_ref.backward(grad_out)
+
+    GlobalBackendManager.set_grouped_gemm_backend(BackendType.FLYDSL)
+    GlobalBackendManager.set_auto_tune(False)
+    mxfp4_grouped_kernel._GMXFP4_WS_CACHE.clear()
+    try:
+        out = grouped_gemm_fp4(a, b, group_lens, trans_b=True, config=_make_config())
+
+        # The dgrad shape has free-N=320 and contraction K=256. Poison its cached
+        # packed-scale workspace after forward: a correct preshuffle overwrites the
+        # complete 512-row physical extent, including all 256-padding slots.
+        _, b_scale_workspace, _ = mxfp4_grouped_kernel._get_grouped_mxfp4_ws(
+            128, k, 2, groups, torch.device(device)
+        )
+        b_scale_workspace.fill_(-1)
+
+        out.backward(grad_out)
+        torch.cuda.synchronize()
+    finally:
+        GlobalBackendManager.set_grouped_gemm_backend(None)
+        GlobalBackendManager.set_auto_tune(None)
+
+    assert torch.isfinite(out).all()
+    assert torch.isfinite(a.grad).all()
+    assert compute_snr(out_ref, out) > SNR_THRESHOLD
+    assert compute_snr(a_ref.grad, a.grad) > SNR_THRESHOLD
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Prevent non-256-aligned MoE dimensions from corrupting adjacent expert scales during dgrad, and add a poisoned-workspace regression.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
