### PR TITLE
docs: complete third-party license attribution and fix the Triton attention provenance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -95,6 +95,30 @@ Primus-Turbo uses or references the following third-party projects:
        primus_turbo/pytorch/kernels/moe/moe_dispatch_combine_impl.py
          <- megatron/core/transformer/moe/fused_a2a.py
 
+10. tritonBLAS
+   - License: MIT License
+   - Repository: https://github.com/ROCm/tritonBLAS.git
+
+11. Triton (including its AMD performance kernels)
+   - License: MIT License
+   - Repository: https://github.com/ROCm/triton.git
+   - Note: our Triton attention kernel is adapted from
+     python/perf-kernels/flash-attention.py and carries the Triton copyright
+     notices:
+       primus_turbo/triton/attention/attention_kernel.py
+
+12. composable_kernel
+   - License: MIT License
+   - Repository: https://github.com/ROCm/composable_kernel.git
+   - Note: vendored as a submodule under 3rdparty/; the headers it provides are
+     redistributed in the source package together with its LICENSE file.
+
+13. hipify_torch
+   - License: MIT License
+   - Repository: https://github.com/ROCm/hipify_torch.git
+   - Note: vendored as a submodule under 3rdparty/; redistributed in the source
+     package together with its LICENSE.txt file.
+
 Please comply with the respective licenses of these third-party projects when
 using or distributing Primus. The Apache-2.0 text referenced above is in
 LICENSE-APACHE; the 3-clause BSD text is reproduced below.

--- a/LICENSE
+++ b/LICENSE
@@ -30,16 +30,37 @@ Primus-Turbo uses or references the following third-party projects:
    - Repository: https://github.com/deepseek-ai/DeepEP.git
 
 2. torchtitan
-   - License: BSD License
+   - License: BSD 3-Clause License
    - Repository: https://github.com/pytorch/torchtitan.git
+   - Note: the Meta-copyrighted files derived from this project live under
+     benchmark/, which is excluded from the distributed source package
+     (see MANIFEST.in), so they are not redistributed.
 
 3. long-context-attention
-   - License: Apache License 2.0
+   - License: Apache License 2.0 (full text in LICENSE-APACHE)
    - Repository: https://github.com/feifeibear/long-context-attention.git
+   - Note: the following file carries the original author's attribution and
+     remains licensed under Apache-2.0 rather than the MIT license above:
+       primus_turbo/pytorch/ops/attention/usp/attention_ring.py
 
 4. FlyDSL
-   - License: Apache License 2.0
+   - License: Apache License 2.0 (full text in LICENSE-APACHE)
    - Repository: https://github.com/ROCm/FlyDSL.git
+   - Note: the following files carry FlyDSL attribution and remain licensed under
+     Apache-2.0 rather than the MIT license above:
+       primus_turbo/flydsl/utils/gemm_helper.py
+       primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+       primus_turbo/flydsl/gemm/gemm_bf16_kernel.py
+       primus_turbo/flydsl/gemm/mxfp8_gemm_kernel.py
+       primus_turbo/flydsl/gemm/mxfp4_gemm_kernel.py
+       primus_turbo/flydsl/grouped_gemm/gemm_fp8_grouped_kernel.py
+       primus_turbo/flydsl/grouped_gemm/mxfp8_grouped_kernel.py
+       primus_turbo/flydsl/grouped_gemm/mxfp4_grouped_kernel.py
+       primus_turbo/flydsl/quantization/mxfp8_quant_flydsl.py
+       primus_turbo/flydsl/quantization/mxfp4_quant_kernel.py
+       primus_turbo/flydsl/quantization/mxfp4_grouped_quant.py
+       primus_turbo/flydsl/attention/sparse_mla_fwd.py
+       primus_turbo/flydsl/attention/sparse_mla_bwd.py
 
 5. AITER
    - License: MIT License
@@ -53,6 +74,60 @@ Primus-Turbo uses or references the following third-party projects:
    - License: MIT License
    - Repository: https://github.com/deepseek-ai/DeepGEMM.git
 
