### PR TITLE
feat: support auto tune on different ops

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -661,18 +661,17 @@ GlobalBackendManager.reset()
 
 `set_auto_tune(True)` turns AutoTune on for every operator. To auto-tune a single
 operator (or a single precision of it) while leaving everything else alone, pass
-`BackendType.AUTOTUNE` where you would normally name a backend:
+`auto_tune=True` instead of naming a backend:
 
 ```python
-from primus_turbo.pytorch.core.backend import BackendType, GlobalBackendManager, PrecisionType
+from primus_turbo.pytorch.core.backend import GlobalBackendManager, PrecisionType
 
 # AutoTune FP8 GEMM only; other precisions keep their defaults.
-GlobalBackendManager.set_gemm_backend(BackendType.AUTOTUNE, PrecisionType.FP8)
+GlobalBackendManager.set_gemm_backend(auto_tune=True, precision=PrecisionType.FP8)
 ```
 
-NOTE: `BackendType.AUTOTUNE` is only accepted by operators that register an
-`AutoTuneEntry` (currently GEMM and Grouped GEMM). MoE dispatch/combine does not
-support it.
+NOTE: a backend and `auto_tune=True` are mutually exclusive. MoE dispatch/combine
+does not support AutoTune at all.
 
 ### 5.3 Environment Variables
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -591,7 +591,7 @@ Priority (high to low):
 
 1. Code settings (`GlobalBackendManager.set_*_backend(...)`)
 2. Environment variables (`PRIMUS_TURBO_*_BACKEND`)
-3. AutoTune (`PRIMUS_TURBO_AUTO_TUNE=1`)
+3. AutoTune (`PRIMUS_TURBO_AUTO_TUNE=1`, or `PRIMUS_TURBO_*_BACKEND=autotune` for a single operator)
 4. Operator defaults
 5. Fallback: try all registered backends
 
@@ -659,6 +659,21 @@ print(out.shape)
 GlobalBackendManager.reset()
 ```
 
+`set_auto_tune(True)` turns AutoTune on for every operator. To auto-tune a single
+operator (or a single precision of it) while leaving everything else alone, pass
+`BackendType.AUTOTUNE` where you would normally name a backend:
+
+```python
+from primus_turbo.pytorch.core.backend import BackendType, GlobalBackendManager, PrecisionType
+
+# AutoTune FP8 GEMM only; other precisions keep their defaults.
+GlobalBackendManager.set_gemm_backend(BackendType.AUTOTUNE, PrecisionType.FP8)
+```
+
+NOTE: `BackendType.AUTOTUNE` is only accepted by operators that register an
+`AutoTuneEntry` (currently GEMM and Grouped GEMM). MoE dispatch/combine does not
+support it.
+
 ### 5.3 Environment Variables
 
 You can also control backend selection and AutoTune via environment variables:
@@ -668,4 +683,16 @@ export PRIMUS_TURBO_AUTO_TUNE=1
 export PRIMUS_TURBO_GEMM_BACKEND=HIPBLASLT
 export PRIMUS_TURBO_GROUPED_GEMM_BACKEND=CK
 export PRIMUS_TURBO_MOE_DISPATCH_COMBINE_BACKEND=DEEP_EP
+```
+
+`PRIMUS_TURBO_*_BACKEND` also accepts `autotune` as a backend name, which enables
+AutoTune for that operator alone instead of the whole library. It composes with
+the per-precision syntax:
+
+```bash
+# AutoTune GEMM at every precision.
+export PRIMUS_TURBO_GEMM_BACKEND=autotune
+
+# AutoTune FP8 Grouped GEMM only; every other precision uses CK.
+export PRIMUS_TURBO_GROUPED_GEMM_BACKEND=fp8:autotune,other:ck
 ```

--- a/primus_turbo/common/constants.py
+++ b/primus_turbo/common/constants.py
@@ -17,6 +17,8 @@ ENV_LOG_LEVEL = "PRIMUS_TURBO_LOG_LEVEL"
 
 # GEMM backend selection (e.g. HIPBLASLT, AITER).
 # Supports per-precision format: "FP4:HIPBLASLT,FP8:AITER" or a single value.
+# Any backend slot also accepts "autotune" to auto-tune that precision only,
+# e.g. "autotune" or "FP8:autotune,other:HIPBLASLT".
 # Default: None (auto-select)
 ENV_GEMM_BACKEND = "PRIMUS_TURBO_GEMM_BACKEND"
 
@@ -25,10 +27,13 @@ ENV_GEMM_BACKEND = "PRIMUS_TURBO_GEMM_BACKEND"
 ENV_GROUPED_GEMM_BACKEND = "PRIMUS_TURBO_GROUPED_GEMM_BACKEND"
 
 # MoE dispatch/combine EP backend (TURBO, DEEP_EP, or custom names like UCCL_EP).
+# Auto-tune is not supported here; "autotune" raises an AssertionError.
 # Default: TURBO
 ENV_MOE_DISPATCH_COMBINE_BACKEND = "PRIMUS_TURBO_MOE_DISPATCH_COMBINE_BACKEND"
 
 # Enable auto-tuning across registered kernel backends ("1" to enable).
+# Global switch: it turns auto-tune on for every op. An explicit per-op backend
+# (e.g. "<OP>_BACKEND=HIPBLASLT") still takes precedence over it.
 # Default: "0" (disabled)
 ENV_AUTO_TUNE = "PRIMUS_TURBO_AUTO_TUNE"
 

