### PR TITLE
docs: credit FlyDSL in fp8/bf16 dense and fp8 grouped GEMM kernels

### DIFF
--- a/primus_turbo/flydsl/gemm/gemm_bf16_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_bf16_kernel.py
@@ -3,6 +3,11 @@
 #
 # See LICENSE for license information.
 ###############################################################################
+
+"""Primus-Turbo dense BF16 GEMM kernel (FlyDSL).
+
+Authored with FlyDSL (https://github.com/ROCm/FlyDSL)."""
+
 import functools
 
 import flydsl.compiler as flyc

--- a/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
@@ -7,7 +7,9 @@
 """Primus-Turbo dense FP8 GEMM kernel (FlyDSL): NT, NN and TN layouts.
 256x256 tile, BLOCK_K=128, 8-wave (wave_m=2 x wave_n=4), mfma_f32_16x16x128_f8f6f4,
 per-tensor scale, bf16/fp16 out, arbitrary K via native K-tail (TT unsupported).
-Primitives are imported from flydsl.utils.gemm_helper as module globals."""
+Primitives are imported from flydsl.utils.gemm_helper as module globals.
+
+Authored with FlyDSL (https://github.com/ROCm/FlyDSL)."""
 
 import functools
 

--- a/primus_turbo/flydsl/grouped_gemm/gemm_fp8_grouped_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/gemm_fp8_grouped_kernel.py
@@ -28,6 +28,8 @@ Design (CPU-sync-free, reuses the dense kernel body verbatim):
 
 Built on the dense kernel's primitives; see gemm_fp8_kernel.py for the K-loop /
 K-tail / barrier rationale (identical here).
+
+Authored with FlyDSL (https://github.com/ROCm/FlyDSL).
 """
 
 import os


### PR DESCRIPTION
# Description

The FlyDSL fp8 per-tensor GEMM / GroupedGEMM and the bf16 dense GEMM kernels
are authored with FlyDSL (https://github.com/ROCm/FlyDSL). FlyDSL is already
credited at the repo level (README acknowledgements + LICENSE third-party
list, #426), but the individual kernel source files carried no attribution.
This PR adds a one-line FlyDSL credit to those kernel file headers so the
provenance is visible at the source-file level.

Fixes # (issue)

## Type of change

- [x] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- `primus_turbo/flydsl/gemm/gemm_fp8_kernel.py` (fp8 per-tensor dense GEMM): append
  "Authored with FlyDSL (https://github.com/ROCm/FlyDSL)." to the module docstring.
- `primus_turbo/flydsl/grouped_gemm/gemm_fp8_grouped_kernel.py` (fp8 per-tensor grouped
  GEMM): append the same FlyDSL credit to the module docstring.
- `primus_turbo/flydsl/gemm/gemm_bf16_kernel.py` (bf16 dense GEMM): add a module
  docstring carrying the FlyDSL credit (the file previously had none).

No functional/code changes — comments only.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings *(pre-commit ruff check/format pass)*
- [ ] I have added tests that prove my fix is effective or that my feature works *(N/A — comment-only, no behavior change)*
- [x] New and existing unit tests pass locally with my changes