### PR TITLE
feat: add device guard for gemm and grouped gemm

### DIFF
--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
@@ -22,7 +22,7 @@ from primus_turbo.pytorch.core.backend import (
     TuneCache,
 )
 from primus_turbo.pytorch.core.low_precision import ScalingGranularity, float4_e2m1fn_x2
-from primus_turbo.pytorch.core.utils import get_device_compute_capability
+from primus_turbo.pytorch.core.utils import is_gfx942, is_gfx950
 
 
 def ceil_div(a, b):
@@ -84,6 +84,7 @@ class GEMMFP4HipBLASLtBackend(KernelBackend):
             return False
 
         supported = True
+        supported &= not is_gfx942()
         # check ScalingGranularity
         supported &= granularity in GEMMFP4HipBLASLtBackend.SUPPORTED_GRANULARITIES
         # check dtype
@@ -156,6 +157,8 @@ class GEMMFP4AITERBackend(KernelBackend):
     ) -> bool:
         del preshuffled  # AITER handles both layouts
         supported = True
+        # TODO(ruibin): add gfx1250 support for aiter backend.
+        supported &= is_gfx950()
         # check ScalingGranularity
         supported &= granularity in GEMMFP4AITERBackend.SUPPORTED_GRANULARITIES
         # check dtype
@@ -243,7 +246,7 @@ class GEMMFP4FlyDSLBackend(KernelBackend):
 
         supported = True
         # gfx950 (CDNA4) only: mfma_scale_f32_16x16x128_f8f6f4 is absent below.
-        supported &= get_device_compute_capability() >= (9, 5)
+        supported &= is_gfx950()
         supported &= granularity in GEMMFP4FlyDSLBackend.SUPPORTED_GRANULARITIES
         supported &= a.ndim == 2 and b.ndim == 2
         supported &= (a.dtype, b.dtype, out_dtype) in GEMMFP4FlyDSLBackend.SUPPORTED_DTYPES

--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
@@ -28,7 +28,8 @@ from primus_turbo.pytorch.core.low_precision import (
 )
 from primus_turbo.pytorch.core.utils import (
     build_ck,
-    get_device_compute_capability,
+    is_gfx942,
+    is_gfx950,
     is_gfx1250,
 )
 from primus_turbo.triton.gemm.gemm_fp8_kernel import (
@@ -96,6 +97,8 @@ class GEMMFP8HipBLASLtBackend(KernelBackend):
         granularity: ScalingGranularity,
     ) -> bool:
         supported = True
+        if granularity == ScalingGranularity.MX_BLOCKWISE:
+            supported &= not is_gfx942()
         # check ScalingGranularity
         supported &= granularity in GEMMFP8HipBLASLtBackend.SUPPORTED_GRANULARITIES
         # check dtype
@@ -150,6 +153,7 @@ class GEMMFP8CKBackend(KernelBackend):
         supported = True
         # check the CK backend was compiled into this build
         supported &= build_ck()
+        supported &= not is_gfx1250()
         # check ScalingGranularity
         supported &= granularity in GEMMFP8CKBackend.SUPPORTED_GRANULARITIES
         # check dtype
@@ -313,8 +317,7 @@ class GEMMFP8TurboBackend(KernelBackend):
         granularity: ScalingGranularity,
     ) -> bool:
         supported = True
-        # TODO(ruibin): add gfx1250 support for turbo backend.
-        supported &= not is_gfx1250()
+        supported &= is_gfx950()
         supported &= granularity in GEMMFP8TurboBackend.SUPPORTED_GRANULARITIES
         supported &= (a.dtype, b.dtype, out_dtype) in GEMMFP8TurboBackend.SUPPORTED_DTYPES
         supported &= not trans_a and trans_b and not trans_c
@@ -367,7 +370,7 @@ class GEMMFP8FlyDSLBackend(KernelBackend):
     ) -> bool:
         supported = True
         # gfx950 (CDNA4) only: kernel uses mfma_f32_16x16x128_f8f6f4, absent on gfx942-.
