### PR TITLE
docs: add missing upstream attribution for DeepEP and Mega MoE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -45,6 +45,14 @@ Primus-Turbo uses or references the following third-party projects:
    - License: MIT License
    - Repository: https://github.com/ROCm/aiter.git
 
+6. Triton-distributed
+   - License: MIT License
+   - Repository: https://github.com/ByteDance-Seed/Triton-distributed.git
+
+7. DeepGEMM
+   - License: MIT License
+   - Repository: https://github.com/deepseek-ai/DeepGEMM.git
+
 Please comply with the respective licenses of these third-party projects when using or distributing Primus.
 
 --------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ Primus-Turbo builds on excellent open-source work from the AMD/ROCm ecosystem. W
 
 - [**FlyDSL**](https://github.com/ROCm/FlyDSL) — a Flexible Layout Python DSL and MLIR compiler stack for authoring high-performance AMD GPU kernels. Many of our kernels (GEMM, GroupedGEMM, Attention, MoE) are authored with FlyDSL, and we thank the FlyDSL team for their close collaboration and support.
 - [**AITER**](https://github.com/ROCm/aiter) — AI Tensor Engine for ROCm, providing high-performance operator backends (e.g. FlashAttention, FP8) that Primus-Turbo integrates.
+- [**Triton-distributed**](https://github.com/ByteDance-Seed/Triton-distributed) — a distributed compiler for computation-communication overlapping. Our Mega MoE comm-compute fused kernels reference its overlapping-kernel design.
+- [**DeepGEMM**](https://github.com/deepseek-ai/DeepGEMM) — a clean and efficient FP8/BF16 GEMM library. Our Mega MoE barrier and symmetric-heap layout designs reference it.
 
 ## 📜 License
 

--- a/benchmark/ops/training/deep_ep/utils.py
+++ b/benchmark/ops/training/deep_ep/utils.py
@@ -1,3 +1,13 @@
+###############################################################################
+# Copyright (c) 2025 DeepSeek. All rights reserved.
+#
+# Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Derived from DeepEP (https://github.com/deepseek-ai/DeepEP), tests/utils.py.
+#
+# See LICENSE for license information.
+###############################################################################
+
 import inspect
 import json
 import os

--- a/csrc/kernels/deep_ep/layout.cu
+++ b/csrc/kernels/deep_ep/layout.cu
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2025 DeepSeek. All rights reserved.
+ *
+ * Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Ported from DeepEP (https://github.com/deepseek-ai/DeepEP), csrc/kernels/layout.cu.
+ *
+ * See LICENSE for license information.
+ */
+
 #include "launch.cuh"
 #include "primus_turbo/deep_ep/configs.h"
 

--- a/docs/README_Mega_MoE.md
+++ b/docs/README_Mega_MoE.md
@@ -127,3 +127,13 @@ python benchmark/ops/training/bench_mega_moe.py --mode grouped_gemm_combine --mo
 | Dispatch prologue (routing tables) | `primus_turbo/flydsl/mega/dispatch_prologue_kernel.py` |
 | SwiGLU fwd/bwd | `primus_turbo/flydsl/mega/swiglu_kernel.py` |
 | Cross-rank tiles (dispatch/combine/reduce) | `primus_turbo/flydsl/mega/ep_intranode.py` |
+
+## Acknowledgements
+
+- [**Triton-distributed**](https://github.com/ByteDance-Seed/Triton-distributed) (ByteDance-Seed,
+  MIT License) — Mega MoE's comm-compute overlapping design (symmetric-memory push, signal/wait
+  synchronization, fusing intra-node EP communication into the GEMM kernel) references
+  Triton-distributed's overlapping-kernel approach.
+- [**DeepGEMM**](https://github.com/deepseek-ai/DeepGEMM) (DeepSeek, MIT License) — Mega MoE's
+  cross-rank barrier and symmetric-buffer layout follow DeepGEMM's design; see the file headers of
+  `primus_turbo/flydsl/mega/barrier.py` and `primus_turbo/flydsl/mega/symm_buffer.py` for details.

--- a/primus_turbo/flydsl/mega/barrier.py
+++ b/primus_turbo/flydsl/mega/barrier.py
@@ -1,5 +1,10 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 DeepSeek. All rights reserved.
+#
+# Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Adapted from DeepGEMM (https://github.com/deepseek-ai/DeepGEMM, MIT License),
+# deep_gemm/include/deep_gemm/comm/barrier.cuh: grid_sync, nvlink_barrier.
 #
 # See LICENSE for license information.
 ###############################################################################
@@ -72,13 +77,7 @@ def xgmi_barrier(
     skip_fence: bool = False,
     tag: str = "xgmi_barrier",
 ):
-    """Cross-rank arrival barrier over XGMI (ported from DeepGEMM ``nvlink_barrier``).
-
-    Self-resetting ping-pong: a local counter's low 2 bits pick one of two signal buffers
-    (phase = bit 0) and the add direction (sign = bit 1). Each round adds +1 (even rounds,
-    wait for ``world_size``) or -1 (odd rounds, wait for 0) to every peer's signal, so the
-    two buffers alternate 0<->world_size with no host-side reset. Only block 0 participates.
-    """
+    """Cross-rank arrival barrier over XGMI."""
     # hoist all workspace-derived values before dynamic control flow (rewriter can't carry Workspace)
     counter_ptr = workspace.get_xgmi_barrier_counter_ptr()
     status = ld(counter_ptr, fx.Int32(0), scope="agent") & fx.Int32(3)

--- a/primus_turbo/flydsl/mega/ep_intranode.py
+++ b/primus_turbo/flydsl/mega/ep_intranode.py
@@ -90,7 +90,7 @@ def dispatch_bf16_tile(
         fx.gpu.barrier()
         if thread_index == fx.Int32(0):
             bank = fx.Int32(0) if disp_parity is None else disp_parity * fx.Int32(num_max_pool_blocks)
-            # DeepEP parity: each task bumps dst expert counter +1 (host-predictable)
+            # each task bumps dst expert counter +1, so the total is host-predictable
             local_expert = task_index // fx.Int32(num_ranks)
             atomic_add(dispatch_flag_address, bank + local_expert, fx.Int64(1), scope="sys")
 

--- a/primus_turbo/flydsl/mega/symm_buffer.py
+++ b/primus_turbo/flydsl/mega/symm_buffer.py
@@ -1,9 +1,16 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 DeepSeek. All rights reserved.
+#
+# Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Adapted from DeepGEMM (https://github.com/deepseek-ai/DeepGEMM, MIT License),
+# deep_gemm/include/deep_gemm/layout/sym_buffer.cuh,
+# deep_gemm/include/deep_gemm/layout/mega_moe.cuh and
+# deep_gemm/mega/__init__.py: SymBuffer, Workspace and the host-side
+# symmetric-buffer allocation / slicing.
 #
 # See LICENSE for license information.
 ###############################################################################
-
 
 import ctypes
 from typing import Callable, List, Optional, Tuple

--- a/tests/pytorch/deep_ep/test_intranode.py
+++ b/tests/pytorch/deep_ep/test_intranode.py
@@ -1,3 +1,12 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# The reference flow this test drives is derived from DeepEP
+# (https://github.com/deepseek-ai/DeepEP); see tests/pytorch/ref/deep_ep_ref.py.
+#
+# See LICENSE for license information.
+###############################################################################
+
 import torch
 import torch.distributed as dist
 from torch.testing._internal.common_distributed import (

--- a/tests/pytorch/ref/deep_ep_ref.py
+++ b/tests/pytorch/ref/deep_ep_ref.py
@@ -1,5 +1,11 @@
 ###############################################################################
-# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 DeepSeek. All rights reserved.
+#
+# Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# The ``tune_and_verify_*`` reference flows and the numeric helpers below are
+# derived from DeepEP (https://github.com/deepseek-ai/DeepEP), tests/test_intranode.py,
+# tests/test_internode.py and tests/utils.py.
 #
 # See LICENSE for license information.
 ###############################################################################


### PR DESCRIPTION
# Description

Add missing attribution for upstream code in the DeepEP port and the Mega MoE kernels. Some files
were ported from DeepEP or DeepGEMM but carried no copyright header, or only AMD's.

Comments and documentation only; no kernel logic is touched.

Fixes # (issue)

## Type of change

- [x] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add DeepSeek copyright and the upstream file path to the four DeepEP-derived files
  (`csrc/kernels/deep_ep/layout.cu`, `benchmark/ops/training/deep_ep/utils.py`,
  `tests/pytorch/ref/deep_ep_ref.py`, `tests/pytorch/deep_ep/test_intranode.py`).
- Credit DeepGEMM in `primus_turbo/flydsl/mega/barrier.py` and
  `primus_turbo/flydsl/mega/symm_buffer.py`, whose designs it follows.
- Credit Triton-distributed for Mega MoE's comm-compute overlapping design.
- List Triton-distributed and DeepGEMM in `LICENSE`, `README.md` and `docs/README_Mega_MoE.md`.
- Drop a stale `# DeepEP parity` comment in `ep_intranode.py`; Mega MoE does not derive from DeepEP.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
