### PR TITLE
fix: mxfp4 and mxfp8 grouepd gemm kernel memory access out of bound

### DIFF
--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_utils.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_utils.py
@@ -62,6 +62,8 @@ class BaseGroupedGEMMKernelDispatcher(AutoKernelDispatcher):
         prof_kwargs = dict(kwargs)
         prof_kwargs["group_lens"] = lb_group_lens
         prof_kwargs["group_offs"] = lb_group_offs
+        if kwargs.get("group_offs_out", None) is not None:
+            prof_kwargs["group_offs_out"] = lb_group_offs
 
         best_backend = None
         best_time = float("inf")


### PR DESCRIPTION
# Description

Autotune on the MX grouped GEMM path (MXFP8 / MXFP4) can read out of bounds and abort with a GPU memory fault, because the tuner only load-balances part of the offset tensors it forwards to the profiled backends.

`BaseGroupedGEMMKernelDispatcher.tune()` replaces `group_lens` / `group_offs` with an evenly distributed version so that profiling is not skewed by highly imbalanced groups, and then profiles every candidate backend with those balanced offsets.

The MX path, however, carries a second offset tensor. With MX the input is zero-padded per group so that each group's M is 128-aligned, so `group_offs` are the **padded read offsets** into `A` / `A_scale`, while `group_offs_out` are the **tight write offsets** into `C` (the output is over-allocated to the padded row count and sliced back by the caller). `tune()` rebalanced `group_offs` but left `group_offs_out` at the caller's real, unbalanced values, so the two tensors handed to the kernel described two different partitions of the same tensors.

The fix propagates the same balanced offsets to `group_offs_out`, so the read partition, the write partition and the tile count all agree again during profiling.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- In `BaseGroupedGEMMKernelDispatcher.tune()`, override `group_offs_out` with the load-balanced offsets alongside `group_lens` / `group_offs`, so every offset tensor passed to `profile()` describes the same partition.
- Guard the override on `kwargs.get("group_offs_out", None) is not None`, so it applies only to the MX callers that actually pass tight write offsets and leaves the rowwise / blockwise / tensorwise paths (which never set the key) untouched.
- The override affects the profiling kwargs only. `can_handle()` and the final `execute()` still run on the caller's original offsets, so numerics are unchanged.

## Notes for reviewers

The bug is only reachable with autotune enabled (`PRIMUS_TURBO_AUTO_TUNE=1` or `GlobalBackendManager.set_auto_tune(True)`) and no explicitly pinned backend, since `dispatch()` calls `tune()` only in that case.

# Checklist:

- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