-        supported &= get_device_compute_capability() >= (9, 5)
+        supported &= is_gfx950()
         supported &= granularity in GEMMFP8FlyDSLBackend.SUPPORTED_GRANULARITIES
         supported &= (a.dtype, b.dtype, out_dtype) in GEMMFP8FlyDSLBackend.SUPPORTED_DTYPES
         m, n, k = get_gemm_logical_shape(a, b, trans_a, trans_b)

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
@@ -28,7 +28,7 @@ from primus_turbo.pytorch.core.backend import (
     TuneCache,
 )
 from primus_turbo.pytorch.core.low_precision import ScalingGranularity, float4_e2m1fn_x2
-from primus_turbo.pytorch.core.utils import get_device_compute_capability
+from primus_turbo.pytorch.core.utils import is_gfx942, is_gfx950
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
     BaseGroupedGEMMKernelDispatcher,
     BaseGroupedGEMMVariableKKernelDispatcher,
@@ -70,6 +70,8 @@ class GroupedGEMMFP4TritonBackend(KernelBackend):
         supported = True
         supported &= a.dim() == 2 and b.dim() == 3
         supported &= granularity in GroupedGEMMFP4TritonBackend.SUPPORTED_GRANULARITIES
+        if granularity == ScalingGranularity.MX_BLOCKWISE:
+            supported &= not is_gfx942()
         supported &= a.dtype == float4_e2m1fn_x2 and b.dtype == float4_e2m1fn_x2
         supported &= out_dtype in (torch.float16, torch.bfloat16)
         # NT only: the kernel infers the contraction from the packed last dim.
@@ -138,12 +140,12 @@ class GroupedGEMMFP4FlyDSLBackend(KernelBackend):
         **kwargs,
     ) -> bool:
         supported = True
+        supported &= is_gfx950()
         supported &= a.dim() == 2 and b.dim() == 3
         supported &= a.dtype == float4_e2m1fn_x2 and b.dtype == float4_e2m1fn_x2
         supported &= out_dtype in (torch.float16, torch.bfloat16)
         supported &= granularity in GroupedGEMMFP4FlyDSLBackend.SUPPORTED_GRANULARITIES
         supported &= not trans_a
-        supported &= get_device_compute_capability() >= (9, 5)
 
         supported &= trans_b
         supported &= b.shape[-2] % 64 == 0
@@ -242,6 +244,7 @@ class GroupedGEMMFP4VariableKTritonBackend(KernelBackend):
         **kwargs,
     ) -> bool:
         supported = True
+        supported &= not is_gfx942()
         supported &= a.dim() == 2 and b.dim() == 2
         supported &= granularity in GroupedGEMMFP4VariableKTritonBackend.SUPPORTED_GRANULARITIES
         supported &= a.dtype == float4_e2m1fn_x2 and b.dtype == float4_e2m1fn_x2
@@ -327,7 +330,7 @@ class GroupedGEMMFP4VariableKFlyDSLBackend(KernelBackend):
         # OUT_M/OUT_N (=a.shape[0]/b.shape[0], swapped by trans_c) must be 64-multiples for
         # the packed-scale preshuffle; non-64 (tiny test shapes) falls back to Triton.
         supported &= a.shape[0] % 64 == 0 and b.shape[0] % 64 == 0
-        supported &= get_device_compute_capability() >= (9, 5)
+        supported &= is_gfx950()
         return supported
 
     @staticmethod

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -19,7 +19,12 @@ from primus_turbo.pytorch.core.low_precision import (
     float8_e4m3,
     float8_e5m2,
 )
-from primus_turbo.pytorch.core.utils import build_ck, get_device_compute_capability
+from primus_turbo.pytorch.core.utils import (
+    build_ck,
+    is_gfx942,
+    is_gfx950,
+    is_gfx1250,
+)
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
     BaseGroupedGEMMKernelDispatcher,
     BaseGroupedGEMMVariableKKernelDispatcher,
