### PR TITLE
 fix(mega-moe): keep pool-sized operands 2D to avoid int32 shape overflow

### DIFF
--- a/benchmark/ops/training/bench_mega_moe.py
+++ b/benchmark/ops/training/bench_mega_moe.py
@@ -465,7 +465,7 @@ def dispatch_only(
     assert x.dtype == torch.bfloat16
     hidden_size = x.size(1)
     pool_capacity = symm.num_max_pool_tokens
-    x_i32 = x.contiguous().view(torch.int32).view(-1)
+    x_i32 = x.contiguous().view(torch.int32)
     launch = _compile_dispatch_only(
         hidden_size,
         pool_capacity,

--- a/benchmark/ops/training/bench_mega_moe.py
+++ b/benchmark/ops/training/bench_mega_moe.py
@@ -166,12 +166,17 @@ def compile_grouped_gemm_bf16(
             block_m = first_pid_m + (pid_in_group % group_size_m)
             block_n = pid_in_group // group_size_m
             g_idx = buffer_load(group_res, block_m, vec_width=1, dtype=fx.T.i32())
-            gbase = g_idx * fx.Int32(K) * c_n
+            pool_ptr_ty = PointerType.get(
+                elem_ty=fx.BFloat16.ir_type, address_space=AddressSpace.Global, alignment=16
+            )
+            # Per-group weight slab rebased in int64: G*K*N overflows an int32 b_group_base.
+            w_base = fx.arith.ArithValue(arith.index_cast(fx.T.i64(), extract_base_index(B)), signed=True)
+            b_byte_off = _i64(g_idx) * fx.Int64(K * 2) * _i64(c_n)
+            B_tile = fx.make_view(
+                fx.inttoptr(pool_ptr_ty, w_base + b_byte_off), fx.make_layout(fx.Int32(K) * c_n, 1)
+            )
             # Worst-case pool (cap*K > 2^31): rebase A/C per tile in int64, int32 in-resource offset. Mirrors fused nt/nn.
             if layout in ("nt", "nn"):
-                pool_ptr_ty = PointerType.get(
-                    elem_ty=fx.BFloat16.ir_type, address_space=AddressSpace.Global, alignment=16
-                )
                 a_byte_off = _i64(block_m) * fx.Int64(BLOCK_M * K * 2)
                 c_byte_off = _i64(block_m * fx.Int32(BLOCK_M)) * _i64(c_n) * fx.Int64(2)
                 a_base = fx.arith.ArithValue(arith.index_cast(fx.T.i64(), extract_base_index(A)), signed=True)
@@ -185,7 +190,7 @@ def compile_grouped_gemm_bf16(
                 )
                 gemm_tile(
                     A_tile,
-                    B,
+                    B_tile,
                     C_tile,
                     fx.Int32(BLOCK_M),
                     c_n,
@@ -197,12 +202,11 @@ def compile_grouped_gemm_bf16(
                     BLOCK_N=BLOCK_N,
                     out_fp16=out_fp16,
                     nt_vmcnt=nt_vmcnt,
-                    b_group_base=gbase,
                 )
             else:
                 gemm_tile(
                     A,
-                    B,
+                    B_tile,
                     C,
                     c_m,
                     c_n,
@@ -214,7 +218,6 @@ def compile_grouped_gemm_bf16(
                     BLOCK_N=BLOCK_N,
                     out_fp16=out_fp16,
                     nt_vmcnt=nt_vmcnt,
-                    b_group_base=gbase,
                 )
 
         if fx.block_idx.x < real_grid:
@@ -374,7 +377,7 @@ def grouped_gemm_variable_k_only(
     args = (
         lhs_e.contiguous(),
         rhs_e.contiguous(),
-        out_dw.view(-1),  # output: view (not contiguous) so writes hit the real buffer
+        flyc.from_torch_tensor(out_dw),  # static memref: full rank, no int32 shape kernarg
         prefix_i64,
         masked_k_i64,
         OUT_M_e,
@@ -417,10 +420,10 @@ def grouped_gemm_bf16_only(
         c_m, hidden_size = pool.shape
     if layout == "nt":  # weight [G, N, K]
         G, N, K = weight.shape
-        weight_flat = weight.reshape(G * N, K).contiguous().view(-1)
+        weight_flat = weight.reshape(G * N, K).contiguous()
     else:  # NN / TN: weight [G, K, N]
         G, K, N = weight.shape
-        weight_flat = weight.reshape(G * K, N).contiguous().view(-1)
+        weight_flat = weight.reshape(G * K, N).contiguous()
     assert K == hidden_size, f"weight K={K} != activation K={hidden_size}"
     out_features = N
     launch = compile_grouped_gemm_bf16(
@@ -437,7 +440,7 @@ def grouped_gemm_bf16_only(
     # Pass A/C as 2-D (flat view(-1) overflows int32 shape ABI); kernel rebases per tile.
     launch(
         pool.contiguous(),
-        weight_flat,
+        flyc.from_torch_tensor(weight_flat),
         output,
         tile_to_expert,
         num_tile_blocks,
@@ -535,9 +538,17 @@ def bench(fn, *, warmup=20, iters=30):
 # --------------------------------------------------------------------------- #
 def gate3(out, ref, *, cos_thresh=0.99, rel_thresh=0.05):
     """(cos, rel_rmse, ok) of a kernel output vs its reference (flattened, fp32)."""
-    g, r = out.float().flatten(), ref.float().flatten()
-    cos = float(torch.dot(g, r) / (g.norm() * r.norm() + 1e-12))
-    rel = float((g - r).norm() / (r.norm() + 1e-12))
+    g, r = out.flatten(), ref.flatten()
+    # chunked fp64 accumulation: torch.dot/norm cap numel at int32
+    dot = gg = rr = dd = 0.0
+    for i in range(0, g.numel(), 1 << 28):
+        gc, rc = g[i : i + (1 << 28)].float(), r[i : i + (1 << 28)].float()
+        dot += float((gc * rc).sum())
+        gg += float((gc * gc).sum())
+        rr += float((rc * rc).sum())
+        dd += float(((gc - rc) ** 2).sum())
+    cos = dot / (math.sqrt(gg) * math.sqrt(rr) + 1e-12)
+    rel = math.sqrt(dd) / (math.sqrt(rr) + 1e-12)
     return cos, rel, (cos >= cos_thresh and rel <= rel_thresh)
 
 

--- a/primus_turbo/flydsl/gemm/gemm_bf16_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_bf16_kernel.py
@@ -1066,6 +1066,10 @@ def _compile_grouped_variable_k_bf16(
 _COMPILED_GROUPED_GEMM_CACHE = {}
 
 
+def _ptr_only_view(t: torch.Tensor) -> torch.Tensor:
+    return t.contiguous().view(torch.int32)
+
+
 def grouped_gemm_variable_k_bf16(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -1104,13 +1108,9 @@ def grouped_gemm_variable_k_bf16(
         out_fp16=out_fp16,
         trans_c=trans_c,
     )
-    # Pass operands as an int32 view: the kernel only reads their base pointer (rebased
-    # by byte offsets in make_bf16_buffer_tensor_rebased), so dtype is irrelevant, while
-    # halving the element count keeps the flyc CABI 32-bit numel field from overflowing
-    # on production pools (>2^31 bf16 elems).
     args = (
-        a.contiguous().view(torch.int32).view(-1),
-        b.contiguous().view(torch.int32).view(-1),
+        _ptr_only_view(a),
+        _ptr_only_view(b),
         out.view(-1),
         offsets_i64,
         masked_k_i64,

--- a/primus_turbo/flydsl/gemm/gemm_bf16_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_bf16_kernel.py
@@ -646,7 +646,9 @@ def _get_compiled_dense(launch, args):
         elif isinstance(a, int):
             key_parts.append(a)
         else:
-            key_parts.append(type(a).__name__)
+            # static-memref JitArgs bake shape into the IR, so shape must be in the key
+            shape = getattr(a, "shape", None)
+            key_parts.append((type(a).__name__, tuple(shape) if shape is not None else None))
     key = tuple(key_parts)
     cached = _COMPILED_DENSE_CACHE.get(key)
     if cached is None:
@@ -1111,7 +1113,7 @@ def grouped_gemm_variable_k_bf16(
     args = (
         _ptr_only_view(a),
         _ptr_only_view(b),
-        out.view(-1),
+        flyc.from_torch_tensor(out),
         offsets_i64,
         masked_k_i64,
         OUT_M,

--- a/primus_turbo/flydsl/mega/dispatch_grouped_gemm_bf16_kernel.py
+++ b/primus_turbo/flydsl/mega/dispatch_grouped_gemm_bf16_kernel.py
@@ -496,7 +496,7 @@ def dispatch_grouped_gemm_bf16_flydsl_kernel(
     hidden_size = x.size(1)
     num_max_pool_tokens = int(symm.num_max_pool_tokens)
     dummy_i32 = get_dummy_tensor()
-    x_i32 = x.contiguous().view(torch.int32).view(-1)
+    x_i32 = x.contiguous().view(torch.int32)
 
     assert layout in ("nt", "nn", "tn"), f"unsupported layout {layout}"
     out_fp16 = out_dtype == torch.float16

--- a/primus_turbo/flydsl/mega/dispatch_grouped_gemm_bf16_kernel.py
+++ b/primus_turbo/flydsl/mega/dispatch_grouped_gemm_bf16_kernel.py
@@ -271,19 +271,23 @@ def _make_kernel(
                         signal = ld(dispatch_flag_base, blk, scope="sys", dtype=fx.T.i64())
                 fx.gpu.barrier()
 
-                gbase = g_idx * fx.Int32(K) * c_n
-                # A base = dispatch_token_pool (int64 symm addr); C base = OUTPUT tensor.
+                # A base = dispatch_token_pool (int64 symm addr); B/C base = WEIGHTS/OUTPUT tensors.
                 out_base = fx.arith.ArithValue(
                     arith.index_cast(fx.T.i64(), extract_base_index(OUTPUT)), signed=True
                 )
-                # Fold per-tile base in int64 (pool >4GB), voffset stays int32. A: precise bound; C: HW num_records via 0x40000000.
+                w_base = fx.arith.ArithValue(
+                    arith.index_cast(fx.T.i64(), extract_base_index(WEIGHTS)), signed=True
+                )
+                # Fold per-tile base in int64 (pool >4GB), voffset stays int32. A/B: precise bound; C: HW num_records via 0x40000000.
                 a_off = cast(block_m, fx.T.i64()) * fx.Int64(BLOCK_M * K * 2)
+                b_off = cast(g_idx, fx.T.i64()) * fx.Int64(K * out_features * 2)
                 c_off = cast(block_m, fx.T.i64()) * fx.Int64(BLOCK_M * 2) * cast(c_n, fx.T.i64())
                 A_tile = make_bf16_fp16_tile_tensor(dispatch_token_pool_base, a_off, BLOCK_M * K)
+                B_tile = make_bf16_fp16_tile_tensor(w_base, b_off, K * out_features)
                 C_tile = make_bf16_fp16_tile_tensor(out_base, c_off, 0x40000000)
                 gemm_tile(
                     A_tile,
-                    WEIGHTS,
+                    B_tile,
                     C_tile,
                     fx.Int32(BLOCK_M),
                     c_n,
@@ -295,7 +299,6 @@ def _make_kernel(
                     BLOCK_N=BLOCK_N,
                     out_fp16=out_fp16,
                     nt_vmcnt=nt_vmcnt,
-                    b_group_base=gbase,
                 )
 
     grid_size = num_dispatch_cu + (TOTAL if is_tn else worst_case_tiles * n_blocks)
@@ -517,7 +520,7 @@ def dispatch_grouped_gemm_bf16_flydsl_kernel(
         G = num_tokens_per_expert_prefix.numel() - 1
         out_shape = (G, OUT_N, OUT_M) if trans_c else (G, OUT_M, OUT_N)
         output = torch.empty(out_shape, device=x.device, dtype=out_dtype)
-        weight_arg, output_arg = rhs.contiguous(), output.view(-1)
+        weight_arg, output_arg = rhs.contiguous(), flyc.from_torch_tensor(output)
         # Bound the wgrad K-contraction to each expert's REAL (unpadded) token count so the
         # GEMM never reads stale block-padding rows (the dW1 floor). real[e] = sum over source
         # ranks of the combine recv counts (seg = e*num_ranks + src). Passed via the TILE arg,
@@ -530,13 +533,13 @@ def dispatch_grouped_gemm_bf16_flydsl_kernel(
     else:
         if layout == "nt":
             G, N, K = l1_weights.shape
-            weight_flat = l1_weights.reshape(G * N, K).contiguous().view(-1)
+            weight_flat = l1_weights.reshape(G * N, K).contiguous()
         else:
             G, K, N = l1_weights.shape
-            weight_flat = l1_weights.reshape(G * K, N).contiguous().view(-1)
+            weight_flat = l1_weights.reshape(G * K, N).contiguous()
         assert K == hidden_size, f"weight K={K} != activation K={hidden_size}"
         output = torch.empty((num_max_pool_tokens, N), dtype=x.dtype, device=x.device)
-        weight_arg, output_arg = weight_flat, output
+        weight_arg, output_arg = flyc.from_torch_tensor(weight_flat), output
         tile_arg, num_tile_arg, group_offs_arg = tile_to_expert, num_tile_blocks, dummy_i32
         c_n, out_m_rt, out_n_rt = N, 0, 0
         out_features_ce, hidden_size_ce = N, hidden_size

--- a/primus_turbo/flydsl/mega/grouped_gemm_combine_bf16_kernel.py
+++ b/primus_turbo/flydsl/mega/grouped_gemm_combine_bf16_kernel.py
@@ -231,19 +231,23 @@ def _make_grouped_gemm_combine(
             if block_m < real_tiles:
                 # GEMM role: one real tile (block_m, block_n) per block (unchanged).
                 group_index = buffer_load(group_resource, block_m, vec_width=1, dtype=fx.T.i32())
-                group_base = group_index * fx.Int32(K) * c_n
-                # A base = ACT tensor; C base = l2_token_buffer (int64 symm addr).
+                # A/B base = ACT/WEIGHTS tensors; C base = l2_token_buffer (int64 symm addr).
                 act_base = fx.arith.ArithValue(
                     fx.arith.index_cast(fx.T.i64(), extract_base_index(ACT)), signed=True
                 )
-                # Fold per-tile base in int64 (pool >4GB), voffset stays int32. A: precise bound; C: HW num_records via 0x40000000.
+                w_base = fx.arith.ArithValue(
+                    fx.arith.index_cast(fx.T.i64(), extract_base_index(WEIGHTS)), signed=True
+                )
+                # Fold per-tile base in int64 (pool >4GB), voffset stays int32. A/B: precise bound; C: HW num_records via 0x40000000.
                 a_off = cast(block_m, fx.T.i64()) * fx.Int64(BLOCK_M * K * 2)
+                b_off = cast(group_index, fx.T.i64()) * fx.Int64(K * out_features * 2)
                 c_off = cast(block_m, fx.T.i64()) * fx.Int64(BLOCK_M * 2) * cast(c_n, fx.T.i64())
                 A_tile = make_bf16_fp16_tile_tensor(act_base, a_off, BLOCK_M * K)
+                B_tile = make_bf16_fp16_tile_tensor(w_base, b_off, K * out_features)
                 C_tile = make_bf16_fp16_tile_tensor(l2_token_buffer_base, c_off, 0x40000000)
                 gemm_tile(
                     A_tile,
-                    WEIGHTS,
+                    B_tile,
                     C_tile,
                     fx.Int32(BLOCK_M),
                     c_n,
@@ -255,7 +259,6 @@ def _make_grouped_gemm_combine(
                     BLOCK_N=BLOCK_N,
                     out_fp16=out_fp16,
                     nt_vmcnt=nt_vmcnt,
-                    b_group_base=group_base,
                     c_cache_modifier=18,  # sc1|nt: agent-visible non-temporal local stage.
                 )
                 fx.rocdl.s_waitcnt(0)
@@ -507,16 +510,16 @@ def grouped_gemm_combine_bf16_flydsl_kernel(
     # Pass 2D: kernel advances ACT base per-tile in int64 (flat MxK overflows int32 ABI).
     act_2d = x.contiguous()
     if layout == "nt":
-        weight_flat = l2_weights.reshape(G * N, K).contiguous().view(-1)
+        weight_flat = l2_weights.reshape(G * N, K).contiguous()
     else:
-        weight_flat = l2_weights.reshape(G * K, N).contiguous().view(-1)
+        weight_flat = l2_weights.reshape(G * K, N).contiguous()
     num_tokens = int(symm.num_tokens)
     output = torch.empty(num_tokens, out_features, dtype=torch.bfloat16, device=device)
-    output_d = output.view(-1)
-    topk_indices_d = topk_indices.contiguous().view(-1)
+    output_d = output
+    topk_indices_d = topk_indices.contiguous()
     num_tokens_d = symm.num_tokens_per_rank
-    topk_weights_d = topk_weights.contiguous().view(-1) if apply_weights else dummy
-    grad_gate_d = grad_gate.contiguous().view(-1) if with_gate else dummy
+    topk_weights_d = topk_weights.contiguous() if apply_weights else dummy
+    grad_gate_d = grad_gate.contiguous() if with_gate else dummy
     d_topk_w = torch.empty(num_combine_slots, dtype=torch.float32, device=device) if with_gate else None
     d_topk_w_d = d_topk_w if with_gate else dummy
 
@@ -524,7 +527,7 @@ def grouped_gemm_combine_bf16_flydsl_kernel(
     # num_combine_cu / num_reduce_cu are tunable per shape+layout (nt/nn optima differ).
     _compiled_grouped_gemm_combine(
         act_2d,
-        weight_flat,
+        flyc.from_torch_tensor(weight_flat),
         tile_to_expert,
         num_tile_blocks,
         recv_dst_rank,

--- a/primus_turbo/flydsl/utils/gemm_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_helper.py
@@ -1349,12 +1349,18 @@ class StoreCBf16:
         self.out_ty = out_ty
         self.cache_modifier = cache_modifier
         c_nbytes = c_rows * c_cols * 2
-        gC = fx.rocdl.make_buffer_tensor(C, max_size=False, num_records_bytes=c_nbytes)
+        # Rebuild a rank-1 view: store indices are linear, so C's host rank must not leak in.
+        c_ptr_ty = PointerType.get(elem_ty=out_ty.ir_type, address_space=AddressSpace.Global, alignment=16)
+        c_base = ArithValue(arith.index_cast(T.i64, _buffer_ops.extract_base_index(C)), signed=True)
+        c_lin = fx.Tensor(fx.make_view(fx.inttoptr(c_ptr_ty, c_base), fx.make_layout(c_rows * c_cols, 1)))
+        gC = fx.rocdl.make_buffer_tensor(c_lin, max_size=False, num_records_bytes=c_nbytes)
         self.c_div = fx.logical_divide(gC, fx.make_layout(1, 1))
         self.out_atom_1 = fx.make_copy_atom(fx.rocdl.BufferCopy16b(), out_ty)
         self.reg_out_1 = fx.make_rmem_tensor(fx.make_layout(1, 1), out_ty)
         self.c_rsrc = (
-            create_buffer_resource(C, max_size=False, num_records_bytes=c_nbytes) if cache_modifier else None
+            create_buffer_resource(c_lin, max_size=False, num_records_bytes=c_nbytes)
+            if cache_modifier
+            else None
         )
         self.oob = fx.Int32(c_rows * c_cols)  # out-of-bounds sink index
 


### PR DESCRIPTION
# Description

The flyc CABI encodes tensor shape fields as 32-bit integers. Flattening pool-sized operands with `.view(-1)` collapses all extents into a single dimension, which overflows int32 once the pool exceeds 2^31 elements (reachable on production MoE configs) and produces corrupted buffer descriptors. Keeping these operands 2D leaves every per-dim extent well inside int32 range; the kernels only need the base pointer plus their own byte offsets, so the shape carried across the ABI is irrelevant to correctness.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- `gemm_bf16_kernel.py`: add `_ptr_only_view()` and pass grouped-GEMM A/B operands as 2D int32 views instead of flattened 1D.
- `dispatch_grouped_gemm_bf16_kernel.py`: keep the dispatch activation int32 view and the L1 weight buffer 2D.
- `bench_mega_moe.py`: same fix in the `dispatch_only` path.
- Add `tests/pytorch/ops/test_mega_moe_dispatch_combine_grouped_gemm.py` covering dispatch + combine + grouped GEMM.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