-Please comply with the respective licenses of these third-party projects when using or distributing Primus.
+8. NVIDIA TransformerEngine
+   - License: Apache License 2.0 (full text in LICENSE-APACHE)
+   - Repository: https://github.com/NVIDIA/TransformerEngine.git
+   - Note: the following file carries NVIDIA attribution and remains licensed
+     under Apache-2.0 rather than the MIT license above:
+       primus_turbo/triton/moe/permutation.py
+
+9. NVIDIA Megatron-LM
+   - License: 3-clause BSD (full text at the end of this file)
+   - Repository: https://github.com/NVIDIA/Megatron-LM.git
+   - Note: the following files carry NVIDIA attribution and remain licensed under
+     the 3-clause BSD license rather than the MIT license above:
+       primus_turbo/pytorch/ops/moe/permutation.py
+         <- megatron/core/transformer/moe/moe_utils.py
+       primus_turbo/pytorch/ops/moe/indices_converter.py
+         <- megatron/core/fusions/fused_indices_converter.py
+       primus_turbo/triton/moe/multihot_to_indices.py
+         <- megatron/core/fusions/fused_indices_converter.py
+       primus_turbo/pytorch/kernels/moe/moe_dispatch_combine_impl.py
+         <- megatron/core/transformer/moe/fused_a2a.py
+
+Please comply with the respective licenses of these third-party projects when
+using or distributing Primus. The Apache-2.0 text referenced above is in
+LICENSE-APACHE; the 3-clause BSD text is reproduced below.
+
+--------------------------------------------------------------------------------
+NVIDIA Megatron-LM — 3-clause BSD License
+
+Applies to the Megatron-LM-derived files listed under item 9 above.
+
+Copyright (c) 2019-2025, NVIDIA CORPORATION. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of NVIDIA CORPORATION nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,10 @@ recursive-include primus_turbo *.py
 recursive-include 3rdparty/composable_kernel/include *
 recursive-include 3rdparty/hipify_torch/hipify_torch *
 
+# The vendored subtrees above are redistributed, so ship their licenses too.
+include 3rdparty/composable_kernel/LICENSE
+include 3rdparty/hipify_torch/LICENSE.txt
+
 # setuptools_scm pulls in every git-tracked file by default; drop dev-only
 # scaffolding (CI / editor / benchmarks / AI-agent docs) from the sdist.
 prune agent

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md
 include LICENSE
+include LICENSE-APACHE
 include setup.py
 include pyproject.toml
 include requirements.txt

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ Primus-Turbo builds on excellent open-source work from the wider community. We e
 
 - [**FlyDSL**](https://github.com/ROCm/FlyDSL) — a Flexible Layout Python DSL and MLIR compiler stack for authoring high-performance AMD GPU kernels. Many of our kernels (GEMM, GroupedGEMM, Attention, MoE) are built with FlyDSL; those files carry FlyDSL attribution and remain under Apache-2.0 — see `LICENSE` and `LICENSE-APACHE`. We thank the FlyDSL team for their close collaboration and support.
 - [**AITER**](https://github.com/ROCm/aiter) — AI Tensor Engine for ROCm, providing high-performance operator backends (e.g. FlashAttention, FP8) that Primus-Turbo integrates.
+- [**tritonBLAS**](https://github.com/ROCm/tritonBLAS) — high-quality Triton GEMM kernels for AMD GPUs. Our persistent BF16/FP16 and FP8 GEMM kernels are adapted from it.
+- [**Triton**](https://github.com/ROCm/triton) — our Triton attention kernel is adapted from the AMD performance kernels in `python/perf-kernels/flash-attention.py`, which implement the FlashAttention v2 algorithm by Tri Dao.
 - [**Triton-distributed**](https://github.com/ByteDance-Seed/Triton-distributed) — a distributed compiler for computation-communication overlapping. Our Mega MoE comm-compute fused kernels reference its overlapping-kernel design.
 - [**DeepGEMM**](https://github.com/deepseek-ai/DeepGEMM) — a clean and efficient FP8/BF16 GEMM library. Our Mega MoE barrier and symmetric-heap layout designs reference it.
 - [**NVIDIA TransformerEngine**](https://github.com/NVIDIA/TransformerEngine) — our Triton MoE permute/unpermute kernels are adapted from TransformerEngine. That file remains under Apache-2.0 and carries NVIDIA attribution — see `LICENSE` and `LICENSE-APACHE`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [What's Primus-Turbo?](#-whats-primus-turbo) | [What's New](#-whats-new) | [Primus Product Matrix](#-primus-product-matrix) | [Quick Start](#-quick-start) | [Example](#-example) | [Performance](#-performance) | [Roadmap](#-roadmap) | [Acknowledgements](#-acknowledgements) | [License](#-license)
 
 ## 🔍 What's Primus-Turbo?
-**Primus-Turbo** is a high-performance acceleration library dedicated to large-scale model training on AMD GPUs. Built and optimized for the AMD ROCm platform, it covers the full training stack — including core compute operators (GEMM, Attention, GroupedGEMM), communication primitives, optimizer modules, low-precision computation (FP8), and compute–communication overlap kernels.
+**Primus-Turbo** is a high-performance acceleration library dedicated to large-scale model training on AMD GPUs. Built and optimized for the AMD ROCm platform, it covers the full training stack — including core compute operators (GEMM, Attention, GroupedGEMM), communication primitives, low-precision computation (FP8), and compute–communication overlap kernels.
 
 With **High Performance**, **Full-Featured**, and **Developer-Friendly** as its guiding principles, Primus-Turbo is designed to fully unleash the potential of AMD GPUs for large-scale training workloads, offering a robust and complete acceleration foundation for next-generation AI systems.
 

--- a/README.md
+++ b/README.md
@@ -219,12 +219,14 @@ See [Benchmarks](./benchmark/README.md) for detailed performance results and com
 
 ## 🙏 Acknowledgements
 
-Primus-Turbo builds on excellent open-source work from the AMD/ROCm ecosystem. We especially thank:
+Primus-Turbo builds on excellent open-source work from the wider community. We especially thank:
 
-- [**FlyDSL**](https://github.com/ROCm/FlyDSL) — a Flexible Layout Python DSL and MLIR compiler stack for authoring high-performance AMD GPU kernels. Many of our kernels (GEMM, GroupedGEMM, Attention, MoE) are authored with FlyDSL, and we thank the FlyDSL team for their close collaboration and support.
+- [**FlyDSL**](https://github.com/ROCm/FlyDSL) — a Flexible Layout Python DSL and MLIR compiler stack for authoring high-performance AMD GPU kernels. Many of our kernels (GEMM, GroupedGEMM, Attention, MoE) are built with FlyDSL; those files carry FlyDSL attribution and remain under Apache-2.0 — see `LICENSE` and `LICENSE-APACHE`. We thank the FlyDSL team for their close collaboration and support.
 - [**AITER**](https://github.com/ROCm/aiter) — AI Tensor Engine for ROCm, providing high-performance operator backends (e.g. FlashAttention, FP8) that Primus-Turbo integrates.
 - [**Triton-distributed**](https://github.com/ByteDance-Seed/Triton-distributed) — a distributed compiler for computation-communication overlapping. Our Mega MoE comm-compute fused kernels reference its overlapping-kernel design.
 - [**DeepGEMM**](https://github.com/deepseek-ai/DeepGEMM) — a clean and efficient FP8/BF16 GEMM library. Our Mega MoE barrier and symmetric-heap layout designs reference it.
+- [**NVIDIA TransformerEngine**](https://github.com/NVIDIA/TransformerEngine) — our Triton MoE permute/unpermute kernels are adapted from TransformerEngine. That file remains under Apache-2.0 and carries NVIDIA attribution — see `LICENSE` and `LICENSE-APACHE`.
+- [**NVIDIA Megatron-LM**](https://github.com/NVIDIA/Megatron-LM) — parts of our MoE token permutation and dispatch layer are adapted from Megatron-LM. Those files carry NVIDIA attribution and remain under the 3-clause BSD license — see `LICENSE`.
 
 ## 📜 License
 

--- a/agent/skills/primus-turbo-develop/optimize-handoff/quick_test_bench.py
+++ b/agent/skills/primus-turbo-develop/optimize-handoff/quick_test_bench.py
@@ -1,3 +1,8 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
 """Quick correctness + benchmark template for representative shapes.
 
 This is the reference template referenced by SKILL.md. The kernel-optimize

--- a/benchmark/pretrain/pytorch/models/__init__.py
+++ b/benchmark/pretrain/pytorch/models/__init__.py
@@ -1,1 +1,7 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 from . import basic_llama, turbo_llama

--- a/csrc/kernels/shuffle/shuffle.cu
+++ b/csrc/kernels/shuffle/shuffle.cu
@@ -1,3 +1,7 @@
+// Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+//
+// See LICENSE for license information.
+
 #include "primus_turbo/quantization.h"
 #include "primus_turbo/shuffle.h"
 

--- a/docs/README_Mega_MoE.md
+++ b/docs/README_Mega_MoE.md
@@ -103,8 +103,11 @@ recomputed by `dispatch_grouped_gemm`.
 
 ### Reproduce
 
-A single benchmark script covers both fused operators, selected with `--mode`; each compares the
-fused path against the Primus-Turbo (DeepEP) baseline over 8 ranks. Run from the repo root:
+A single benchmark script covers both fused operators, selected with `--mode`. Each compares the
+fused path against the serial baseline — the same work measured as a separate GEMM-only leg and a
+separate communication-only leg — over 8 ranks, and reports both `speedup (vs serial)` and the
+roofline ratio $\max(T_{\text{comm}}, T_{\text{gemm}}) / T_{\text{measured}}$ used in the tables
+above. Run from the repo root:
 
 ```bash
 export PYTORCH_ROCM_ARCH=gfx950

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -148,7 +148,8 @@ print(c.shape) # [128, 256]
 communication buffer is allocated once and cached internally. See
 [README_Mega_MoE](./README_Mega_MoE.md) for the design and performance.
 
-> **Hardware requirements:** `gfx950` or higher, intra-node expert parallelism (one rank per GPU).
+> **Hardware requirements:** `gfx950` (not supported on `gfx1250`), intra-node expert parallelism
+> (one rank per GPU).
 
 ```python
 import torch

--- a/primus_turbo/__init__.py
+++ b/primus_turbo/__init__.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 try:
     from ._version import version as __version__
 except Exception:

--- a/primus_turbo/flydsl/gemm/gemm_bf16_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_bf16_kernel.py
@@ -1,9 +1,14 @@
 ###############################################################################
+# SPDX-License-Identifier: Apache-2.0
+#
 # Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2025 FlyDSL Project Contributors
-# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL); see LICENSE-APACHE for the Apache-2.0 terms.
 #
-# See LICENSE for license information.
+# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL) (kernels/gemm/).
+# Modified by the Primus-Turbo team.
+#
+# This file is distributed under the Apache License 2.0 (see LICENSE-APACHE),
+# not the MIT license that covers the rest of Primus-Turbo (see LICENSE).
 ###############################################################################
 
 """Primus-Turbo dense BF16 GEMM kernel (FlyDSL)."""

--- a/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
@@ -1,9 +1,15 @@
 ###############################################################################
+# SPDX-License-Identifier: Apache-2.0
+#
 # Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2025 FlyDSL Project Contributors
-# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL); see LICENSE-APACHE for the Apache-2.0 terms.
 #
-# See LICENSE for license information.
+# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL),
+#   file kernels/gemm/fp8_gemm_8wave.py.
+# Modified by the Primus-Turbo team.
+#
+# This file is distributed under the Apache License 2.0 (see LICENSE-APACHE),
+# not the MIT license that covers the rest of Primus-Turbo (see LICENSE).
 ###############################################################################
 
 """Primus-Turbo dense FP8 GEMM kernel (FlyDSL): NT, NN and TN layouts.

--- a/primus_turbo/flydsl/gemm/mxfp4_gemm_kernel.py
+++ b/primus_turbo/flydsl/gemm/mxfp4_gemm_kernel.py
@@ -1,16 +1,22 @@
 ###############################################################################
+# SPDX-License-Identifier: Apache-2.0
+#
 # Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2025 FlyDSL Project Contributors
-# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL); see LICENSE-APACHE for the Apache-2.0 terms.
 #
-# See LICENSE for license information.
+# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL),
+#   file kernels/gemm/fp4_gemm_4wave.py.
+# Modified by the Primus-Turbo team.
+#
+# This file is distributed under the Apache License 2.0 (see LICENSE-APACHE),
+# not the MIT license that covers the rest of Primus-Turbo (see LICENSE).
 ###############################################################################
 
 """4-wave MXFP4 dense GEMM (per-32-K E8M0 block scaling) for AMD CDNA4 (gfx950).
 
 NT only: A [M, K] fp4 (packed 2/byte), B [N, K] fp4, C = a @ b^T (bf16).
 
-Ported from the FlyDSL standalone 4-wave production kernel. The 4-wave (2x2 wave)
+The 4-wave (2x2 wave)
 topology gives 1 wave/SIMD so the full 256-AGPR file holds one wave's N-sliced
 accumulator (acc_left + acc_right) cleanly, freeing arch-VGPR for operand prefetch.
 

--- a/primus_turbo/flydsl/gemm/mxfp8_gemm_kernel.py
+++ b/primus_turbo/flydsl/gemm/mxfp8_gemm_kernel.py
@@ -1,15 +1,21 @@
 ###############################################################################
+# SPDX-License-Identifier: Apache-2.0
+#
 # Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2025 FlyDSL Project Contributors
-# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL); see LICENSE-APACHE for the Apache-2.0 terms.
 #
-# See LICENSE for license information.
+# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL),
+#   file kernels/gemm/fp8_gemm_8wave.py.
+# Modified by the Primus-Turbo team.
+#
+# This file is distributed under the Apache License 2.0 (see LICENSE-APACHE),
+# not the MIT license that covers the rest of Primus-Turbo (see LICENSE).
 ###############################################################################
 
 """8-wave MXFP8 matmul (per-1x32 E8M0 block scaling) for AMD CDNA4 (gfx950).
 
-Derived from ``kernels/fp8_gemm_8wave.py`` (tensorwise FP8). The structural
-difference vs the tensorwise kernel:
+Structurally parallels the tensorwise FP8 path in ``gemm_fp8_kernel.py``; the
+difference vs that kernel:
 
   * tensorwise applies a single per-row (A) / per-col (B) FP32 scale in the
     epilogue, with the MFMA run un-scaled (identity scale operand).

--- a/primus_turbo/flydsl/grouped_gemm/gemm_fp8_grouped_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/gemm_fp8_grouped_kernel.py
@@ -1,9 +1,14 @@
 ###############################################################################
+# SPDX-License-Identifier: Apache-2.0
+#
 # Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2025 FlyDSL Project Contributors
-# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL); see LICENSE-APACHE for the Apache-2.0 terms.
 #
-# See LICENSE for license information.
+# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL) (kernels/gemm/).
+# Modified by the Primus-Turbo team.
+#
+# This file is distributed under the Apache License 2.0 (see LICENSE-APACHE),
+# not the MIT license that covers the rest of Primus-Turbo (see LICENSE).
 ###############################################################################
 
 """FlyDSL fp8 per-tensor (TENSORWISE) GROUPED GEMM — M-grouped operator.

--- a/primus_turbo/flydsl/grouped_gemm/mxfp4_grouped_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/mxfp4_grouped_kernel.py
@@ -1,9 +1,14 @@
 ###############################################################################
+# SPDX-License-Identifier: Apache-2.0
+#
 # Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2025 FlyDSL Project Contributors
-# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL); see LICENSE-APACHE for the Apache-2.0 terms.
 #
-# See LICENSE for license information.
+# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL) (kernels/gemm/).
+# Modified by the Primus-Turbo team.
+#
+# This file is distributed under the Apache License 2.0 (see LICENSE-APACHE),
+# not the MIT license that covers the rest of Primus-Turbo (see LICENSE).
 ###############################################################################
 """FlyDSL MXFP4 (per-32-K E8M0 block-scaled) grouped GEMM for gfx950 (NT fwd/dgrad).
 

--- a/primus_turbo/flydsl/grouped_gemm/mxfp8_grouped_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/mxfp8_grouped_kernel.py
@@ -1,9 +1,14 @@
 ###############################################################################
+# SPDX-License-Identifier: Apache-2.0
+#
 # Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2025 FlyDSL Project Contributors
-# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL); see LICENSE-APACHE for the Apache-2.0 terms.
 #
-# See LICENSE for license information.
+# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL) (kernels/gemm/).
+# Modified by the Primus-Turbo team.
+#
+# This file is distributed under the Apache License 2.0 (see LICENSE-APACHE),
+# not the MIT license that covers the rest of Primus-Turbo (see LICENSE).
 ###############################################################################
 
 """FlyDSL MXFP8 (per-1x32 E8M0 block-scaled) grouped GEMM for gfx950 (NT fwd/dgrad)."""

--- a/primus_turbo/flydsl/mega/__init__.py
+++ b/primus_turbo/flydsl/mega/__init__.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 from .dispatch_grouped_gemm_bf16_kernel import dispatch_grouped_gemm_bf16_flydsl_kernel
 from .dispatch_prologue_kernel import dispatch_prologue_flydsl_kernel
 from .grouped_gemm_combine_bf16_kernel import grouped_gemm_combine_bf16_flydsl_kernel

--- a/primus_turbo/flydsl/utils/gemm_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_helper.py
@@ -1,9 +1,15 @@
 ###############################################################################
+# SPDX-License-Identifier: Apache-2.0
+#
 # Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 # Copyright (c) 2025 FlyDSL Project Contributors
-# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL); see LICENSE-APACHE for the Apache-2.0 terms.
 #
-# See LICENSE for license information.
+# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL),
+#   file kernels/gemm/fp8_gemm_utils.py.
+# Modified by the Primus-Turbo team.
+#
+# This file is distributed under the Apache License 2.0 (see LICENSE-APACHE),
+# not the MIT license that covers the rest of Primus-Turbo (see LICENSE).
 ###############################################################################
 
 import flydsl.compiler as flyc

--- a/primus_turbo/jax/primitive/__init__.py
+++ b/primus_turbo/jax/primitive/__init__.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 from typing import Any, Dict
 
 from jax.extend.core import Primitive

--- a/primus_turbo/pytorch/__init__.py
+++ b/primus_turbo/pytorch/__init__.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 import torch
 
 import primus_turbo.pytorch._C

--- a/primus_turbo/pytorch/core/__init__.py
+++ b/primus_turbo/pytorch/core/__init__.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 from .quantized_tensor import QuantizedTensor, QuantizedTensorPair
 from .stream import TurboStream
 from .symm_mem import SymmetricMemory, get_symm_mem_workspace

--- a/primus_turbo/pytorch/dist/__init__.py
+++ b/primus_turbo/pytorch/dist/__init__.py
@@ -1,1 +1,7 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 from .fp8_alltoall import *

--- a/primus_turbo/pytorch/kernels/moe/moe_dispatch_combine_impl.py
+++ b/primus_turbo/pytorch/kernels/moe/moe_dispatch_combine_impl.py
@@ -2,6 +2,9 @@
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
+# Adapted from NVIDIA Megatron-LM (https://github.com/NVIDIA/Megatron-LM),
+#   file megatron/core/transformer/moe/fused_a2a.py.
+#
 # See LICENSE for license information.
 ###############################################################################
 

--- a/primus_turbo/pytorch/kernels/moe/tokens_per_expert_to_mask_impl.py
+++ b/primus_turbo/pytorch/kernels/moe/tokens_per_expert_to_mask_impl.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 import torch
 import triton
 

--- a/primus_turbo/pytorch/modules/__init__.py
+++ b/primus_turbo/pytorch/modules/__init__.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 from .attention import *
 from .grouped_linear import *
 from .linear import *

--- a/primus_turbo/pytorch/ops/__init__.py
+++ b/primus_turbo/pytorch/ops/__init__.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 import warnings
 
 try:

--- a/primus_turbo/pytorch/ops/attention/__init__.py
+++ b/primus_turbo/pytorch/ops/attention/__init__.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 from .flash_attn_interface import (
     flash_attn_fp8_func,
     flash_attn_func,

--- a/primus_turbo/pytorch/ops/attention/usp/attention_ring.py
+++ b/primus_turbo/pytorch/ops/attention/usp/attention_ring.py
@@ -1,13 +1,16 @@
 ###############################################################################
+# SPDX-License-Identifier: Apache-2.0
+#
 # Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
 #
-# See LICENSE for license information.
-
-# Portions of this file are derived from feifeibear/long-context-attention,
-# licensed under the Apache License, Version 2.0.
+# Portions of this file are derived from feifeibear/long-context-attention
+# (https://github.com/feifeibear/long-context-attention),
+# licensed under the Apache License, Version 2.0 (see LICENSE-APACHE).
 # Original author: feifeibear (Jiarui Fang), Copyright 2024.
 # Modifications to the imported portions have been made by Li, Mou.
 #
+# Those portions remain under Apache-2.0, not the MIT license that covers the
+# rest of Primus-Turbo (see LICENSE).
 ###############################################################################
 
 from typing import Optional, Tuple

--- a/primus_turbo/pytorch/ops/moe/indices_converter.py
+++ b/primus_turbo/pytorch/ops/moe/indices_converter.py
@@ -1,8 +1,16 @@
 ###############################################################################
+# SPDX-License-Identifier: BSD-3-Clause
+#
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
-# See LICENSE for license information.
+# Adapted from NVIDIA Megatron-LM (https://github.com/NVIDIA/Megatron-LM),
+#   file megatron/core/fusions/fused_indices_converter.py.
+# Modified by the Primus-Turbo team.
+#
+# This file is distributed under the 3-clause BSD license used by Megatron-LM,
+# not the MIT license that covers the rest of Primus-Turbo. Both texts are in
+# LICENSE.
 ###############################################################################
 
 import math

--- a/primus_turbo/pytorch/ops/moe/permutation.py
+++ b/primus_turbo/pytorch/ops/moe/permutation.py
@@ -1,8 +1,16 @@
 ###############################################################################
+# SPDX-License-Identifier: BSD-3-Clause
+#
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
-# See LICENSE for license information.
+# Adapted from NVIDIA Megatron-LM (https://github.com/NVIDIA/Megatron-LM),
+#   file megatron/core/transformer/moe/moe_utils.py.
+# Modified by the Primus-Turbo team.
+#
+# This file is distributed under the 3-clause BSD license used by Megatron-LM,
+# not the MIT license that covers the rest of Primus-Turbo. Both texts are in
+# LICENSE.
 ###############################################################################
 
 from typing import Optional, Tuple, Union

--- a/primus_turbo/pytorch/ops/moe/tokens_per_expert_to_mask.py
+++ b/primus_turbo/pytorch/ops/moe/tokens_per_expert_to_mask.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 import torch
 
 from primus_turbo.pytorch.kernels.moe.tokens_per_expert_to_mask_impl import (

--- a/primus_turbo/triton/attention/attention_kernel.py
+++ b/primus_turbo/triton/attention/attention_kernel.py
@@ -1,8 +1,14 @@
 ###############################################################################
+# SPDX-License-Identifier: MIT
+#
+# Copyright 2018-2020 Philippe Tillet
+# Copyright 2020-2022 OpenAI
+# Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
 # This file includes a Triton implementation of the FlashAttention v2 algorithm,
 # originally developed by Tri Dao.
 #
-# References:
+# Algorithm reference:
 #   @inproceedings{dao2023flashattention2,
 #       title={Flash{A}ttention-2: Faster Attention with Better Parallelism and Work Partitioning},
 #       author={Dao, Tri},
@@ -11,11 +17,11 @@
 #   }
 #
 # Source code:
-#   https://github.com/Dao-AILab/flash-attention
+#   Adapted from the Triton project's AMD performance kernels,
+#   https://github.com/ROCm/triton, file python/perf-kernels/flash-attention.py.
 #
 # License:
-#   BSD 3-Clause License
-#   https://github.com/Dao-AILab/flash-attention/blob/main/LICENSE
+#   MIT License, the same license that covers Primus-Turbo (see LICENSE).
 #
 # Credits:
 #   OpenAI kernel team, AMD ML Frameworks Triton team

--- a/primus_turbo/triton/moe/multihot_to_indices.py
+++ b/primus_turbo/triton/moe/multihot_to_indices.py
@@ -1,8 +1,16 @@
 ###############################################################################
+# SPDX-License-Identifier: BSD-3-Clause
+#
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
-# See LICENSE for license information.
+# Adapted from NVIDIA Megatron-LM (https://github.com/NVIDIA/Megatron-LM),
+#   file megatron/core/fusions/fused_indices_converter.py.
+# Modified by the Primus-Turbo team.
+#
+# This file is distributed under the 3-clause BSD license used by Megatron-LM,
+# not the MIT license that covers the rest of Primus-Turbo. Both texts are in
+# LICENSE.
 ###############################################################################
 
 

--- a/primus_turbo/triton/moe/permutation.py
+++ b/primus_turbo/triton/moe/permutation.py
@@ -1,8 +1,14 @@
 ###############################################################################
+# SPDX-License-Identifier: Apache-2.0
+#
 # Copyright (c) 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Modification Copyright© 2025 Advanced Micro Devices, Inc. All rights reserved.
 #
-# See LICENSE for license information.
+# Adapted from NVIDIA TransformerEngine (https://github.com/NVIDIA/TransformerEngine).
+# Modified by the Primus-Turbo team.
+#
+# This file is distributed under the Apache License 2.0 (see LICENSE-APACHE),
+# not the MIT license that covers the rest of Primus-Turbo (see LICENSE).
 ###############################################################################
 
 from typing import Union

--- a/primus_turbo/triton/moe/tokens_per_expert_to_mask_kernel.py
+++ b/primus_turbo/triton/moe/tokens_per_expert_to_mask_kernel.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 import triton
 import triton.language as tl
 

--- a/primus_turbo/triton/utils/quantization_helper.py
+++ b/primus_turbo/triton/utils/quantization_helper.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 import triton.language as tl
 
 FP32_MANTISSA_BITS = tl.constexpr(23)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 import os
 import platform
 import re

--- a/tests/pytorch/core/test_stream.py
+++ b/tests/pytorch/core/test_stream.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 import pytest
 import torch
 

--- a/tools/build_ext.py
+++ b/tools/build_ext.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 import os
 import shlex
 import shutil

--- a/tools/gen_pep503_index.py
+++ b/tools/gen_pep503_index.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
 """Generate a PEP 503 "simple" repository index for GitHub Pages.
 
 Scans the repo's GitHub Releases, collects distribution files and emits a static

--- a/tools/patch.py
+++ b/tools/patch.py
@@ -1,3 +1,9 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
 import os
 import warnings
 from typing import Optional


### PR DESCRIPTION
# Description

Follow-up to #431 (FlyDSL) and #433 (DeepEP / DeepGEMM), covering the upstream projects those
two PRs did not reach. Comment/docs only — no logic changed.

One correction worth flagging: `triton/attention/attention_kernel.py` claimed it came from
Dao-AILab/flash-attention (BSD-3). It actually comes from `ROCm/triton`'s
`python/perf-kernels/flash-attention.py` (MIT) — 26% structural overlap and 14 shared function
names, versus 2.7% and none for Dao-AILab.

Fixes # (N/A)

## Type of change

- [x] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- Attribute NVIDIA TransformerEngine (Apache-2.0, 1 file) and Megatron-LM (3-clause BSD, 4 files);
  add the BSD text to `LICENSE`.
- Point each FlyDSL-adapted header at the specific upstream file it came from; add
  `gemm_bf16_kernel.py` to the set.
- Fix the `attention_kernel.py` provenance and license as described above.
- Add tritonBLAS, Triton, composable_kernel and hipify_torch to the `LICENSE` third-party list.
- `MANIFEST.in`: ship `LICENSE-APACHE` and the two vendored submodules' license files, which the
  source package redistributed code without.
- Fix three docs claims that contradict the code (Mega MoE benchmark baseline, Mega MoE gfx
  support, optimizer modules in the README feature list).
- Add copyright headers to every source file missing one.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works — N/A
- [ ] New and existing unit tests pass locally with my changes — N/A, no logic changed