### PR TITLE
perf(quantization): use pack16 for aligned tensorwise FP8 casts

### DIFF
--- a/csrc/include/primus_turbo/device/utils.cuh
+++ b/csrc/include/primus_turbo/device/utils.cuh
@@ -16,8 +16,9 @@ using namespace primus_turbo::dtype;
 // TODO: ASM
 template <typename T, const int N> PRIMUS_TURBO_DEVICE void load_data(const T *src, T *dst) {
     constexpr int BYTES = N * sizeof(T);
-    static_assert(BYTES == 1 || BYTES == 2 || BYTES == 4 || BYTES == 8 || BYTES == 16,
-                  "Only 1/2/4/8/16 bytes are supported.");
+    static_assert(BYTES == 1 || BYTES == 2 || BYTES == 4 || BYTES == 8 || BYTES == 16 ||
+                      BYTES == 32,
+                  "Only 1/2/4/8/16/32 bytes are supported.");
     if constexpr (BYTES == 1) {
         *reinterpret_cast<uint8 *>(dst) = *(reinterpret_cast<const uint8 *>(src));
     } else if constexpr (BYTES == 2) {
@@ -28,6 +29,9 @@ template <typename T, const int N> PRIMUS_TURBO_DEVICE void load_data(const T *s
         *reinterpret_cast<uint64 *>(dst) = *(reinterpret_cast<const uint64 *>(src));
     } else if constexpr (BYTES == 16) {
         *reinterpret_cast<uint4 *>(dst) = *(reinterpret_cast<const uint4 *>(src));
+    } else if constexpr (BYTES == 32) {
+        reinterpret_cast<uint4 *>(dst)[0] = reinterpret_cast<const uint4 *>(src)[0];
+        reinterpret_cast<uint4 *>(dst)[1] = reinterpret_cast<const uint4 *>(src)[1];
     }
 }
 

--- a/csrc/kernels/quantization/quantization_tensorwise.cu
+++ b/csrc/kernels/quantization/quantization_tensorwise.cu
@@ -63,12 +63,11 @@ void quantize_tensorwise_impl(const FType *x, const float *scale, QType *y, cons
     // their existing dispatch widths.
     constexpr int32_t PACK16 = 16;
     if constexpr (sizeof(FType) * PACK16 == 32 && sizeof(QType) * PACK16 == 16) {
-        const bool aligned = reinterpret_cast<uintptr_t>(x) % 32 == 0 &&
-                             reinterpret_cast<uintptr_t>(y) % 16 == 0;
+        const bool aligned =
+            reinterpret_cast<uintptr_t>(x) % 32 == 0 && reinterpret_cast<uintptr_t>(y) % 16 == 0;
         if (aligned) {
             PackedEltwiseConfig pack_cfg(n, PACK16, BLOCK_SIZE);
-            unary_kernel<BLOCK_SIZE, PACK16, FType, QType,
-                         QuantTensorwiseScalePtrOp<ComputeType>>
+            unary_kernel<BLOCK_SIZE, PACK16, FType, QType, QuantTensorwiseScalePtrOp<ComputeType>>
                 <<<pack_cfg.nBlock, BLOCK_SIZE, 0, stream>>>(x, y, op, pack_cfg);
             return;
         }

--- a/csrc/kernels/quantization/quantization_tensorwise.cu
+++ b/csrc/kernels/quantization/quantization_tensorwise.cu
@@ -57,6 +57,23 @@ void quantize_tensorwise_impl(const FType *x, const float *scale, QType *y, cons
 
     const int32_t BLOCK_SIZE = 512;
 
+    // Tensorwise BF16/FP16 -> FP8 can process 16 elements per thread with a
+    // 32-byte input load and a 16-byte output store. Keep this selection local
+    // so the shared memory-pack limits, dequantize, and other recipes stay on
+    // their existing dispatch widths.
+    constexpr int32_t PACK16 = 16;
+    if constexpr (sizeof(FType) * PACK16 == 32 && sizeof(QType) * PACK16 == 16) {
+        const bool aligned = reinterpret_cast<uintptr_t>(x) % 32 == 0 &&
+                             reinterpret_cast<uintptr_t>(y) % 16 == 0;
+        if (aligned) {
+            PackedEltwiseConfig pack_cfg(n, PACK16, BLOCK_SIZE);
+            unary_kernel<BLOCK_SIZE, PACK16, FType, QType,
+                         QuantTensorwiseScalePtrOp<ComputeType>>
+                <<<pack_cfg.nBlock, BLOCK_SIZE, 0, stream>>>(x, y, op, pack_cfg);
+            return;
+        }
+    }
+
     int32_t pack_size = std::min(get_pack_size<FType>(x), get_pack_size<QType>(y));
     switch (pack_size) {
     case 8: {

--- a/tests/pytorch/ops/test_quantization.py
+++ b/tests/pytorch/ops/test_quantization.py
@@ -28,15 +28,41 @@ from tests.pytorch.ref.quantization_ref import dequantize_fp8_ref, quantize_fp8_
 from tests.pytorch.test_utils import get_tolerances
 
 
-@pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16, torch.float32])
 @pytest.mark.parametrize("dest_dtype", [turbo.float8_e4m3, turbo.float8_e5m2])
-@pytest.mark.parametrize("numel", [6 * 1 * 7168 * 8192])
-@pytest.mark.parametrize("torch_compile", [True, False])
+@pytest.mark.parametrize(
+    "orig_dtype,numel,torch_compile,check_unaligned_fallback",
+    [
+        (orig_dtype, 6 * 1 * 7168 * 8192, torch_compile, False)
+        for orig_dtype in [torch.bfloat16, torch.float16, torch.float32]
+        for torch_compile in [True, False]
+    ]
+    + [
+        (orig_dtype, numel, False, True)
+        for orig_dtype in [torch.bfloat16, torch.float16]
+        for numel in [15, 16, 17, 2880, 2881]
+    ],
+)
 @pytest.mark.parametrize("granularity", [ScalingGranularity.TENSORWISE])
-def test_quantize_fp8_tensorwise(orig_dtype, dest_dtype, numel, torch_compile, granularity):
+def test_quantize_fp8_tensorwise(
+    orig_dtype,
+    dest_dtype,
+    numel,
+    torch_compile,
+    check_unaligned_fallback,
+    granularity,
+):
     torch.manual_seed(42)
 
     x = torch.rand(numel, device="cuda", dtype=orig_dtype)
+    if check_unaligned_fallback:
+        storage = torch.empty(numel + 1, device="cuda", dtype=orig_dtype)
+        x_unaligned = storage[1:]
+        x_unaligned.copy_(x)
+
+        assert x.data_ptr() % 32 == 0
+        assert x_unaligned.is_contiguous()
+        assert x_unaligned.data_ptr() % 32 != 0
+
     x_ref = x.detach().clone()
     x_fp8_ref, x_scale_ref, x_scale_inv_ref = quantize_fp8_ref(x_ref, dest_dtype, granularity)
 
@@ -63,32 +89,16 @@ def test_quantize_fp8_tensorwise(orig_dtype, dest_dtype, numel, torch_compile, g
     x_dq_ref = dequantize_fp8_ref(x_fp8_ref, orig_dtype, granularity, scale_inv=x_scale_inv_ref)
     torch.testing.assert_close(x_dq, x_dq_ref, **get_tolerances(dest_dtype))
 
+    if check_unaligned_fallback:
+        x_fp8_fallback, x_scale_inv_fallback = quantize_fp8(
+            x_unaligned,
+            dest_dtype,
+            granularity=granularity,
+        )
 
-@pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("dest_dtype", [turbo.float8_e4m3, turbo.float8_e5m2])
-@pytest.mark.parametrize("numel", [15, 16, 17, 2880, 2881])
-def test_quantize_fp8_tensorwise_pack16_matches_unaligned_fallback(orig_dtype, dest_dtype, numel):
-    """The aligned pack16 path must be byte-exact with the legacy fallback."""
-    torch.manual_seed(42)
-    x = torch.rand(numel, device="cuda", dtype=orig_dtype)
-    storage = torch.empty(numel + 1, device="cuda", dtype=orig_dtype)
-    x_unaligned = storage[1:]
-    x_unaligned.copy_(x)
-
-    assert x.data_ptr() % 32 == 0
-    assert x_unaligned.is_contiguous()
-    assert x_unaligned.data_ptr() % 32 != 0
-
-    x_fp8, x_scale_inv = quantize_fp8(x, dest_dtype, granularity=ScalingGranularity.TENSORWISE)
-    x_fp8_fallback, x_scale_inv_fallback = quantize_fp8(
-        x_unaligned,
-        dest_dtype,
-        granularity=ScalingGranularity.TENSORWISE,
-    )
-
-    assert x_fp8.data_ptr() % 16 == 0
-    assert torch.equal(x_fp8.view(torch.uint8), x_fp8_fallback.view(torch.uint8))
-    torch.testing.assert_close(x_scale_inv, x_scale_inv_fallback, rtol=0, atol=0)
+        assert x_fp8.data_ptr() % 16 == 0
+        assert torch.equal(x_fp8.view(torch.uint8), x_fp8_fallback.view(torch.uint8))
+        torch.testing.assert_close(x_scale_inv, x_scale_inv_fallback, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16, torch.float32])

--- a/tests/pytorch/ops/test_quantization.py
+++ b/tests/pytorch/ops/test_quantization.py
@@ -64,6 +64,33 @@ def test_quantize_fp8_tensorwise(orig_dtype, dest_dtype, numel, torch_compile, g
     torch.testing.assert_close(x_dq, x_dq_ref, **get_tolerances(dest_dtype))
 
 
+@pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dest_dtype", [turbo.float8_e4m3, turbo.float8_e5m2])
+@pytest.mark.parametrize("numel", [15, 16, 17, 2880, 2881])
+def test_quantize_fp8_tensorwise_pack16_matches_unaligned_fallback(orig_dtype, dest_dtype, numel):
+    """The aligned pack16 path must be byte-exact with the legacy fallback."""
+    torch.manual_seed(42)
+    x = torch.rand(numel, device="cuda", dtype=orig_dtype)
+    storage = torch.empty(numel + 1, device="cuda", dtype=orig_dtype)
+    x_unaligned = storage[1:]
+    x_unaligned.copy_(x)
+
+    assert x.data_ptr() % 32 == 0
+    assert x_unaligned.is_contiguous()
+    assert x_unaligned.data_ptr() % 32 != 0
+
+    x_fp8, x_scale_inv = quantize_fp8(x, dest_dtype, granularity=ScalingGranularity.TENSORWISE)
+    x_fp8_fallback, x_scale_inv_fallback = quantize_fp8(
+        x_unaligned,
+        dest_dtype,
+        granularity=ScalingGranularity.TENSORWISE,
+    )
+
+    assert x_fp8.data_ptr() % 16 == 0
+    assert torch.equal(x_fp8.view(torch.uint8), x_fp8_fallback.view(torch.uint8))
+    torch.testing.assert_close(x_scale_inv, x_scale_inv_fallback, rtol=0, atol=0)
+
+
 @pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16, torch.float32])
 @pytest.mark.parametrize("dest_dtype", [turbo.float8_e4m3, turbo.float8_e5m2])
 @pytest.mark.parametrize("granularity", [ScalingGranularity.TENSORWISE])


### PR DESCRIPTION
## Summary
- use 16-element vectorization for aligned BF16/FP16-to-FP8 tensorwise casts
- keep the wider dispatch local so dequantization and other scaling recipes retain their current pack widths
- cover aligned pack16, unaligned fallback, and partial-tail sizes for E4M3/E5M2

## Test plan
- [x] `git diff --check`
- [x] `python3 -m py_compile tests/pytorch/ops/test_quantization.py`
- [ ] `python3 -m pytest tests/pytorch/ops/test_quantization.py -k tensorwise_pack16 -q` (local environment lacks pytest and a ROCm PyTorch runtime)