### PR TITLE
Use a torch reduction for tall dgamma partial buffers

### DIFF
--- a/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
+++ b/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
@@ -82,9 +82,25 @@ def _pick_bwd_config(H: int, B: int) -> Tuple[str, int, int, int, int]:
     return "grid", BLOCK_H, grid, 0, 0
 
 
+# Above this many partials the Triton finalize loses badly to a torch
+# reduction: it parallelizes over H only (ceil(H/BLOCK_H) programs) and walks
+# n_parts serially, so a tall, narrow buffer leaves the GPU idle. Measured on
+# MI355X (median over 50 runs, triton vs torch):
+#   (256, 2880)     21.1 us vs  22.7 us   triton wins slightly
+#   (4096, 2880)    61.6 us vs  34.6 us   1.8x slower
+#   (16384, 2880)  190.8 us vs  51.8 us   3.7x slower
+#   (65536, 128)   686.1 us vs  32.6 us    21x slower
+#   (262144, 128) 2684.0 us vs  51.0 us    53x slower
+# The multi-row backward emits ceil(B / ROWS_PER_BLOCK) partials, which reaches
+# the tall regime for q_norm/k_norm (B in the millions, H=128).
+_FINALIZE_TRITON_MAX_PARTS = 512
+
+
 def _finalize_dgamma(dg_partial: torch.Tensor, gamma_dtype: torch.dtype) -> torch.Tensor:
     """Reduce (n_parts, H) fp32 partials to dgamma[H]."""
     n_parts, H = dg_partial.shape
+    if n_parts > _FINALIZE_TRITON_MAX_PARTS:
+        return dg_partial.sum(dim=0).to(gamma_dtype)
     dg = torch.empty(H, device=dg_partial.device, dtype=gamma_dtype)
     BLOCK_H = 64 if H >= 64 else _next_pow2(H)
     BLOCK_N = 64 if n_parts >= 64 else _next_pow2(max(n_parts, 1))

--- a/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
+++ b/primus_turbo/pytorch/kernels/normalization/rmsnorm_impl.py
@@ -84,13 +84,7 @@ def _pick_bwd_config(H: int, B: int) -> Tuple[str, int, int, int, int]:
 
 # Above this many partials the Triton finalize loses badly to a torch
 # reduction: it parallelizes over H only (ceil(H/BLOCK_H) programs) and walks
-# n_parts serially, so a tall, narrow buffer leaves the GPU idle. Measured on
-# MI355X (median over 50 runs, triton vs torch):
-#   (256, 2880)     21.1 us vs  22.7 us   triton wins slightly
-#   (4096, 2880)    61.6 us vs  34.6 us   1.8x slower
-#   (16384, 2880)  190.8 us vs  51.8 us   3.7x slower
-#   (65536, 128)   686.1 us vs  32.6 us    21x slower
-#   (262144, 128) 2684.0 us vs  51.0 us    53x slower
+# n_parts serially, so a tall, narrow buffer leaves the GPU idle.
 # The multi-row backward emits ceil(B / ROWS_PER_BLOCK) partials, which reaches
 # the tall regime for q_norm/k_norm (B in the millions, H=128).
 _FINALIZE_TRITON_MAX_PARTS = 512


### PR DESCRIPTION
The Triton finalize parallelizes over H only and walks n_parts serially, so the tall, narrow buffers the multi-row backward produces for q_norm/k_norm (B in the millions, H=128) leave nearly the whole GPU idle: 2.68 ms against 0.05 ms for torch at (262144, 128).

## Benchmark

Measured on MI355X (median over 50 runs, Triton finalize vs torch reduction):

- `(n_parts=256, H=2880)`: 21.1 us vs 22.7 us; Triton wins slightly
- `(n_parts=4096, H=2880)`: 61.6 us vs 34.6 us; Triton is 1.8x slower
- `(n_parts=16384, H=2880)`: 190.8 us vs 51.8 us; Triton is 3.7x slower
- `(n_parts=65536, H=128)`: 686.1 us vs 32.6 us; Triton is 21x slower
- `(n_parts=262144, H=128)`: 2684.0 us vs 51.0 us; Triton is 53x slower

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes