### PR TITLE
refactor(megamoe): narrow memory coherence scopes

### DIFF
--- a/primus_turbo/flydsl/mega/dispatch_prologue_kernel.py
+++ b/primus_turbo/flydsl/mega/dispatch_prologue_kernel.py
@@ -245,7 +245,7 @@ def _make_dispatch_prologue(
                 destination_rank = comm_task_index % fx.Int32(num_ranks)
                 local_expert_index = comm_task_index // fx.Int32(num_ranks)
                 expert_id = destination_rank * fx.Int32(experts_per_rank) + local_expert_index
-                count_value = ld(expert_count_base, fx.Int32(rank * num_experts) + expert_id, scope="sys")
+                count_value = ld(expert_count_base, fx.Int32(rank * num_experts) + expert_id)
                 start_value = buffer_load(
                     scratch_resource, fx.Int32(SCRATCH_START) + expert_id, vec_width=1, dtype=fx.T.i32()
                 )

--- a/primus_turbo/flydsl/mega/ep_intranode.py
+++ b/primus_turbo/flydsl/mega/ep_intranode.py
@@ -81,7 +81,7 @@ def dispatch_bf16_tile(
             hidden_bytes,
             dst_off=dest_row * fx.Int32(hidden_i32),
             src_off=source_row * fx.Int32(hidden_i32),
-            load_cache_modifier=19,
+            load_cache_modifier=18,  # sc1|nt: read data produced by the same agent.
             store_cache_modifier=19,
         )
 
@@ -169,7 +169,7 @@ def combine_bf16_tile(
             bank = fx.Int32(0) if bank_offset is None else bank_offset
             # Wait for CM19 payload stores before publishing the relaxed completion flag.
             fx.rocdl.s_waitcnt(0)
-            st(barrier_addr, bank + slot, epoch, order="relaxed", scope="sys")
+            st(barrier_addr, bank + slot, epoch, scope="sys")
 
 
 @ASTRewriter.transform
@@ -217,7 +217,6 @@ def topk_reduce_bf16_tile(
                             flag = ld(
                                 barrier_base,
                                 reduce_bank + slot,
-                                order="relaxed",
                                 scope="sys",
                                 dtype=fx.T.i64(),
                             )
@@ -244,7 +243,6 @@ def topk_reduce_bf16_tile(
                                 flag = ld(
                                     barrier_base,
                                     reduce_bank + slot,
-                                    order="relaxed",
                                     scope="sys",
                                     dtype=fx.T.i64(),
                                 )
@@ -281,7 +279,7 @@ def topk_reduce_bf16_tile(
                         token * fx.Int32(topk) + fx.Int32(j),
                         vec_width=1,
                         dtype=fx.T.f32(),
-                        cache_modifier=19,
+                        cache_modifier=18,
                     )
                     for j in range_constexpr(topk)
                 ]

--- a/primus_turbo/flydsl/mega/grouped_gemm_combine_bf16_kernel.py
+++ b/primus_turbo/flydsl/mega/grouped_gemm_combine_bf16_kernel.py
@@ -185,7 +185,6 @@ def _make_grouped_gemm_combine(
                             signal_count = ld(
                                 combine_flag_base,
                                 combine_bank + tile_cursor,
-                                scope="sys",
                                 dtype=fx.T.i64(),
                             )
                             while signal_count != expected_combine_i64:
@@ -202,8 +201,6 @@ def _make_grouped_gemm_combine(
                                 signal_count = ld(
                                     combine_flag_base,
                                     combine_bank + tile_cursor,
-                                    order="relaxed",
-                                    scope="sys",
                                     dtype=fx.T.i64(),
                                 )
                             tile_cursor = tile_cursor + fx.Int32(1)
@@ -268,7 +265,6 @@ def _make_grouped_gemm_combine(
                         combine_flag_base,
                         combine_bank + block_m,
                         fx.Int64(1),
-                        scope="sys",
                     )
             else:
                 # Empty region: first num_reduce_cu blocks do topk reduce, rest early-exit.
@@ -285,7 +281,6 @@ def _make_grouped_gemm_combine(
                                 combine_flag_base,
                                 combine_bank + empty_block_m,
                                 fx.Int64(n_blocks),
-                                scope="sys",
                             )
 
                     n_reduce_tiles = n_empty * fx.Int32(n_blocks)


### PR DESCRIPTION
# Description

Regularize where the Mega MoE kernels use system scope: keep it only where a
peer rank consumes the data, and drop it where the producer and consumer are
the same agent.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- `dispatch_prologue_kernel.py`: `expert_count` load drops `scope="sys"`.
- `ep_intranode.py`: same-agent loads drop `cache_modifier` 19 → 18, peer-visible stores stay at 19; drops redundant `order="relaxed"`.
- `grouped_gemm_combine_bf16_kernel.py`: combine flag loads and the completion `atomic_add` drop `scope="sys"`.
- `dispatch_grouped_gemm_bf16_kernel.py`: gate spin `s_sleep(1)` → `s_sleep(2)`.
- `benchmark/ops/training/config.py`: add the `DeepSeek-V4-Flash` MoE config.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