@@ -81,6 +86,7 @@ class GroupedGEMMFP8CKBackend(KernelBackend):
         supported = True
         # check the CK backend was compiled into this build
         supported &= build_ck()
+        supported &= not is_gfx1250()
         supported &= a.dim() == 2 and b.dim() == 3
         supported &= (a.dtype, b.dtype, out_dtype) in GroupedGEMMFP8CKBackend.SUPPORTED_DTYPES
         supported &= granularity in GroupedGEMMFP8CKBackend.SUPPORTED_GRANULARITIES
@@ -145,6 +151,7 @@ class GroupedGEMMFP8VariableKCKBackend(KernelBackend):
         supported = True
         # check the CK backend was compiled into this build
         supported &= build_ck()
+        supported &= not is_gfx1250()
         supported &= a.dim() == 2 and b.dim() == 2
         supported &= (a.dtype, b.dtype, out_dtype) in GroupedGEMMFP8VariableKCKBackend.SUPPORTED_DTYPES
         supported &= granularity in GroupedGEMMFP8VariableKCKBackend.SUPPORTED_GRANULARITIES
@@ -362,6 +369,7 @@ class GroupedGEMMFP8TritonBackend(KernelBackend):
         else:
             # MXFP8: both operands must be fp8 (e4m3/e5m2) — the kernel infers the
             # format from a.dtype — and the layout is NT only (trans_b=True).
+            supported &= not is_gfx942()
             supported &= a.dtype in (float8_e4m3, float8_e5m2)
             supported &= b.dtype in (float8_e4m3, float8_e5m2)
             supported &= out_dtype in (torch.float16, torch.bfloat16)
@@ -466,7 +474,7 @@ class GroupedGEMMFP8FlyDSLBackend(KernelBackend):
         supported &= granularity in GroupedGEMMFP8FlyDSLBackend.SUPPORTED_GRANULARITIES
         supported &= not trans_a
         # gfx950 (CDNA4) only: kernel uses mfma[_scale]_f32_16x16x128_f8f6f4.
-        supported &= get_device_compute_capability() >= (9, 5)
+        supported &= is_gfx950()
 
         if granularity == ScalingGranularity.MX_BLOCKWISE:
             # NT only; per-1x32 raw E8M0 scales; K % 128 == 0 and K >= 256.
@@ -604,6 +612,7 @@ class GroupedGEMMFP8VariableKTritonBackend(KernelBackend):
         else:
             # MXFP8 variable-K wgrad: both operands fp8 (e4m3/e5m2), and the kernel
             # expects the non-transposed (OUT_M, M_total) / (OUT_N, M_total) layout.
+            supported &= not is_gfx942()
             supported &= a.dtype in (float8_e4m3, float8_e5m2)
             supported &= b.dtype in (float8_e4m3, float8_e5m2)
             supported &= out_dtype in (torch.float16, torch.bfloat16)
@@ -713,7 +722,7 @@ class GroupedGEMMFP8VariableKFlyDSLBackend(KernelBackend):
         supported &= (a.dtype, b.dtype, out_dtype) in GroupedGEMMFP8VariableKFlyDSLBackend.SUPPORTED_DTYPES
         supported &= granularity in GroupedGEMMFP8VariableKFlyDSLBackend.SUPPORTED_GRANULARITIES
         # gfx950 (CDNA4) only: kernel uses mfma[_scale]_f32_16x16x128_f8f6f4.
-        supported &= get_device_compute_capability() >= (9, 5)
+        supported &= is_gfx950()
 
         if granularity == ScalingGranularity.MX_BLOCKWISE:
             # MXFP8 wgrad: non-transposed operands (TN), contraction M_total % 128 == 0.

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
@@ -14,30 +14,15 @@ from primus_turbo.pytorch.core.backend import (
     PrecisionType,
     TuneCache,
 )
