### PR TITLE
fix(moe): add barrier between s_acc read and update in permute_preprocessing

### DIFF
--- a/csrc/kernels/moe_permute/moe_permute.cu
+++ b/csrc/kernels/moe_permute/moe_permute.cu
@@ -168,7 +168,11 @@ __launch_bounds__(kNumThreads, 1) __global__
             const int local = s_tile[thread_id * E + e];
             int       excl_block, scan_total;
             BlockScan(shared_temp.scan).ExclusiveSum(local, excl_block, scan_total);
-            const int prev            = s_acc[e];
+            const int prev = s_acc[e];
+            // Every thread must finish reading the pre-tile base before thread 0
+            // advances it; otherwise late wavefronts pick up this tile's own
+            // aggregate and their slot indices come out kNumItemsPerTile too high.
+            __syncthreads();
             s_tile[thread_id * E + e] = (local == 1) ? (excl_block + prev + 1) : 0;
             if (thread_id == 0)
                 s_acc[e] += scan_total;


### PR DESCRIPTION
# Description

Fix a race condition in the MoE `permute_preprocessing` kernel.

In the per-expert scan loop, every thread reads the pre-tile base `s_acc[e]` while
thread 0 updates it with the tile aggregate in the same loop iteration. With more
than one wavefront, a late wavefront could read `s_acc[e]` **after** thread 0 had
already advanced it, so its slot indices came out up to `kNumItemsPerTile` too
high — producing wrong `row_id_map` entries and corrupted permutation results.

Fix: add a `__syncthreads()` between the `s_acc[e]` read and thread 0's update,
so all threads see the same pre-tile base.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- `csrc/kernels/moe_permute/moe_permute.cu`: insert `__syncthreads()` between reading
  `s_acc[e]` and thread 0's `s_acc[e] += scan_total`.
- Add a short comment explaining why the barrier is required.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