--- a/primus_turbo/pytorch/core/backend.py
+++ b/primus_turbo/pytorch/core/backend.py
@@ -30,7 +30,7 @@ except ImportError:
 
 
 __all__ = [
-    "AutoTuneEntry",
+    "BackendChoice",
     "BackendEntry",
     "BackendType",
     "GlobalBackendManager",
@@ -56,6 +56,8 @@ _PRECISION_TYPE_MAPPING = {
 }
 _PRECISION_TYPE_SET = set(_PRECISION_TYPE_MAPPING.values())
 _OTHER_PRECISION_HOLDER = "OTHER"
+# Accepted wherever a backend name is, to auto-tune that op/precision alone.
+_AUTO_TUNE_HOLDER = "AUTOTUNE"
 
 
 class BackendType(Enum):
@@ -66,9 +68,12 @@ class BackendType(Enum):
     DEEP_EP = auto()
     TURBO = auto()
     FLYDSL = auto()
-    # Not a kernel provider: asks the dispatcher to profile and pick one of the
-    # real backends. Only valid for ops that register an ``AutoTuneEntry``.
-    AUTOTUNE = auto()
+
+
+@dataclass
+class BackendChoice:
+    backend: Optional[BackendType] = None
+    auto_tune: bool = False
 
 
 class GlobalBackendManager:
@@ -78,20 +83,32 @@ class GlobalBackendManager:
     Priority (high to low):
     1. Code settings - set_gemm_backend(), etc.
     2. Environment variables - PRIMUS_TURBO_GEMM_BACKEND, etc.
-    3. Auto-tune - PRIMUS_TURBO_AUTO_TUNE=1 for every op, or BackendType.AUTOTUNE
-       via 1./2. to auto-tune a single op/precision.
+    3. Auto-tune - PRIMUS_TURBO_AUTO_TUNE=1 for every op, or
+       set_*_backend(auto_tune=True) to auto-tune a single op/precision.
     4. Code defaults
     5. Fallback: try all backends
     """
 
-    _gemm_backend: Dict[PrecisionType, Optional[BackendType]] = None
-    _grouped_gemm_backend: Dict[PrecisionType, Optional[BackendType]] = None
-    _moe_dispatch_combine_backend: Dict[PrecisionType, Optional[BackendType]] = None
+    _gemm_backend: Optional[Dict[PrecisionType, BackendChoice]] = None
+    _grouped_gemm_backend: Optional[Dict[PrecisionType, BackendChoice]] = None
+    _moe_dispatch_combine_backend: Optional[Dict[PrecisionType, BackendChoice]] = None
     _auto_tune: Optional[bool] = None
-    _env_cache: Dict[str, Dict["PrecisionType", "BackendType"]] = {}
+    _env_cache: Dict[str, Dict["PrecisionType", "BackendChoice"]] = {}
+
+    @staticmethod
+    def _parse_backend_choice(name: str) -> BackendChoice:
+        """Turn one backend name from an env var into a ``BackendChoice``.
+
+        Raises ``KeyError`` for names that are neither ``AUTOTUNE`` nor a
+        ``BackendType`` member; callers decide whether that is fatal.
+        """
+        name = name.strip().upper()
+        if name == _AUTO_TUNE_HOLDER:
+            return BackendChoice(auto_tune=True)
+        return BackendChoice(backend=BackendType[name])
 
     @classmethod
-    def _extract_backend_from_env(cls, env_value: str) -> Dict[PrecisionType, BackendType]:
+    def _extract_backend_from_env(cls, env_value: str) -> Dict[PrecisionType, BackendChoice]:
         """
         Extract the backend from the environment variable.
         Support formats. Example:
@@ -99,7 +116,8 @@ class GlobalBackendManager:
         2. ENV_KEY=<precision1>:<backend1>,<precision2>:<backend2>,... -> Each precision uses a different backend
         3. ENV_KEY=<precision1>:<backend1>,other:<backend2>,... -> precision1 use backend1, other precisions use backend2
 
-        Precision types are defined in the _PRECISION_TYPE_MAPPING.
+        Precision types are defined in the _PRECISION_TYPE_MAPPING. Any backend
+        slot also accepts "autotune" to auto-tune that precision alone.
         """
         if env_value in cls._env_cache:
             return cls._env_cache[env_value]
@@ -117,10 +135,12 @@ class GlobalBackendManager:
                 precision, backend = pair.split(":")
                 precision, backend = precision.strip().upper(), backend.strip().upper()
                 if precision == _OTHER_PRECISION_HOLDER:
-                    other_precision_backend = BackendType[backend]
+                    other_precision_backend = cls._parse_backend_choice(backend)
                     continue
                 assert precision in _PRECISION_TYPE_MAPPING, f"Precision {precision} not supported."
-                precision_backend_dict[_PRECISION_TYPE_MAPPING[precision]] = BackendType[backend]
+                precision_backend_dict[_PRECISION_TYPE_MAPPING[precision]] = cls._parse_backend_choice(
+                    backend
+                )
 
             # Set rest precisions to the other precision backend
             for precision in _PRECISION_TYPE_MAPPING.values():
@@ -128,8 +148,9 @@ class GlobalBackendManager:
                     precision_backend_dict[precision] = other_precision_backend
         else:
             # Parse format 1: ENV_KEY=backend -> All precison use the same backend
+            choice = cls._parse_backend_choice(env_value)
             for value in _PRECISION_TYPE_MAPPING.values():
-                precision_backend_dict[value] = BackendType[env_value.upper()]
+                precision_backend_dict[value] = choice
 
         cls._env_cache[env_value] = precision_backend_dict
         return precision_backend_dict
@@ -145,43 +166,97 @@ class GlobalBackendManager:
         """
         cls._env_cache.clear()
 
+    @staticmethod
+    def _updated_backend_table(
+        table: Optional[Dict[PrecisionType, BackendChoice]],
+        backend: Optional[BackendType],
+        precision: Optional[PrecisionType],
+        auto_tune: bool,
+    ) -> Dict[PrecisionType, BackendChoice]:
+        """Build the per-precision table produced by one ``set_*_backend`` call.
+
+        ``precision=None`` applies the choice to every precision; otherwise only
+        that precision is updated and the rest of ``table`` is kept.
+        """
+        if auto_tune:
+            assert backend is None, "Backend must be None when auto-tune is enabled"
+
+        choice = BackendChoice(backend=backend, auto_tune=auto_tune)
+        if precision is None:
+            return {p: choice for p in _PRECISION_TYPE_SET}
+
+        table = table if table is not None else {}
+        table[precision] = choice
+        return table
+
+    @classmethod
+    def _backend_from_env(
+        cls, env_key: str, precision: PrecisionType, allow_unknown_backend: bool = False
+    ) -> Optional[BackendChoice]:
+        """Read one precision's backend out of ``env_key``. None if unset or unusable.
+
+        With ``allow_unknown_backend``, a name that is not a ``BackendType`` yields
+        None instead of raising, for ops whose backends are not all modelled by the
+        enum (MoE dispatch/combine accepts custom EP names such as ``UCCL_EP``).
+        """
+        env_value = os.environ.get(env_key, None)
+        # Treat an empty / whitespace-only env var as missing (else
+        # _extract_backend_from_env raises KeyError on BackendType['']).
+        if env_value is None or not env_value.strip():
+            return None
+
+        try:
+            choice = cls._extract_backend_from_env(env_value).get(precision, None)
+        except KeyError:
+            if allow_unknown_backend:
+                return None
+            raise
+
+        if choice is None:
+            logger.warning(
+                f"Precision {precision.name} not found in the environment variable {env_key}. "
+                f"Using default backend.",
+                once=True,
+            )
+            return None
+
+        return choice
+
     @classmethod
     def set_gemm_backend(
-        cls, backend: Optional[BackendType] = None, precision: Optional[PrecisionType] = None
+        cls,
+        backend: Optional[BackendType] = None,
+        precision: Optional[PrecisionType] = None,
+        auto_tune: bool = False,
     ) -> None:
         """Set the GEMM backend in code."""
-        if backend is None:
-            cls._gemm_backend = None
-            return
-
-        if cls._gemm_backend is None:
-            cls._gemm_backend = {}
-
-        # backend is not None
-        if precision is None:
-            # preicision is None -> set all precisions to the same backend
-            cls._gemm_backend = {precision: backend for precision in _PRECISION_TYPE_SET}
-        else:
-            cls._gemm_backend[precision] = backend
+        cls._gemm_backend = cls._updated_backend_table(cls._gemm_backend, backend, precision, auto_tune)
 
     @classmethod
     def set_grouped_gemm_backend(
-        cls, backend: Optional[BackendType] = None, precision: Optional[PrecisionType] = None
+        cls,
+        backend: Optional[BackendType] = None,
+        precision: Optional[PrecisionType] = None,
+        auto_tune: bool = False,
     ) -> None:
         """Set the Grouped GEMM backend in code."""
-        if backend is None:
-            cls._grouped_gemm_backend = None
-            return
+        cls._grouped_gemm_backend = cls._updated_backend_table(
+            cls._grouped_gemm_backend, backend, precision, auto_tune
+        )
 
-        if cls._grouped_gemm_backend is None:
-            cls._grouped_gemm_backend = {}
+    @classmethod
+    def set_moe_dispatch_combine_backend(
+        cls,
+        backend: Optional[BackendType] = None,
+        precision: Optional[PrecisionType] = None,
+        auto_tune: bool = False,
+    ) -> None:
+        """Set the MoE dispatch/combine backend in code."""
+        assert auto_tune is False, "Auto-tune is not supported for MOE dispatch combine backend"
 
-        # backend is not None
-        if precision is None:
-            # preicision is None -> set all precisions to the same backend
-            cls._grouped_gemm_backend = {precision: backend for precision in _PRECISION_TYPE_SET}
-        else:
-            cls._grouped_gemm_backend[precision] = backend
+        cls._moe_dispatch_combine_backend = cls._updated_backend_table(
+            cls._moe_dispatch_combine_backend, backend, precision, auto_tune
+        )
 
     @classmethod
     def set_auto_tune(cls, enabled: Optional[bool]) -> None:
@@ -189,45 +264,22 @@ class GlobalBackendManager:
         cls._auto_tune = enabled
 
     @classmethod
-    def get_gemm_backend(cls, precision: PrecisionType) -> Optional[BackendType]:
+    def get_gemm_backend(cls, precision: PrecisionType) -> Optional[BackendChoice]:
         """Get the GEMM backend configuration. Returns None if not set."""
         if cls._gemm_backend is not None:
-            return cls._gemm_backend[precision]
-        env_value = os.environ.get(ENV_GEMM_BACKEND, None)
-        # Treat an empty / whitespace-only env var as missing (else
-        # _extract_backend_from_env raises KeyError on BackendType['']).
-        if env_value is not None and env_value.strip():
-            backend = cls._extract_backend_from_env(env_value).get(precision, None)
-            if backend is None:
-                logger.warning(
-                    f"Precision {precision.name} not found in the environment variable {ENV_GEMM_BACKEND}. "
-                    f"Using default backend.",
-                    once=True,
-                )
-            return backend
-
-        return None
+            # .get(): setting one precision leaves the others unconfigured.
+            return cls._gemm_backend.get(precision)
+        return cls._backend_from_env(ENV_GEMM_BACKEND, precision)
 
     @classmethod
-    def get_grouped_gemm_backend(cls, precision: PrecisionType) -> Optional[BackendType]:
+    def get_grouped_gemm_backend(cls, precision: PrecisionType) -> Optional[BackendChoice]:
         """Get the Grouped GEMM backend configuration. Returns None if not set."""
         if cls._grouped_gemm_backend is not None:
-            return cls._grouped_gemm_backend[precision]
-        env_value = os.environ.get(ENV_GROUPED_GEMM_BACKEND, None)
-        if env_value is not None and env_value.strip():
-            backend = cls._extract_backend_from_env(env_value).get(precision, None)
-            if backend is None:
-                logger.warning(
-                    f"Precision {precision.name} not found in the environment variable "
-                    f"{ENV_GROUPED_GEMM_BACKEND}. Using default backend.",
-                    once=True,
-                )
-            return backend
-
-        return None
+            return cls._grouped_gemm_backend.get(precision)
+        return cls._backend_from_env(ENV_GROUPED_GEMM_BACKEND, precision)
 
     @classmethod
-    def get_moe_dispatch_combine_backend(cls, precision: PrecisionType) -> Optional[BackendType]:
+    def get_moe_dispatch_combine_backend(cls, precision: PrecisionType) -> Optional[BackendChoice]:
         """Get the MoE dispatch combine backend configuration. Returns None if not set.
 
         If the environment variable contains a value that is not a valid ``BackendType``
@@ -235,43 +287,33 @@ class GlobalBackendManager:
         the EP-specific backend registry in ``moe_dispatch_combine_impl`` can handle it.
         """
         if cls._moe_dispatch_combine_backend is not None:
-            return cls._moe_dispatch_combine_backend[precision]
-        env_value = os.environ.get(ENV_MOE_DISPATCH_COMBINE_BACKEND, None)
-        if env_value is not None and env_value.strip():
-            try:
-                backend = cls._extract_backend_from_env(env_value).get(precision, None)
-            except KeyError:
-                return None
+            return cls._moe_dispatch_combine_backend.get(precision)
 
-            if backend is None:
-                logger.warning(
-                    f"Precision {precision.name} not found in the environment variable "
-                    f"{ENV_MOE_DISPATCH_COMBINE_BACKEND}. Using default backend.",
-                    once=True,
-                )
+        choice = cls._backend_from_env(
+            ENV_MOE_DISPATCH_COMBINE_BACKEND, precision, allow_unknown_backend=True
+        )
+        if choice is None:
+            return None
 
-            # Dispatch/combine picks an EP backend that owns persistent communication
-            # buffers, so there is nothing to profile and swap per call.
-            assert backend != BackendType.AUTOTUNE, (
-                f"{ENV_MOE_DISPATCH_COMBINE_BACKEND}=AUTOTUNE is not supported: "
-                "MoE dispatch/combine has no auto-tune path."
+        # Dispatch/combine picks an EP backend that owns persistent communication
+        # buffers, so there is nothing to profile and swap per call.
+        assert not choice.auto_tune, (
+            f"{ENV_MOE_DISPATCH_COMBINE_BACKEND}=AUTOTUNE is not supported: "
+            "MoE dispatch/combine has no auto-tune path."
+        )
+
+        if choice.backend == BackendType.DEEP_EP:
+            assert HAVE_DEEP_EP, (
+                "DeepEP is required for this module. Install from https://github.com/uccl-project/uccl or https://github.com/ROCm/DeepEP"
             )
-
-            if backend == BackendType.DEEP_EP:
-                assert HAVE_DEEP_EP, (
-                    "DeepEP is required for this module. Install from https://github.com/uccl-project/uccl or https://github.com/ROCm/DeepEP"
-                )
-            return backend
-
-        return None
+        return choice
 
     @classmethod
     def auto_tune_enabled(cls) -> bool:
         """Check whether the global auto-tune switch is on.
 
         This is the process-wide switch only; an op may still be auto-tuned
-        through a per-op ``BackendType.AUTOTUNE`` request while this returns
-        False.
+        through a per-op request while this returns False.
         """
         if cls._auto_tune is not None:
             return cls._auto_tune
@@ -306,41 +348,14 @@ class BackendEntry:
     """Metadata wrapper for a registered kernel backend.
 
     Attributes:
-        impl: The kernel backend class, or None for a marker entry that carries
-              no kernel (see ``AutoTuneEntry``). Guard every use with
-              ``is_executable``.
+        impl: The kernel backend class.
         autotune: Whether this backend participates in auto-tuning.
                   Backends with autotune=False can still be selected via
                   explicit user configuration or as a fallback.
     """
 
-    impl: Optional[Type[KernelBackend]]
+    impl: Type[KernelBackend]
     autotune: bool = True
-
-    @property
-    def is_executable(self) -> bool:
-        """False for marker entries such as ``AutoTuneEntry`` that carry no kernel."""
-        return self.impl is not None
-
-
-@dataclass(frozen=True)
-class AutoTuneEntry(BackendEntry):
-    """Marker entry that opts an op into ``BackendType.AUTOTUNE``.
-
-    Register it as ``BackendType.AUTOTUNE: AutoTuneEntry()`` to let users request
-    auto-tuning for that op alone (``PRIMUS_TURBO_<OP>_BACKEND=autotune`` or
-    ``set_*_backend(BackendType.AUTOTUNE)``) instead of flipping the global
-    ``PRIMUS_TURBO_AUTO_TUNE`` switch. It holds no kernel, so it is never
-    profiled and never executed; the dispatcher skips it everywhere and reads it
-    purely as "this op accepts AUTOTUNE".
-    """
-
-    impl: Optional[Type[KernelBackend]] = None
-    autotune: bool = False
-
-    def __post_init__(self) -> None:
-        assert self.impl is None, "AutoTuneEntry is a marker and must not carry a kernel backend."
-        assert not self.autotune, "AutoTuneEntry must not participate in auto-tuning itself."
 
 
 class TuneCache:
@@ -464,7 +479,7 @@ class AutoKernelDispatcher(ABC):  # noqa: B024
         best_backend = None
         best_time = float("inf")
         for entry in cls._backends.values():
-            if not entry.is_executable or not entry.autotune:
+            if not entry.autotune:
                 continue
             if entry.impl.can_handle(**kwargs):
                 torch.cuda.synchronize()
@@ -484,18 +499,14 @@ class AutoKernelDispatcher(ABC):  # noqa: B024
 
     @classmethod
     def dispatch(
-        cls, default_backend_enum: BackendType, user_backend_enum: Optional[BackendType] = None, **kwargs
+        cls,
+        default_backend_choice: BackendChoice,
+        user_backend_choice: Optional[BackendChoice] = None,
+        **kwargs,
     ) -> Any:
         # 1. User specified backend (env or code) - highest priority
-        # AUTOTUNE is not a kernel provider: it only says "this op accepts
-        # auto-tuning", so it falls through to step 2 instead of executing.
-        if user_backend_enum == BackendType.AUTOTUNE:
-            if user_backend_enum not in cls._backends:
-                raise ValueError(
-                    f"{cls.__name__} does not support AUTOTUNE: no AutoTuneEntry is registered for it. "
-                    f"Available backends: {[b.name for b in cls._backends.keys()]}"
-                )
-        elif user_backend_enum is not None:
+        if user_backend_choice is not None and user_backend_choice.backend is not None:
+            user_backend_enum = user_backend_choice.backend
             if user_backend_enum not in cls._backends:
                 raise ValueError(
                     f"User specified backend {user_backend_enum.name} is not registered for {cls.__name__}. "
@@ -512,24 +523,22 @@ class AutoKernelDispatcher(ABC):  # noqa: B024
         # 2. Auto tune
         # NOTE: Skip autotune during cuda graph capture.
         if (
-            user_backend_enum == BackendType.AUTOTUNE or GlobalBackendManager.auto_tune_enabled()
+            (user_backend_choice is not None and user_backend_choice.auto_tune)
+            or default_backend_choice.auto_tune
+            or GlobalBackendManager.auto_tune_enabled()
         ) and not cls._is_graph_capturing():
             backend_cls = cls.tune(**kwargs)
             if backend_cls is not None:
                 return backend_cls.execute(**kwargs)
 
         # 3. Default backend
-        default_entry = cls._backends.get(default_backend_enum)
-        if (
-            default_entry is not None
-            and default_entry.is_executable
-            and default_entry.impl.can_handle(**kwargs)
-        ):
+        default_entry = cls._backends.get(default_backend_choice.backend)
+        if default_entry is not None and default_entry.impl.can_handle(**kwargs):
             return default_entry.impl.execute(**kwargs)
 
         # 4. Fallback: try all backends
         for fallback_backend_enum, fallback_backend_entry in cls._backends.items():
-            if fallback_backend_entry.is_executable and fallback_backend_entry.impl.can_handle(**kwargs):
+            if fallback_backend_entry.impl.can_handle(**kwargs):
                 logger.warning(
                     f"For inputs: {_format_kwargs(kwargs)}, the default backend is not compatible, fallback backend {fallback_backend_enum.name} is selected. The fallback backend may hurt performance!",
                     once=True,

--- a/primus_turbo/pytorch/core/backend.py
+++ b/primus_turbo/pytorch/core/backend.py
@@ -30,10 +30,12 @@ except ImportError:
 
 
 __all__ = [
+    "AutoTuneEntry",
     "BackendEntry",
     "BackendType",
     "GlobalBackendManager",
     "KernelBackend",
+    "PrecisionType",
     "TuneCache",
     "AutoKernelDispatcher",
 ]
@@ -64,6 +66,9 @@ class BackendType(Enum):
     DEEP_EP = auto()
     TURBO = auto()
     FLYDSL = auto()
+    # Not a kernel provider: asks the dispatcher to profile and pick one of the
+    # real backends. Only valid for ops that register an ``AutoTuneEntry``.
+    AUTOTUNE = auto()
 
 
 class GlobalBackendManager:
@@ -73,7 +78,8 @@ class GlobalBackendManager:
     Priority (high to low):
     1. Code settings - set_gemm_backend(), etc.
     2. Environment variables - PRIMUS_TURBO_GEMM_BACKEND, etc.
-    3. Auto-tune - PRIMUS_TURBO_AUTO_TUNE=1
+    3. Auto-tune - PRIMUS_TURBO_AUTO_TUNE=1 for every op, or BackendType.AUTOTUNE
+       via 1./2. to auto-tune a single op/precision.
     4. Code defaults
     5. Fallback: try all backends
     """
@@ -244,6 +250,13 @@ class GlobalBackendManager:
                     once=True,
                 )
 
+            # Dispatch/combine picks an EP backend that owns persistent communication
+            # buffers, so there is nothing to profile and swap per call.
+            assert backend != BackendType.AUTOTUNE, (
+                f"{ENV_MOE_DISPATCH_COMBINE_BACKEND}=AUTOTUNE is not supported: "
+                "MoE dispatch/combine has no auto-tune path."
+            )
+
             if backend == BackendType.DEEP_EP:
                 assert HAVE_DEEP_EP, (
                     "DeepEP is required for this module. Install from https://github.com/uccl-project/uccl or https://github.com/ROCm/DeepEP"
@@ -254,7 +267,12 @@ class GlobalBackendManager:
 
     @classmethod
     def auto_tune_enabled(cls) -> bool:
-        """Check if auto-tune is enabled."""
+        """Check whether the global auto-tune switch is on.
+
+        This is the process-wide switch only; an op may still be auto-tuned
+        through a per-op ``BackendType.AUTOTUNE`` request while this returns
+        False.
+        """
         if cls._auto_tune is not None:
             return cls._auto_tune
         return os.environ.get(ENV_AUTO_TUNE, "0") == "1"
@@ -264,6 +282,7 @@ class GlobalBackendManager:
         """Reset all backend settings and clear all dispatcher caches."""
         cls._gemm_backend = None
         cls._grouped_gemm_backend = None
+        cls._moe_dispatch_combine_backend = None
         cls._auto_tune = None
         cls._env_cache = {}
         AutoKernelDispatcher.clear_all_caches()
@@ -287,14 +306,41 @@ class BackendEntry:
     """Metadata wrapper for a registered kernel backend.
 
     Attributes:
-        impl: The kernel backend class.
+        impl: The kernel backend class, or None for a marker entry that carries
+              no kernel (see ``AutoTuneEntry``). Guard every use with
+              ``is_executable``.
         autotune: Whether this backend participates in auto-tuning.
                   Backends with autotune=False can still be selected via
                   explicit user configuration or as a fallback.
     """
 
-    impl: Type[KernelBackend]
+    impl: Optional[Type[KernelBackend]]
     autotune: bool = True
+
+    @property
+    def is_executable(self) -> bool:
+        """False for marker entries such as ``AutoTuneEntry`` that carry no kernel."""
+        return self.impl is not None
+
+
+@dataclass(frozen=True)
+class AutoTuneEntry(BackendEntry):
+    """Marker entry that opts an op into ``BackendType.AUTOTUNE``.
+
+    Register it as ``BackendType.AUTOTUNE: AutoTuneEntry()`` to let users request
+    auto-tuning for that op alone (``PRIMUS_TURBO_<OP>_BACKEND=autotune`` or
+    ``set_*_backend(BackendType.AUTOTUNE)``) instead of flipping the global
+    ``PRIMUS_TURBO_AUTO_TUNE`` switch. It holds no kernel, so it is never
+    profiled and never executed; the dispatcher skips it everywhere and reads it
+    purely as "this op accepts AUTOTUNE".
+    """
+
+    impl: Optional[Type[KernelBackend]] = None
+    autotune: bool = False
+
+    def __post_init__(self) -> None:
+        assert self.impl is None, "AutoTuneEntry is a marker and must not carry a kernel backend."
+        assert not self.autotune, "AutoTuneEntry must not participate in auto-tuning itself."
 
 
 class TuneCache:
@@ -418,7 +464,7 @@ class AutoKernelDispatcher(ABC):  # noqa: B024
         best_backend = None
         best_time = float("inf")
         for entry in cls._backends.values():
-            if not entry.autotune:
+            if not entry.is_executable or not entry.autotune:
                 continue
             if entry.impl.can_handle(**kwargs):
                 torch.cuda.synchronize()
@@ -441,8 +487,15 @@ class AutoKernelDispatcher(ABC):  # noqa: B024
         cls, default_backend_enum: BackendType, user_backend_enum: Optional[BackendType] = None, **kwargs
     ) -> Any:
         # 1. User specified backend (env or code) - highest priority
-
-        if user_backend_enum is not None:
+        # AUTOTUNE is not a kernel provider: it only says "this op accepts
+        # auto-tuning", so it falls through to step 2 instead of executing.
+        if user_backend_enum == BackendType.AUTOTUNE:
+            if user_backend_enum not in cls._backends:
+                raise ValueError(
+                    f"{cls.__name__} does not support AUTOTUNE: no AutoTuneEntry is registered for it. "
+                    f"Available backends: {[b.name for b in cls._backends.keys()]}"
+                )
+        elif user_backend_enum is not None:
             if user_backend_enum not in cls._backends:
                 raise ValueError(
                     f"User specified backend {user_backend_enum.name} is not registered for {cls.__name__}. "
@@ -458,19 +511,25 @@ class AutoKernelDispatcher(ABC):  # noqa: B024
 
         # 2. Auto tune
         # NOTE: Skip autotune during cuda graph capture.
-        if GlobalBackendManager.auto_tune_enabled() and not cls._is_graph_capturing():
+        if (
+            user_backend_enum == BackendType.AUTOTUNE or GlobalBackendManager.auto_tune_enabled()
+        ) and not cls._is_graph_capturing():
             backend_cls = cls.tune(**kwargs)
             if backend_cls is not None:
                 return backend_cls.execute(**kwargs)
 
         # 3. Default backend
         default_entry = cls._backends.get(default_backend_enum)
-        if default_entry is not None and default_entry.impl.can_handle(**kwargs):
+        if (
+            default_entry is not None
+            and default_entry.is_executable
+            and default_entry.impl.can_handle(**kwargs)
+        ):
             return default_entry.impl.execute(**kwargs)
 
         # 4. Fallback: try all backends
         for fallback_backend_enum, fallback_backend_entry in cls._backends.items():
-            if fallback_backend_entry.impl.can_handle(**kwargs):
+            if fallback_backend_entry.is_executable and fallback_backend_entry.impl.can_handle(**kwargs):
                 logger.warning(
                     f"For inputs: {_format_kwargs(kwargs)}, the default backend is not compatible, fallback backend {fallback_backend_enum.name} is selected. The fallback backend may hurt performance!",
                     once=True,

--- a/primus_turbo/pytorch/kernels/fused_mega_moe/fused_mega_moe_backward_impl.py
+++ b/primus_turbo/pytorch/kernels/fused_mega_moe/fused_mega_moe_backward_impl.py
@@ -19,6 +19,7 @@ from primus_turbo.flydsl.mega import (
 )
 from primus_turbo.pytorch.core.backend import (
     AutoKernelDispatcher,
+    BackendChoice,
     BackendEntry,
     BackendType,
     KernelBackend,
@@ -176,7 +177,7 @@ def _fused_mega_moe_backward(
     default_backend: int,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     group = _resolve_process_group(group_name)
-    default_backend_enum = BackendType(default_backend)
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
 
     kwargs = dict(
         grad_y=grad_y,
@@ -191,7 +192,7 @@ def _fused_mega_moe_backward(
         num_tokens=num_tokens,
         num_topk=num_topk,
     )
-    return FusedMegaMoEBackwardKernelDispatcher.dispatch(default_backend_enum, None, **kwargs)
+    return FusedMegaMoEBackwardKernelDispatcher.dispatch(default_backend_choice, None, **kwargs)
 
 
 @_fused_mega_moe_backward.register_fake

--- a/primus_turbo/pytorch/kernels/fused_mega_moe/fused_mega_moe_forward_impl.py
+++ b/primus_turbo/pytorch/kernels/fused_mega_moe/fused_mega_moe_forward_impl.py
@@ -18,6 +18,7 @@ from primus_turbo.flydsl.mega import (
 )
 from primus_turbo.pytorch.core.backend import (
     AutoKernelDispatcher,
+    BackendChoice,
     BackendEntry,
     BackendType,
     KernelBackend,
@@ -142,7 +143,7 @@ def _fused_mega_moe_forward(
     layout: str,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, List[torch.Tensor]]:
     group = _resolve_process_group(group_name)
-    default_backend_enum = BackendType(default_backend)
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
 
     kwargs = dict(
         x=x,
@@ -153,7 +154,7 @@ def _fused_mega_moe_forward(
         topk_weights=topk_weights,
         layout=layout,
     )
-    return FusedMegaMoEForwardKernelDispatcher.dispatch(default_backend_enum, None, **kwargs)
+    return FusedMegaMoEForwardKernelDispatcher.dispatch(default_backend_choice, None, **kwargs)
 
 
 @_fused_mega_moe_forward.register_fake

--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
@@ -14,6 +14,7 @@ from primus_turbo.common.aiter_utils import get_aiter
 from primus_turbo.flydsl.gemm.mxfp4_gemm_kernel import gemm_mxfp4_flydsl_kernel
 from primus_turbo.pytorch.core.backend import (
     AutoKernelDispatcher,
+    AutoTuneEntry,
     BackendEntry,
     BackendType,
     GlobalBackendManager,
@@ -292,6 +293,7 @@ _GEMM_FP4_BACKENDS = {
     BackendType.AITER: BackendEntry(GEMMFP4AITERBackend, autotune=False),
     BackendType.HIPBLASLT: BackendEntry(GEMMFP4HipBLASLtBackend),
     BackendType.FLYDSL: BackendEntry(GEMMFP4FlyDSLBackend, autotune=False),
+    BackendType.AUTOTUNE: AutoTuneEntry(),
 }
 
 

--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
@@ -14,7 +14,7 @@ from primus_turbo.common.aiter_utils import get_aiter
 from primus_turbo.flydsl.gemm.mxfp4_gemm_kernel import gemm_mxfp4_flydsl_kernel
 from primus_turbo.pytorch.core.backend import (
     AutoKernelDispatcher,
-    AutoTuneEntry,
+    BackendChoice,
     BackendEntry,
     BackendType,
     GlobalBackendManager,
@@ -293,7 +293,6 @@ _GEMM_FP4_BACKENDS = {
     BackendType.AITER: BackendEntry(GEMMFP4AITERBackend, autotune=False),
     BackendType.HIPBLASLT: BackendEntry(GEMMFP4HipBLASLtBackend),
     BackendType.FLYDSL: BackendEntry(GEMMFP4FlyDSLBackend, autotune=False),
-    BackendType.AUTOTUNE: AutoTuneEntry(),
 }
 
 
@@ -321,8 +320,8 @@ def gemm_fp4_impl(
     default_backend: int,
     preshuffled: bool = False,
 ) -> torch.Tensor:
-    default_backend_enum = BackendType(default_backend)
-    user_backend_enum = GlobalBackendManager.get_gemm_backend(PrecisionType.FP4)
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_gemm_backend(PrecisionType.FP4)
     granularity_enum = ScalingGranularity(granularity)
 
     kwargs = dict(
@@ -338,7 +337,7 @@ def gemm_fp4_impl(
         preshuffled=preshuffled,
     )
 
-    return GEMMFP4KernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    return GEMMFP4KernelDispatcher.dispatch(default_backend_choice, user_backend_choice, **kwargs)
 
 
 @gemm_fp4_impl.register_fake

--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
@@ -14,6 +14,7 @@ from primus_turbo.flydsl.gemm.gemm_fp8_kernel import gemm_fp8_tensorwise_flydsl_
 from primus_turbo.flydsl.gemm.mxfp8_gemm_kernel import gemm_mxfp8_flydsl_kernel
 from primus_turbo.pytorch.core.backend import (
     AutoKernelDispatcher,
+    AutoTuneEntry,
     BackendEntry,
     BackendType,
     GlobalBackendManager,
@@ -430,6 +431,7 @@ _GEMM_FP8_BACKENDS = {
     BackendType.CK: BackendEntry(GEMMFP8CKBackend),
     BackendType.TRITON: BackendEntry(GEMMFP8TritonBackend),
     BackendType.FLYDSL: BackendEntry(GEMMFP8FlyDSLBackend),
+    BackendType.AUTOTUNE: AutoTuneEntry(),
 }
 
 

--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
@@ -14,7 +14,7 @@ from primus_turbo.flydsl.gemm.gemm_fp8_kernel import gemm_fp8_tensorwise_flydsl_
 from primus_turbo.flydsl.gemm.mxfp8_gemm_kernel import gemm_mxfp8_flydsl_kernel
 from primus_turbo.pytorch.core.backend import (
     AutoKernelDispatcher,
-    AutoTuneEntry,
+    BackendChoice,
     BackendEntry,
     BackendType,
     GlobalBackendManager,
@@ -431,7 +431,6 @@ _GEMM_FP8_BACKENDS = {
     BackendType.CK: BackendEntry(GEMMFP8CKBackend),
     BackendType.TRITON: BackendEntry(GEMMFP8TritonBackend),
     BackendType.FLYDSL: BackendEntry(GEMMFP8FlyDSLBackend),
-    BackendType.AUTOTUNE: AutoTuneEntry(),
 }
 
 
@@ -458,8 +457,8 @@ def gemm_fp8_impl(
     granularity: int,
     default_backend: int,
 ) -> torch.Tensor:
-    default_backend_enum = BackendType(default_backend)
-    user_backend_enum = GlobalBackendManager.get_gemm_backend(PrecisionType.FP8)
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_gemm_backend(PrecisionType.FP8)
     granularity_enum = ScalingGranularity(granularity)
 
     kwargs = dict(
@@ -474,7 +473,7 @@ def gemm_fp8_impl(
         granularity=granularity_enum,
     )
 
-    return GEMMFP8KernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    return GEMMFP8KernelDispatcher.dispatch(default_backend_choice, user_backend_choice, **kwargs)
 
 
 @gemm_fp8_impl.register_fake

--- a/primus_turbo/pytorch/kernels/gemm/gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_impl.py
@@ -10,6 +10,7 @@ _torch_custom_op_wrapper = torch.library.custom_op
 
 from primus_turbo.pytorch.core.backend import (
     AutoKernelDispatcher,
+    AutoTuneEntry,
     BackendEntry,
     BackendType,
     GlobalBackendManager,
@@ -84,6 +85,7 @@ class GEMMTritonBackend(KernelBackend):
 _GEMM_BACKENDS = {
     BackendType.HIPBLASLT: BackendEntry(GEMMHipBLASLtBackend),
     BackendType.TRITON: BackendEntry(GEMMTritonBackend),
+    BackendType.AUTOTUNE: AutoTuneEntry(),
 }
 
 

--- a/primus_turbo/pytorch/kernels/gemm/gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_impl.py
@@ -10,7 +10,7 @@ _torch_custom_op_wrapper = torch.library.custom_op
 
 from primus_turbo.pytorch.core.backend import (
     AutoKernelDispatcher,
-    AutoTuneEntry,
+    BackendChoice,
     BackendEntry,
     BackendType,
     GlobalBackendManager,
@@ -85,7 +85,6 @@ class GEMMTritonBackend(KernelBackend):
 _GEMM_BACKENDS = {
     BackendType.HIPBLASLT: BackendEntry(GEMMHipBLASLtBackend),
     BackendType.TRITON: BackendEntry(GEMMTritonBackend),
-    BackendType.AUTOTUNE: AutoTuneEntry(),
 }
 
 
@@ -111,8 +110,8 @@ def gemm_impl(
     trans_c: bool,
     default_backend: int,
 ) -> torch.Tensor:
-    default_backend_enum = BackendType(default_backend)
-    user_backend_enum = GlobalBackendManager.get_gemm_backend(PrecisionType.BF16_FP16_FP32)
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_gemm_backend(PrecisionType.BF16_FP16_FP32)
 
     kwargs = dict(
         a=a,
@@ -123,7 +122,7 @@ def gemm_impl(
         trans_c=trans_c,
     )
 
-    return GEMMKernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    return GEMMKernelDispatcher.dispatch(default_backend_choice, user_backend_choice, **kwargs)
 
 
 @gemm_impl.register_fake

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
@@ -20,7 +20,7 @@ caller slices ``[:total_m]``; ``group_offs_out`` packs each group tight.
 import torch
 
 from primus_turbo.pytorch.core.backend import (
-    AutoTuneEntry,
+    BackendChoice,
     BackendEntry,
     BackendType,
     GlobalBackendManager,
@@ -190,7 +190,6 @@ class GroupedGEMMFP4KernelDispatcher(BaseGroupedGEMMKernelDispatcher):
     _backends = {
         BackendType.FLYDSL: BackendEntry(GroupedGEMMFP4FlyDSLBackend),
         BackendType.TRITON: BackendEntry(GroupedGEMMFP4TritonBackend),
-        BackendType.AUTOTUNE: AutoTuneEntry(),
     }
     _cache = TuneCache(1024)
 
@@ -381,7 +380,6 @@ class GroupedGEMMFP4VariableKKernelDispatcher(BaseGroupedGEMMVariableKKernelDisp
     _backends = {
         BackendType.FLYDSL: BackendEntry(GroupedGEMMFP4VariableKFlyDSLBackend),
         BackendType.TRITON: BackendEntry(GroupedGEMMFP4VariableKTritonBackend),
-        BackendType.AUTOTUNE: AutoTuneEntry(),
     }
     _cache = TuneCache(1024)
 
@@ -432,8 +430,8 @@ def grouped_gemm_fp4_impl(
     group_offs_out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Forward / dgrad (NT): C[g] = A[g] @ B[g]^T, contraction over (packed) K."""
-    default_backend_enum = BackendType(default_backend)
-    user_backend_enum = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP4)
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP4)
     granularity_enum = ScalingGranularity(granularity)
 
     kwargs = dict(
@@ -452,7 +450,7 @@ def grouped_gemm_fp4_impl(
         group_offs_out=group_offs_out,
     )
 
-    out = GroupedGEMMFP4KernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    out = GroupedGEMMFP4KernelDispatcher.dispatch(default_backend_choice, user_backend_choice, **kwargs)
     # Over-allocated output: zero the unwritten tail past the tight write bound
     # (group_offs_out for MX; group_offs otherwise) so the caller's [:total_m]
     # slice never exposes uninitialized rows.
@@ -480,8 +478,8 @@ def grouped_gemm_fp4_variable_k_impl(
     maybe_pre_sync: bool = False,
 ) -> torch.Tensor:
     """Backward wgrad: C[g] (OUT_M, OUT_N) = lhs[:,g] @ rhs[:,g]^T, reduction over M."""
-    default_backend_enum = BackendType(default_backend)
-    user_backend_enum = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP4)
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP4)
     granularity_enum = ScalingGranularity(granularity)
 
     kwargs = dict(
@@ -500,7 +498,9 @@ def grouped_gemm_fp4_variable_k_impl(
         maybe_pre_sync=maybe_pre_sync,
     )
 
-    return GroupedGEMMFP4VariableKKernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    return GroupedGEMMFP4VariableKKernelDispatcher.dispatch(
+        default_backend_choice, user_backend_choice, **kwargs
+    )
 
 
 @grouped_gemm_fp4_impl.register_fake

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
@@ -20,6 +20,7 @@ caller slices ``[:total_m]``; ``group_offs_out`` packs each group tight.
 import torch
 
 from primus_turbo.pytorch.core.backend import (
+    AutoTuneEntry,
     BackendEntry,
     BackendType,
     GlobalBackendManager,
@@ -189,6 +190,7 @@ class GroupedGEMMFP4KernelDispatcher(BaseGroupedGEMMKernelDispatcher):
     _backends = {
         BackendType.FLYDSL: BackendEntry(GroupedGEMMFP4FlyDSLBackend),
         BackendType.TRITON: BackendEntry(GroupedGEMMFP4TritonBackend),
+        BackendType.AUTOTUNE: AutoTuneEntry(),
     }
     _cache = TuneCache(1024)
 
@@ -379,6 +381,7 @@ class GroupedGEMMFP4VariableKKernelDispatcher(BaseGroupedGEMMVariableKKernelDisp
     _backends = {
         BackendType.FLYDSL: BackendEntry(GroupedGEMMFP4VariableKFlyDSLBackend),
         BackendType.TRITON: BackendEntry(GroupedGEMMFP4VariableKTritonBackend),
+        BackendType.AUTOTUNE: AutoTuneEntry(),
     }
     _cache = TuneCache(1024)
 

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -7,6 +7,7 @@
 import torch
 
 from primus_turbo.pytorch.core.backend import (
+    AutoTuneEntry,
     BackendEntry,
     BackendType,
     GlobalBackendManager,
@@ -530,6 +531,7 @@ class GroupedGEMMFP8KernelDispatcher(BaseGroupedGEMMKernelDispatcher):
         BackendType.HIPBLASLT: BackendEntry(GroupedGEMMFP8HipblasltBackend, autotune=False),
         BackendType.TRITON: BackendEntry(GroupedGEMMFP8TritonBackend),
         BackendType.FLYDSL: BackendEntry(GroupedGEMMFP8FlyDSLBackend),
+        BackendType.AUTOTUNE: AutoTuneEntry(),
     }
     _cache = TuneCache(1024)
 
@@ -786,6 +788,7 @@ class GroupedGEMMFP8VariableKKernelDispatcher(BaseGroupedGEMMVariableKKernelDisp
         BackendType.HIPBLASLT: BackendEntry(GroupedGEMMFP8VariableKHipblasltBackend),
         BackendType.TRITON: BackendEntry(GroupedGEMMFP8VariableKTritonBackend),
         BackendType.FLYDSL: BackendEntry(GroupedGEMMFP8VariableKFlyDSLBackend),
+        BackendType.AUTOTUNE: AutoTuneEntry(),
     }
     _cache = TuneCache(1024)
 

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -7,7 +7,7 @@
 import torch
 
 from primus_turbo.pytorch.core.backend import (
-    AutoTuneEntry,
+    BackendChoice,
     BackendEntry,
     BackendType,
     GlobalBackendManager,
@@ -531,7 +531,6 @@ class GroupedGEMMFP8KernelDispatcher(BaseGroupedGEMMKernelDispatcher):
         BackendType.HIPBLASLT: BackendEntry(GroupedGEMMFP8HipblasltBackend, autotune=False),
         BackendType.TRITON: BackendEntry(GroupedGEMMFP8TritonBackend),
         BackendType.FLYDSL: BackendEntry(GroupedGEMMFP8FlyDSLBackend),
-        BackendType.AUTOTUNE: AutoTuneEntry(),
     }
     _cache = TuneCache(1024)
 
@@ -788,7 +787,6 @@ class GroupedGEMMFP8VariableKKernelDispatcher(BaseGroupedGEMMVariableKKernelDisp
         BackendType.HIPBLASLT: BackendEntry(GroupedGEMMFP8VariableKHipblasltBackend),
         BackendType.TRITON: BackendEntry(GroupedGEMMFP8VariableKTritonBackend),
         BackendType.FLYDSL: BackendEntry(GroupedGEMMFP8VariableKFlyDSLBackend),
-        BackendType.AUTOTUNE: AutoTuneEntry(),
     }
     _cache = TuneCache(1024)
 
@@ -838,8 +836,8 @@ def grouped_gemm_fp8_impl(
     maybe_pre_sync: bool = False,
     group_offs_out: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    default_backend_enum = BackendType(default_backend)
-    user_backend_enum = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP8)
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP8)
     granularity_enum = ScalingGranularity(granularity)
 
     kwargs = dict(
@@ -858,7 +856,7 @@ def grouped_gemm_fp8_impl(
         group_offs_out=group_offs_out,
     )
 
-    out = GroupedGEMMFP8KernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    out = GroupedGEMMFP8KernelDispatcher.dispatch(default_backend_choice, user_backend_choice, **kwargs)
     # Over-allocated output: zero the unwritten tail past the tight write bound
     # (group_offs_out for MX; group_offs otherwise) so the caller's [:total_m]
     # slice never exposes uninitialized rows.
@@ -885,8 +883,8 @@ def grouped_gemm_fp8_variable_k_impl(
     default_backend: int,
     maybe_pre_sync: bool = False,
 ) -> torch.Tensor:
-    default_backend_enum = BackendType(default_backend)
-    user_backend_enum = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP8)
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP8)
     granularity_enum = ScalingGranularity(granularity)
 
     kwargs = dict(
@@ -905,7 +903,9 @@ def grouped_gemm_fp8_variable_k_impl(
         maybe_pre_sync=maybe_pre_sync,
     )
 
-    return GroupedGEMMFP8VariableKKernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    return GroupedGEMMFP8VariableKKernelDispatcher.dispatch(
+        default_backend_choice, user_backend_choice, **kwargs
+    )
 
 
 @grouped_gemm_fp8_impl.register_fake

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
@@ -7,6 +7,7 @@
 import torch
 
 from primus_turbo.pytorch.core.backend import (
+    AutoTuneEntry,
     BackendEntry,
     BackendType,
     GlobalBackendManager,
@@ -374,6 +375,7 @@ _GROUPED_GEMM_BACKENDS = {
     BackendType.CK: BackendEntry(GroupedGEMMCKBackend),
     BackendType.HIPBLASLT: BackendEntry(GroupedGEMMHipblasltBackend, autotune=False),
     BackendType.TRITON: BackendEntry(GroupedGEMMTritonBackend),
+    BackendType.AUTOTUNE: AutoTuneEntry(),
 }
 
 
@@ -431,6 +433,7 @@ _GROUPED_GEMM_VARIABLE_K_BACKENDS = {
     BackendType.CK: BackendEntry(GroupedGEMMVariableKCKBackend),
     BackendType.HIPBLASLT: BackendEntry(GroupedGEMMVariableKHipblasltBackend, autotune=False),
     BackendType.TRITON: BackendEntry(GroupedGEMMVariableKTritonBackend),
+    BackendType.AUTOTUNE: AutoTuneEntry(),
 }
 
 

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
@@ -7,7 +7,7 @@
 import torch
 
 from primus_turbo.pytorch.core.backend import (
-    AutoTuneEntry,
+    BackendChoice,
     BackendEntry,
     BackendType,
     GlobalBackendManager,
@@ -375,7 +375,6 @@ _GROUPED_GEMM_BACKENDS = {
     BackendType.CK: BackendEntry(GroupedGEMMCKBackend),
     BackendType.HIPBLASLT: BackendEntry(GroupedGEMMHipblasltBackend, autotune=False),
     BackendType.TRITON: BackendEntry(GroupedGEMMTritonBackend),
-    BackendType.AUTOTUNE: AutoTuneEntry(),
 }
 
 
@@ -433,7 +432,6 @@ _GROUPED_GEMM_VARIABLE_K_BACKENDS = {
     BackendType.CK: BackendEntry(GroupedGEMMVariableKCKBackend),
     BackendType.HIPBLASLT: BackendEntry(GroupedGEMMVariableKHipblasltBackend, autotune=False),
     BackendType.TRITON: BackendEntry(GroupedGEMMVariableKTritonBackend),
-    BackendType.AUTOTUNE: AutoTuneEntry(),
 }
 
 
@@ -484,8 +482,8 @@ def grouped_gemm_impl(
     maybe_pre_sync: bool = False,
     schedule: str = "static",
 ) -> torch.Tensor:
-    default_backend_enum = BackendType(default_backend)
-    user_backend_enum = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.BF16_FP16_FP32)
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.BF16_FP16_FP32)
 
     kwargs = dict(
         a=a,
@@ -499,7 +497,7 @@ def grouped_gemm_impl(
         schedule=schedule,
     )
 
-    out = GroupedGEMMKernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    out = GroupedGEMMKernelDispatcher.dispatch(default_backend_choice, user_backend_choice, **kwargs)
     out = grouped_gemm_output_tail_kernel(out, group_offs)
     return out
 
@@ -518,8 +516,8 @@ def grouped_gemm_variable_k_impl(
     maybe_pre_sync: bool = False,
     schedule: str = "static",
 ) -> torch.Tensor:
-    default_backend_enum = BackendType(default_backend)
-    user_backend_enum = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.BF16_FP16_FP32)
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.BF16_FP16_FP32)
     kwargs = dict(
         a=a,
         b=b,
@@ -532,7 +530,9 @@ def grouped_gemm_variable_k_impl(
         maybe_pre_sync=maybe_pre_sync,
         schedule=schedule,
     )
-    return GroupedGEMMVariableKKernelDispatcher.dispatch(default_backend_enum, user_backend_enum, **kwargs)
+    return GroupedGEMMVariableKKernelDispatcher.dispatch(
+        default_backend_choice, user_backend_choice, **kwargs
+    )
 
 
 @grouped_gemm_impl.register_fake

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_utils.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_utils.py
@@ -68,7 +68,7 @@ class BaseGroupedGEMMKernelDispatcher(AutoKernelDispatcher):
         best_backend = None
         best_time = float("inf")
         for entry in cls._backends.values():
-            if not entry.autotune:
+            if not entry.is_executable or not entry.autotune:
                 continue
             if entry.impl.can_handle(**kwargs):
                 torch.cuda.synchronize()
@@ -132,7 +132,7 @@ class BaseGroupedGEMMVariableKKernelDispatcher(AutoKernelDispatcher):
         best_backend = None
         best_time = float("inf")
         for entry in cls._backends.values():
-            if not entry.autotune:
+            if not entry.is_executable or not entry.autotune:
                 continue
             if entry.impl.can_handle(**kwargs):
                 torch.cuda.synchronize()

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_utils.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_utils.py
@@ -68,7 +68,7 @@ class BaseGroupedGEMMKernelDispatcher(AutoKernelDispatcher):
         best_backend = None
         best_time = float("inf")
         for entry in cls._backends.values():
-            if not entry.is_executable or not entry.autotune:
+            if not entry.autotune:
                 continue
             if entry.impl.can_handle(**kwargs):
                 torch.cuda.synchronize()
@@ -132,7 +132,7 @@ class BaseGroupedGEMMVariableKKernelDispatcher(AutoKernelDispatcher):
         best_backend = None
         best_time = float("inf")
         for entry in cls._backends.values():
-            if not entry.is_executable or not entry.autotune:
+            if not entry.autotune:
                 continue
             if entry.impl.can_handle(**kwargs):
                 torch.cuda.synchronize()

--- a/primus_turbo/pytorch/kernels/moe/moe_dispatch_combine_impl.py
+++ b/primus_turbo/pytorch/kernels/moe/moe_dispatch_combine_impl.py
@@ -487,8 +487,9 @@ def _resolve_backend_name() -> str:
       2. ``PRIMUS_TURBO_MOE_DISPATCH_COMBINE_BACKEND`` env var (supports names beyond ``BackendType``)
       3. Default: ``TURBO``
     """
-    user_backend = GlobalBackendManager.get_moe_dispatch_combine_backend(PrecisionType.BF16_FP16_FP32)
-    if user_backend is not None:
+    user_backend_choice = GlobalBackendManager.get_moe_dispatch_combine_backend(PrecisionType.BF16_FP16_FP32)
+    if user_backend_choice is not None and user_backend_choice.backend is not None:
+        user_backend = user_backend_choice.backend
         return _BACKEND_TYPE_TO_NAME.get(user_backend, user_backend.name)
 
     env_val = os.environ.get(ENV_MOE_DISPATCH_COMBINE_BACKEND)

--- a/tests/pytorch/core/test_global_backend_manager.py
+++ b/tests/pytorch/core/test_global_backend_manager.py
@@ -7,6 +7,7 @@
 import pytest
 
 from primus_turbo.pytorch.core.backend import (
+    BackendChoice,
     BackendType,
     GlobalBackendManager,
     PrecisionType,
@@ -34,23 +35,27 @@ class TestGlobalBackendManagerEnvVar:
     def test_gemm_backend_single_format(self, monkeypatch):
         """Format 1: PRIMUS_TURBO_GEMM_BACKEND=ck -> all precisions use CK."""
         monkeypatch.setenv("PRIMUS_TURBO_GEMM_BACKEND", "ck")
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP4) == BackendType.CK
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP8) == BackendType.CK
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.BF16_FP16_FP32) == BackendType.CK
+        get_gemm = GlobalBackendManager.get_gemm_backend
+        assert get_gemm(PrecisionType.FP4) == BackendChoice(BackendType.CK)
+        assert get_gemm(PrecisionType.FP8) == BackendChoice(BackendType.CK)
+        assert get_gemm(PrecisionType.BF16_FP16_FP32) == BackendChoice(BackendType.CK)
 
     def test_gemm_backend_per_precision_format(self, monkeypatch):
         """Format 2: fp4:hipblaslt,fp8:ck -> per-precision mapping."""
         monkeypatch.setenv("PRIMUS_TURBO_GEMM_BACKEND", "fp4:hipblaslt,fp8:ck")
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP4) == BackendType.HIPBLASLT
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP8) == BackendType.CK
+        get_gemm = GlobalBackendManager.get_gemm_backend
+        assert get_gemm(PrecisionType.FP4) == BackendChoice(BackendType.HIPBLASLT)
+        assert get_gemm(PrecisionType.FP8) == BackendChoice(BackendType.CK)
 
     def test_grouped_gemm_backend_env(self, monkeypatch):
         monkeypatch.setenv("PRIMUS_TURBO_GROUPED_GEMM_BACKEND", "hipblaslt")
-        assert GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP8) == BackendType.HIPBLASLT
+        choice = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP8)
+        assert choice == BackendChoice(BackendType.HIPBLASLT)
 
     def test_moe_dispatch_combine_backend_env(self, monkeypatch):
         monkeypatch.setenv("PRIMUS_TURBO_MOE_DISPATCH_COMBINE_BACKEND", "triton")
-        assert GlobalBackendManager.get_moe_dispatch_combine_backend(PrecisionType.FP8) == BackendType.TRITON
+        choice = GlobalBackendManager.get_moe_dispatch_combine_backend(PrecisionType.FP8)
+        assert choice == BackendChoice(BackendType.TRITON)
 
     def test_auto_tune_env_enabled(self, monkeypatch):
         monkeypatch.setenv("PRIMUS_TURBO_AUTO_TUNE", "1")
@@ -63,9 +68,10 @@ class TestGlobalBackendManagerEnvVar:
     def test_gemm_backend_other_precision_format(self, monkeypatch):
         """Format 3: fp8:ck,other:hipblaslt -> FP8 uses CK, rest use HIPBLASLT."""
         monkeypatch.setenv("PRIMUS_TURBO_GEMM_BACKEND", "fp8:ck,other:hipblaslt")
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP8) == BackendType.CK
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP4) == BackendType.HIPBLASLT
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.BF16_FP16_FP32) == BackendType.HIPBLASLT
+        get_gemm = GlobalBackendManager.get_gemm_backend
+        assert get_gemm(PrecisionType.FP8) == BackendChoice(BackendType.CK)
+        assert get_gemm(PrecisionType.FP4) == BackendChoice(BackendType.HIPBLASLT)
+        assert get_gemm(PrecisionType.BF16_FP16_FP32) == BackendChoice(BackendType.HIPBLASLT)
 
     def test_gemm_backend_invalid_precision_raises(self, monkeypatch):
         """Invalid precision name should raise AssertionError."""
@@ -73,37 +79,39 @@ class TestGlobalBackendManagerEnvVar:
         with pytest.raises(AssertionError, match="Precision INVALID not supported"):
             GlobalBackendManager.get_gemm_backend(PrecisionType.FP8)
 
-    def test_returns_none_when_env_not_set(self):
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP8) is None
-        assert GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP8) is None
-        assert GlobalBackendManager.get_moe_dispatch_combine_backend(PrecisionType.FP8) is None
-        assert GlobalBackendManager.auto_tune_enabled() is False
-
     def test_autotune_backend_single_format(self, monkeypatch):
         """PRIMUS_TURBO_GEMM_BACKEND=autotune -> AutoTune GEMM at every precision."""
         monkeypatch.setenv("PRIMUS_TURBO_GEMM_BACKEND", "autotune")
         for precision in PrecisionType:
-            assert GlobalBackendManager.get_gemm_backend(precision) == BackendType.AUTOTUNE
+            assert GlobalBackendManager.get_gemm_backend(precision) == BackendChoice(auto_tune=True)
         # Per-op AutoTune must not flip the global switch.
         assert GlobalBackendManager.auto_tune_enabled() is False
 
     def test_autotune_backend_per_precision_format(self, monkeypatch):
         """AutoTune composes with named backends: only FP8 is tuned."""
         monkeypatch.setenv("PRIMUS_TURBO_GEMM_BACKEND", "fp8:autotune,other:hipblaslt")
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP8) == BackendType.AUTOTUNE
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP4) == BackendType.HIPBLASLT
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.BF16_FP16_FP32) == BackendType.HIPBLASLT
+        get_gemm = GlobalBackendManager.get_gemm_backend
+        assert get_gemm(PrecisionType.FP8) == BackendChoice(auto_tune=True)
+        assert get_gemm(PrecisionType.FP4) == BackendChoice(BackendType.HIPBLASLT)
+        assert get_gemm(PrecisionType.BF16_FP16_FP32) == BackendChoice(BackendType.HIPBLASLT)
 
     def test_autotune_grouped_gemm_backend(self, monkeypatch):
         monkeypatch.setenv("PRIMUS_TURBO_GROUPED_GEMM_BACKEND", "fp4:autotune,other:ck")
-        assert GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP4) == BackendType.AUTOTUNE
-        assert GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP8) == BackendType.CK
+        get_grouped = GlobalBackendManager.get_grouped_gemm_backend
+        assert get_grouped(PrecisionType.FP4) == BackendChoice(auto_tune=True)
+        assert get_grouped(PrecisionType.FP8) == BackendChoice(BackendType.CK)
 
     def test_autotune_moe_dispatch_combine_rejected(self, monkeypatch):
         """MoE dispatch/combine picks an EP backend and has no AutoTune path."""
         monkeypatch.setenv("PRIMUS_TURBO_MOE_DISPATCH_COMBINE_BACKEND", "autotune")
         with pytest.raises(AssertionError, match="AUTOTUNE is not supported"):
             GlobalBackendManager.get_moe_dispatch_combine_backend(PrecisionType.BF16_FP16_FP32)
+
+    def test_returns_none_when_env_not_set(self):
+        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP8) is None
+        assert GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP8) is None
+        assert GlobalBackendManager.get_moe_dispatch_combine_backend(PrecisionType.FP8) is None
+        assert GlobalBackendManager.auto_tune_enabled() is False
 
 
 class TestGlobalBackendManagerFunction:
@@ -118,7 +126,7 @@ class TestGlobalBackendManagerFunction:
     def test_set_get_gemm_backend(self):
         self._init_gemm_backend()
         GlobalBackendManager.set_gemm_backend(BackendType.CK, PrecisionType.FP8)
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP8) == BackendType.CK
+        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP8) == BackendChoice(BackendType.CK)
         assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP4) is None
 
     def test_set_get_gemm_backend_multiple_precisions(self):
@@ -126,9 +134,10 @@ class TestGlobalBackendManagerFunction:
         GlobalBackendManager.set_gemm_backend(BackendType.HIPBLASLT, PrecisionType.FP4)
         GlobalBackendManager.set_gemm_backend(BackendType.CK, PrecisionType.FP8)
         GlobalBackendManager.set_gemm_backend(BackendType.HIPBLASLT, PrecisionType.BF16_FP16_FP32)
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP4) == BackendType.HIPBLASLT
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP8) == BackendType.CK
-        assert GlobalBackendManager.get_gemm_backend(PrecisionType.BF16_FP16_FP32) == BackendType.HIPBLASLT
+        get_gemm = GlobalBackendManager.get_gemm_backend
+        assert get_gemm(PrecisionType.FP4) == BackendChoice(BackendType.HIPBLASLT)
+        assert get_gemm(PrecisionType.FP8) == BackendChoice(BackendType.CK)
+        assert get_gemm(PrecisionType.BF16_FP16_FP32) == BackendChoice(BackendType.HIPBLASLT)
 
     def test_set_get_grouped_gemm_backend(self):
         self._init_grouped_gemm_backend()

--- a/tests/pytorch/core/test_global_backend_manager.py
+++ b/tests/pytorch/core/test_global_backend_manager.py
@@ -79,6 +79,32 @@ class TestGlobalBackendManagerEnvVar:
         assert GlobalBackendManager.get_moe_dispatch_combine_backend(PrecisionType.FP8) is None
         assert GlobalBackendManager.auto_tune_enabled() is False
 
+    def test_autotune_backend_single_format(self, monkeypatch):
+        """PRIMUS_TURBO_GEMM_BACKEND=autotune -> AutoTune GEMM at every precision."""
+        monkeypatch.setenv("PRIMUS_TURBO_GEMM_BACKEND", "autotune")
+        for precision in PrecisionType:
+            assert GlobalBackendManager.get_gemm_backend(precision) == BackendType.AUTOTUNE
+        # Per-op AutoTune must not flip the global switch.
+        assert GlobalBackendManager.auto_tune_enabled() is False
+
+    def test_autotune_backend_per_precision_format(self, monkeypatch):
+        """AutoTune composes with named backends: only FP8 is tuned."""
+        monkeypatch.setenv("PRIMUS_TURBO_GEMM_BACKEND", "fp8:autotune,other:hipblaslt")
+        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP8) == BackendType.AUTOTUNE
+        assert GlobalBackendManager.get_gemm_backend(PrecisionType.FP4) == BackendType.HIPBLASLT
+        assert GlobalBackendManager.get_gemm_backend(PrecisionType.BF16_FP16_FP32) == BackendType.HIPBLASLT
+
+    def test_autotune_grouped_gemm_backend(self, monkeypatch):
+        monkeypatch.setenv("PRIMUS_TURBO_GROUPED_GEMM_BACKEND", "fp4:autotune,other:ck")
+        assert GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP4) == BackendType.AUTOTUNE
+        assert GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP8) == BackendType.CK
+
+    def test_autotune_moe_dispatch_combine_rejected(self, monkeypatch):
+        """MoE dispatch/combine picks an EP backend and has no AutoTune path."""
+        monkeypatch.setenv("PRIMUS_TURBO_MOE_DISPATCH_COMBINE_BACKEND", "autotune")
+        with pytest.raises(AssertionError, match="AUTOTUNE is not supported"):
+            GlobalBackendManager.get_moe_dispatch_combine_backend(PrecisionType.BF16_FP16_FP32)
+
 
 class TestGlobalBackendManagerFunction:
     @staticmethod


### PR DESCRIPTION
# Description

Today AutoTune is an all-or-nothing, process-wide switch: `PRIMUS_TURBO_AUTO_TUNE=1` (or `GlobalBackendManager.set_auto_tune(True)`) turns profiling on for every registered operator at once. That is too coarse in practice — a user who only wants the best FP8 GEMM backend has to pay tuning cost on Grouped GEMM and every other op as well, and there is no way to say "tune this one op, leave the rest on their defaults".

This PR introduces per-operator (and per-precision) AutoTune. `BackendType.AUTOTUNE` becomes a value that can be passed anywhere a backend name is accepted — code API, environment variable, and the existing per-precision environment-variable syntax — so AutoTune composes naturally with the backend-selection mechanism that already exists instead of living beside it as a separate global flag.

`BackendType.AUTOTUNE` is not a kernel provider. An operator opts into it by registering an `AutoTuneEntry()` marker in its backend table; the marker carries no kernel, is never profiled, and is never executed. When the dispatcher sees a user request for `AUTOTUNE`, it validates that the operator registered the marker and then falls through to the tuning path. Operators without the marker reject the request with a clear error. MoE dispatch/combine explicitly does not support it, because that operator selects an EP backend that owns persistent communication buffers — there is nothing meaningful to profile and swap per call.

The global `PRIMUS_TURBO_AUTO_TUNE` switch keeps its existing behavior and priority; per-op AutoTune does not flip it, and an explicit named backend still wins over it.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `BackendType.AUTOTUNE`, a non-executable backend value that requests auto-tuning for a single operator instead of the whole library.
- Add `AutoTuneEntry`, a frozen marker `BackendEntry` (`impl=None`, `autotune=False`) that an operator registers to declare "this op accepts AUTOTUNE". Its `__post_init__` asserts it never carries a kernel and never participates in tuning itself.
- Add `BackendEntry.is_executable` and guard every `entry.impl` use behind it, in `AutoKernelDispatcher.dispatch()` / `tune()` and in the Grouped GEMM dispatchers' `tune()` overrides, so marker entries are skipped in the tune loop, the default-backend path, and the fallback loop.
- Teach `AutoKernelDispatcher.dispatch()` to treat a user-specified `AUTOTUNE` as "fall through to the tuning step" rather than "execute this backend", raising a `ValueError` that lists the available backends when the op registered no `AutoTuneEntry`.
- Trigger the tuning step when either the global switch is on or the op was asked for `AUTOTUNE`, keeping the existing skip during CUDA graph capture.
- Reject `PRIMUS_TURBO_MOE_DISPATCH_COMBINE_BACKEND=autotune` with an explanatory `AssertionError`, since MoE dispatch/combine has no auto-tune path.
- Register `BackendType.AUTOTUNE: AutoTuneEntry()` for GEMM, FP8 GEMM, FP4 GEMM, Grouped GEMM, Grouped GEMM VariableK, FP8 Grouped GEMM (+ VariableK), and FP4 Grouped GEMM (+ VariableK).
- Fix `GlobalBackendManager.reset()` failing to clear `_moe_dispatch_combine_backend`, which leaked a code-set MoE backend across resets and tests.
- Export `AutoTuneEntry` and `PrecisionType` from `primus_turbo.pytorch.core.backend.__all__`.
- Document the feature in `docs/examples.md` and in the environment-variable comments in `primus_turbo/common/constants.py`, including the per-precision form `PRIMUS_TURBO_GROUPED_GEMM_BACKEND=fp8:autotune,other:ck`.
- Add unit tests in `tests/pytorch/core/test_global_backend_manager.py` covering the single-value form, the per-precision form for GEMM and Grouped GEMM, the fact that per-op AutoTune does not flip the global switch, and the MoE dispatch/combine rejection.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