-from primus_turbo.pytorch.core.utils import _get_device_compute_capability
-
-
-def _is_gfx950_device(device: torch.device) -> bool:
-    """Compute capability check bound to a specific tensor's device.
-
-    ``is_gfx950()`` inspects the *current* CUDA device via
-    ``torch.cuda.current_device()``, which is wrong when the tensor lives
-    on a different device than the ambient one (multi-GPU / mixed-arch
-    hosts). Route by the tensor's device instead.
-    """
-    if device.type != "cuda":
-        return False
-    return _get_device_compute_capability(device) == (9, 5)
-
-
-from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_ck_ws_heuristic import (
-    approximate_ck_standard_total_tiles,
-    compute_ck_variable_k_total_tiles,
-    resolve_ck_ws_local_per_xcd,
-)
+from primus_turbo.pytorch.core.utils import build_ck, is_gfx950, is_gfx1250
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
     BaseGroupedGEMMKernelDispatcher,
     BaseGroupedGEMMVariableKKernelDispatcher,
+)
+from primus_turbo.pytorch.kernels.grouped_gemm.ws_ck_heuristic import (
+    approximate_ck_standard_total_tiles,
+    compute_ck_variable_k_total_tiles,
+    resolve_ck_ws_local_per_xcd,
 )
 from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
     grouped_gemm_output_tail_kernel,
@@ -100,6 +85,8 @@ class GroupedGEMMCKBackend(KernelBackend):
         **kwargs,
     ) -> bool:
         supported = True
+        supported &= build_ck()
+        supported &= not is_gfx1250()
         supported &= a.dim() == 2 and b.dim() == 3
         supported &= a.dtype in _COMMON_SUPPORTED_DTYPES and b.dtype in _COMMON_SUPPORTED_DTYPES
         supported &= not trans_a
@@ -108,9 +95,7 @@ class GroupedGEMMCKBackend(KernelBackend):
         # broadcast slot, which fits on gfx950 (MI355X) but overflows
         # gfx942's 64 KB LDS budget. The device-side WS body is stubbed
         # out on gfx942, so refuse to dispatch WS to CK on that arch.
-        # Check the *tensor's* device (multi-GPU safe), not the ambient
-        # ``current_device()``.
-        if schedule == "work_steal" and not _is_gfx950_device(a.device):
+        if schedule == "work_steal" and not is_gfx950():
             supported = False
         return supported
 
@@ -177,13 +162,15 @@ class GroupedGEMMVariableKCKBackend(KernelBackend):
         **kwargs,
     ) -> bool:
         supported = True
+        supported &= build_ck()
+        supported &= not is_gfx1250()
         supported &= a.dim() == 2 and b.dim() == 2
         supported &= a.dtype in _COMMON_SUPPORTED_DTYPES and b.dtype in _COMMON_SUPPORTED_DTYPES
         supported &= trans_a and not trans_b
         supported &= schedule in _WS_SUPPORTED_SCHEDULES
         # See GroupedGEMMCKBackend.can_handle: the CK WS kernel is
-        # gfx950-only due to LDS budget. Route by the tensor's device.
-        if schedule == "work_steal" and not _is_gfx950_device(a.device):
+        # gfx950-only due to LDS budget.
+        if schedule == "work_steal" and not is_gfx950():
             supported = False
         return supported
 

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
@@ -15,14 +15,14 @@ from primus_turbo.pytorch.core.backend import (
     TuneCache,
 )
 from primus_turbo.pytorch.core.utils import build_ck, is_gfx950, is_gfx1250
-from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
-    BaseGroupedGEMMKernelDispatcher,
-    BaseGroupedGEMMVariableKKernelDispatcher,
-)
-from primus_turbo.pytorch.kernels.grouped_gemm.ws_ck_heuristic import (
+from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_ck_ws_heuristic import (
     approximate_ck_standard_total_tiles,
     compute_ck_variable_k_total_tiles,
     resolve_ck_ws_local_per_xcd,
+)
+from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
+    BaseGroupedGEMMKernelDispatcher,
+    BaseGroupedGEMMVariableKKernelDispatcher,
 )
 from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
     grouped_gemm_output_tail_kernel,

