### PR TITLE
fix: triton version deps on v26.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -507,7 +507,7 @@ if __name__ == "__main__":
     # TODO(ruibin): Triton 3.7.0 and flydsl 0.2.0 does not support gfx1250, so we skip their installation when building for gfx1250.
     offload_arch_list, _ = get_offload_archs()
     if "--offload-arch=gfx1250" not in offload_arch_list:
-        install_requires.append("triton==3.7.0")
+        install_requires.append("triton>=3.7.0")
         install_requires.append("flydsl==0.2.4")
     else:
         print("[Primus-Turbo Setup] Building for gfx1250; skipping triton dependency.")


### PR DESCRIPTION
# Description

The `v26.5` base container images (`rocm/primus:v26.5`, `rocm/jax-training:maxtext-v26.5`) already ship a ROCm-built Triton that is newer than `3.7.0`.

Because `setup.py` declared the dependency as an exact match (`triton==3.7.0`), installing Primus-Turbo inside one of those images made `pip` uninstall the Triton that came with the image and pull `3.7.0` from PyPI instead. That replaces a working ROCm Triton with a mismatched build and breaks every Triton kernel path in the package.

`3.7.0` is a floor, not an exclusive requirement: Primus-Turbo needs the features and the AMD backend fixes that landed in `3.7.0`, but it does not need that exact release and carries no upper bound. Relaxing the specifier to `triton>=3.7.0` lets a newer pre-installed Triton satisfy the requirement as-is, while genuinely older versions are still upgraded.

This unblocks running on `v26.5` and prepares the way for bumping the CI and base images from `v26.2` to `v26.5`.

Two things are intentionally left alone:

- `flydsl` keeps its exact pin (`flydsl==0.2.4`), because it is not yet known to be forward-compatible.
- The `gfx1250` branch of the condition is unchanged, so Triton and flydsl are still skipped entirely for that architecture, exactly as the existing `TODO` note above the block describes.

Fixes # (N/A — no tracking issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- `setup.py`: relax the Triton dependency from the exact pin `triton==3.7.0` to the lower bound `triton>=3.7.0`, so that the newer Triton shipped by the `v26.5` images is kept instead of being downgraded at install time.

# Checklist:

- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
