### PR TITLE
fix: remove force nt path in tensorwise grouped gemm

### DIFF
--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -24,7 +24,6 @@ from primus_turbo.pytorch.core.quantized_tensor import (
     QuantizedTensorPair,
     check_quantized_tensor,
 )
-from primus_turbo.pytorch.core.utils import is_gfx942
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_fp8_impl import (
     grouped_gemm_fp8_impl,
     grouped_gemm_fp8_variable_k_impl,
@@ -61,15 +60,6 @@ def _ensure_contiguous_grad_out(grad_out: torch.Tensor) -> torch.Tensor:
     # Some upstream reductions can produce expanded zero-stride grad_out views.
     # Custom grouped GEMM kernels expect dense layouts.
     return grad_out if grad_out.is_contiguous() else grad_out.contiguous()
-
-
-def _deter_use_nt_layout_gemm_in_bwd(trans_a: bool, trans_b: bool):
-    if is_gfx942():
-        return False
-
-    # NOTE: the non-NT layout gemm is not optimized for mi350/mi450.
-    # Force to use NT layout GEMM in backward for now.
-    return trans_a == False and trans_b == True
 
 
 class FP8GroupedGemmBlockFunc(torch.autograd.Function):
@@ -413,7 +403,7 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
         a: Union[torch.Tensor, QuantizedTensor],
         b: Union[torch.Tensor, QuantizedTensor],
         a_t: Optional[QuantizedTensor],  # not used
-        b_t: Optional[QuantizedTensor],
+        b_t: Optional[QuantizedTensor],  # not used
         group_lens: torch.Tensor,  # [B,] int64
         group_offs: torch.Tensor,  # [B + 1,] int64
         trans_b: bool,
@@ -421,8 +411,6 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
         config: Float8QuantConfig,
         num_cu: int | None,
     ):
-        use_nt_layout_gemm_in_bwd = _deter_use_nt_layout_gemm_in_bwd(False, trans_b)
-
         assert config.granularity == ScalingGranularity.TENSORWISE
 
         if isinstance(a, QuantizedTensor):
@@ -455,12 +443,6 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
                 block_size=config.block_size,
             )
 
-        if use_nt_layout_gemm_in_bwd:
-            if b_t is not None and isinstance(b_t, QuantizedTensor):
-                quantized_b_t = b_t
-            else:
-                quantized_b_t = quantized_b.transpose(-1, -2).contiguous()
-
         out = grouped_gemm_fp8_impl(
             quantized_a.qdata,
             quantized_b.qdata,
@@ -477,27 +459,16 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
             maybe_pre_sync=True,
         )
 
-        if use_nt_layout_gemm_in_bwd:
-            ctx.save_for_backward(
-                quantized_a.qdata,
-                quantized_b_t.qdata,
-                quantized_a.scale_inv,
-                quantized_b_t.scale_inv,
-                group_lens,
-                group_offs,
-            )
-        else:
-            ctx.save_for_backward(
-                quantized_a.qdata,
-                quantized_b.qdata,
-                quantized_a.scale_inv,
-                quantized_b.scale_inv,
-                group_lens,
-                group_offs,
-            )
+        ctx.save_for_backward(
+            quantized_a.qdata,
+            quantized_b.qdata,
+            quantized_a.scale_inv,
+            quantized_b.scale_inv,
+            group_lens,
+            group_offs,
+        )
         ctx.trans_a = False
         ctx.trans_b = trans_b
-        ctx.use_nt_layout_gemm_in_bwd = use_nt_layout_gemm_in_bwd
         ctx.config = config
         ctx.out_dtype = out_dtype
         ctx.num_cu = num_cu
@@ -519,37 +490,20 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
             group_lens=group_lens,
         )
 
-        if ctx.use_nt_layout_gemm_in_bwd:
-            # b_fp8 is the per-group (K, N) transpose cache; grad_a runs as NT.
-            grad_a = grouped_gemm_fp8_impl(
-                quantized_grad_out.qdata,
-                b_fp8,
-                quantized_grad_out.scale_inv,
-                b_scale_inv,
-                group_lens,
-                group_offs,
-                trans_a=False,
-                trans_b=True,
-                out_dtype=ctx.out_dtype,
-                granularity=ctx.config.granularity.value,
-                num_cu=ctx.num_cu,
-                default_backend=BackendType.TRITON.value,
-            )
-        else:
-            grad_a = grouped_gemm_fp8_impl(
-                quantized_grad_out.qdata,
-                b_fp8,
-                quantized_grad_out.scale_inv,
-                b_scale_inv,
-                group_lens,
-                group_offs,
-                trans_a=False,
-                trans_b=not ctx.trans_b,
-                out_dtype=ctx.out_dtype,
-                granularity=ctx.config.granularity.value,
-                num_cu=ctx.num_cu,
-                default_backend=BackendType.TRITON.value,
-            )
+        grad_a = grouped_gemm_fp8_impl(
+            quantized_grad_out.qdata,
+            b_fp8,
+            quantized_grad_out.scale_inv,
+            b_scale_inv,
+            group_lens,
+            group_offs,
+            trans_a=False,
+            trans_b=not ctx.trans_b,
+            out_dtype=ctx.out_dtype,
+            granularity=ctx.config.granularity.value,
+            num_cu=ctx.num_cu,
+            default_backend=BackendType.TRITON.value,
+        )
 
         grad_b = grouped_gemm_fp8_variable_k_impl(
             a_fp8,


### PR DESCRIPTION
# Description

The non-NT layout grouped GEMM backends **(triton and flydsl)** are now performant enough on MI350 , so this workaround is no longer needed. This PR removes it and lets TENSORWISE grouped GEMM take the original code path on all architectures: the backward `grad_a` is computed directly from the untransposed weight with `trans_b=not ctx.trans_b`, matching what gfx942 has been doing all along.

This is a pure code-path simplification for the TENSORWISE granularity. The ROWWISE, BLOCKWISE and MX_BLOCKWISE paths are untouched, and the identically named helper in `gemm_fp8.py` (non-grouped GEMM) is intentionally left in place. Keeping non-NT layout in gemm because we still use hipblaslt backend in gemm. And the non-NT layout performance is not good enough in hipbalslt backend.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Removed the `_deter_use_nt_layout_gemm_in_bwd` helper from `primus_turbo/pytorch/ops/grouped_gemm_fp8.py`, together with the now-unused `is_gfx942` import.
- `FP8GroupedGemmTensorFunc.forward`: dropped the transposed-weight cache branch (both the `b_t` reuse and the `transpose(-1, -2).contiguous()` fallback), and now always saves the untransposed `quantized_b` for backward. The `b_t` argument is unused and annotated as such, consistent with `a_t`.
- `FP8GroupedGemmTensorFunc.forward`: no longer stores `use_nt_layout_gemm_in_bwd` on `ctx`.
- `FP8GroupedGemmTensorFunc.backward`: collapsed the two `grad_a` branches into the single original call with `trans_b=not ctx.trans_b`. The `grad_b` (variable-K wgrad) call is unchanged.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