--- a/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
+++ b/primus_turbo/pytorch/kernels/quantization/quantization_impl.py
@@ -23,6 +23,7 @@ from primus_turbo.pytorch.core.low_precision import (
     check_mxfp4_support,
     check_mxfp8_support,
 )
+from primus_turbo.pytorch.core.utils import is_gfx1250
 from primus_turbo.triton.quantization.quant_blockwise import (
     dequant_fp8_blockwise_for_weight_kernel,
     dequant_fp8_blockwise_kernel,
@@ -525,6 +526,25 @@ def quantize_mxfp8_impl(
         assert axis is None, "The axis must be None when with_trans is True."
 
     if with_trans:
+        # FlyDSL dual-cast quant (raw E8M0 bit-matching the HIP dual, and faster): a 3D
+        # [B, M, K] input does all B experts in one launch, and ``use_2d_block`` (per 32x32
+        # tile scale, weights) is honored on both directions. Shuffled layouts fall through
+        # to HIP, as does gfx1250: the kernel is CDNA4-only but check_mxfp8_support accepts (12, 5).
+        fly_ok = (
+            not is_gfx1250()
+            and x.dtype in (torch.bfloat16, torch.float16)
+            and not scaling_recipe.shuffle_scale
+            and not scaling_recipe.shuffle_out
+            and not scaling_recipe_for_trans.shuffle_scale
+            and not scaling_recipe_for_trans.shuffle_out
+        )
+        if fly_ok:
+            x = x.contiguous()
+            row_2d = scaling_recipe.use_2d_block
+            col_2d = scaling_recipe_for_trans.use_2d_block
+            if x.ndim == 3:
+                return quant_mxfp8_raw_batched(x, out_dtype, row_2d=row_2d, col_2d=col_2d)
+            return quant_mxfp8_raw(x, out_dtype, row_2d=row_2d, col_2d=col_2d)
         return torch.ops.primus_turbo_cpp_extension.quantize_mxfp8_dual(
             x,
             out_dtype,
@@ -590,6 +610,22 @@ def grouped_quantize_mxfp8_impl(
             ScalingRecipe() if scaling_recipe_for_trans is None else scaling_recipe_for_trans
         )
 
+        # FlyDSL grouped dual quant, a drop-in for the HIP grouped dual on the recipes it
+        # supports. This is the A / grad_out (activation) operand quant, which is 1D
+        # per-32-block, so ``use_2d_block`` (weight-only) falls back to HIP along with the
+        # shuffled layouts and gfx1250 (CDNA4-only kernel, still cleared by check_mxfp8_support).
+        fly_ok = (
+            not is_gfx1250()
+            and x.dtype in (torch.bfloat16, torch.float16)
+            and not scaling_recipe.use_2d_block
+            and not scaling_recipe_for_trans.use_2d_block
+            and not scaling_recipe.shuffle_scale
+            and not scaling_recipe.shuffle_out
+            and not scaling_recipe_for_trans.shuffle_scale
+            and not scaling_recipe_for_trans.shuffle_out
+        )
+        if fly_ok:
+            return grouped_quant_mxfp8_raw(x.contiguous(), group_lens, group_offs, out_dtype)
         return torch.ops.primus_turbo_cpp_extension.grouped_quantize_mxfp8_dual(
             x,
             group_lens,
@@ -615,55 +651,6 @@ def grouped_quantize_mxfp8_impl(
             scaling_recipe.shuffle_scale,
             scaling_recipe.shuffle_out,
         )
-
-
-def quantize_mxfp8_flydsl_impl(
-    x: torch.Tensor,
-    out_dtype: torch.dtype,
-    block_size: int = MXFP8_BLOCK_SIZE,
-    scaling_recipe: Optional[ScalingRecipe] = None,
-    scaling_recipe_for_trans: Optional[ScalingRecipe] = None,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """FlyDSL dual-cast (row-wise + transposed col-wise) MXFP8 quant (gfx950), the MX GEMM operand
-    quant. Honors ``use_2d_block`` (per 32x32 tile scale, weights) on the row / col recipe; raw
-    E8M0 layout bit-matching the HIP quantize_mxfp8_dual. A 3D [B, M, K] input does all B experts
-    in one launch. Returns (row_fp8, row_scale, col_fp8, col_scale)."""
-    assert block_size == MXFP8_BLOCK_SIZE, f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
-    row_2d = bool(scaling_recipe is not None and scaling_recipe.use_2d_block)
-    col_2d = bool(scaling_recipe_for_trans is not None and scaling_recipe_for_trans.use_2d_block)
-    x = x.contiguous()
-    if x.ndim == 3:
-        return quant_mxfp8_raw_batched(x, out_dtype, row_2d=row_2d, col_2d=col_2d)
-    return quant_mxfp8_raw(x, out_dtype, row_2d=row_2d, col_2d=col_2d)
-
-
-def grouped_quantize_mxfp8_flydsl_impl(
-    x: torch.Tensor,
-    out_dtype: torch.dtype,
-    group_lens: torch.Tensor,
-    group_offs: torch.Tensor,
-    block_size: int = MXFP8_BLOCK_SIZE,
-    scaling_recipe: Optional[ScalingRecipe] = None,
-    scaling_recipe_for_trans: Optional[ScalingRecipe] = None,
-) -> Tuple[
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-    torch.Tensor,
-]:
-    """FlyDSL grouped dual-cast MXFP8 quant (gfx950), the A / grad_out (activation) operand quant
-    for the MX grouped GEMM. Returns the 8-tuple (rowwise fp8/scale, colwise fp8/scale, then
-    row-64 / col-128 padded lens/offs). Activation is 1D per-32-block; ``use_2d_block`` (weight-only)
-    is not applicable here (grouped weights go through ``quantize_mxfp8_flydsl_impl``)."""
-    assert block_size == MXFP8_BLOCK_SIZE, f"The block size must be {MXFP8_BLOCK_SIZE} for MXFP8 quantization"
-    assert not (scaling_recipe is not None and scaling_recipe.use_2d_block) and not (
-        scaling_recipe_for_trans is not None and scaling_recipe_for_trans.use_2d_block
-    ), "grouped activation quant does not support use_2d_block"
-    return grouped_quant_mxfp8_raw(x.contiguous(), group_lens, group_offs, out_dtype)
 
 
 def grouped_quantize_mxfp4_impl(
@@ -743,7 +730,8 @@ def grouped_quantize_mxfp4_impl(
         # the per-block recipes it supports. bf16 upcasts via the top-16-bits shift, fp16
         # via a real fpext; SR is supported (unbiased, not bit-exact); 2d-block -> HIP.
         fly_ok = (
-            not scaling_recipe.use_2d_block
+            not is_gfx1250()
+            and not scaling_recipe.use_2d_block
             and not scaling_recipe_for_trans.use_2d_block
             and x.dtype in (torch.bfloat16, torch.float16)
         )
@@ -789,7 +777,12 @@ def grouped_quantize_mxfp4_impl(
         # layout is identical to grouped_quantize_fp4_with_trans' colwise -- the wgrad
         # consumes both under one group_offs_padded_colwise, and the HIP single op pads
         # to a different alignment. Same fly_ok gate as the dual path (bf16 + fp16).
-        fly_ok = axis == 0 and not scaling_recipe.use_2d_block and x.dtype in (torch.bfloat16, torch.float16)
+        fly_ok = (
+            not is_gfx1250()
+            and axis == 0
+            and not scaling_recipe.use_2d_block
+            and x.dtype in (torch.bfloat16, torch.float16)
+        )
         if fly_ok:
             from primus_turbo.flydsl.quantization.mxfp4_grouped_quant import grouped_quant_mxfp4_raw
 
@@ -907,17 +900,17 @@ def quantize_mxfp4_impl(
     assert x.is_contiguous(), "The x tensor must be contiguous."
 
     if with_trans:
-        # FlyDSL dual quant (bit-exact vs the HIP dual for RTN): 3D [G,N,K] weight in one
-        # launch, 2D [R,C] dense. SR is supported (unbiased, not bit-exact); shuffle / fp16
-        # / unaligned dims fall through to HIP below.
-        from primus_turbo.flydsl.quantization.mxfp4_quant_kernel import (
-            dual3_eligible,
-            dual_eligible,
-            flydsl_dual_quant,
-            flydsl_dual_quant_batched,
-        )
+        # FlyDSL dual quant (bit-exact vs the HIP dual): 3D [G,N,K] weight in one launch,
+        # 2D [R,C] dense. SR / shuffle / fp16 / unaligned dims fall through to HIP below,
+        # as does gfx1250: the kernel is CDNA4-only but check_mxfp4_support accepts (12, 5).
+        if x.dtype == torch.bfloat16 and not is_gfx1250():
+            from primus_turbo.flydsl.quantization.mxfp4_quant_kernel import (
+                dual3_eligible,
+                dual_eligible,
+                flydsl_dual_quant,
+                flydsl_dual_quant_batched,
+            )
 
-        if x.dtype == torch.bfloat16:
             if x.ndim == 3 and dual3_eligible(
                 x.shape[1], x.shape[2], scaling_recipe, scaling_recipe_for_trans
             ):

--- a/primus_turbo/pytorch/ops/gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/gemm_fp8.py
@@ -27,7 +27,7 @@ from primus_turbo.pytorch.core.quantized_tensor import (
 )
 from primus_turbo.pytorch.core.utils import is_gfx942
 from primus_turbo.pytorch.kernels.gemm.gemm_fp8_impl import gemm_fp8_impl
-from primus_turbo.pytorch.kernels.quantization.quantization_impl import quantize_mxfp8_flydsl_impl
+from primus_turbo.pytorch.kernels.quantization.quantization_impl import quantize_mxfp8_impl
 from primus_turbo.pytorch.ops.quantization import (
     quantize_fp8,
     quantize_fp8_with_trans,
@@ -547,10 +547,12 @@ class FP8GemmMXFunction(torch.autograd.Function):
                 )
             a_col, a_col_scale = a_t.qdata, a_t.scale_inv
         else:
-            a_row, a_row_scale, a_col, a_col_scale = quantize_mxfp8_flydsl_impl(
+            a_row, a_row_scale, a_col, a_col_scale = quantize_mxfp8_impl(
                 a,
                 fp8_dtype,
-                block_size=block_size,
+                None,
+                block_size,
+                with_trans=True,
                 scaling_recipe=a_scaling_recipe,
                 scaling_recipe_for_trans=a_scaling_recipe,
             )
@@ -570,10 +572,12 @@ class FP8GemmMXFunction(torch.autograd.Function):
                 )
             b_col, b_col_scale = b_t.qdata, b_t.scale_inv
         else:
-            b_row, b_row_scale, b_col, b_col_scale = quantize_mxfp8_flydsl_impl(
+            b_row, b_row_scale, b_col, b_col_scale = quantize_mxfp8_impl(
                 b,
                 fp8_dtype,
-                block_size=block_size,
+                None,
+                block_size,
+                with_trans=True,
                 scaling_recipe=b_scaling_recipe,
                 scaling_recipe_for_trans=b_scaling_recipe,
             )
@@ -609,10 +613,12 @@ class FP8GemmMXFunction(torch.autograd.Function):
 
         # Dual-cast grad_out: one kernel emits both the row-wise (grad_a, NN->NT) and
         # col-wise (grad_b, TN->NT) directions -- no second single-direction pass.
-        g_row, g_row_scale, g_col, g_col_scale = quantize_mxfp8_flydsl_impl(
+        g_row, g_row_scale, g_col, g_col_scale = quantize_mxfp8_impl(
             grad_out,
             grad_out_dtype,
-            block_size=ctx.config.block_size,
+            None,
+            ctx.config.block_size,
+            with_trans=True,
             scaling_recipe=ScalingRecipe(),
             scaling_recipe_for_trans=ScalingRecipe(),
         )


### PR DESCRIPTION
# Description

Backend selection for GEMM, grouped GEMM and MX quantization relied on open-ended compute-capability comparisons such as `get_device_compute_capability() >= (9, 5)`.
On gfx1250 the capability tuple is `(12, 5)`, so every one of those checks silently evaluates to true and CDNA4-only kernels (FlyDSL `mfma[_scale]_f32_16x16x128_f8f6f4`, CK, Turbo) get dispatched onto an architecture that cannot run them.
The same class of hole exists on the low end: `check_mxfp8_support` / `check_mxfp4_support` clear gfx1250, and several MX paths were never excluded on gfx942, which has no MX support at all.

This PR replaces the ordered comparisons with explicit architecture guards (`is_gfx950()`, `is_gfx942()`, `is_gfx1250()`) so that each backend declares exactly the architectures it supports, and unsupported architectures fall back to a working backend instead of failing at kernel launch.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

### Device guards for GEMM backends

- `GEMMFP4FlyDSLBackend` / `GEMMFP8FlyDSLBackend`: replace `get_device_compute_capability() >= (9, 5)` with `is_gfx950()`, so gfx1250 no longer matches the CDNA4-only kernels.
- `GEMMFP8TurboBackend`: replace the `not is_gfx1250()` denylist with the `is_gfx950()` allowlist.
- `GEMMFP4AITERBackend`: restrict to gfx950, with a `TODO(ruibin)` for future gfx1250 enablement.
- `GEMMFP4HipBLASLtBackend`: exclude gfx942, which has no FP4 support.
- `GEMMFP8HipBLASLtBackend`: exclude gfx942 for `MX_BLOCKWISE` granularity only, leaving the other granularities untouched.
- `GEMMFP8CKBackend`: exclude gfx1250.

### Device guards for grouped GEMM backends

- `GroupedGEMMFP4FlyDSLBackend`, `GroupedGEMMFP4VariableKFlyDSLBackend`, `GroupedGEMMFP8FlyDSLBackend`, `GroupedGEMMFP8VariableKFlyDSLBackend`: same `>= (9, 5)` to `is_gfx950()` replacement.
- `GroupedGEMMFP8CKBackend` and `GroupedGEMMFP8VariableKCKBackend`: exclude gfx1250.
- `GroupedGEMMCKBackend` and `GroupedGEMMVariableKCKBackend`: exclude gfx1250 and add the missing `build_ck()` check, which was previously absent so the backend could be selected on builds compiled without CK.
- `GroupedGEMMFP4TritonBackend` (`MX_BLOCKWISE`), `GroupedGEMMFP4VariableKTritonBackend`, `GroupedGEMMFP8TritonBackend` (MXFP8 branch) and `GroupedGEMMFP8VariableKTritonBackend` (MXFP8 wgrad branch): exclude gfx942.
- Remove the local `_is_gfx950_device(device)` helper in `grouped_gemm_impl.py` and route the CK work-steal LDS check through the shared `is_gfx950()`.

### Quantization

- Inline `quantize_mxfp8_flydsl_impl` and `grouped_quantize_mxfp8_flydsl_impl` into `quantize_mxfp8_impl` and `grouped_quantize_mxfp8_impl` as a guarded `fly_ok` fast path, and delete the two standalone functions.
  The FlyDSL kernels are CDNA4-only while `check_mxfp8_support` accepts `(12, 5)`, so gfx1250 (along with shuffled layouts, non-bf16/fp16 dtypes and `use_2d_block` on the grouped activation path) now falls through to the HIP dual-cast op.
- Add the same `not is_gfx1250()` condition to the FlyDSL `fly_ok` gates in `grouped_quantize_mxfp4_impl` (both the dual and the single-direction path) and in `quantize_mxfp4_impl`.
- In `quantize_mxfp4_impl`, hoist the `x.dtype == torch.bfloat16 and not is_gfx1250()` check above the FlyDSL import so the import is skipped entirely when the fast path is not eligible.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
