### PR TITLE
perf(flydsl): dense fp8 NT/NN/TN optimisations

### DIFF
--- a/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
@@ -2583,7 +2583,7 @@ def _dense_nt_wave4_tile(
 
 
 @functools.lru_cache(maxsize=128)
-def _compile_dense_nt_wave4(
+def _compile_dense_wave4(
     M: int,
     N: int,
     K: int,
@@ -2597,16 +2597,19 @@ def _compile_dense_nt_wave4(
     pair_n: bool = False,  # fold the n-fragment pair into one dword store (needs even N)
     col_safe: bool = False,  # N % BLOCK_N == 0: drop the epilogue's per-store column clamp
     beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
+    tr_b: bool = False,  # B is K-major (NN), so its side pays the transpose reader
+    ring: bool = False,  # carry the pool fills across the tile boundary
 ):
-    """Whole-loop dense NT over ``geom``'s macro tile: a resident workgroup per CU walks a
-    column of tiles. K must be whole BLOCK_K blocks -- a partial one would need the
-    read-ahead to mask, and the 8-wave kernel already carries the native K-tail."""
+    """Whole-loop dense NT (``tr_b=False``) or NN over ``geom``'s macro tile: a resident
+    workgroup per CU walks a column of tiles. K must be whole BLOCK_K blocks -- a partial one
+    would need the read-ahead to mask, and the 8-wave kernel carries the native K-tail."""
     BM, BN = geom.bm, geom.bn
+    NTHR = _tn4_nthr(geom)
     phases = _tn4_phases(geom)
-    # A whole-line epilogue needs a wave's n-fragments to form one run of columns, and the run
-    # is written as an unmasked unit; the fold must divide the wave's n-extent evenly.
+    # The whole-line epilogue interleaves the n-fragments by permuting B's global row order,
+    # which a K-major B cannot be given; the fold must also divide the wave's n-extent.
     _bt = sum(p.tiles for p in _tn4_pools(geom) if p.side == geom.gl_side)
-    fold = geom.fold if col_safe and _bt % geom.fold == 0 else 0
+    fold = 0 if tr_b else (geom.fold if col_safe and _bt % geom.fold == 0 else 0)
     _pools = _nt4_pools(geom, fold)
     NBM, NBN = ceildiv(M, BM), ceildiv(N, BN)
     n_tile = NBM * NBN
@@ -2616,130 +2619,9 @@ def _compile_dense_nt_wave4(
     tiles_per_wg = 1 if beta_is_one else ceildiv(n_tile, min(n_tile, _dense_num_cus()))
     n_wg = ceildiv(n_tile, tiles_per_wg)
     K_ITERS = K // _TN4_BLOCK_K
-    assert K % _TN4_BLOCK_K == 0, "4-wave dense NT has no K-tail path"
-    assert K_ITERS >= phases, "4-wave dense NT needs a K of at least one main-loop pass"
-    _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
-
-    SharedStorage = fx.struct(
-        type(
-            "SharedStorage",
-            (),
-            {
-                "__annotations__": {
-                    f"p{i}": fx.Array[fx.Float8E4M3FN, p.nbuf * p.buf, 16] for i, p in enumerate(_pools)
-                }
-            },
-        )
-    )
-
-    @flyc.kernel(known_block_size=[256, 1, 1])
-    def kernel_dense_nt_wave4(
-        A: fx.Tensor,
-        B_T: fx.Tensor,
-        C: fx.Tensor,
-        A_scale: fx.Tensor,
-        B_scale: fx.Tensor,
-    ):
-        _ = str(fx.thread_idx.x)
-        lane_id = fx.thread_idx.x % 64
-        wave_id = fx.thread_idx.x // 64
-        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
-        gl_off = {
-            k: (
-                _nt4_fold_gl_off(lane_id, wave_id, K, k[1] * _TN4_BLOCK_K // (256 * 16), k[2], fold)
-                if fold and k[0] == geom.gl_side
-                else compute_global_swizzle(
-                    lane_id, wave_id, K, k[1] * _TN4_BLOCK_K // (256 * 16), preshuffled=False
-                )
-            )
-            for k in _tn4_gl_keys(_pools)
-        }
-        targs = dict(
-            M=M,
-            N=N,
-            K=K,
-            K_ITERS=K_ITERS,
-            NBM=NBM,
-            NBN=NBN,
-            group_m=group_m,
-            group_n=group_n,
-            num_xcd=num_xcd,
-            store_aux=_CSTORE_AUX,
-            lds=lds,
-            geom=geom,
-            A=A,
-            B=B_T,
-            C=C,
-            A_scale=A_scale,
-            B_scale=B_scale,
-            gl_off=gl_off,
-            wave_id=wave_id,
-            **dict(zip(("wave_m", "wave_n"), _tn4_wave_coord(wave_id, geom))),
-            cbsz=cbsz,
-            blgp=blgp,
-            out_ty=_out_ty,
-            col_safe=col_safe,
-            beta_is_one=beta_is_one,
-            pair_n=pair_n,
-            fold=fold,
-        )
-
-        for t in range(fx.Int32(0), fx.Int32(tiles_per_wg), fx.Int32(1)):
-            d = fx.block_idx.x + t * n_wg
-            _dense_nt_wave4_tile(arith.select(d < fx.Int32(n_tile), d, fx.Int32(n_tile - 1)), **targs)
-
-    _ATTRS = make_value_attrs(1, 0, "256,256")
-
-    @flyc.jit
-    def launch_dense_nt_wave4(
-        A: fx.Tensor,
-        B_T: fx.Tensor,
-        C: fx.Tensor,
-        A_scale: fx.Tensor,
-        B_scale: fx.Tensor,
-        c_m: fx.Int32,
-        c_n: fx.Int32,
-        stream: fx.Stream,
-    ):
-        _ = c_m, c_n  # the tile count is compile-time here; the grid is the resident set
-        kernel_dense_nt_wave4(A, B_T, C, A_scale, B_scale, value_attrs=_ATTRS).launch(
-            grid=(n_wg, 1, 1), block=(256, 1, 1), stream=stream
-        )
-
-    return launch_dense_nt_wave4
-
-
-@functools.lru_cache(maxsize=128)
-def _compile_dense_nn_wave4(
-    M: int,
-    N: int,
-    K: int,
-    group_m: int = 4,
-    group_n: int = 0,
-    num_xcd: int = 8,
-    geom=_NT4_SQUARE,
-    cbsz: int = 0,  # srcA fp8 fmt: 0=E4M3, 1=E5M2
-    blgp: int = 0,  # srcB fp8 fmt: 0=E4M3, 1=E5M2
-    out_fp16: bool = False,
-    pair_n: bool = False,  # fold the n-fragment pair into one dword store (needs even N)
-    col_safe: bool = False,  # N % BLOCK_N == 0: drop the epilogue's per-store column clamp
-    beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
-):
-    """Whole-loop dense NN: a resident workgroup per CU walks a column of ``geom``'s tiles."""
-    BM, BN = geom.bm, geom.bn
-    NTHR = _tn4_nthr(geom)
-    phases = _tn4_phases(geom)
-    # The whole-line epilogue interleaves the n-fragments by permuting B's global row order,
-    # which NN cannot do: its output columns are B's contiguous dim.
-    _pools = _nt4_pools(geom, 0)
-    NBM, NBN = ceildiv(M, BM), ceildiv(N, BN)
-    n_tile = NBM * NBN
-    tiles_per_wg = 1 if beta_is_one else ceildiv(n_tile, min(n_tile, _dense_num_cus()))
-    n_wg = ceildiv(n_tile, tiles_per_wg)
-    K_ITERS = K // _TN4_BLOCK_K
-    assert K % _TN4_BLOCK_K == 0, "whole-loop dense NN has no K-tail path"
-    assert K_ITERS >= phases, "whole-loop dense NN needs a K of at least one main-loop pass"
-    carry = K_ITERS % phases == 0
+    assert K % _TN4_BLOCK_K == 0, "the dense whole loop has no K-tail path"
+    assert K_ITERS >= phases, "the dense whole loop needs a K of at least one main-loop pass"
+    carry = ring and K_ITERS % phases == 0
     _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
 
     SharedStorage = fx.struct(
@@ -2755,7 +2637,7 @@ def _compile_dense_nn_wave4(
     )
 
     @flyc.kernel(known_block_size=[NTHR, 1, 1])
-    def kernel_dense_nn_wave4(
+    def kernel_dense_wave4(
         A: fx.Tensor,
         B: fx.Tensor,
         C: fx.Tensor,
@@ -2766,16 +2648,18 @@ def _compile_dense_nn_wave4(
         lane_id = fx.thread_idx.x % 64
         wave_id = fx.thread_idx.x // 64
         lds = fx.SharedAllocator().allocate(SharedStorage).peek()
-        # The B pools are filled K-row by K-row and read back transposed, so their write side
-        # takes the bank swizzle the transpose reader looks for.
-        gl_off = {
-            _tn4_gl_key(p): (
-                compute_global_swizzle_nn(lane_id, wave_id, N, p.steps, width=p.width, wswz=True)
-                if p.side == 1
-                else compute_global_swizzle(lane_id, wave_id, K, p.steps, preshuffled=False)
-            )
-            for p in _pools
-        }
+        # A K-major B is filled row by row and read back transposed, so its write side takes
+        # the bank swizzle the transpose reader looks for.
+        gl_off = {}
+        for k in _tn4_gl_keys(_pools):
+            side, width, gq = k
+            steps = width * _TN4_BLOCK_K // (NTHR * 16)
+            if tr_b and side == 1:
+                gl_off[k] = compute_global_swizzle_nn(lane_id, wave_id, N, steps, width=width, wswz=True)
+            elif fold and side == geom.gl_side:
+                gl_off[k] = _nt4_fold_gl_off(lane_id, wave_id, K, steps, gq, fold)
+            else:
+                gl_off[k] = compute_global_swizzle(lane_id, wave_id, K, steps, preshuffled=False)
         targs = dict(
             M=M,
             N=N,
@@ -2803,23 +2687,23 @@ def _compile_dense_nn_wave4(
             col_safe=col_safe,
             beta_is_one=beta_is_one,
             pair_n=pair_n,
-            fold=0,
-            tr_b=True,
+            fold=fold,
+            tr_b=tr_b,
         )
 
         if const_expr(carry):
-            w0 = _nt4_tile_window(fx.block_idx.x, M, N, K, NBM, NBN, group_m, group_n, num_xcd, geom, True)
+            w0 = _nt4_tile_window(fx.block_idx.x, M, N, K, NBM, NBN, group_m, group_n, num_xcd, geom, tr_b)
             _nt4_prime(
                 _pools,
                 [getattr(lds, f"p{i}") for i in range(len(_pools))],
                 _nt4_g2s(A, B, w0[2], _pools, gl_off, wave_id),
                 _nt4_carry_bufs(_pools, True),
                 K,
-                _TN4_BLOCK_K * N,
-                True,
+                _TN4_BLOCK_K * N if tr_b else _TN4_BLOCK_K,
+                tr_b,
             )
 
-        scale = load_per_tensor_scale(A_scale, B_scale)
+        scale = load_per_tensor_scale(A_scale, B_scale) if carry else None
 
         for t in range(fx.Int32(0), fx.Int32(tiles_per_wg), fx.Int32(1)):
             d = fx.block_idx.x + t * n_wg
@@ -2834,7 +2718,7 @@ def _compile_dense_nn_wave4(
     _ATTRS = make_value_attrs(NTHR // 256, 0, f"{NTHR},{NTHR}")
 
     @flyc.jit
-    def launch_dense_nn_wave4(
+    def launch_dense_wave4(
         A: fx.Tensor,
         B: fx.Tensor,
         C: fx.Tensor,
@@ -2845,11 +2729,15 @@ def _compile_dense_nn_wave4(
         stream: fx.Stream,
     ):
         _ = c_m, c_n  # the tile count is compile-time here; the grid is the resident set
-        kernel_dense_nn_wave4(A, B, C, A_scale, B_scale, value_attrs=_ATTRS).launch(
+        kernel_dense_wave4(A, B, C, A_scale, B_scale, value_attrs=_ATTRS).launch(
             grid=(n_wg, 1, 1), block=(NTHR, 1, 1), stream=stream
         )
 
-    return launch_dense_nn_wave4
+    return launch_dense_wave4
+
+
+_compile_dense_nt_wave4 = functools.partial(_compile_dense_wave4, tr_b=False, ring=False)
+_compile_dense_nn_wave4 = functools.partial(_compile_dense_wave4, tr_b=True, ring=True)
 
 
 _COMPILED_DENSE_CACHE: dict = {}

--- a/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
@@ -12,12 +12,13 @@
 # not the MIT license that covers the rest of Primus-Turbo (see LICENSE).
 ###############################################################################
 
-"""Primus-Turbo dense FP8 GEMM kernel (FlyDSL): NT, NN and TN layouts.
-256x256 tile, BLOCK_K=128, 8-wave (wave_m=2 x wave_n=4), mfma_f32_16x16x128_f8f6f4,
-per-tensor scale, bf16/fp16 out, arbitrary K via native K-tail (TT unsupported).
-Primitives are imported from flydsl.utils.gemm_helper as module globals."""
+"""Primus-Turbo dense FP8 GEMM kernel (FlyDSL): NT, NN and TN layouts,
+mfma_f32_16x16x128_f8f6f4, per-tensor scale, bf16/fp16 out, arbitrary K (TT unsupported).
+Each layout races an 8-wave skeleton against a 4-wave whole-loop per shape."""
 
 import functools
+import math
+from typing import NamedTuple
 
 import torch
 
@@ -26,31 +27,50 @@ import torch
 # submodule; flydsl, the compiler, is the only FlyDSL dep) and imported as module
 # globals (@flyc.kernel needs its dependencies as globals).
 from primus_turbo.flydsl.utils.gemm_helper import (
+    resolve_accum_out,
     G2SLoader,
     Mfma16x16x128,
     S2RLoader,
     S2RLoaderTr,
     StoreCPerTensor,
+    StoreCPerTensorLineN,
+    StoreCPerTensorPairN,
+    StoreCPerTensorQuadN,
+    XPOSE_SLOT,
+    XPOSE_SLOTS,
+    _lds_barrier,
+    _readfirstlane_i32,
+    _robust_time,
     asm_mma_do,
+    block_mn,
     ceildiv,
-    compile_with_scratch_out,
     compute_global_swizzle,
     compute_global_swizzle_nn,
+    floordiv_pow2,
+    load_per_tensor_scale,
     make_fp8_buffer_tensor_rebased,
+    make_row_band_resource,
     make_value_attrs,
     mask_a_tail,
-    resolve_accum_out,
     wait_barrier,
     xcd_remap_pid,
 )
 import flydsl.compiler as flyc
 import flydsl.expr as fx
+from flydsl._mlir import ir
 from flydsl._mlir.dialects import llvm as _llvm
 from flydsl.expr import arith
-from flydsl.expr import range_constexpr, rocdl
+from flydsl.expr import buffer_ops as _buffer_ops
+from flydsl.expr import const_expr, range_constexpr, rocdl
 from flydsl.expr.typing import T
+from flydsl.expr.typing import Vector as Vec
 
 # isort: on
+
+# `nt` aux bit: C is write-once, so caching it evicts the A/B band the L2 swizzle keeps.
+_CSTORE_AUX = 2
+
+_PICK_RAMP_ITERS = 200  # throwaway launches before timing: the leading candidate else pays the ramp
 
 
 @functools.lru_cache(maxsize=256)
@@ -66,6 +86,8 @@ def _compile_dense_nt(
     cbsz: int = 0,  # srcA fp8 fmt: 0=E4M3, 1=E5M2
     blgp: int = 0,  # srcB fp8 fmt: 0=E4M3, 1=E5M2
     out_fp16: bool = False,  # StoreCPerTensor out dtype: True -> fp16, else bf16
+    pair_n: bool = False,  # fold the n-fragment pair into one dword store (needs even N)
+    col_safe: bool = False,  # N % BLOCK_N == 0: drop the epilogue's per-store column clamp
     beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
 ):
     """Build & cache the (K, BLOCK_M, BLOCK_N, GROUP_M)-specialised NT launch.
@@ -189,8 +211,19 @@ def _compile_dense_nt(
         a_s2r = S2RLoader(wave_m, N_TILES_A)
         b_s2r = S2RLoader(wave_n, N_TILES_B)
         _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
-        store_c = StoreCPerTensor(
-            A_scale, B_scale, C, c_m, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty, beta_is_one=beta_is_one
+        store_c = (StoreCPerTensorPairN if pair_n else StoreCPerTensor)(
+            A_scale,
+            B_scale,
+            C,
+            c_m,
+            c_n,
+            mfma.idx,
+            N_TILES_A,
+            N_TILES_B,
+            _out_ty,
+            col_safe=col_safe,
+            store_aux=_CSTORE_AUX,
+            beta_is_one=beta_is_one,
         )
 
         c00_frag = [mfma.zero_value] * N_ACCUMS
@@ -311,8 +344,9 @@ def _compile_dense_nt(
         b_cur0, b_next0 = b_next0, b_cur0
         b_cur1, b_next1 = b_next1, b_cur1
 
-        # Epilog 2 (k = K_ITERS - 1) -- the K-tail block. Mask the A operand
-        # so invalid K-columns (>= K_TAIL) contribute 0. No-op when K_TAIL==0.
+        # K-tail block: mask A so columns past K_TAIL contribute 0. Past wait_barrier(0)
+        # nothing writes LDS, so a group store drains in the next group mfma shadow --
+        # the two share neither vmcnt nor lgkmcnt.
         a0_frag = a_s2r.load(a_cur0)
         a0_frag = mask_a_tail(a0_frag, lane_id, K_TAIL)
         wait_barrier(0)
@@ -330,24 +364,27 @@ def _compile_dense_nt(
         rocdl.s_setprio(0)
         rocdl.s_barrier()
 
-        a1_frag = a_s2r.load(a_cur1)
-        a1_frag = mask_a_tail(a1_frag, lane_id, K_TAIL)
-        rocdl.s_barrier()
-
-        rocdl.s_setprio(1)
-        c10_frag = mfma.call(a1_frag, b0_frag, c10_frag)
-        c11_frag = mfma.call(a1_frag, b1_frag, c11_frag)
-        rocdl.s_setprio(0)
-        rocdl.s_barrier()
-
-        # Scale + store.
         wave_n_offset = wave_n * (N_TILES_B * 16)
         wave_m_offset = wave_m * (N_TILES_A * 16)
         base_row = block_m * BLOCK_M + wave_m_offset
         base_col = block_n * BLOCK_N + wave_n_offset
 
+        a1_frag = a_s2r.load(a_cur1)
+        a1_frag = mask_a_tail(a1_frag, lane_id, K_TAIL)
         store_c.store(c00_frag, base_row + 0, base_col + 0)
+
+        rocdl.s_setprio(1)
+        c10_frag = mfma.call(a1_frag, b0_frag, c10_frag)
+        rocdl.s_setprio(0)
+        rocdl.s_barrier()
+
         store_c.store(c01_frag, base_row + 0, base_col + LDS_BLOCK_N)
+
+        rocdl.s_setprio(1)
+        c11_frag = mfma.call(a1_frag, b1_frag, c11_frag)
+        rocdl.s_setprio(0)
+        rocdl.s_barrier()
+
         store_c.store(c10_frag, base_row + LDS_BLOCK_M, base_col + 0)
         store_c.store(c11_frag, base_row + LDS_BLOCK_M, base_col + LDS_BLOCK_N)
 
@@ -386,6 +423,7 @@ def _compile_dense_nn(
     BLOCK_M: int = 256,
     BLOCK_N: int = 256,
     GROUP_M: int = 4,
+    group_n: int = 0,  # 0 = 1D GROUP_M swizzle; >0 = 2D band (width group_n), as in NT
     num_xcd: int = 8,  # XCD-aware PID remap for per-XCD L2 reuse (MI355X = 8 XCD); 1 disables. See xcd_remap_pid.
     waves_per_eu: int = 2,
     agpr_alloc: int = 0,
@@ -397,6 +435,8 @@ def _compile_dense_nn(
     blgp: int = 0,  # srcB fp8 fmt: 0=E4M3, 1=E5M2
     out_fp16: bool = False,  # StoreCPerTensor out dtype: True -> fp16, else bf16
     i64_traverse: bool = False,  # B[K,N] traversal via per-load i64 SRD re-base (lifts k*n < 2^32 cap)
+    pair_n: bool = False,  # fold the n-fragment pair into one dword store (needs even N)
+    col_safe: bool = False,  # N % BLOCK_N == 0: drop the epilogue's per-store column clamp
     beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
 ):
     """NN-layout fp8 dense kernel. A [M, K], B [K, N], C [M, N].
@@ -471,18 +511,9 @@ def _compile_dense_nn(
         wave_id = fx.thread_idx.x // 64
         wave_m = wave_id // 4
         wave_n = wave_id % 4
-        # Super-block tile swizzle for L2 reuse; group_size_m clamps the last
-        # band so any GROUP_M >= 1 is correct (same as NT).
         num_pid_m = ceildiv(c_m, BLOCK_M)
         pid = xcd_remap_pid(fx.block_idx.x, num_pid_m * n_blocks, num_xcd)
-        num_pid_in_group = GROUP_M * n_blocks
-        group_id = pid // num_pid_in_group
-        pid_in_group = pid % num_pid_in_group
-        first_pid_m = group_id * GROUP_M
-        remaining_m = num_pid_m - first_pid_m
-        group_size_m = arith.select(remaining_m < GROUP_M, remaining_m, fx.Int32(GROUP_M))
-        block_m = first_pid_m + (pid_in_group % group_size_m)
-        block_n = pid_in_group // group_size_m
+        block_m, block_n = block_mn(pid, num_pid_m, n_blocks, GROUP_M, group_n)
 
         # i64 input re-base. A[M,K]: fold row base (m_row*K) into SRD. B[K,N]: the
         # k*BLOCK_K*c_n contraction is i64 per load (cn_i), capped at 4GB by num_records.
@@ -502,8 +533,9 @@ def _compile_dense_nn(
         a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
         b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
 
+        _nnwz = True  # wave bank-swizzle B; write and read sides must match
         gl_off_a = compute_global_swizzle(lane_id, wave_id, K, N_LDS_ROUNDS, preshuffled=False)
-        gl_off_b = compute_global_swizzle_nn(lane_id, wave_id, c_n, N_LDS_ROUNDS)
+        gl_off_b = compute_global_swizzle_nn(lane_id, wave_id, c_n, N_LDS_ROUNDS, wswz=_nnwz)
 
         mfma = Mfma16x16x128(N_TILES_A, N_TILES_B)
         if cbsz or blgp:
@@ -520,10 +552,23 @@ def _compile_dense_nn(
         b_rebase = (B, F8_IR_t, b_base, b_nrec) if i64_traverse else None
         b_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_B, F8_IR_t, wave_id, rebase=b_rebase)
         a_s2r = S2RLoader(wave_m, N_TILES_A)
-        b_s2r = S2RLoaderTr(wave_n, N_TILES_B, 32, inline_asm=b_inline_asm_load, vmcnt_hint=vmcnt_hint)
+        b_s2r = S2RLoaderTr(
+            wave_n, N_TILES_B, 32, inline_asm=b_inline_asm_load, vmcnt_hint=vmcnt_hint, wswz=_nnwz
+        )
         _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
-        store_c = StoreCPerTensor(
-            A_scale, B_scale, C, c_m, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty, beta_is_one=beta_is_one
+        store_c = (StoreCPerTensorPairN if pair_n else StoreCPerTensor)(
+            A_scale,
+            B_scale,
+            C,
+            c_m,
+            c_n,
+            mfma.idx,
+            N_TILES_A,
+            N_TILES_B,
+            _out_ty,
+            col_safe=col_safe,
+            store_aux=_CSTORE_AUX,
+            beta_is_one=beta_is_one,
         )
 
         c00_frag = [mfma.zero_value] * N_ACCUMS
@@ -550,8 +595,9 @@ def _compile_dense_nn(
 
         # Main loop. Emits 7 barriers per K-iter (before/after each MFMA);
         # all are load-bearing — dropping any risks a compiler-reorder race.
+        # vmcnt=-1: the trailing wait_barrier already drains g2s (the epilogue keeps its own).
         for k in range_constexpr(K_ITERS - 2):
-            b0_frag = b_s2r.load(b_cur0)
+            b0_frag = b_s2r.load(b_cur0, vmcnt=-1)
             a0_frag = a_s2r.load(a_cur0)
             a_g2s.load(a_next1, A1_gl_offset + (k + 1) * BLOCK_K)
             rocdl.s_barrier()
@@ -561,7 +607,7 @@ def _compile_dense_nn(
             rocdl.s_setprio(0)
             rocdl.s_barrier()
 
-            b1_frag = b_s2r.load(b_cur1)
+            b1_frag = b_s2r.load(b_cur1, vmcnt=-1)
             b_g2s.load(b_cur0, B0_gl_offset + arith.index((k + 2) * BLOCK_K) * cn_i)
             rocdl.s_barrier()
 
@@ -633,6 +679,11 @@ def _compile_dense_nn(
         b_cur0, b_next0 = b_next0, b_cur0
         b_cur1, b_next1 = b_next1, b_cur1
 
+        wave_n_offset = _readfirstlane_i32(wave_n * (N_TILES_B * 16))
+        wave_m_offset = _readfirstlane_i32(wave_m * (N_TILES_A * 16))
+        base_row = block_m * BLOCK_M + wave_m_offset
+        base_col = block_n * BLOCK_N + wave_n_offset
+
         # Epilog 2 -- K-tail block. Mask A so K-cols >= K_TAIL contribute 0.
         a0_frag = a_s2r.load(a_cur0)
         a0_frag = mask_a_tail(a0_frag, lane_id, K_TAIL)
@@ -643,6 +694,9 @@ def _compile_dense_nn(
         rocdl.s_setprio(0)
         rocdl.s_barrier()
 
+        # Issue each group at its own last mfma: the exposed drain is the burst's tail.
+        store_c.store(c00_frag, base_row, base_col)
+
         b1_frag = b_s2r.load(b_cur1)
         rocdl.s_barrier()
 
@@ -651,24 +705,25 @@ def _compile_dense_nn(
         rocdl.s_setprio(0)
         rocdl.s_barrier()
 
+        store_c.store(c01_frag, base_row, base_col + LDS_BLOCK_N)
+
         a1_frag = a_s2r.load(a_cur1)
         a1_frag = mask_a_tail(a1_frag, lane_id, K_TAIL)
         rocdl.s_barrier()
 
         rocdl.s_setprio(1)
         c10_frag = mfma.call(a1_frag, b0_frag, c10_frag)
+        rocdl.s_setprio(0)
+
+        # Split the tail block's last two groups so the store issues under the second and
+        # the matrix core covers a quadrant that used to drain after the final mfma.
+        store_c.store(c10_frag, base_row + LDS_BLOCK_M, base_col)
+
+        rocdl.s_setprio(1)
         c11_frag = mfma.call(a1_frag, b1_frag, c11_frag)
         rocdl.s_setprio(0)
         rocdl.s_barrier()
 
-        wave_n_offset = wave_n * (N_TILES_B * 16)
-        wave_m_offset = wave_m * (N_TILES_A * 16)
-        base_row = block_m * BLOCK_M + wave_m_offset
-        base_col = block_n * BLOCK_N + wave_n_offset
-
-        store_c.store(c00_frag, base_row + 0, base_col + 0)
-        store_c.store(c01_frag, base_row + 0, base_col + LDS_BLOCK_N)
-        store_c.store(c10_frag, base_row + LDS_BLOCK_M, base_col + 0)
         store_c.store(c11_frag, base_row + LDS_BLOCK_M, base_col + LDS_BLOCK_N)
 
     @flyc.jit
@@ -877,7 +932,17 @@ def _compile_dense_tn(
         )
         _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
         store_c = StoreCPerTensor(
-            A_scale, B_scale, C, c_m, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty, beta_is_one=beta_is_one
+            A_scale,
+            B_scale,
+            C,
+            c_m,
+            c_n,
+            mfma.idx,
+            N_TILES_A,
+            N_TILES_B,
+            _out_ty,
+            store_aux=_CSTORE_AUX,
+            beta_is_one=beta_is_one,
         )
 
         c00_frag = [mfma.zero_value] * N_ACCUMS
@@ -1034,19 +1099,1787 @@ def _compile_dense_tn(
     return launch_dense_tn
 
 
-# NN 4-wave kernel removed (consistently slower than 8w; HW caps 1
-# wave/SIMD for this layout).
+# TN 4-wave (occ=1): one tile per WG, whole K loop in one bare-asm region, accumulators in AGPR.
+_TN4_BLOCK_K = 128  # K depth of one mfma_f32_16x16x128 pass, so a K-block is one pass deep
+_TN4_CS = 1024  # per-wave LDS chunk stride, shared by the G2S writer and the S2R reader
+_TN4_PIN = 8  # first VGPR of the pinned operand-fragment window
+_TN4_AGPR = 64  # vector<4xf32> accumulators the AGPR file holds; any beyond it take VGPRs
+_TN4_RED_VEC = 8  # out_ty elements one lane folds per load (a b128 request)
+_TN4_RED_WPT = 8  # reduce workgroups per split-K window tile
+_TN4_HAND_S = 2  # split-K slices the in-register handoff covers
+# sc0|sc1: nothing pins a tile's two slices to one XCD's L2, so the handoff is device-scope.
+_TN4_HAND_AUX = 17
+_TN4_ISSUE_PAD = "s_nop 0"  # one wait state between the body's instruction groups
+_TN4_ASM_CACHE: dict = {}
+
+
+class _Tn4Geom(NamedTuple):
+    """A macro tile: ``pools`` are (side, width, nbuf), A first and the deepest last so the
+    partial phase drain has somewhere to land; ``wgrid`` is how many waves split one along
+    each side's axis."""
+
+    bm: int
+    bn: int
+    pools: tuple
+    bstep: int
+    # Boundaries taking a wait state, "<before><after>" over m (mfma), d (ds_read), g (g2s).
+    pad: tuple = ("mm", "md", "mg", "dm", "dd", "dg", "gm", "gd", "gg")
+    wgrid: tuple = (2, 2)  # a square split shares both operands' reads four ways, not one side's
+    # Epilogue: which side the fold reorders, n-fragments it folds into one request, store units
+    # a quadrant's rows divide into folded and unfolded, units the peel leads by, drain wait.
+    gl_side: int = 1
+    fold: int = 8
+    store_split: int = 2
+    store_split_flat: int = 4
+    peel_lead: int = 3
+    drain_lgkm: int = 12
+
+
+_TN4_LINE = 128  # global cache line: a g2s row costs one request per line it spans
+_TN4_SQUARE = _Tn4Geom(
+    256,
+    256,
+    ((0, 128, 2), (0, 128, 2), (1, 128, 3), (1, 128, 3)),
+    0,
+)
+# Finer grid for shapes the square tile cannot round onto whole CU passes, same operand bytes.
+_TN4_RECT = _Tn4Geom(
+    384,
+    192,
+    ((0, 128, 2), (0, 128, 2), (0, 128, 2), (1, 64, 2), (1, 128, 3)),
+    1,
+)
+_TN4_GEOMS = (_TN4_SQUARE, _TN4_RECT)
+
+
+def _tn4_pad(groups, pad):
+    """Space a phase's instruction groups at the boundaries ``pad`` names: at one wave per
+    SIMD the memory issue arrives in bursts that back-pressure the matrix pipe. The last group
+    of a phase always takes one, since the drain follows it."""
+    kinds, out = "mdg", []
+    for i, (k, txt) in enumerate(groups):
+        out.append(txt)
+        if i + 1 == len(groups) or kinds[k] + kinds[groups[i + 1][0]] in pad:
+            out.append(_TN4_ISSUE_PAD)
+    return out
+
+
+def _tn4_phases(geom):
+    """K-blocks one main-loop pass consumes: the lcm of the pool depths, so a pass always
+    ends with every pool back on buffer 0."""
+    n = 1
+    for _side, _w, nbuf in geom.pools:
+        n = n * nbuf // math.gcd(n, nbuf)
+    return n
+
+
+class _Tn4Pool:
+    """One LDS operand pool: `width` columns of its side's macro tile, starting at `col`,
+    `nbuf` buffers deep. Every other size follows from the width at BLOCK_K / 256 threads."""
+
+    def __init__(self, side, width, nbuf, col, wsplit=2, nthr=256):
+        self.side, self.width, self.nbuf, self.col = side, width, nbuf, col
+        self.gcol = col  # column the tile actually reads/writes; _tn4_line_cols may rotate it
+        self.gq = 0  # rank among the pools that share a global row order; see _tn4_gl_key
+        self.tiles = width // (16 * wsplit)  # mfma tiles one wave's share of the pool holds
+        self.steps = width * _TN4_BLOCK_K // (nthr * 16)  # dwordx4 G2S steps per buffer
+        self.buf = width * _TN4_BLOCK_K  # bytes per buffer
+        self.rs = (width // 16) * _TN4_CS  # halves of a tile's transpose reads, BLOCK_K/2 apart
+        assert (nbuf - 1) * self.buf + self.rs < 65536, "buffer delta overflows ds offset"
+
+
+def _tn4_nthr(geom):
+    return 64 * geom.wgrid[0] * geom.wgrid[1]
+
+
+def _tn4_wave_coord(wave_id, geom):
+    wn = geom.wgrid[1]
+    return wave_id // wn, wave_id % wn
+
+
+def _tn4_pools(geom):
+    """Expand a geometry's pool spec, giving each pool its column offset within its side."""
+    wg, nthr = geom.wgrid, _tn4_nthr(geom)
+    col, out = [0, 0], []
+    for side, width, nbuf in geom.pools:
+        out.append(_Tn4Pool(side, width, nbuf, col[side], wg[side], nthr))
+        col[side] += width
+    assert col == [geom.bm, geom.bn], "pools must cover the macro tile exactly"
+    return out
+
+
+def _tn4_line_cols(pools, geom, off):
+    """Point every pool's ``gcol`` at a cache-line-aligned column of its macro tile: rotating
+    a misaligned side's pool window by the complement of the misalignment covers the same
+    columns off aligned boundaries. Only windows that rotate on a pool boundary take part."""
+    for p in pools:
+        extent = geom[p.side]
+        r = extent % _TN4_LINE
+        if r == 0 or any(q.side == p.side and q.col < r < q.col + q.width for q in pools):
+            continue
+        p.gcol = fx.Int32(
+            _readfirstlane_i32(
+                arith.select(
+                    off[p.side] % fx.Int32(_TN4_LINE) == fx.Int32(0),
+                    fx.Int32((p.col + extent - r) % extent),
+                    fx.Int32(p.col),
+                )
+            )
+        )
+
+
+def _tn4_gl_key(p):
+    """Identity of a pool's global-swizzle offset set: pools that read the same operand at the
+    same LDS width share one, unless a caller gave them different global row orders (``gq``)."""
+    return (p.side, p.width, p.gq)
+
+
+def _tn4_gl_keys(pools):
+    """Every distinct global-swizzle offset set, in pool order."""
+    keys = []
+    for p in pools:
+        if _tn4_gl_key(p) not in keys:
+            keys.append(_tn4_gl_key(p))
+    return keys
+
+
+def _dense_tn_slice_div(x, s):
+    """``x // s`` for a compile-time split-K slice factor: one shift, or one fixed-point
+    reciprocal multiply. Exact for every dividend the slice bounds reach (see _TN4_RCP_MAX)."""
+    if s & (s - 1) == 0:
+        return fx.Int32(floordiv_pow2(x, s))
+    return fx.Int32(fx.Int32(x * (-(-(1 << 16) // s))) >> 16)
+
+
+def _dense_tn_tile_mn(t, NBM, NBN, group_m, group_n):
+    """Tile id -> (block_m, block_n) for the whole-loop TN kernel and its reduce. Both go
+    through here so a window tile's slices and its fold agree on the tile id."""
+    return block_mn(t, fx.Int32(NBM), fx.Int32(NBN), group_m, group_n)
+
+
+def _dense_tn_reduce_rows(
+    ws_base, c_base, M, N, s, base_row, base_col, rows, bn, tid, nthr, out_ty, col_safe
+):
+    """Sum slice 0's partial, already in C, and the s-1 WS bands of a ``rows`` x ``bn`` block
+    back into C. A lane takes a _TN4_RED_VEC-wide run so a row is full-width requests, and the
+    bands keep C's row pitch so band j only moves the SRD base."""
+    ir_ty = out_ty.ir_type
+    f32v = fx.T.VectorType.get([_TN4_RED_VEC], fx.T.f32())
+    outv = fx.T.VectorType.get([_TN4_RED_VEC], ir_ty)
+    lanes_per_row = bn // _TN4_RED_VEC
+    rows_per_pass = nthr // lanes_per_row
+    row = tid // fx.Int32(lanes_per_row)
+    col = base_col + (tid % fx.Int32(lanes_per_row)) * fx.Int32(_TN4_RED_VEC)
+    mask = None if col_safe else col < fx.Int32(N)
+    if nthr % lanes_per_row:
+        whole = row < fx.Int32(rows_per_pass)
+        mask = whole if mask is None else arith.andi(mask, whole)
+    base = row * fx.Int32(N) + col
+    dst = make_row_band_resource(c_base, base_row, fx.Int32(M), N, 2)
+    src = [dst] + [
+        make_row_band_resource(ws_base, fx.Int32(j * M) + base_row, fx.Int32((j + 1) * M), N, 2)
+        for j in range_constexpr(s - 1)
+    ]
+    for p in range_constexpr(ceildiv(rows, rows_per_pass)):
+        off = base + fx.Int32(p * rows_per_pass * N)
+        m = mask
+        if (p + 1) * rows_per_pass > rows:
+            live = row < fx.Int32(rows - p * rows_per_pass)
+            m = live if mask is None else arith.andi(mask, live)
+        acc = None
+        for j in range_constexpr(s):
+            v = arith.extf(
+                f32v,
+                _buffer_ops.buffer_load(src[j], off, vec_width=_TN4_RED_VEC, dtype=ir_ty, mask=m),
+            )
+            acc = v if acc is None else arith.addf(acc, v)
+        _buffer_ops.buffer_store(arith.trunc_f(outv, acc), dst, off, mask=m, cache_modifier=_CSTORE_AUX)
+
+
+def _tn4_handoff(split):
+    """True when the split-K window settles in-kernel: two slices can hand off, deeper ones
+    need the reduce."""
+    return split is not None and split[2] == _TN4_HAND_S
+
+
+def _tn4_handoff_wait(flag, off, want, rows):
+    """Spin until this tile's flag reads ``want``, then pass ``rows`` back out: routing the
+    scratch descriptor's size through this block keeps the partial's loads below the wait.
+    Slice 0 wants the resting value, as does a tile outside the window."""
+    r = _llvm.inline_asm(
+        ir.Type.parse("!llvm.struct<(i32, i32, i32)>"),
+        [arith._to_raw(v) for v in (flag, off, want, rows)],
+        "\n".join(
+            [
+                "1:",
+                "buffer_load_dword $0, $4, $3, 0 offen sc0 sc1",
+                "s_waitcnt vmcnt(0)",
+                "v_readfirstlane_b32 $1, $0",
+                "s_cmp_lg_u32 $1, $5",
+                "s_cbranch_scc0 2f",
+                "s_sleep 8",
+                "s_branch 1b",
+                "2:",
+                "s_mov_b32 $2, $6",
+            ]
+        ),
+        "=&v,=&s,=&s,s,v,s,s",
+        has_side_effects=True,
+    )
+    return fx.Int32(_llvm.extractvalue(T.i32, r, [2]))
+
+
+# Accumulators a lane hands over per request; the slot is lane-contiguous so a pair rides one.
+_TN4_HAND_PACK = 2
+
+
+def _tn4_frag_off(wave_id, lane_id, q, nacc):
+    """Element offset of accumulator ``q``'s pack in a tile's handoff scratch slot; C's own
+    layout would scatter a lane's four values over four rows instead."""
+    lane_elems = 4 * _TN4_HAND_PACK
+    return (wave_id * fx.Int32(nacc) + fx.Int32(q)) * fx.Int32(256) + lane_id * fx.Int32(lane_elems)
+
+
+def _tn4_publish_frag(frag, rsrc, wave_id, lane_id, q0, nacc, out_ty, aux):
+    """Hand this slice's accumulators to the tile's scratch slot, unscaled: the folding slice
+    adds them to its own and its store is what applies the per-tensor scale, once. A slice
+    that owns no slot takes a zero-record descriptor and its stores drop."""
+    n = _TN4_HAND_PACK
+    assert len(frag) % n == 0 and q0 % n == 0, "handoff pack must divide the accumulator run"
+    for i in range_constexpr(len(frag) // n):
+        vals = [frag[n * i + h].to(out_ty) for h in range(n)]
+        _buffer_ops.buffer_store(
+            Vec.from_elements([v[j] for v in vals for j in range(4)], out_ty),
+            rsrc,
+            _tn4_frag_off(wave_id, lane_id, q0 + n * i, nacc),
+            cache_modifier=aux,
+        )
+
+
+def _tn4_fold_frag(frag, rsrc, wave_id, lane_id, q0, nacc, out_ty, aux):
+    """Add the predecessor slice's published accumulators into this one's. A non-folding
+    slice reads a zero-record descriptor, which returns zero and leaves its own values."""
+    n = _TN4_HAND_PACK
+    assert len(frag) % n == 0 and q0 % n == 0, "handoff pack must divide the accumulator run"
+    out = []
+    for i in range_constexpr(len(frag) // n):
+        got = Vec(
+            _buffer_ops.buffer_load(
+                rsrc,
+                _tn4_frag_off(wave_id, lane_id, q0 + n * i, nacc),
+                vec_width=4 * n,
+                dtype=out_ty.ir_type,
+                cache_modifier=aux,
+            )
+        ).to(fx.Float32)
+        for h in range(n):
+            add = Vec.from_elements([got[4 * h + j] for j in range(4)], fx.Float32)
+            out.append(Vec(frag[n * i + h]) + add)
+    return out
+
+
+def _dense_tn_wave4_asm(geom, cbsz, blgp):
+    """Bare-asm K body for one output tile: the mfma quadrants, the ds_read refills that feed
+    them and a later K-block's global->LDS writes, rotated over each pool's buffers. Trip
+    count and fused tail passes are runtime SGPRs. Returns (asm, constraints, type)."""
+    if (geom, cbsz, blgp) in _TN4_ASM_CACHE:
+        return _TN4_ASM_CACHE[(geom, cbsz, blgp)]
+    pools = _tn4_pools(geom)
+    npool = len(pools)
+    ap = [i for i, p in enumerate(pools) if p.side == 0]
+    bp = [i for i, p in enumerate(pools) if p.side == 1]
+    assert ap == list(range(len(ap))), "A pools must lead the pool list"
+    nt = pools[0].tiles  # tiles per A pool; the B side may split its extent unevenly
+    assert all(pools[i].tiles == nt for i in ap), "A pools must be equally wide"
+    na = sum(pools[i].tiles for i in ap)
+    nb = sum(pools[i].tiles for i in bp)
+    nacc, n_frag = na * nb, na + nb  # accumulators, live operand fragments
+    phases = _tn4_phases(geom)
+    pad = geom.pad
+    ds_sep = f"\n{_TN4_ISSUE_PAD}\n" if "d" in pad else "\n"
+    g2s_sep = f"\n{_TN4_ISSUE_PAD}\n" if "g" in pad else "\n"
+    mods = f" cbsz:{cbsz} blgp:{blgp}" if (cbsz or blgp) else ""
+    frag = [(i, t) for i in range(npool) for t in range(pools[i].tiles)]
+    bcol = [(j, t) for j, i in enumerate(bp) for t in range(pools[i].tiles)]
+    qoff, o = {}, 0  # accumulator base of each (A pool, B pool) quadrant
+    for ai in range(len(ap)):
+        for bi in range(len(bp)):
+            qoff[(ai, bi)] = o
+            o += nt * pools[bp[bi]].tiles
+
+    # Outputs: accumulators, fragments, counter, per-pool soffset; unwritten "=&s" = regalloc hazard.
+    o_cnt = nacc + n_frag
+    o_wsoff = [o_cnt + 1 + p for p in range(npool)]
+    _at = o_cnt + 1 + npool
+
+    def take(n):
+        nonlocal _at
+        _at += n
+        return list(range(_at - n, _at))
+
+    i_base = [take(2 * p.tiles) for p in pools]
+    i_gbase = [take(p.nbuf) for p in pools]
+    gl = {k: take(k[1] * _TN4_BLOCK_K // (256 * 16)) for k in _tn4_gl_keys(pools)}
+    i_rsrc_a, i_rsrc_b = take(1)[0], take(1)[0]
+    i_kstep_a, i_kstep_b = take(1)[0], take(1)[0]
+    i_nval, i_tail = take(1)[0], take(1)[0]
+    i_soff0 = take(npool)
+    i_gl = [gl[_tn4_gl_key(p)] for p in pools]
+    i_rsrc = [(i_rsrc_a, i_rsrc_b)[p.side] for p in pools]
+    i_kstep = [(i_kstep_a, i_kstep_b)[p.side] for p in pools]
+
+    def ds_reads(rbuf, tt):
+        # The buffer delta rides the ds_read immediate, so one address pair covers the pool.
+        p, ti = frag[tt - nacc]
+        bo = rbuf[p] * pools[p].buf
+        v = _TN4_PIN + (tt - nacc) * 8
+        ptr = (i_base[p][2 * ti], i_base[p][2 * ti + 1])
+        return ds_sep.join(
+            f"ds_read_b64_tr_b8 v[{v + 2 * j}:{v + 2 * j + 1}], "
+            f"${ptr[j % 2]} offset:{bo + (j // 2) * pools[p].rs}"
+            for j in range(4)
+        )
+
+    def emit_g2s(wbuf):
+        # A pools step-interleaved to share the 128B line; B pools last, per the partial drain.
+        order = [(p, st) for st in range(pools[0].steps) for p in ap]
+        order += [(p, st) for p in bp for st in range(pools[p].steps)]
+        return [
+            f"s_add_u32 m0, ${i_gbase[p][wbuf[p]]}, {st * _tn4_nthr(geom) // 64 * _TN4_CS}{g2s_sep}"
+            f"buffer_load_dwordx4 ${i_gl[p][st]}, ${i_rsrc[p]}, ${o_wsoff[p]} offen lds"
+            for p, st in order
+        ]
+
+    def mfma_seq():
+        # srcA pool outer (this mfma is srcA-movement sensitive); the diagonal spreads refills.
+        bm, bn = 2, geom.bstep or nb // 2
+        n_row_steps, n_col_steps = nt // bm, nb // bn
+        seq = []
+        for d in range(n_row_steps + n_col_steps - 1):
+            for iib in range(n_row_steps):
+                if not 0 <= d - iib < n_col_steps:
+                    continue
+                for di in range(bm):
+                    for ah in range(len(ap)):
+                        for dj in range(bn):
+                            col, ii = (d - iib) * bn + dj, iib * bm + di
+                            bi, bt = bcol[col]
+                            q = qoff[(ah, bi)] + ii * pools[bp[bi]].tiles + bt
+                            at = nacc + ah * nt + ii
+                            br = nacc + na + col
+                            seq.append(
+                                (
+                                    f"v_mfma_f32_16x16x128_f8f6f4 ${q}, ${at}, ${br}, ${q}{mods}",
+                                    at,
+                                    br,
+                                )
+                            )
+        return seq
+
+    def emit_phase(rbuf, wbuf):
+        # Refill a fragment right after its last consumer; global writes take the free slots.
+        g2sl, mlist = emit_g2s(wbuf), mfma_seq()
+        last = {}
+        for mi, (_m, at, bt) in enumerate(mlist):
+            last[at] = last[bt] = mi
+        busy = {mi for mi, (_m, at, bt) in enumerate(mlist) if last[at] == mi or last[bt] == mi}
+        free = [mi for mi in range(len(mlist)) if mi not in busy]
+        gap = max(len(free) // len(g2sl), 1)
+        gslot = {fi: k // gap for k, fi in enumerate(free) if k % gap == 0 and k // gap < len(g2sl)}
+        out, gi, refilled = [], 0, set()
+        for mi, (ml, at, bt) in enumerate(mlist):
+            out.append((0, ml))
+            for rt in (at, bt):
+                if last[rt] == mi and rt not in refilled:
+                    out.append((1, ds_reads(rbuf, rt)))
+                    refilled.add(rt)
+            if mi in gslot and gi < len(g2sl):
+                out.append((2, g2sl[gi]))
+                gi += 1
+        out += [(2, g) for g in g2sl[gi:]]
+        out += [(1, ds_reads(rbuf, tt)) for tt in range(nacc, nacc + n_frag) if tt not in refilled]
+        return _tn4_pad(out, pad)
+
+    # A buffer written this phase is read nbuf-1 later, so only a deeper pool stays in flight.
+    tailp = [i for i, p in enumerate(pools) if p.nbuf > 2]
+    assert tailp == list(range(npool - len(tailp), npool)), "deep pools must be issued last"
+    assert all(phases % p.nbuf == 0 for p in pools), "a pass must end on every pool's buf 0"
+    n_out = sum(pools[i].steps for i in tailp)
+    drain = f"s_waitcnt vmcnt({n_out}) lgkmcnt({geom.drain_lgkm})\ns_barrier"
+
+    def phase_block(ph):
+        blk = emit_phase([(ph + 1) % p.nbuf for p in pools], [ph % p.nbuf for p in pools])
+        blk.append(drain)
+        return blk + [f"s_add_u32 ${o_wsoff[p]}, ${o_wsoff[p]}, ${i_kstep[p]}" for p in range(npool)]
+
+    L = [f"s_mov_b32 ${o_cnt}, 0"]
+    L += [f"s_mov_b32 ${o_wsoff[p]}, ${i_soff0[p]}" for p in range(npool)]
+    L += [ds_reads([0] * npool, tt) for tt in range(nacc, nacc + n_frag)]
+    # Deeper primes wait here to overlap the ds_read issue; the barrier still guards buf0.
+    L += [f"s_waitcnt vmcnt({n_out}) lgkmcnt(0)", "s_barrier", "1:"]
+    for ph in range(phases):
+        L += phase_block(ph)
+    L += [
+        f"s_add_u32 ${o_cnt}, ${o_cnt}, {phases}",
+        f"s_cmp_lt_u32 ${o_cnt}, ${i_nval}",
+        "s_cbranch_scc1 1b",
+        # A partial drain needs a next phase, which no longer exists past the exit.
+        f"s_cmp_eq_u32 ${i_tail}, 0",
+        "s_cbranch_scc1 3f",
+        "s_waitcnt vmcnt(0) lgkmcnt(0)",
+        "s_barrier",
+        "3:",
+    ]
+    for j in range(phases - 1):  # gated single-K-block passes reusing the loop block
+        L += [f"s_cmp_le_u32 ${i_tail}, {j}", f"s_cbranch_scc1 {j + 4}f"]
+        L += phase_block(j) + [f"{j + 4}:"]
+    L.append("s_waitcnt vmcnt(0) lgkmcnt(0)")
+
+    # Accumulators past the AGPR file take a pinned VGPR window above the fragments.
+    nag = min(nacc, _TN4_AGPR)
+    vacc = _TN4_PIN + n_frag * 8
+    L = [f"v_mov_b32 v{vacc + j}, 0" for j in range(4 * (nacc - nag))] + L
+    cons = ",".join(
+        ["=a"] * nag
+        + [f"=&{{v[{vacc + 4 * i}:{vacc + 4 * i + 3}]}}" for i in range(nacc - nag)]
+        + [f"=&{{v[{_TN4_PIN + f * 8}:{_TN4_PIN + f * 8 + 7}]}}" for f in range(n_frag)]
+        + ["=&s"] * (1 + npool)
+        + ["v"] * sum(2 * p.tiles for p in pools)
+        + ["s"] * sum(p.nbuf for p in pools)
+        + ["v"] * sum(len(g) for g in gl.values())
+        + ["s"] * (6 + npool)
+        + [str(q) for q in range(nag)]
+    )
+    st = (
+        "!llvm.struct<("
+        + ", ".join(["vector<4xf32>"] * nacc + ["vector<8xi32>"] * n_frag + ["i32"] * (1 + npool))
+        + ")>"
+    )
+    _TN4_ASM_CACHE[(geom, cbsz, blgp)] = ("\n".join(L), cons, st)
+    return _TN4_ASM_CACHE[(geom, cbsz, blgp)]
+
+
+# Must stay top-level: nested in @flyc.kernel its asm cache would look like global drift.
+def _dense_tn_wave4_tile(
+    d,
+    *,
+    M,
+    N,
+    K,
+    K_ITERS,
+    NBM,
+    NBN,
+    group_m,
+    group_n,
+    split,
+    handoff,
+    store_aux,
+    lds,
+    geom,
+    A,
+    B,
+    C,
+    WS,
+    FL,
+    A_scale,
+    B_scale,
+    gl_off,
+    wave_id,
+    wave_m,
+    wave_n,
+    lane_id,
+    cbsz,
+    blgp,
+    out_ty,
+    col_safe,
+):
+    """Emit one dispatch id's output tile. ``split`` is None or the (lo, n, s) split-K window
+    at the grid tail, whose ids carry a (tile, slice) pair: slice 0 writes C and slice j>0 band
+    j-1 of WS. Under ``handoff`` every slice writes C and the last folds its predecessor in."""
+    row_shift, store_base, c_rows, flag, flag_off, slot_base = (None,) * 6
+    k0 = fx.Int32(0)
+    ki = fx.Int32(K_ITERS)
+    if split is None:
+        t = d
+    else:
+        lo, nwin, s = split
+        win_off = fx.Int32(d) - fx.Int32(lo)
+        # sid < 0 = whole tile: the ids below the window take the whole K range.
+        sid = _dense_tn_slice_div(win_off, nwin)
+        tile_in_window = win_off - sid * fx.Int32(nwin)
+        if lo:
+            pre = win_off < fx.Int32(0)
+            t = _readfirstlane_i32(arith.select(pre, d, fx.Int32(lo) + tile_in_window))
+            sid = fx.Int32(_readfirstlane_i32(arith.select(pre, fx.Int32(-1), sid)))
+            whole = sid < fx.Int32(0)
+            slice_id = fx.Int32(arith.select(whole, fx.Int32(0), sid))
+        else:
+            t = _readfirstlane_i32(fx.Int32(lo) + tile_in_window)
+            sid = fx.Int32(_readfirstlane_i32(sid))
+            slice_id = sid
+        k0 = _dense_tn_slice_div(fx.Int32(K_ITERS) * slice_id, s)
+        ki = (
+            fx.Int32(
+                arith.select(
+                    slice_id + fx.Int32(1) < fx.Int32(s),
+                    _dense_tn_slice_div(fx.Int32(K_ITERS) * (slice_id + fx.Int32(1)), s),
+                    fx.Int32(K_ITERS),
+                )
+            )
+            - k0
+        )
+        if lo:
+            k0 = fx.Int32(arith.select(whole, fx.Int32(0), k0))
+            ki = fx.Int32(arith.select(whole, fx.Int32(K_ITERS), ki))
+        ki = fx.Int32(_readfirstlane_i32(ki))
+        if handoff:
+            # Which side of the protocol this id is on; a tile below the window issues neither.
+            slot = geom.bm * geom.bn * 2
+            pub = sid == fx.Int32(0)
+            fold = sid == fx.Int32(1)
+            fold_rec = fx.Int32(_readfirstlane_i32(arith.select(fold, fx.Int32(slot), fx.Int32(0))))
+            pub_rec = arith.index_cast(
+                T.index, fx.Int32(_readfirstlane_i32(arith.select(pub, fx.Int32(slot), fx.Int32(0))))
+            )
+            slot_base = arith.index_cast(T.index, fx.Int32(_readfirstlane_i32(tile_in_window))) * arith.index(
+                slot
+            )
+            hand_st = _buffer_ops.create_buffer_resource(
+                WS, max_size=False, num_records_bytes=pub_rec, base_byte_offset=slot_base
+            )
+            nrec = arith.index(4 * nwin)
+            if lo:
+                nrec = arith.select(whole, arith.index(0), nrec)
+            flag = _buffer_ops.create_buffer_resource(FL, max_size=False, num_records_bytes=nrec)
+            flag_off = fx.Int32(_readfirstlane_i32(tile_in_window)) * fx.Int32(4)
+            flag_val = fx.Int32(1) - slice_id
+            # The publishing slice writes no C at all, so its output band bases zero records.
+            c_rows = fx.Int32(_readfirstlane_i32(arith.select(pub, fx.Int32(0), fx.Int32(M))))
+        else:
+            # Slice 0 lands in C and slice j>0 in WS rows [(j-1)*M, j*M): s-1 bands, one stride.
+            row_shift = _readfirstlane_i32((slice_id - fx.Int32(1)) * fx.Int32(M))
+            store_base = _buffer_ops.extract_base_index(WS)
+            home = slice_id < fx.Int32(1)  # whole tiles carry slice 0, so this covers them too
+            row_shift = _readfirstlane_i32(arith.select(home, fx.Int32(0), fx.Int32(row_shift)))
+            store_base = arith.select(home, _buffer_ops.extract_base_index(C), store_base)
+
+    pools = _tn4_pools(geom)
+    phases = _tn4_phases(geom)
+    apool = [p for p in pools if p.side == 0]
+    bpool = [p for p in pools if p.side == 1]
+    block_m, block_n = _dense_tn_tile_mn(t, NBM, NBN, group_m, group_n)
+    bm_off = _readfirstlane_i32(block_m) * fx.Int32(geom.bm)
+    bn_off = _readfirstlane_i32(block_n) * fx.Int32(geom.bn)
+    _tn4_line_cols(pools, geom, (bm_off, bn_off))
+    n_main = (ki // phases) * phases
+    nval = _readfirstlane_i32(n_main)
+    tail = _readfirstlane_i32(ki - n_main)
+
+    # A [K,M] / B [K,N] stride K: fold slice row + tile column into the SRD, num_records clamps.
+    F8_IR_t = fx.Float8E4M3FN.ir_type
+    k_row = arith.index_cast(T.index, k0) * arith.index(_TN4_BLOCK_K)
+    rows = arith.index(K) - k_row
+    a_base = k_row * arith.index(M) + arith.index_cast(T.index, bm_off)
+    a_nrec = arith.maxsi(rows * arith.index(M) - arith.index_cast(T.index, bm_off), arith.index(0))
+    b_base = k_row * arith.index(N) + arith.index_cast(T.index, bn_off)
+    b_nrec = arith.maxsi(rows * arith.index(N) - arith.index_cast(T.index, bn_off), arith.index(0))
+    gA = make_fp8_buffer_tensor_rebased(A, F8_IR_t, a_base, a_nrec)
+    gB = make_fp8_buffer_tensor_rebased(B, F8_IR_t, b_base, b_nrec)
+
+    # One loader pair per (operand, LDS width): pools sharing one differ only in start column.
+    gdiv = (fx.logical_divide(gA, fx.make_layout(1, 1)), fx.logical_divide(gB, fx.make_layout(1, 1)))
+    s2r, g2s = {}, {}
+    for p in pools:
+        if (p.side, p.width) in s2r:
+            continue
+        s2r[(p.side, p.width)] = S2RLoaderTr(
+            wave_m if p.side == 0 else wave_n,
+            n_tiles=p.tiles,
+            tile_stride=p.tiles * 16,
+            n_waves=_tn4_nthr(geom) // 64,
+            chunk_stride=_TN4_CS,
+            width=p.width,
+            wswz=True,  # wave bank-swizzle (matches gl_off in the kernel body)
+        )
+        g2s[_tn4_gl_key(p)] = G2SLoader(
+            gdiv[p.side],
+            gl_off[_tn4_gl_key(p)],
+            p.steps,
+            F8_IR_t,
+            wave_id,
+            chunk_stride=_TN4_CS,
+        )
+
+    mfma = {p.tiles: Mfma16x16x128(apool[0].tiles, p.tiles) for p in bpool}
+    if c_rows is None:
+        c_rows = fx.Int32(M) if row_shift is None else fx.Int32(M) + row_shift
+    store_c = {
+        nb: (StoreCPerTensorPairN if col_safe and nb % 2 == 0 else StoreCPerTensor)(
+            A_scale,
+            B_scale,
+            C,
+            c_rows,
+            fx.Int32(N),
+            m.idx,
+            apool[0].tiles,
+            nb,
+            out_ty,
+            col_safe=col_safe,
+            store_aux=store_aux,
+            c_base=store_base,
+        )
+        for nb, m in mfma.items()
+    }
+
+    a_k = arith.index(_TN4_BLOCK_K) * arith.index(M)
+    b_k = arith.index(_TN4_BLOCK_K) * arith.index(N)
+    pool_lds = [getattr(lds, f"p{i}") for i in range(len(pools))]
+    for b in range(max(p.nbuf for p in pools)):
+        for i, p in enumerate(pools):
+            if b < p.nbuf:
+                kb = b * (a_k, b_k)[p.side]
+                col = p.gcol if isinstance(p.gcol, int) else arith.index_cast(T.index, p.gcol)
+                g2s[_tn4_gl_key(p)].load(pool_lds[i], col + kb, base_off=fx.Int32(b * p.buf))
+    # Covers the buf0 primes only; the deeper ones are waited on inside the asm.
+    wait_barrier(sum((p.nbuf - 1) * p.steps for p in pools))
+
+    # A pool's buffers are read the same way, so only buffer 0 needs live address VGPRs.
+    ins = [
+        v for i, p in enumerate(pools) for pair in s2r[(p.side, p.width)].base_addr(pool_lds[i]) for v in pair
+    ]
+    ins += [
+        rocdl.readfirstlane(
+            T.i32,
+            fx.Int32(fx.ptrtoint(pool_lds[i].ptr))
+            + fx.Int32(b * p.buf)
+            + fx.Int32(wave_id) * fx.Int32(_TN4_CS),
+        )
+        for i, p in enumerate(pools)
+        for b in range(p.nbuf)
+    ]
+    for key in _tn4_gl_keys(pools):
+        ins += [fx.Int32(o) for o in gl_off[key]]
+    kstep_a = rocdl.readfirstlane(T.i32, fx.Int32(_TN4_BLOCK_K) * fx.Int32(M))
+    kstep_b = rocdl.readfirstlane(T.i32, fx.Int32(_TN4_BLOCK_K) * fx.Int32(N))
+    ins += [
+        _buffer_ops.create_buffer_resource(
+            A, max_size=False, num_records_bytes=a_nrec, base_byte_offset=a_base
+        ),
+        _buffer_ops.create_buffer_resource(
+            B, max_size=False, num_records_bytes=b_nrec, base_byte_offset=b_base
+        ),
+        kstep_a,
+        kstep_b,
+        nval,
+        tail,
+    ]
+    for p in pools:
+        step = fx.Int32(p.nbuf) * (kstep_a, kstep_b)[p.side]
+        if isinstance(p.gcol, int):
+            soff = step if p.gcol == 0 else fx.Int32(p.gcol) + step
+        else:
+            soff = p.gcol + step
+        ins.append(rocdl.readfirstlane(T.i32, soff))
+    nacc = sum(p.tiles for p in apool) * sum(p.tiles for p in bpool)
+    ins += [mfma[bpool[0].tiles].zero_value] * min(nacc, _TN4_AGPR)
+
+    asm, cons, st = _dense_tn_wave4_asm(geom, cbsz, blgp)
+    r = _llvm.inline_asm(ir.Type.parse(st), [arith._to_raw(v) for v in ins], asm, cons, has_side_effects=True)
+    acc_ty = ir.Type.parse("vector<4xf32>")
+    res = [Vec(_llvm.extractvalue(acc_ty, r, [q])) for q in range_constexpr(nacc)]
+
+    row_q = bm_off + wave_m * fx.Int32(apool[0].tiles * 16)
+    base_row = row_q if row_shift is None else row_q + row_shift
+
+    if handoff:
+        _tn4_publish_frag(res, hand_st, wave_id, lane_id, 0, nacc, out_ty, handoff)
+        # The raise trails this tile's stores; the second barrier keeps a wave past the poll
+        # from resetting the flag under one still spinning.
+        wait_barrier(0)
+        recs = _tn4_handoff_wait(flag, flag_off, slice_id, fold_rec)
+        wait_barrier(0)
+        _buffer_ops.buffer_store(
+            flag_val,
+            flag,
+            flag_off,
+            mask=lane_id == fx.Int32(0),
+            cache_modifier=_TN4_HAND_AUX,
+            offset_is_bytes=True,
+        )
+        hand_ld = _buffer_ops.create_buffer_resource(
+            WS,
+            max_size=False,
+            num_records_bytes=arith.index_cast(T.index, recs),
+            base_byte_offset=slot_base,
+        )
+    q = 0
+    for pa in apool:
+        for pb in bpool:
+            n = pa.tiles * pb.tiles
+            col_q = bn_off + wave_n * fx.Int32(pb.tiles * 16)
+            frag = res[q : q + n]
+            if handoff:
+                frag = _tn4_fold_frag(frag, hand_ld, wave_id, lane_id, q, nacc, out_ty, handoff)
+            store_c[pb.tiles].store(frag, base_row + pa.gcol, col_q + pb.gcol)
+            q += n
+
+
+_TN4_SPLIT_S = (2, 3, 4)  # slice factors; an odd one is fine, the slices stay co-resident
+_TN4_RCP_MAX = 1 << 15  # exactness bound on _dense_tn_slice_div's dividend
+_TN4_OUT_ALIGN = 8  # out_ty elements the split-K bands keep aligned at C's row pitch
+
+
+def _tn4_split_rounds(tiles, n, s, ncu):
+    """Rounds the split-K window's ``n * s`` slices occupy."""
+    return ceildiv(n * s, ncu) if tiles <= ncu else (1 if s * n <= ncu else s)
+
+
+def _dense_tn_split(tiles, k_iters, ncu, phases):
+    """Split-K window ``(lo, n, s)`` for one dense TN grid, or None. With one uniform K the
+    makespan quantizes only on the last partial round, so slice its ``rem`` tiles s ways;
+    keep the shortest s that still fits the window inside one round."""
+    rem = tiles % ncu
+    if rem == 0:
+        return None
+    best, best_rounds, best_s = 1, 1, 1
+    for s in _TN4_SPLIT_S:
+        if k_iters < phases * s or k_iters * (s - 1) >= _TN4_RCP_MAX:
+            continue  # every slice must keep a whole main-loop pass, and stay exactly divisible
+        rounds = _tn4_split_rounds(tiles, rem, s, ncu)
+        if rounds * best_s < best_rounds * s:
+            best, best_rounds, best_s = s, rounds, s
+    return None if best == 1 else (tiles - rem, rem, best)
+
+
+_NUM_CUS = 0
+
+
+def _dense_num_cus():
+    """Device CU count, memoised: the property query is otherwise on the dispatch path."""
+    global _NUM_CUS
+    if not _NUM_CUS:
+        _NUM_CUS = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+    return _NUM_CUS
+
+
+def _compile_dense_tn_wave4(
+    M: int,
+    N: int,
+    K: int,
+    group_m: int,
+    group_n: int,
+    geom=_TN4_SQUARE,
+    cbsz: int = 0,  # srcA fp8 fmt: 0=E4M3, 1=E5M2
+    blgp: int = 0,  # srcB fp8 fmt: 0=E4M3, 1=E5M2
+    out_fp16: bool = False,
+):
+    """4-wave (occ=1) dense TN C[M,N] = A[K,M]^T @ B[K,N] over ``geom``'s macro tile, one
+    tile per workgroup. Returns (launch, split-K scratch band count)."""
+    BM, BN = geom.bm, geom.bn
+    _pools = _tn4_pools(geom)
+    phases = _tn4_phases(geom)
+    NBM, NBN = ceildiv(M, BM), ceildiv(N, BN)
+    TILES = NBM * NBN
+    K_ITERS = ceildiv(K, _TN4_BLOCK_K)
+    assert K_ITERS >= phases, "4-wave dense TN needs a K of at least one main-loop pass"
+    split = _dense_tn_split(TILES, K_ITERS, _dense_num_cus(), phases)
+    _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
+    # Doubles as the switch and the traffic policy; a closure scalar lands in the jit key.
+    _hand = _TN4_HAND_AUX if _tn4_handoff(split) else 0
+    # Slice 0 keeps C, so the WS holds s-1 bands and each window tile takes s-1 extra WGs.
+    _bands = 0 if split is None else split[2] - 1
+    _NWIN = 0 if split is None else split[1]
+    _GRID = TILES + _NWIN * (split[2] - 1 if split is not None else 0)
+
+    # ONE field per pool holding its buffers back to back: separate fields may reorder.
+    SharedStorage = fx.struct(
+        type(
+            "SharedStorage",
+            (),
+            {
+                "__annotations__": {
+                    f"p{i}": fx.Array[fx.Float8E4M3FN, p.nbuf * p.buf, 16] for i, p in enumerate(_pools)
+                }
+            },
+        )
+    )
+
+    @flyc.kernel(known_block_size=[256, 1, 1])
+    def kernel_dense_tn_wave4(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+        WS: fx.Tensor,
+        FL: fx.Tensor,
+    ):
+        _ = str(fx.thread_idx.x)
+        lane_id = fx.thread_idx.x % 64
+        wave_id = fx.thread_idx.x // 64
+        _dense_tn_wave4_tile(
+            fx.block_idx.x,
+            M=M,
+            N=N,
+            K=K,
+            K_ITERS=K_ITERS,
+            NBM=NBM,
+            NBN=NBN,
+            group_m=group_m,
+            group_n=group_n,
+            geom=geom,
+            split=split,
+            handoff=_hand,
+            store_aux=_CSTORE_AUX,
+            lds=fx.SharedAllocator().allocate(SharedStorage).peek(),
+            A=A,
+            B=B,
+            C=C,
+            WS=WS,
+            FL=FL,
+            A_scale=A_scale,
+            B_scale=B_scale,
+            gl_off={
+                k: compute_global_swizzle_nn(
+                    lane_id,
+                    wave_id,
+                    M if k[0] == 0 else N,
+                    k[1] * _TN4_BLOCK_K // (256 * 16),
+                    width=k[1],
+                    wswz=True,
+                )
+                for k in _tn4_gl_keys(_pools)
+            },
+            wave_id=wave_id,
+            wave_m=wave_id // 2,
+            wave_n=wave_id % 2,
+            lane_id=lane_id,
+            cbsz=cbsz,
+            blgp=blgp,
+            out_ty=_out_ty,
+            col_safe=N % BN == 0,
+        )
+
+    _ATTRS = make_value_attrs(1, 0, "256,256")
+    _LO = 0 if split is None else split[0]
+    _S = 0 if split is None else split[2]
+    _RED_GRID = 0 if _hand else _NWIN * _TN4_RED_WPT
+    _RED_ROWS = BM // _TN4_RED_WPT
+
+    @flyc.kernel(known_block_size=[256, 1, 1])
+    def kernel_dense_tn_wave4_reduce(C: fx.Tensor, WS: fx.Tensor):
+        """Fold the split-K window's slice bands into C, one row slab per workgroup. It runs
+        the whole grid, so the fold spreads over every CU instead of only the window's."""
+        tid = fx.thread_idx.x
+        wt = _dense_tn_slice_div(fx.Int32(fx.block_idx.x), _TN4_RED_WPT)
+        part = fx.Int32(fx.block_idx.x) - wt * fx.Int32(_TN4_RED_WPT)
+        block_m, block_n = _dense_tn_tile_mn(
+            _readfirstlane_i32(fx.Int32(_LO) + wt), NBM, NBN, group_m, group_n
+        )
+        _dense_tn_reduce_rows(
+            _buffer_ops.extract_base_index(WS),
+            _buffer_ops.extract_base_index(C),
+            M,
+            N,
+            _S,
+            _readfirstlane_i32(block_m) * fx.Int32(BM) + part * fx.Int32(_RED_ROWS),
+            _readfirstlane_i32(block_n) * fx.Int32(BN),
+            _RED_ROWS,
+            BN,
+            tid,
+            256,
+            _out_ty,
+            N % BN == 0,
+        )
+
+    @flyc.jit
+    def launch_dense_tn_wave4(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+        WS: fx.Tensor,
+        FL: fx.Tensor,
+        stream: fx.Stream,
+    ):
+        kernel_dense_tn_wave4(A, B, C, A_scale, B_scale, WS, FL, value_attrs=_ATTRS).launch(
+            grid=(_GRID, 1, 1), block=(256, 1, 1), stream=stream
+        )
+        if const_expr(_RED_GRID):
+            kernel_dense_tn_wave4_reduce(C, WS).launch(
+                grid=(_RED_GRID, 1, 1), block=(256, 1, 1), stream=stream
+            )
+
+    return launch_dense_tn_wave4, _bands
+
+
+# Accumulators live in the AGPR file: moving them to the arch file to save the epilogue's
+# v_accvgpr_read trades one hazard for another -- an mfma writing an arch VGPR that a VALU then
+# reads needs wait states the occ=1 lane has nothing to fill, and it measured a wash.
+_NT4_SQUARE = _Tn4Geom(
+    256,
+    256,
+    ((0, 128, 2), (0, 128, 2), (1, 128, 3), (1, 128, 3)),
+    0,
+    drain_lgkm=6,  # NT's plain reads leave fewer in flight than the transpose path's
+)
+_NT4_ASM_CACHE: dict = {}
+_NT4_BAND = 64  # B rows one wave's four n-fragments span in a pool
+
+
+def _nt4_pools(geom, fold):
+    """``_tn4_pools`` with the B pools grouped by the epilogue fold: the pools of one group hold
+    interleaved columns of one output run, so each gets its own global row order (``gq``) and
+    they all address the group's rows from its base."""
+    pools = _tn4_pools(geom)
+    bpool = [p for p in pools if p.side == geom.gl_side]
+    npg = max(1, fold // bpool[0].tiles)  # pools per group
+    for i, p in enumerate(bpool):
+        p.gq = i % npg
+        p.gcol = p.col - p.gq * p.width
+    return pools
+
+
+def _nt4_fold_gl_off(lane_id, wave_id, K, n_rounds, gq, fold):
+    """B-side global row order for the folded-N epilogue: sourcing LDS row 16*t + m from group
+    row fold*m + t + 4*gq leaves a lane holding adjacent columns, so the epilogue writes
+    whole lines. Only the source row moves; the LDS slot and its swizzle are untouched."""
+    offs = compute_global_swizzle(lane_id, wave_id, K, n_rounds, preshuffled=False)
+    rows_per_round = (fx.block_dim.x // 64) * 8
+    out = []
+    for r in range_constexpr(n_rounds):
+        row = lane_id // 8 + wave_id * 8 + r * rows_per_round
+        band = row % _NT4_BAND
+        delta = (
+            (fold * 16 - _NT4_BAND) * (row // _NT4_BAND)
+            + (fold - 1) * (band % 16)
+            - 15 * (band // 16)
+            + 4 * gq
+        )
+        out.append(offs[r] + delta * K)
+    return out
+
+
+def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN4_BLOCK_K, carry=False):
+    """Bare-asm K body for one NT output tile; ``carry`` hands the closing fills to the next tile."""
+    key = (geom, k_iters, cbsz, blgp, fold, tr_b, b_kstep, carry)
+    if key in _NT4_ASM_CACHE:
+        return _NT4_ASM_CACHE[key]
+    pools = _nt4_pools(geom, fold)
+    npool = len(pools)
+    nwaves = _tn4_nthr(geom) // 64  # the g2s chunks of one step, one per wave
+    ap = [i for i, p in enumerate(pools) if p.side == 0]
+    bp = [i for i, p in enumerate(pools) if p.side == 1]
+    rp = ap + bp
+    assert ap == list(range(len(ap))), "A pools must lead the pool list"
+    nt = pools[0].tiles  # tiles per A pool; the B side may split its extent unevenly
+    assert all(pools[i].tiles == nt for i in ap), "A pools must be equally wide"
+    na = sum(pools[i].tiles for i in ap)
+    nb = sum(pools[i].tiles for i in bp)
+    nacc, n_frag = na * nb, na + nb  # accumulators, live operand fragments
+    phases = _tn4_phases(geom)
+    n_main = (k_iters // phases) * phases
+    tail = k_iters - n_main
+    assert n_main >= phases, "the NT whole-loop needs a K of at least one main-loop pass"
+    assert not (carry and tail), "a carried ring needs the trip to end on a whole pass"
+    pad = geom.pad
+    ds_sep = f"\n{_TN4_ISSUE_PAD}\n" if "d" in pad else "\n"
+    g2s_sep = f"\n{_TN4_ISSUE_PAD}\n" if "g" in pad else "\n"
+    mods = f" cbsz:{cbsz} blgp:{blgp}" if (cbsz or blgp) else ""
+    frag = [(i, t) for i in rp for t in range(pools[i].tiles)]
+    bcol = [(j, t) for j, i in enumerate(bp) for t in range(pools[i].tiles)]
+    qoff, o = {}, 0  # accumulator base of each (A pool, B pool) quadrant
+    for ai in range(len(ap)):
+        for bi in range(len(bp)):
+            qoff[(ai, bi)] = o
+            o += nt * pools[bp[bi]].tiles
+
+    o_cnt = nacc + n_frag
+    o_wsoff = [o_cnt + 1 + p for p in range(npool)]
+    _at = o_cnt + 1 + npool
+
+    def take(n):
+        nonlocal _at
+        _at += n
+        return list(range(_at - n, _at))
+
+    tr = [bool(tr_b) and p.side == 1 for p in pools]
+    # A transposed pool carries its column XOR in the address, so every one of its tiles
+    # brings a pair; a plain pool's row-tile step is a read immediate and one pair covers it.
+    # A plain pool's fragment is one lane's share of a 16xBLOCK_K tile, read as b128 halves.
+    reads = 16 * _TN4_BLOCK_K // 64 // 16
+    i_base = {i: take(2 * pools[i].tiles if tr[i] else reads) for i in rp}
+    i_gbase = [take(p.nbuf) for p in pools]
+    gl: dict = {}
+    for p in pools:
+        if _tn4_gl_key(p) not in gl:
+            gl[_tn4_gl_key(p)] = take(p.steps)
+    i_rsrc_a, i_rsrc_b = take(1)[0], take(1)[0]
+    i_rsrc2 = [take(1)[0], take(1)[0]] if carry else []
+    i_soff0 = take(npool)
+    cbuf = _nt4_carry_bufs(pools, carry)
+    i_pfsoff = [take(len(b)) for b in cbuf]
+    i_gl = [gl[_tn4_gl_key(p)] for p in pools]
+    i_rsrc = [(i_rsrc_a, i_rsrc_b)[p.side] for p in pools]
+    i_pfrsrc = [i_rsrc2[p.side] for p in pools] if carry else []
+    ksteps = [(b_kstep if p.side else _TN4_BLOCK_K) for p in pools]
+
+    def ds_reads(rbuf, tt):
+        p, ti = frag[tt - nacc]
+        v = _TN4_PIN + (tt - nacc) * 8
+        bo = rbuf[p] * pools[p].buf
+        if tr[p]:
+            ptr = (i_base[p][2 * ti], i_base[p][2 * ti + 1])
+            return ds_sep.join(
+                f"ds_read_b64_tr_b8 v[{v + 2 * j}:{v + 2 * j + 1}], "
+                f"${ptr[j % 2]} offset:{bo + (j // 2) * pools[p].rs}"
+                for j in range(4)
+            )
+        bo += ti * 16 * _TN4_BLOCK_K
+        assert bo < 65536, "buffer + tile delta overflows the ds offset"
+        return ds_sep.join(
+            f"ds_read_b128 v[{v + 4 * h}:{v + 4 * h + 3}], ${i_base[p][h]} offset:{bo}" for h in range(reads)
+        )
+
+    def src2(q, init):
+        # An init phase writes its quadrant from the mfma itself, so nothing zeroes it first.
+        return "0" if init else f"${q}"
+
+    def carried(p, left):
+        # Past the last phase a fill would fetch a K-block nothing reads; a successor takes it.
+        return carry and pools[p].nbuf > left
+
+    def emit_g2s(wbuf, left):
+        order = [(p, st) for st in range(pools[0].steps) for p in ap]
+        order += [(p, st) for p in bp for st in range(pools[p].steps)]
+        assert all(not carried(p, left) or wbuf[p] < len(i_pfsoff[p]) for p, _st in order), (
+            "a carried fill must aim at a buffer the next tile top leaves alone"
+        )
+        return [
+            f"s_add_u32 m0, ${i_gbase[p][wbuf[p]]}, {st * nwaves * _TN4_CS}{g2s_sep}"
+            f"buffer_load_dwordx4 ${i_gl[p][st]}, "
+            f"${i_pfrsrc[p] if carried(p, left) else i_rsrc[p]}, "
+            f"${i_pfsoff[p][wbuf[p]] if carried(p, left) else o_wsoff[p]} offen lds"
+            for p, st in order
+        ]
+
+    def mfma_seq(init):
+        bm, bn = 2, geom.bstep or nb // 2
+        n_row_steps, n_col_steps = nt // bm, nb // bn
+        seq = []
+        for d in range(n_row_steps + n_col_steps - 1):
+            for iib in range(n_row_steps):
+                if not 0 <= d - iib < n_col_steps:
+                    continue
+                for di in range(bm):
+                    for ah in range(len(ap)):
+                        for dj in range(bn):
+                            col, ii = (d - iib) * bn + dj, iib * bm + di
+                            bi, bt = bcol[col]
+                            q = qoff[(ah, bi)] + ii * pools[bp[bi]].tiles + bt
+                            at = nacc + ah * nt + ii
+                            br = nacc + na + col
+                            seq.append(
+                                (
+                                    f"v_mfma_f32_16x16x128_f8f6f4 ${q}, ${at}, ${br}, {src2(q, init)}{mods}",
+                                    at,
+                                    br,
+                                    q,
+                                )
+                            )
+        return seq
+
+    def emit_phase(rbuf, wbuf, init, left):
+        g2sl, mlist = emit_g2s(wbuf, left), mfma_seq(init)
+        last = {}
+        for mi, (_m, at, bt, _q) in enumerate(mlist):
+            last[at] = last[bt] = mi
+        busy = {mi for mi, (_m, at, bt, _q) in enumerate(mlist) if last[at] == mi or last[bt] == mi}
+        free = [mi for mi in range(len(mlist)) if mi not in busy]
+        # Spread over the free slots, not stepped by their ratio, which bares the phase tail.
+        gslot = {free[k * len(free) // len(g2sl)]: k for k in range(len(g2sl))}
+        out, gi, refilled = [], 0, set()
+        for mi, (ml, at, bt, _q) in enumerate(mlist):
+            out.append((0, ml))
+            for rt in (at, bt):
+                if last[rt] == mi and rt not in refilled:
+                    refilled.add(rt)
+                    out.append((1, ds_reads(rbuf, rt)))
+            if mi in gslot and gi < len(g2sl):
+                out.append((2, g2sl[gi]))
+                gi += 1
+        out += [(2, g) for g in g2sl[gi:]]
+        out += [(1, ds_reads(rbuf, tt)) for tt in range(nacc, nacc + n_frag) if tt not in refilled]
+        return _tn4_pad(out, pad)
+
+    tailp = [i for i, p in enumerate(pools) if p.nbuf > 2]
+    assert tailp == list(range(npool - len(tailp), npool)), "deep pools must be issued last"
+    assert all(phases % p.nbuf == 0 for p in pools), "a pass must end on every pool's buf 0"
+    n_out = sum(pools[i].steps for i in tailp)
+
+    def n_flight(lf):
+        """Fills the phase drain may leave outstanding: the trailing run nothing later waits on."""
+        n, l = 0, lf
+        while True:
+            for i in reversed(range(npool)):
+                if not (carried(i, l) or (l == lf and i in tailp)):
+                    return n
+                n += pools[i].steps
+            l += 1
+
+    def phase_block(ph, init=False, left=None):
+        lf = k_iters if left is None else left
+        blk = emit_phase([(ph + 1) % p.nbuf for p in pools], [ph % p.nbuf for p in pools], init, lf)
+        blk.append(f"s_waitcnt vmcnt({n_flight(lf)}) lgkmcnt({geom.drain_lgkm})\ns_barrier")
+        return blk + [f"s_add_u32 ${o_wsoff[p]}, ${o_wsoff[p]}, {ksteps[p]}" for p in range(npool)]
+
+    def pass_block(first, last, left0=None):
+        blk = []
+        for ph in range(phases - int(last)):
+            blk += phase_block(ph, first and ph == 0, None if left0 is None else left0 - ph)
+        return blk
+
+    def loop_block(trip):
+        return (
+            ["1:"]
+            + pass_block(False, False)
+            + [
+                f"s_add_u32 ${o_cnt}, ${o_cnt}, {phases}",
+                f"s_cmp_lt_u32 ${o_cnt}, {trip}",
+                "s_cbranch_scc1 1b",
+            ]
+        )
+
+    L = [f"s_mov_b32 ${o_cnt}, 0"]
+    L += [f"s_mov_b32 ${o_wsoff[p]}, ${i_soff0[p]}" for p in range(npool)]
+    L += [ds_reads([0] * npool, tt) for tt in range(nacc, nacc + n_frag)]
+    L += [f"s_waitcnt vmcnt({n_out}) lgkmcnt(0)", "s_barrier"]
+    # The first pass is peeled so its opening phase writes the accumulators rather than
+    # accumulating, sparing the zero-init; the closing phase is peeled the other way and
+    # handed back, its mfma the window an occ=1 epilogue has nowhere else to sink into.
+    if tail:
+        L += pass_block(True, False)
+        if n_main > phases:
+            L += loop_block(n_main - phases)
+        L += ["s_waitcnt vmcnt(0) lgkmcnt(0)", "s_barrier"]
+        for j in range(tail - 1):
+            L += phase_block(j)
+    else:
+        _tl = phases - 1 if carry else None
+        L += pass_block(True, n_main == phases, _tl if n_main == phases else None)
+        if n_main > 2 * phases:
+            L += loop_block(n_main - 2 * phases)
+        if n_main > phases:
+            L += pass_block(False, True, _tl)
+    L.append("s_waitcnt lgkmcnt(0)" if carry else "s_waitcnt vmcnt(0) lgkmcnt(0)")
+    peel = [(q, at - nacc, br - nacc) for _m, at, br, q in mfma_seq(False)]
+
+    nag = min(nacc, _TN4_AGPR)
+    vacc = _TN4_PIN + n_frag * 8
+    cons = ",".join(
+        ["=a"] * nag
+        + [f"=&{{v[{vacc + 4 * i}:{vacc + 4 * i + 3}]}}" for i in range(nacc - nag)]
+        + [f"=&{{v[{_TN4_PIN + f * 8}:{_TN4_PIN + f * 8 + 7}]}}" for f in range(n_frag)]
+        + ["=&s"] * (1 + npool)
+        + ["v"] * sum(len(i_base[i]) for i in rp)
+        + ["s"] * sum(p.nbuf for p in pools)
+        + ["v"] * sum(len(g) for g in gl.values())
+        + ["s"] * (2 + len(i_rsrc2) + npool + sum(len(s) for s in i_pfsoff))
+    )
+    st = (
+        "!llvm.struct<("
+        + ", ".join(["vector<4xf32>"] * nacc + ["vector<8xi32>"] * n_frag + ["i32"] * (1 + npool))
+        + ")>"
+    )
+    _NT4_ASM_CACHE[key] = ("\n".join(L), cons, st, peel)
+    return _NT4_ASM_CACHE[key]
+
+
+def _nt4_tile_window(d, M, N, K, NBM, NBN, group_m, group_n, num_xcd, geom, tr_b):
+    """One dispatch id's operand windows, num_records bounded so read-ahead past the tile drops."""
+    pid = xcd_remap_pid(d, NBM * NBN, num_xcd)
+    block_m, block_n = block_mn(pid, fx.Int32(NBM), fx.Int32(NBN), group_m, group_n)
+    bm_off = _readfirstlane_i32(block_m) * fx.Int32(geom.bm)
+    bn_off = _readfirstlane_i32(block_n) * fx.Int32(geom.bn)
+    a_base = arith.index_cast(T.index, bm_off) * arith.index(K)
+    a_nrec = arith.minui(arith.index(M * K) - a_base, arith.index(geom.bm * K))
+    if tr_b:
+        b_base = arith.index_cast(T.index, bn_off)
+        b_nrec = arith.index(K * N) - b_base
+    else:
+        b_base = arith.index_cast(T.index, bn_off) * arith.index(K)
+        b_nrec = arith.minui(arith.index(N * K) - b_base, arith.index(geom.bn * K))
+    return bm_off, bn_off, ((a_base, a_nrec), (b_base, b_nrec))
+
+
+def _nt4_buf_off(p, b, K, b_kstep, tr_b):
+    return p.gcol + b * b_kstep if tr_b and p.side == 1 else p.gcol * K + b * _TN4_BLOCK_K
+
+
+def _nt4_g2s(A, B, win, pools, gl_off, wave_id):
+    src = [
+        fx.logical_divide(
+            make_fp8_buffer_tensor_rebased(g, fx.Float8E4M3FN.ir_type, base, nrec),
+            fx.make_layout(1, 1),
+        )
+        for g, (base, nrec) in ((A, win[0]), (B, win[1]))
+    ]
+    g2s = {}
+    for p in pools:
+        g2s.setdefault(
+            _tn4_gl_key(p),
+            G2SLoader(
+                src[p.side],
+                gl_off[_tn4_gl_key(p)],
+                p.steps,
+                fx.Float8E4M3FN.ir_type,
+                wave_id,
+                chunk_stride=_TN4_CS,
+            ),
+        )
+    return g2s
+
+
+def _nt4_prime(pools, pool_lds, g2s, bufs, K, b_kstep, tr_b):
+    for b in range(max(p.nbuf for p in pools)):
+        for i, p in enumerate(pools):
+            if b in bufs[i]:
+                g2s[_tn4_gl_key(p)].load(
+                    pool_lds[i], _nt4_buf_off(p, b, K, b_kstep, tr_b), base_off=fx.Int32(b * p.buf)
+                )
+
+
+def _nt4_carry_bufs(pools, carry):
+    """Buffers the closing phases hand on: all but the last, whose K-block this trip still reads."""
+    return [list(range(p.nbuf - 1)) if carry else [] for p in pools]
+
+
+def _nt4_xpose_lds(p, lds, wave_id, n_waves):
+    """Per-wave epilogue scratch in the buffer the tile top re-primes, which its barrier orders."""
+    assert n_waves * XPOSE_SLOTS * XPOSE_SLOT <= p.buf, "the transpose scratch must fit the buffer"
+    return (
+        fx.Int32(fx.ptrtoint(lds.ptr))
+        + fx.Int32((p.nbuf - 1) * p.buf)
+        + fx.Int32(wave_id) * fx.Int32(XPOSE_SLOTS * XPOSE_SLOT)
+    )
+
+
+def _dense_nt_wave4_tile(
+    d,
+    *,
+    M,
+    N,
+    K,
+    K_ITERS,
+    NBM,
+    NBN,
+    group_m,
+    group_n,
+    num_xcd,
+    store_aux,
+    lds,
+    geom,
+    A,
+    B,
+    C,
+    A_scale,
+    B_scale,
+    gl_off,
+    wave_id,
+    wave_m,
+    wave_n,
+    cbsz,
+    blgp,
+    out_ty,
+    col_safe,
+    pair_n,
+    fold,
+    tr_b=False,
+    d_next=None,
+    scale=None,
+    beta_is_one=False,
+):
+    """Emit one dispatch id's output tile; ``d_next`` carries the pool ring on, ``scale`` is hoisted."""
+    pools = _nt4_pools(geom, fold)
+    apool = [p for p in pools if p.side == 0]
+    bpool = [p for p in pools if p.side == 1]
+    assert len({p.tiles for p in pools if p.side == 1}) == 1, "B pools must be equally wide"
+    b_kstep = _TN4_BLOCK_K * N if tr_b else _TN4_BLOCK_K
+    pool_lds = [getattr(lds, f"p{i}") for i in range(len(pools))]
+    n_waves = _tn4_nthr(geom) // 64
+    carry = d_next is not None
+    cbuf = _nt4_carry_bufs(pools, carry)
+    wargs = (M, N, K, NBM, NBN, group_m, group_n, num_xcd, geom, tr_b)
+    bm_off, bn_off, win = _nt4_tile_window(d, *wargs)
+
+    s2r = {}
+    for p in pools:
+        s2r.setdefault(
+            (p.side, p.width),
+            S2RLoaderTr(
+                wave_n,
+                p.tiles,
+                p.tiles * 16,
+                chunk_stride=_TN4_CS,
+                n_waves=n_waves,
+                width=p.width,
+                wswz=True,  # wave bank-swizzle (matches gl_off in the kernel body)
+            )
+            if tr_b and p.side == 1
+            else S2RLoader(wave_m if p.side == 0 else wave_n, p.tiles),
+        )
+
+    # A fraction of a quadrant's rows is the store unit, so the peel has more mfma to hide a
+    # store behind. A folded unit leaves few whole-line requests; an unfolded one leaves
+    # narrow ones that spread better over the peel when the rows are cut finer.
+    nsplit = geom.store_split if fold else geom.store_split_flat
+    split = math.gcd(nsplit, apool[0].tiles)
+    nfold = fold or bpool[0].tiles
+    npg = nfold // bpool[0].tiles  # B pools one store spans
+    a_step = apool[0].tiles * bpool[0].tiles // (split * nfold)
+    mfma = Mfma16x16x128(a_step, nfold)
+    line_n = not fold and col_safe and nfold % 4 == 0
+    store_c = (
+        StoreCPerTensorQuadN
+        if fold
+        else (
+            StoreCPerTensorLineN
+            if line_n
+            else (StoreCPerTensorPairN if pair_n and nfold % 2 == 0 else StoreCPerTensor)
+        )
+    )(
+        A_scale,
+        B_scale,
+        C,
+        fx.Int32(M),
+        fx.Int32(N),
+        mfma.idx,
+        a_step,
+        nfold,
+        out_ty,
+        col_safe=col_safe,
+        store_aux=store_aux,
+        beta_is_one=beta_is_one,
+        **(
+            {"lds_xpose": _nt4_xpose_lds(pools[0], pool_lds[0], wave_id, n_waves), "scale": scale}
+            if line_n
+            else {}
+        ),
+    )
+
+    g2s = _nt4_g2s(A, B, win, pools, gl_off, wave_id)
+    _lds_barrier()
+    top = [[p.nbuf - 1] if carry else list(range(p.nbuf)) for p in pools]
+    _nt4_prime(pools, pool_lds, g2s, top, K, b_kstep, tr_b)
+    wait_barrier(sum(p.steps * sum(1 for b in t if b) for p, t in zip(pools, top)))
+
+    ins = []
+    for i, p in enumerate(pools):
+        addr = s2r[(p.side, p.width)].base_addr(pool_lds[i])
+        ins += [v for pair in (addr if tr_b and p.side == 1 else addr[:1]) for v in pair]
+    ins += [
+        rocdl.readfirstlane(
+            T.i32,
+            fx.Int32(fx.ptrtoint(pool_lds[i].ptr))
+            + fx.Int32(b * p.buf)
+            + fx.Int32(wave_id) * fx.Int32(_TN4_CS),
+        )
+        for i, p in enumerate(pools)
+        for b in range(p.nbuf)
+    ]
+    for key in _tn4_gl_keys(pools):
+        ins += [fx.Int32(o) for o in gl_off[key]]
+    ins += [
+        _buffer_ops.create_buffer_resource(g, max_size=False, num_records_bytes=nrec, base_byte_offset=base)
+        for g, (base, nrec) in ((A, win[0]), (B, win[1]))
+    ]
+    if carry:
+        _win2 = _nt4_tile_window(d_next, *wargs)[2]
+        ins += [
+            _buffer_ops.create_buffer_resource(
+                g, max_size=False, num_records_bytes=nrec, base_byte_offset=base
+            )
+            for g, (base, nrec) in ((A, _win2[0]), (B, _win2[1]))
+        ]
+    ins += [fx.Int32(_nt4_buf_off(p, p.nbuf, K, b_kstep, tr_b)) for p in pools]
+    ins += [fx.Int32(_nt4_buf_off(p, b, K, b_kstep, tr_b)) for i, p in enumerate(pools) for b in cbuf[i]]
+    nacc = sum(p.tiles for p in apool) * sum(p.tiles for p in bpool)  # over the pools it reads
+
+    asm, cons, st, peel = _dense_nt_wave4_asm(geom, K_ITERS, cbsz, blgp, fold, tr_b, b_kstep, carry)
+    r = _llvm.inline_asm(ir.Type.parse(st), [arith._to_raw(v) for v in ins], asm, cons, has_side_effects=True)
+    acc_ty = ir.Type.parse("vector<4xf32>")
+    res = [Vec(_llvm.extractvalue(acc_ty, r, [q])) for q in range_constexpr(nacc)]
+    # The K body stops one phase short and hands its mfma over here, where they are ordinary
+    # SSA values: the scheduler can then interleave the epilogue with them instead of queueing
+    # it behind an opaque asm block.
+    frag_ty = ir.Type.parse("vector<8xi32>")
+    n_frag = sum(p.tiles for p in apool + bpool)
+    frg = [Vec(_llvm.extractvalue(frag_ty, r, [nacc + f])) for f in range_constexpr(n_frag)]
+    if store_c.stages_lds:
+        _lds_barrier()
+
+    base_row = bm_off + wave_m * fx.Int32(apool[0].tiles * 16)
+    qoff, o = {}, 0  # accumulator base of each (A pool, B pool) quadrant, as the asm lays them out
+    for ai in range(len(apool)):
+        for bi, pb in enumerate(bpool):
+            qoff[(ai, bi)] = o
+            o += apool[0].tiles * pb.tiles
+    unit = []
+    for ai, pa in enumerate(apool):
+        for gi in range(len(bpool) // npg):
+            for h in range(pa.tiles // a_step):
+                unit.append(
+                    (
+                        [
+                            qoff[(ai, gi * npg + j)] + (h * a_step + ti) * bpool[0].tiles + bt
+                            for ti in range(a_step)
+                            for j in range(npg)
+                            for bt in range(bpool[0].tiles)
+                        ],
+                        pa.col + h * a_step * 16,
+                        bn_off + wave_n * fx.Int32(nfold * 16) + gi * npg * bpool[0].width,
+                    )
+                )
+    # A unit's mfma all precede the store of the previous unit: that store's reads and
+    # converts then issue while this unit's mfma occupy the matrix core. Reordering the
+    # phase's mfma by unit is free -- they are independent and their refills already ran.
+    grp = [[m for m in peel if m[0] in set(acc)] for acc, _row, _col in unit]
+
+    def emit_store(i, tap=None):
+        acc, row, col = unit[i]
+        store_c.store([res[q] for q in acc], base_row + row, col, **({"tap": tap} if tap else {}))
+
+    def emit_mfma(m):
+        q, at, br = m
+        res[q] = asm_mma_do(frg[at], frg[br], res[q], mode="2", cbsz=cbsz, blgp=blgp)
+
+    lead = geom.peel_lead if line_n else 0
+    if lead:
+        # One mfma per output row under the store keeps the matrix core busy underneath it.
+        for i in range_constexpr(lead):
+            for m in grp[i]:
+                emit_mfma(m)
+        for i in range_constexpr(len(unit)):
+            ahead = list(grp[i + lead]) if i + lead < len(unit) else []
+
+            def tap(pending=ahead):
+                if pending:
+                    emit_mfma(pending.pop(0))
+                    rocdl.sched_barrier(0)
+
+            emit_store(i, tap=tap)
+            for m in ahead:  # a group wider than the slots the unit offered
+                emit_mfma(m)
+    else:
+        for i in range_constexpr(len(unit)):
+            for m in grp[i]:
+                emit_mfma(m)
+            if i:
+                rocdl.sched_barrier(0)
+                emit_store(i - 1)
+        emit_store(len(unit) - 1)
+    store_c.flush()
+
+
+@functools.lru_cache(maxsize=128)
+def _compile_dense_nt_wave4(
+    M: int,
+    N: int,
+    K: int,
+    group_m: int = 4,
+    group_n: int = 0,
+    num_xcd: int = 8,
+    geom=_NT4_SQUARE,
+    cbsz: int = 0,  # srcA fp8 fmt: 0=E4M3, 1=E5M2
+    blgp: int = 0,  # srcB fp8 fmt: 0=E4M3, 1=E5M2
+    out_fp16: bool = False,
+    pair_n: bool = False,  # fold the n-fragment pair into one dword store (needs even N)
+    col_safe: bool = False,  # N % BLOCK_N == 0: drop the epilogue's per-store column clamp
+    beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
+):
+    """Whole-loop dense NT over ``geom``'s macro tile: a resident workgroup per CU walks a
+    column of tiles. K must be whole BLOCK_K blocks -- a partial one would need the
+    read-ahead to mask, and the 8-wave kernel already carries the native K-tail."""
+    BM, BN = geom.bm, geom.bn
+    phases = _tn4_phases(geom)
+    # A whole-line epilogue needs a wave's n-fragments to form one run of columns, and the run
+    # is written as an unmasked unit; the fold must divide the wave's n-extent evenly.
+    _bt = sum(p.tiles for p in _tn4_pools(geom) if p.side == geom.gl_side)
+    fold = geom.fold if col_safe and _bt % geom.fold == 0 else 0
+    _pools = _nt4_pools(geom, fold)
+    NBM, NBN = ceildiv(M, BM), ceildiv(N, BN)
+    n_tile = NBM * NBN
+    # Every workgroup runs the tile loop the same number of times, so a ragged count repeats
+    # the last id. An overwrite store makes that idempotent; an accumulate would fold it
+    # in twice, so beta=1 gives up residency and takes one tile per group.
+    tiles_per_wg = 1 if beta_is_one else ceildiv(n_tile, min(n_tile, _dense_num_cus()))
+    n_wg = ceildiv(n_tile, tiles_per_wg)
+    K_ITERS = K // _TN4_BLOCK_K
+    assert K % _TN4_BLOCK_K == 0, "4-wave dense NT has no K-tail path"
+    assert K_ITERS >= phases, "4-wave dense NT needs a K of at least one main-loop pass"
+    _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
+
+    SharedStorage = fx.struct(
+        type(
+            "SharedStorage",
+            (),
+            {
+                "__annotations__": {
+                    f"p{i}": fx.Array[fx.Float8E4M3FN, p.nbuf * p.buf, 16] for i, p in enumerate(_pools)
+                }
+            },
+        )
+    )
+
+    @flyc.kernel(known_block_size=[256, 1, 1])
+    def kernel_dense_nt_wave4(
+        A: fx.Tensor,
+        B_T: fx.Tensor,
+        C: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+    ):
+        _ = str(fx.thread_idx.x)
+        lane_id = fx.thread_idx.x % 64
+        wave_id = fx.thread_idx.x // 64
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        gl_off = {
+            k: (
+                _nt4_fold_gl_off(lane_id, wave_id, K, k[1] * _TN4_BLOCK_K // (256 * 16), k[2], fold)
+                if fold and k[0] == geom.gl_side
+                else compute_global_swizzle(
+                    lane_id, wave_id, K, k[1] * _TN4_BLOCK_K // (256 * 16), preshuffled=False
+                )
+            )
+            for k in _tn4_gl_keys(_pools)
+        }
+        targs = dict(
+            M=M,
+            N=N,
+            K=K,
+            K_ITERS=K_ITERS,
+            NBM=NBM,
+            NBN=NBN,
+            group_m=group_m,
+            group_n=group_n,
+            num_xcd=num_xcd,
+            store_aux=_CSTORE_AUX,
+            lds=lds,
+            geom=geom,
+            A=A,
+            B=B_T,
+            C=C,
+            A_scale=A_scale,
+            B_scale=B_scale,
+            gl_off=gl_off,
+            wave_id=wave_id,
+            **dict(zip(("wave_m", "wave_n"), _tn4_wave_coord(wave_id, geom))),
+            cbsz=cbsz,
+            blgp=blgp,
+            out_ty=_out_ty,
+            col_safe=col_safe,
+            beta_is_one=beta_is_one,
+            pair_n=pair_n,
+            fold=fold,
+        )
+
+        for t in range(fx.Int32(0), fx.Int32(tiles_per_wg), fx.Int32(1)):
+            d = fx.block_idx.x + t * n_wg
+            _dense_nt_wave4_tile(arith.select(d < fx.Int32(n_tile), d, fx.Int32(n_tile - 1)), **targs)
+
+    _ATTRS = make_value_attrs(1, 0, "256,256")
+
+    @flyc.jit
+    def launch_dense_nt_wave4(
+        A: fx.Tensor,
+        B_T: fx.Tensor,
+        C: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+        c_m: fx.Int32,
+        c_n: fx.Int32,
+        stream: fx.Stream,
+    ):
+        _ = c_m, c_n  # the tile count is compile-time here; the grid is the resident set
+        kernel_dense_nt_wave4(A, B_T, C, A_scale, B_scale, value_attrs=_ATTRS).launch(
+            grid=(n_wg, 1, 1), block=(256, 1, 1), stream=stream
+        )
+
+    return launch_dense_nt_wave4
+
+
+@functools.lru_cache(maxsize=128)
+def _compile_dense_nn_wave4(
+    M: int,
+    N: int,
+    K: int,
+    group_m: int = 4,
+    group_n: int = 0,
+    num_xcd: int = 8,
+    geom=_NT4_SQUARE,
+    cbsz: int = 0,  # srcA fp8 fmt: 0=E4M3, 1=E5M2
+    blgp: int = 0,  # srcB fp8 fmt: 0=E4M3, 1=E5M2
+    out_fp16: bool = False,
+    pair_n: bool = False,  # fold the n-fragment pair into one dword store (needs even N)
+    col_safe: bool = False,  # N % BLOCK_N == 0: drop the epilogue's per-store column clamp
+    beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
+):
+    """Whole-loop dense NN: a resident workgroup per CU walks a column of ``geom``'s tiles."""
+    BM, BN = geom.bm, geom.bn
+    NTHR = _tn4_nthr(geom)
+    phases = _tn4_phases(geom)
+    # The whole-line epilogue interleaves the n-fragments by permuting B's global row order,
+    # which NN cannot do: its output columns are B's contiguous dim.
+    _pools = _nt4_pools(geom, 0)
+    NBM, NBN = ceildiv(M, BM), ceildiv(N, BN)
+    n_tile = NBM * NBN
+    tiles_per_wg = 1 if beta_is_one else ceildiv(n_tile, min(n_tile, _dense_num_cus()))
+    n_wg = ceildiv(n_tile, tiles_per_wg)
+    K_ITERS = K // _TN4_BLOCK_K
+    assert K % _TN4_BLOCK_K == 0, "whole-loop dense NN has no K-tail path"
+    assert K_ITERS >= phases, "whole-loop dense NN needs a K of at least one main-loop pass"
+    carry = K_ITERS % phases == 0
+    _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
+
+    SharedStorage = fx.struct(
+        type(
+            "SharedStorage",
+            (),
+            {
+                "__annotations__": {
+                    f"p{i}": fx.Array[fx.Float8E4M3FN, p.nbuf * p.buf, 16] for i, p in enumerate(_pools)
+                }
+            },
+        )
+    )
+
+    @flyc.kernel(known_block_size=[NTHR, 1, 1])
+    def kernel_dense_nn_wave4(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+    ):
+        _ = str(fx.thread_idx.x)
+        lane_id = fx.thread_idx.x % 64
+        wave_id = fx.thread_idx.x // 64
+        lds = fx.SharedAllocator().allocate(SharedStorage).peek()
+        # The B pools are filled K-row by K-row and read back transposed, so their write side
+        # takes the bank swizzle the transpose reader looks for.
+        gl_off = {
+            _tn4_gl_key(p): (
+                compute_global_swizzle_nn(lane_id, wave_id, N, p.steps, width=p.width, wswz=True)
+                if p.side == 1
+                else compute_global_swizzle(lane_id, wave_id, K, p.steps, preshuffled=False)
+            )
+            for p in _pools
+        }
+        targs = dict(
+            M=M,
+            N=N,
+            K=K,
+            K_ITERS=K_ITERS,
+            NBM=NBM,
+            NBN=NBN,
+            group_m=group_m,
+            group_n=group_n,
+            num_xcd=num_xcd,
+            store_aux=_CSTORE_AUX,
+            lds=lds,
+            geom=geom,
+            A=A,
+            B=B,
+            C=C,
+            A_scale=A_scale,
+            B_scale=B_scale,
+            gl_off=gl_off,
+            wave_id=wave_id,
+            **dict(zip(("wave_m", "wave_n"), _tn4_wave_coord(wave_id, geom))),
+            cbsz=cbsz,
+            blgp=blgp,
+            out_ty=_out_ty,
+            col_safe=col_safe,
+            beta_is_one=beta_is_one,
+            pair_n=pair_n,
+            fold=0,
+            tr_b=True,
+        )
+
+        if const_expr(carry):
+            w0 = _nt4_tile_window(fx.block_idx.x, M, N, K, NBM, NBN, group_m, group_n, num_xcd, geom, True)
+            _nt4_prime(
+                _pools,
+                [getattr(lds, f"p{i}") for i in range(len(_pools))],
+                _nt4_g2s(A, B, w0[2], _pools, gl_off, wave_id),
+                _nt4_carry_bufs(_pools, True),
+                K,
+                _TN4_BLOCK_K * N,
+                True,
+            )
+
+        scale = load_per_tensor_scale(A_scale, B_scale)
+
+        for t in range(fx.Int32(0), fx.Int32(tiles_per_wg), fx.Int32(1)):
+            d = fx.block_idx.x + t * n_wg
+            dn = d + n_wg if carry else None
+            _dense_nt_wave4_tile(
+                arith.select(d < fx.Int32(n_tile), d, fx.Int32(n_tile - 1)),
+                d_next=arith.select(dn < fx.Int32(n_tile), dn, fx.Int32(n_tile - 1)) if carry else None,
+                scale=scale,
+                **targs,
+            )
+
+    _ATTRS = make_value_attrs(NTHR // 256, 0, f"{NTHR},{NTHR}")
+
+    @flyc.jit
+    def launch_dense_nn_wave4(
+        A: fx.Tensor,
+        B: fx.Tensor,
+        C: fx.Tensor,
+        A_scale: fx.Tensor,
+        B_scale: fx.Tensor,
+        c_m: fx.Int32,
+        c_n: fx.Int32,
+        stream: fx.Stream,
+    ):
+        _ = c_m, c_n  # the tile count is compile-time here; the grid is the resident set
+        kernel_dense_nn_wave4(A, B, C, A_scale, B_scale, value_attrs=_ATTRS).launch(
+            grid=(n_wg, 1, 1), block=(NTHR, 1, 1), stream=stream
+        )
+
+    return launch_dense_nn_wave4
 
 
 _COMPILED_DENSE_CACHE: dict = {}
 
+_raw_stream = torch._C._cuda_getCurrentRawStream
+
+
+def _static_layout(args):
+    """Wrap the tensor arguments as static-layout memrefs for a one-time compile: a bare
+    torch.Tensor compiles layout-dynamic and re-reads shape/stride per launch, while the
+    compiled object is already one per operand geometry."""
+    return tuple(flyc.from_torch_tensor(a) if isinstance(a, torch.Tensor) else a for a in args)
+
+
+def _compile_scratch_out(launch, args, out_index=2):
+    """``compile_with_scratch_out`` through ``_static_layout``: the scratch has to be swapped
+    in while the arguments are still tensors, and the layout wrap has to be what reaches
+    ``flyc.compile``."""
+    scratch = torch.zeros_like(args[out_index])
+    return flyc.compile(launch, *_static_layout(args[:out_index] + (scratch,) + args[out_index + 1 :]))
+
 
 def _get_compiled_dense(launch, args):
-    """Cache compiled launcher by (shape, dtype, int-arg) tuple."""
+    """Cache compiled launcher by (shape, stride, dtype, int-arg) tuple. Strides are in the
+    key because the compile pins the operand layout; the trailing queue handle is not, as
+    it selects where a launch goes and keying on it would recompile per stream."""
     key_parts = [id(launch)]
-    for a in args:
+    for a in args[:-1]:
         if isinstance(a, torch.Tensor):
-            key_parts.append((tuple(a.shape), a.dtype))
+            key_parts.append((tuple(a.shape), a.stride(), a.dtype))
         elif isinstance(a, int):
             key_parts.append(a)
         else:
@@ -1054,18 +2887,15 @@ def _get_compiled_dense(launch, args):
     key = tuple(key_parts)
     cached = _COMPILED_DENSE_CACHE.get(key)
     if cached is None:
-        cached = compile_with_scratch_out(launch, args)
+        cached = _compile_scratch_out(launch, args)
         _COMPILED_DENSE_CACHE[key] = cached
     return cached
 
 
 def _bench_dense_args(args):
-    """Bench copy of the launch args with a scratch C, plus that scratch.
-
-    Each candidate is run 23 times while racing. Against a beta=1 build that would
-    fold 23 GEMMs into the caller's accumulation buffer, so the race never touches
-    it: the winning config is re-compiled with the accumulate epilogue afterwards.
-    """
+    """Launch args with a scratch C, plus that scratch: racing a beta=1 build against the
+    caller buffer would fold every timed launch into it, so the winner is recompiled
+    with the accumulate epilogue afterwards instead."""
     bench_c = torch.empty_like(args[2])
     return (args[0], args[1], bench_c) + tuple(args[3:]), bench_c
 
@@ -1084,6 +2914,20 @@ def _dense_beta1_entry(cache, key, tuned):
     return entry
 
 
+def _pick_dense_candidate(cands, args):
+    """Fastest of ``cands`` = [[launch, cfg, compiled, factory], ...], sampled twice with the second
+    pass reversed and kept at its min, behind a throwaway pass: the leading candidates sit
+    closer than one sample's spread, so otherwise clock drift and warm-up do the ranking."""
+    for _ in range(_PICK_RAMP_ITERS):
+        cands[0][2](*args)
+    torch.cuda.synchronize()
+    order = list(range(len(cands)))
+    ts = [float("inf")] * len(cands)
+    for i in order + order[::-1]:
+        ts[i] = min(ts[i], _robust_time(cands[i][2], args, warmup=2, reps=2, iters=40))
+    return cands[min(order, key=ts.__getitem__)]
+
+
 def _run_dense(entry, args):
     """Mode-split steady-state launch. entry = [raw @flyc.jit launch, cfg, compiled].
     Eager: run the one-time flyc.compile'd object (skips @flyc.jit's per-call drift-
@@ -1093,51 +2937,45 @@ def _run_dense(entry, args):
         entry[0](*args)
     else:
         if entry[2] is None:
-            entry[2] = compile_with_scratch_out(entry[0], args)
+            entry[2] = _compile_scratch_out(entry[0], args)
         entry[2](*args)
 
 
-def _as_i8_flat(t: torch.Tensor) -> torch.Tensor:
-    # Zero-copy i8 view. Recomputed every call (no id()-keyed cache: a
-    # freed tensor's id + data_ptr can both be reused, and a recycled pair with a
-    # different numel would alias the wrong length). The view ops are ~1us and
-    # allocate nothing.
-    if t.element_size() == 1 and t.dtype != torch.int8:  # fp8
-        return t.contiguous().view(torch.int8)
-    return t.contiguous()
+def _dense_operand(t: torch.Tensor) -> torch.Tensor:
+    return t if t.is_contiguous() else t.contiguous()
 
 
 def _scalar_scale(scale: torch.Tensor, device: torch.device) -> torch.Tensor:
-    """Tensorwise scalar -> length-1 fp32 buffer (no broadcast). The kernel reads
-    the single value and applies it per-tensor, so only an fp32/device cast is
-    needed (no per-row/col vector to materialize)."""
+    """Tensorwise scalar -> length-1 fp32 buffer (no broadcast): the kernel applies the
+    single value per-tensor, so only an fp32/device cast is needed. A conforming buffer is
+    returned as is, since .to()/.reshape() are no-ops on it but still cost two dispatches."""
+    if scale.dtype is torch.float32 and scale.shape == (1,) and scale.device == device:
+        return scale
     assert scale.numel() == 1, f"per-tensor expects scalar, got {scale.shape}"
     return scale.to(dtype=torch.float32, device=device).reshape(1)
 
 
-# NN per-shape autotune candidates (BLOCK_M, GROUP_M, num_xcd, AGPR). GROUP_M
-# and num_xcd are fixed at the analytic L2 optimum; AGPR must be nonzero (the
-# inline-asm ds_read_b64_tr_b8 path needs a pinned AGPR count).
-_NN_CANDIDATES = [
-    (256, 4, 8, 32),
-    (256, 4, 8, 64),
-    (128, 4, 8, 48),
-]
+# (BLOCK_M, GROUP_M, group_n, num_xcd, AGPR)
+# (BLOCK_M, GROUP_M, group_n, num_xcd, AGPR), keyed on whether the whole loop is eligible:
+# it takes two of the four slots when it is, so a shape never races more than four builds.
+_NN_CANDIDATES = {
+    True: [(256, 1, 0, 4, 32), (256, 4, 4, 8, 44)],
+    False: [(256, 4, 4, 8, 44), (256, 4, 8, 8, 44), (256, 1, 0, 4, 32), (128, 4, 0, 8, 48)],
+}
+# Past this K the per-tile epilogue is amortised enough to race. The resident set is
+# the whole device, so a narrow grid band already spans its columns and only the
+# XCD group count is left to spread the rows.
+_NN4_MIN_K_ITERS = 16
+_NN4_BANDS = [(2, 0, 2), (4, 8, 8)]  # (GROUP_M, group_n, num_xcd) the whole loop races
 _NN_AUTOTUNE_CACHE: dict = {}
 
 
 def _autotune_nn_dispatch(
     args, M, N, K, cbsz=0, blgp=0, out_fp16=False, i64_traverse=False, beta_is_one=False
 ):
-    """First-call bench NN candidates, cache best (launch, cfg) by (M,N,K).
-
-    Runtime micro-benches each (BM, GROUP_M, num_xcd, AG) candidate,
-    finite-checks the output, times 2-warmup + 20-iter, and caches the
-    fastest by shape. ``i64_traverse`` re-bases B's SRD per load (lifts the
-    k*n < 2^32 cap; threaded to _compile_dense_nn). The race always runs the
-    beta=0 build; ``beta_is_one`` re-compiles the winner with the accumulate
-    epilogue.
-    """
+    """First-call bench of the NN candidates, best (launch, cfg) cached by (M,N,K); each is
+    finite-checked before it is timed (see _pick_dense_candidate). ``i64_traverse`` re-bases
+    B's SRD per load, lifting the k*n < 2^32 cap."""
     import torch as _torch
 
     key = (M, N, K, cbsz, blgp, out_fp16, i64_traverse)
@@ -1145,21 +2983,33 @@ def _autotune_nn_dispatch(
     if tuned is not None:
         return _dense_beta1_entry(_NN_AUTOTUNE_CACHE, key, tuned) if beta_is_one else tuned
     bargs, out_view = _bench_dense_args(args)
-    best_us = float("inf")
-    best = None
-    for bm, gm, xcd, ag in _NN_CANDIDATES:
-        # odd-M (M % bm != 0) is fine: the partial last M-tile is
-        # bounded by c_m (StoreCPerTensor clamp) and the global SRD (HW OOB
+    cands = []
+    pair_n, col_safe = N % 2 == 0 and not out_fp16, N % 256 == 0
+
+    w4 = not i64_traverse and K % _TN4_BLOCK_K == 0 and K // _TN4_BLOCK_K >= _NN4_MIN_K_ITERS
+
+    def add(build, cfg):
         # clamp on the A G2S load), so no even-tiling filter is needed.
         try:
-            # inline-asm ds_read_b64_tr_b8 on by default (drops the per-K-iter
-            # compiler-auto vmcnt(0) drains).
-            mk = functools.partial(
+            launch = build(beta_is_one=False)
+            c = _get_compiled_dense(launch, bargs)
+            c(*bargs)
+            _torch.cuda.synchronize()
+            if not _torch.isfinite(out_view.view(-1)[:1024].float()).all().item():
+                return
+            cands.append([launch, cfg, c, build])  # c: compiled, reused eager
+        except Exception:
+            return
+
+    for bm, gm, gn, xcd, ag in _NN_CANDIDATES[w4]:
+        add(
+            functools.partial(
                 _compile_dense_nn,
                 K=K,
                 BLOCK_M=bm,
                 BLOCK_N=256,
                 GROUP_M=gm,
+                group_n=gn,
                 num_xcd=xcd,
                 agpr_alloc=ag,
                 b_inline_asm_load=True,
@@ -1168,57 +3018,65 @@ def _autotune_nn_dispatch(
                 blgp=blgp,
                 out_fp16=out_fp16,
                 i64_traverse=i64_traverse,
+                pair_n=pair_n,
+                col_safe=col_safe,
+            ),
+            (bm, gm, gn, xcd, ag),
+        )
+    # The whole-loop joins the race where it applies: one barrier per K-block and a wave
+    # tile twice as wide, against an epilogue occ=1 cannot shadow. Its B side is one
+    # 32-bit soffset chain, so a span needing the i64 re-base stays with the 8-wave tiles.
+    if w4:
+        for gm, gn, xcd in _NN4_BANDS:
+            add(
+                functools.partial(
+                    _compile_dense_nn_wave4,
+                    M,
+                    N,
+                    K,
+                    group_m=gm,
+                    group_n=gn,
+                    num_xcd=xcd,
+                    cbsz=cbsz,
+                    blgp=blgp,
+                    out_fp16=out_fp16,
+                    pair_n=pair_n,
+                    col_safe=col_safe,
+                ),
+                ("nn4", gm, gn, xcd),
             )
-            launch = mk(beta_is_one=False)
-            c = _get_compiled_dense(launch, bargs)
-            c(*bargs)
-            _torch.cuda.synchronize()
-            sample = out_view.view(-1)[:1024].float()
-            if not _torch.isfinite(sample).all().item():
-                continue
-            for _ in range(2):
-                c(*bargs)
-            _torch.cuda.synchronize()
-            e0 = _torch.cuda.Event(enable_timing=True)
-            e1 = _torch.cuda.Event(enable_timing=True)
-            _torch.cuda.synchronize()
-            e0.record()
-            for _ in range(20):
-                c(*bargs)
-            e1.record()
-            _torch.cuda.synchronize()
-            us = e0.elapsed_time(e1) * 1000.0 / 20
-            if us < best_us:
-                best_us = us
-                best = [launch, (bm, gm, xcd, ag), c, mk]  # c: compiled winner (reused eager)
-        except Exception:
-            continue
-    if best is None:
+    if not cands:
         raise RuntimeError(f"NN autotune found no working cfg for ({M},{N},{K})")
+    best = _pick_dense_candidate(cands, bargs)
     _NN_AUTOTUNE_CACHE[key] = best
     return _dense_beta1_entry(_NN_AUTOTUNE_CACHE, key, best) if beta_is_one else best
 
 
-# NT per-shape autotune candidates (BLOCK_M, GROUP_M, num_xcd, AGPR). GROUP_M
-# and num_xcd are fixed at the analytic L2 optimum; only BLOCK_M and AGPR are
-# benched (occupancy/compute effects the hot-cache bench measures reliably).
-_NT_CANDIDATES = [
-    (256, 4, 8, 64),
-    (256, 4, 8, 32),
-    (128, 4, 8, 48),
-    (128, 4, 8, 32),
-]
+# (BLOCK_M, GROUP_M, num_xcd, AGPR); the live band is a GROUP_M-wide super-row of A
+# (BLOCK_M, GROUP_M, num_xcd, AGPR); the live band is a GROUP_M-wide super-row of A. One
+# table per regime, four wide: a race compiles every entry, so the list is what first-call
+# latency costs. Once the band outgrows an XCD L2 slice, clustering onto XCDs buys no reuse
+# and only costs balance, which is why the wide table drops to a plain round-robin.
+_NT_BAND_L2_BYTES = 4 << 20
+_NT_CANDIDATES = {
+    # (whole-loop eligible, band past the L2 slice)
+    (True, False): [(128, 4, 8, 32), (256, 4, 8, 32)],
+    (True, True): [(128, 4, 8, 48), (256, 2, 1, 32)],
+    (False, False): [(256, 4, 8, 64), (256, 4, 8, 32), (128, 4, 8, 48), (128, 4, 8, 32)],
+    (False, True): [(256, 4, 8, 32), (128, 4, 8, 48), (256, 2, 1, 32), (256, 4, 1, 32)],
+}
+# The whole-loop moves a third less LDS traffic per MFMA, which buys clock on a
+# power-limited part, against an epilogue occ=1 cannot shadow; a column-safe tile
+# writes it a whole line at a time, which pays off even on the short-K shapes.
+_NT4_MIN_K_ITERS = 16
+_NT4_BANDS = [(2, 1), (4, 8)]  # (GROUP_M, num_xcd) the whole loop races
 _NT_AUTOTUNE_CACHE: dict = {}
 
 
 def _autotune_nt_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, beta_is_one=False):
-    """First-call bench NT candidates, cache best (launch, cfg) by (M,N,K).
-
-    Runtime micro-benches each (BM, GROUP_M, num_xcd, AG) candidate,
-    finite-checks the output, times 2-warmup + 20-iter, and caches the
-    fastest by shape. The race always runs the beta=0 build; ``beta_is_one``
-    re-compiles the winner with the accumulate epilogue.
-    """
+    """First-call bench of the NT candidates, best (launch, cfg) cached by (M,N,K); each is
+    finite-checked before it is timed (see _pick_dense_candidate). The 8-wave tiles are joined
+    by the 4-wave whole-loop on the long-K shapes whose steady state pays for it."""
     import torch as _torch
 
     key = (M, N, K, cbsz, blgp, out_fp16)
@@ -1226,14 +3084,26 @@ def _autotune_nt_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, beta_is
     if tuned is not None:
         return _dense_beta1_entry(_NT_AUTOTUNE_CACHE, key, tuned) if beta_is_one else tuned
     bargs, out_view = _bench_dense_args(args)
-    best_us = float("inf")
-    best = None
-    for bm, gm, xcd, ag in _NT_CANDIDATES:
-        # odd-M (M % bm != 0) is fine: the partial last M-tile is
-        # bounded by c_m (StoreCPerTensor clamp) and the global SRD (HW OOB
-        # clamp on the A G2S load), so no even-tiling filter is needed.
+    cands = []
+    pair_n, col_safe = N % 2 == 0 and not out_fp16, N % 256 == 0
+
+    def add(build, cfg):
         try:
-            mk = functools.partial(
+            launch = build(beta_is_one=False)
+            c = _get_compiled_dense(launch, bargs)
+            c(*bargs)
+            _torch.cuda.synchronize()
+            if not _torch.isfinite(out_view.view(-1)[:1024].float()).all().item():
+                return
+            cands.append([launch, cfg, c, build])  # c: compiled, reused eager
+        except Exception:
+            return
+
+    w4 = K % _TN4_BLOCK_K == 0 and K // _TN4_BLOCK_K >= _NT4_MIN_K_ITERS
+    wide = 4 * 256 * K > _NT_BAND_L2_BYTES  # GROUP_M * BLOCK_M * K of the leading cfg
+    for bm, gm, xcd, ag in _NT_CANDIDATES[(w4, wide)]:
+        add(
+            functools.partial(
                 _compile_dense_nt,
                 K=K,
                 BLOCK_M=bm,
@@ -1244,41 +3114,182 @@ def _autotune_nt_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, beta_is
                 cbsz=cbsz,
                 blgp=blgp,
                 out_fp16=out_fp16,
+                pair_n=pair_n,
+                col_safe=col_safe,
+            ),
+            (bm, gm, xcd, ag),
+        )
+    if w4:
+        for gm, xcd in _NT4_BANDS:
+            add(
+                functools.partial(
+                    _compile_dense_nt_wave4,
+                    M,
+                    N,
+                    K,
+                    group_m=gm,
+                    num_xcd=xcd,
+                    cbsz=cbsz,
+                    blgp=blgp,
+                    out_fp16=out_fp16,
+                    pair_n=pair_n,
+                    col_safe=col_safe,
+                ),
+                ("nt4", gm, xcd),
             )
-            launch = mk(beta_is_one=False)
-            c = _get_compiled_dense(launch, bargs)
-            c(*bargs)
-            _torch.cuda.synchronize()
-            sample = out_view.view(-1)[:1024].float()
-            if not _torch.isfinite(sample).all().item():
-                continue
-            for _ in range(2):
-                c(*bargs)
-            _torch.cuda.synchronize()
-            e0 = _torch.cuda.Event(enable_timing=True)
-            e1 = _torch.cuda.Event(enable_timing=True)
-            _torch.cuda.synchronize()
-            e0.record()
-            for _ in range(20):
-                c(*bargs)
-            e1.record()
-            _torch.cuda.synchronize()
-            us = e0.elapsed_time(e1) * 1000.0 / 20
-            if us < best_us:
-                best_us = us
-                best = [launch, (bm, gm, xcd, ag), c, mk]  # c: compiled winner (reused eager)
-        except Exception:
-            continue
-    if best is None:
+    if not cands:
         raise RuntimeError(f"NT autotune found no working cfg for ({M},{N},{K})")
+    best = _pick_dense_candidate(cands, bargs)
     _NT_AUTOTUNE_CACHE[key] = best
     return _dense_beta1_entry(_NT_AUTOTUNE_CACHE, key, best) if beta_is_one else best
 
 
-# TN dispatch: a single inplace-A kernel (inline-asm tr8 on both operands +
-# asm_mma=2 → accumulators aliased into AGPR, spill-free, no per-K-iter A-side
-# vmcnt(0) drain). Same 1D GROUP_M=4 + XCD-aware PID remap as NT/NN; only the
-# num_xcd on/off is benched per shape (L2-resident shapes pick num_xcd=1).
+_TN_WAVE4_CACHE: dict = {}
+_TN4_WS_CACHE: dict = {}
+_TN4_FLAG_CACHE: dict = {}
+_TN4_PLAN_CACHE: dict = {}
+_TN4_MS_MARGIN = 1.05  # makespan spread inside which the model does not order the macro tiles
+_TN4_XCD = 8  # XCDs the dispatcher round-robins over; each fills a private L2 slice
+
+
+def _tn_wave4_supported(N: int, K: int, i64_traverse: bool) -> bool:
+    """The whole-loop reaches each operand through one per-tile buffer SRD and its split-K
+    bands keep C's row pitch, so spans needing the per-load i64 re-base, vector-unaligned
+    output widths, and a K too short for one main-loop pass all go to the 8-wave kernel."""
+    min_iters = min(_tn4_phases(g) for g in _TN4_GEOMS)
+    return (not i64_traverse) and N % _TN4_OUT_ALIGN == 0 and ceildiv(K, _TN4_BLOCK_K) >= min_iters
+
+
+def _tn4_band_group(stripes):
+    """Snap a group height to a divisor of _TN4_XCD. Only on a divisor do the workgroups one
+    XCD owns within a group share a block_m, which is what keeps its resident set a rectangle
+    instead of a staircase spanning every row the group covers."""
+    return min((1, 2, 4, 8), key=lambda g: abs(math.log(max(stripes, 0.5) / g)))
+
+
+def _tn_wave4_band(M, N, geom, ncu):
+    """(group_m, group_n) sized so one XCD's resident tiles form the rectangle that pulls the
+    fewest operand bytes through its L2 slice. A tall grid, where a band would leave a ragged
+    last stripe, spreads the stripes inside the group instead."""
+    m_blocks, n_blocks = ceildiv(M, geom.bm), ceildiv(N, geom.bn)
+    resident = ncu / _TN4_XCD
+    stripes = math.sqrt(resident * geom.bm / geom.bn)
+    if n_blocks < m_blocks:
+        return _tn4_band_group(stripes * _TN4_XCD / n_blocks), n_blocks
+    group_m = _tn4_band_group(stripes * m_blocks / resident)
+    return group_m, min(_TN4_XCD // group_m, n_blocks)
+
+
+def _tn4_geom_split(M, N, K, ncu, geom):
+    """This geometry's split-K window, at its own BLOCK_K."""
+    return _dense_tn_split(
+        ceildiv(M, geom.bm) * ceildiv(N, geom.bn), ceildiv(K, _TN4_BLOCK_K), ncu, _tn4_phases(geom)
+    )
+
+
+def _tn4_makespan(M, N, K, ncu, geom):
+    """Device time one geometry needs for this shape, in macro-tile cells: full tiles retire
+    ncu at a time and the split-K window's slices, being 1/s of a tile each, share the rounds
+    they land in. It only orders the candidates; the race is what picks one."""
+    tiles = ceildiv(M, geom.bm) * ceildiv(N, geom.bn)
+    cells = geom.bm * geom.bn
+    split = _tn4_geom_split(M, N, K, ncu, geom)
+    if split is None:
+        return ceildiv(tiles, ncu) * cells
+    lo, n, s = split
+    return (lo // ncu) * cells + _tn4_split_rounds(tiles, n, s, ncu) * cells / s
+
+
+def _tn4_grid(M, N, K, ncu, geom):
+    """Workgroups one geometry launches, plus ``(bands, flags)`` in units of the M x N scratch
+    band: the reduce route needs s-1 bands, the handoff one fragment-ordered slot and one flag
+    per window tile."""
+    tiles = ceildiv(M, geom.bm) * ceildiv(N, geom.bn)
+    split = _tn4_geom_split(M, N, K, ncu, geom)
+    if split is None:
+        return tiles, 0, 0
+    grid = tiles + split[1] * (split[2] - 1)
+    if _tn4_handoff(split):
+        return grid, ceildiv(split[1] * geom.bm * geom.bn, M * N), split[1]
+    return grid, split[2] - 1, 0
+
+
+def _tn4_plan(M, N, K, ncu):
+    """Whole-loop macro tiles for one TN shape, most promising first, with the scratch bands
+    and flags the widest needs. Ordered by predicted makespan, ties going to the smaller grid.
+    Memoised because the steady-state launch path reads it on every call."""
+    key = (M, N, K, ncu)
+    plan = _TN4_PLAN_CACHE.get(key)
+    if plan is None:
+        scored = []
+        for g in _TN4_GEOMS:
+            grid, bands, flags = _tn4_grid(M, N, K, ncu, g)
+            scored.append((_tn4_makespan(M, N, K, ncu, g), grid, bands, flags, g))
+        lo = min(s[0] for s in scored)
+        scored.sort(key=lambda s: (s[0] > lo * _TN4_MS_MARGIN, s[1]))
+        plan = (
+            tuple(s[4] for s in scored),
+            max(s[2] for s in scored),
+            max(s[3] for s in scored),
+        )
+        _TN4_PLAN_CACHE[key] = plan
+    return plan
+
+
+def _tn_wave4_workspace(M, N, bands, device, dtype, out):
+    """Scratch for the split-K slice partials: ``bands`` bands of M rows at C's row pitch, so
+    a slice store only swaps the band SRD's base. Kept per (shape, device) because a fixed
+    buffer is what CUDA-graph capture needs; no window -> pass C and allocate nothing."""
+    if bands == 0:
+        return out
+    key = (device.index, dtype, bands * M, N)
+    ws = _TN4_WS_CACHE.get(key)
+    if ws is None:
+        ws = torch.empty((bands * M, N), device=device, dtype=dtype)
+        _TN4_WS_CACHE[key] = ws
+    return ws
+
+
+def _tn_wave4_flags(n, device):
+    """Handoff flags, one per split-K window tile and zero at rest: slice 0 raises its tile's
+    flag once its partial is device-visible and the folding slice clears it again, so one
+    buffer serves every launch. Kept per (size, device) for the same reason the scratch is."""
+    key = (device.index, max(n, 1))
+    fl = _TN4_FLAG_CACHE.get(key)
+    if fl is None:
+        fl = torch.zeros(max(n, 1), device=device, dtype=torch.int32)
+        _TN4_FLAG_CACHE[key] = fl
+    return fl
+
+
+def _tn_wave4_dispatch(args, M, N, K, geoms, cbsz=0, blgp=0, out_fp16=False):
+    """First-call race of the whole-loop macro tiles for one TN problem, best (launch, cfg)
+    cached by (M,N,K); each is finite-checked before it is timed. The losers stay in the cache
+    entry: _get_compiled_dense keys on the launch object, so a freed id could hit a stale one."""
+    key = (M, N, K, cbsz, blgp, out_fp16)
+    hit = _TN_WAVE4_CACHE.get(key)
+    if hit is not None:
+        return hit[0]
+    out_view = args[2]
+    ncu = _dense_num_cus()
+    cands = []
+    for geom in geoms:
+        try:
+            group_m, group_n = _tn_wave4_band(M, N, geom, ncu)
+            launch, _bands = _compile_dense_tn_wave4(M, N, K, group_m, group_n, geom, cbsz, blgp, out_fp16)
+            c = _get_compiled_dense(launch, args)
+            c(*args)
+            torch.cuda.synchronize()
+            if not torch.isfinite(out_view.view(-1)[:1024].float()).all().item():
+                continue
+            cands.append([launch, (geom.bm, geom.bn, group_m, group_n), c])
+        except Exception:
+            continue
+    if not cands:
+        raise RuntimeError(f"TN whole-loop found no working cfg for ({M},{N},{K})")
+    best = _pick_dense_candidate(cands, args)
+    _TN_WAVE4_CACHE[key] = (best, cands)
+    return best
 
 
 _TN_AUTOTUNE_CACHE: dict = {}
@@ -1293,8 +3304,6 @@ def _autotune_tn_dispatch(
     (HBM-streaming) shapes expose the per-XCD L2 reuse on the hot bench,
     L2-resident shapes pick num_xcd=1. ``i64_traverse`` re-bases A's and B's
     SRDs per load (lifts the k*m / k*n < 2^32 cap; threaded to _compile_dense_tn).
-    The race always runs the beta=0 build; ``beta_is_one`` re-compiles the winner
-    with the accumulate epilogue.
     """
     import torch as _torch
 
@@ -1302,15 +3311,9 @@ def _autotune_tn_dispatch(
     tuned = _TN_AUTOTUNE_CACHE.get(key)
     if tuned is not None:
         return _dense_beta1_entry(_TN_AUTOTUNE_CACHE, key, tuned) if beta_is_one else tuned
-    # Occupancy routing: BLOCK_M=BLOCK_N=256 yields ceil(M/256)*ceil(N/256)
-    # tiles; below NUM_CUS the grid can't fill every CU, so BLOCK_M=128 doubles
-    # the M-tile count. Above it the smaller block's per-tile overhead dominates.
-    NUM_CUS = 256
-    tiles_256 = ((M + 255) // 256) * ((N + 255) // 256)
-    bm = 128 if tiles_256 < NUM_CUS else 256
+    bm = 256
     bargs, out_view = _bench_dense_args(args)
-    best_us = float("inf")
-    best = None
+    cands = []
     for xcd in (8, 1):
         try:
             mk = functools.partial(
@@ -1334,25 +3337,12 @@ def _autotune_tn_dispatch(
             sample = out_view.view(-1)[:1024].float()
             if not _torch.isfinite(sample).all().item():
                 continue
-            for _ in range(2):
-                c(*bargs)
-            _torch.cuda.synchronize()
-            e0 = _torch.cuda.Event(enable_timing=True)
-            e1 = _torch.cuda.Event(enable_timing=True)
-            _torch.cuda.synchronize()
-            e0.record()
-            for _ in range(20):
-                c(*bargs)
-            e1.record()
-            _torch.cuda.synchronize()
-            us = e0.elapsed_time(e1) * 1000.0 / 20
-            if us < best_us:
-                best_us = us
-                best = [launch, (bm, 4, 0, xcd), c, mk]  # c: compiled winner (reused eager)
+            cands.append([launch, (bm, 4, 0, xcd), c, mk])  # c: compiled, reused eager
         except Exception:
             continue
-    if best is None:
+    if not cands:
         raise RuntimeError(f"TN autotune found no working cfg for ({M},{N},{K})")
+    best = _pick_dense_candidate(cands, bargs)
     _TN_AUTOTUNE_CACHE[key] = best
     return _dense_beta1_entry(_TN_AUTOTUNE_CACHE, key, best) if beta_is_one else best
 
@@ -1402,24 +3392,40 @@ def gemm_fp8_tensorwise_flydsl_kernel(
         K_b, N = b.shape
         assert K_a == K_b, f"TN K mismatch: a {a.shape}, b {b.shape}"
         K = K_a
-        a_scale_v = _scalar_scale(a_scale_inv, a.device)
-        b_scale_v = _scalar_scale(b_scale_inv, a.device)
-        out = resolve_accum_out(out, beta, (M, N), a.device, out_dtype)
-        # TN: per-shape autotune picks the best candidate cfg, cached by (M,N,K).
-        args = (
-            _as_i8_flat(a),
-            _as_i8_flat(b),
-            out,
-            a_scale_v,
-            b_scale_v,
-            M,
-            N,
-            torch.cuda.current_stream(),
-        )
+        device = a.device
+        a_scale_v = _scalar_scale(a_scale_inv, device)
+        b_scale_v = _scalar_scale(b_scale_inv, device)
+        out = resolve_accum_out(out, beta, (M, N), device, out_dtype)
         # TN both operands traverse K: span k*m / k*n past 2^32 fp8 needs the
         # per-load i64 SRD re-base (else the 32-bit soffset wraps).
         i64_tr = (K * M >= cap) or (K * N >= cap)
-        _run_dense(_autotune_tn_dispatch(args, M, N, K, cbsz, blgp, out_fp16, i64_tr, beta_is_one), args)
+        # The split writes a workspace a later pass reduces, so an accumulate on the tile
+        # store would be folded in twice; beta=1 takes the 8-wave epilogue instead.
+        if _tn_wave4_supported(N, K, i64_tr) and not beta_is_one:
+            geoms, bands, flags = _tn4_plan(M, N, K, _dense_num_cus())
+            wargs = (
+                _dense_operand(a),
+                _dense_operand(b),
+                out,
+                a_scale_v,
+                b_scale_v,
+                _tn_wave4_workspace(M, N, bands, device, out_dtype, out),
+                _tn_wave4_flags(flags, device),
+                _raw_stream(device.index),
+            )
+            _run_dense(_tn_wave4_dispatch(wargs, M, N, K, geoms, cbsz, blgp, out_fp16), wargs)
+        else:
+            args = (
+                _dense_operand(a),
+                _dense_operand(b),
+                out,
+                a_scale_v,
+                b_scale_v,
+                M,
+                N,
+                _raw_stream(device.index),
+            )
+            _run_dense(_autotune_tn_dispatch(args, M, N, K, cbsz, blgp, out_fp16, i64_tr, beta_is_one), args)
         if trans_c:
             return out.t().contiguous()
         return out
@@ -1431,20 +3437,21 @@ def gemm_fp8_tensorwise_flydsl_kernel(
         K_b, N = b.shape
         assert K_a == K_b, f"NN K mismatch: a {a.shape}, b {b.shape}"
         K = K_a
-        a_scale_v = _scalar_scale(a_scale_inv, a.device)
-        b_scale_v = _scalar_scale(b_scale_inv, a.device)
-        out = resolve_accum_out(out, beta, (M, N), a.device, out_dtype)
+        device = a.device
+        a_scale_v = _scalar_scale(a_scale_inv, device)
+        b_scale_v = _scalar_scale(b_scale_inv, device)
+        out = resolve_accum_out(out, beta, (M, N), device, out_dtype)
         # NN: per-shape runtime autotune over the candidate tiles, caches by
         # (M,N,K). Build args before autotune (it benches against them).
         args = (
-            _as_i8_flat(a),
-            _as_i8_flat(b),
+            _dense_operand(a),
+            _dense_operand(b),
             out,
             a_scale_v,
             b_scale_v,
             M,
             N,
-            torch.cuda.current_stream(),
+            _raw_stream(device.index),
         )
         # NN: only B[K,N] traverses K; k*n past 2^32 fp8 needs the i64 re-base.
         i64_tr = K * N >= cap
@@ -1455,20 +3462,21 @@ def gemm_fp8_tensorwise_flydsl_kernel(
         N, K_b = b.shape
         assert K_a == K_b, f"NT K mismatch: a {a.shape}, b {b.shape}"
         K = K_a
-        a_scale_v = _scalar_scale(a_scale_inv, a.device)
-        b_scale_v = _scalar_scale(b_scale_inv, a.device)
-        out = resolve_accum_out(out, beta, (M, N), a.device, out_dtype)
+        device = a.device
+        a_scale_v = _scalar_scale(a_scale_inv, device)
+        b_scale_v = _scalar_scale(b_scale_inv, device)
+        out = resolve_accum_out(out, beta, (M, N), device, out_dtype)
         # NT: per-shape runtime autotune over the 8w/v3 candidate tiles, caches
         # by (M,N,K). Build args before autotune (it benches against them).
         args = (
-            _as_i8_flat(a),
-            _as_i8_flat(b),
+            _dense_operand(a),
+            _dense_operand(b),
             out,
             a_scale_v,
             b_scale_v,
             M,
             N,
-            torch.cuda.current_stream(),
+            _raw_stream(device.index),
         )
         _run_dense(_autotune_nt_dispatch(args, M, N, K, cbsz, blgp, out_fp16, beta_is_one), args)
     else:

--- a/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
@@ -1452,29 +1452,10 @@ def _dense_tn_wave4_asm(geom, cbsz, blgp):
 
     def mfma_seq():
         # srcA pool outer (this mfma is srcA-movement sensitive); the diagonal spreads refills.
-        bm, bn = 2, geom.bstep or nb // 2
-        n_row_steps, n_col_steps = nt // bm, nb // bn
-        seq = []
-        for d in range(n_row_steps + n_col_steps - 1):
-            for iib in range(n_row_steps):
-                if not 0 <= d - iib < n_col_steps:
-                    continue
-                for di in range(bm):
-                    for ah in range(len(ap)):
-                        for dj in range(bn):
-                            col, ii = (d - iib) * bn + dj, iib * bm + di
-                            bi, bt = bcol[col]
-                            q = qoff[(ah, bi)] + ii * pools[bp[bi]].tiles + bt
-                            at = nacc + ah * nt + ii
-                            br = nacc + na + col
-                            seq.append(
-                                (
-                                    f"v_mfma_f32_16x16x128_f8f6f4 ${q}, ${at}, ${br}, ${q}{mods}",
-                                    at,
-                                    br,
-                                )
-                            )
-        return seq
+        return [
+            (f"v_mfma_f32_16x16x128_f8f6f4 ${q}, ${at}, ${br}, ${q}{mods}", at, br)
+            for q, at, br in _tn4_mfma_order(geom, nt, nb, na, nacc, ap, bp, bcol, qoff, pools)
+        ]
 
     def emit_phase(rbuf, wbuf):
         # Refill a fragment right after its last consumer; global writes take the free slots.
@@ -2061,6 +2042,27 @@ def _nt4_fold_gl_off(lane_id, wave_id, K, n_rounds, gq, fold):
     return out
 
 
+def _tn4_mfma_order(geom, nt, nb, na, nacc, ap, bp, bcol, qoff, pools):
+    """(accumulator, srcA, srcB) of one phase's mfma, in issue order: the srcA pool is outer
+    because this mfma is srcA-movement sensitive, and the diagonal spreads the refills."""
+    bm, bn = 2, geom.bstep or nb // 2
+    n_row_steps, n_col_steps = nt // bm, nb // bn
+    for d in range(n_row_steps + n_col_steps - 1):
+        for iib in range(n_row_steps):
+            if not 0 <= d - iib < n_col_steps:
+                continue
+            for di in range(bm):
+                for ah in range(len(ap)):
+                    for dj in range(bn):
+                        col, ii = (d - iib) * bn + dj, iib * bm + di
+                        bi, bt = bcol[col]
+                        yield (
+                            qoff[(ah, bi)] + ii * pools[bp[bi]].tiles + bt,
+                            nacc + ah * nt + ii,
+                            nacc + na + col,
+                        )
+
+
 def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN4_BLOCK_K, carry=False):
     """Bare-asm K body for one NT output tile; ``carry`` hands the closing fills to the next tile."""
     key = (geom, k_iters, cbsz, blgp, fold, tr_b, b_kstep, carry)
@@ -2165,30 +2167,10 @@ def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN
         ]
 
     def mfma_seq(init):
-        bm, bn = 2, geom.bstep or nb // 2
-        n_row_steps, n_col_steps = nt // bm, nb // bn
-        seq = []
-        for d in range(n_row_steps + n_col_steps - 1):
-            for iib in range(n_row_steps):
-                if not 0 <= d - iib < n_col_steps:
-                    continue
-                for di in range(bm):
-                    for ah in range(len(ap)):
-                        for dj in range(bn):
-                            col, ii = (d - iib) * bn + dj, iib * bm + di
-                            bi, bt = bcol[col]
-                            q = qoff[(ah, bi)] + ii * pools[bp[bi]].tiles + bt
-                            at = nacc + ah * nt + ii
-                            br = nacc + na + col
-                            seq.append(
-                                (
-                                    f"v_mfma_f32_16x16x128_f8f6f4 ${q}, ${at}, ${br}, {src2(q, init)}{mods}",
-                                    at,
-                                    br,
-                                    q,
-                                )
-                            )
-        return seq
+        return [
+            (f"v_mfma_f32_16x16x128_f8f6f4 ${q}, ${at}, ${br}, {src2(q, init)}{mods}", at, br, q)
+            for q, at, br in _tn4_mfma_order(geom, nt, nb, na, nacc, ap, bp, bcol, qoff, pools)
+        ]
 
     def emit_phase(rbuf, wbuf, init, left):
         g2sl, mlist = emit_g2s(wbuf, left), mfma_seq(init)
@@ -2802,6 +2784,31 @@ def _dense_beta1_entry(cache, key, tuned):
     return entry
 
 
+def _dense_race(cache, key, args, layout, builders, beta_is_one):
+    """First-call race of ``builders`` -- (cfg, factory) pairs -- with the winner cached by
+    ``key``. A candidate that fails to build, or whose output sample is not finite, is dropped
+    before it is timed, so a geometry that does not hold for the shape just leaves the race."""
+    tuned = cache.get(key)
+    if tuned is None:
+        bargs, out_view = _bench_dense_args(args)
+        cands = []
+        for cfg, build in builders:
+            try:
+                launch = build(beta_is_one=False)
+                c = _get_compiled_dense(launch, bargs)
+                c(*bargs)
+                torch.cuda.synchronize()
+                if not torch.isfinite(out_view.view(-1)[:1024].float()).all().item():
+                    continue
+                cands.append([launch, cfg, c, build])  # c: compiled, reused eager
+            except Exception:
+                continue
+        if not cands:
+            raise RuntimeError(f"{layout} autotune found no working cfg for {key[:3]}")
+        cache[key] = tuned = _pick_dense_candidate(cands, bargs)
+    return _dense_beta1_entry(cache, key, tuned) if beta_is_one else tuned
+
+
 def _pick_dense_candidate(cands, args):
     """Fastest of ``cands`` = [[launch, cfg, compiled, factory], ...], sampled twice with the second
     pass reversed and kept at its min, behind a throwaway pass: the leading candidates sit
@@ -2843,7 +2850,6 @@ def _scalar_scale(scale: torch.Tensor, device: torch.device) -> torch.Tensor:
     return scale.to(dtype=torch.float32, device=device).reshape(1)
 
 
-# (BLOCK_M, GROUP_M, group_n, num_xcd, AGPR)
 # (BLOCK_M, GROUP_M, group_n, num_xcd, AGPR), keyed on whether the whole loop is eligible:
 # it takes two of the four slots when it is, so a shape never races more than four builds.
 _NN_CANDIDATES = {
@@ -2861,36 +2867,13 @@ _NN_AUTOTUNE_CACHE: dict = {}
 def _autotune_nn_dispatch(
     args, M, N, K, cbsz=0, blgp=0, out_fp16=False, i64_traverse=False, beta_is_one=False
 ):
-    """First-call bench of the NN candidates, best (launch, cfg) cached by (M,N,K); each is
-    finite-checked before it is timed (see _pick_dense_candidate). ``i64_traverse`` re-bases
-    B's SRD per load, lifting the k*n < 2^32 cap."""
-    import torch as _torch
-
-    key = (M, N, K, cbsz, blgp, out_fp16, i64_traverse)
-    tuned = _NN_AUTOTUNE_CACHE.get(key)
-    if tuned is not None:
-        return _dense_beta1_entry(_NN_AUTOTUNE_CACHE, key, tuned) if beta_is_one else tuned
-    bargs, out_view = _bench_dense_args(args)
-    cands = []
+    """NN candidates for the shape, raced on first call (see _dense_race). ``i64_traverse``
+    re-bases B's SRD per load, lifting the k*n < 2^32 cap."""
     pair_n, col_safe = N % 2 == 0 and not out_fp16, N % 256 == 0
-
     w4 = not i64_traverse and K % _TN4_BLOCK_K == 0 and K // _TN4_BLOCK_K >= _NN4_MIN_K_ITERS
-
-    def add(build, cfg):
-        # clamp on the A G2S load), so no even-tiling filter is needed.
-        try:
-            launch = build(beta_is_one=False)
-            c = _get_compiled_dense(launch, bargs)
-            c(*bargs)
-            _torch.cuda.synchronize()
-            if not _torch.isfinite(out_view.view(-1)[:1024].float()).all().item():
-                return
-            cands.append([launch, cfg, c, build])  # c: compiled, reused eager
-        except Exception:
-            return
-
-    for bm, gm, gn, xcd, ag in _NN_CANDIDATES[w4]:
-        add(
+    builders = [
+        (
+            (bm, gm, gn, xcd, ag),
             functools.partial(
                 _compile_dense_nn,
                 K=K,
@@ -2909,14 +2892,16 @@ def _autotune_nn_dispatch(
                 pair_n=pair_n,
                 col_safe=col_safe,
             ),
-            (bm, gm, gn, xcd, ag),
         )
+        for bm, gm, gn, xcd, ag in _NN_CANDIDATES[w4]
+    ]
     # The whole-loop joins the race where it applies: one barrier per K-block and a wave
     # tile twice as wide, against an epilogue occ=1 cannot shadow. Its B side is one
     # 32-bit soffset chain, so a span needing the i64 re-base stays with the 8-wave tiles.
     if w4:
-        for gm, gn, xcd in _NN4_BANDS:
-            add(
+        builders += [
+            (
+                ("nn4", gm, gn, xcd),
                 functools.partial(
                     _compile_dense_nn_wave4,
                     M,
@@ -2931,16 +2916,13 @@ def _autotune_nn_dispatch(
                     pair_n=pair_n,
                     col_safe=col_safe,
                 ),
-                ("nn4", gm, gn, xcd),
             )
-    if not cands:
-        raise RuntimeError(f"NN autotune found no working cfg for ({M},{N},{K})")
-    best = _pick_dense_candidate(cands, bargs)
-    _NN_AUTOTUNE_CACHE[key] = best
-    return _dense_beta1_entry(_NN_AUTOTUNE_CACHE, key, best) if beta_is_one else best
+            for gm, gn, xcd in _NN4_BANDS
+        ]
+    key = (M, N, K, cbsz, blgp, out_fp16, i64_traverse)
+    return _dense_race(_NN_AUTOTUNE_CACHE, key, args, "NN", builders, beta_is_one)
 
 
-# (BLOCK_M, GROUP_M, num_xcd, AGPR); the live band is a GROUP_M-wide super-row of A
 # (BLOCK_M, GROUP_M, num_xcd, AGPR); the live band is a GROUP_M-wide super-row of A. One
 # table per regime, four wide: a race compiles every entry, so the list is what first-call
 # latency costs. Once the band outgrows an XCD L2 slice, clustering onto XCDs buys no reuse
@@ -2962,35 +2944,14 @@ _NT_AUTOTUNE_CACHE: dict = {}
 
 
 def _autotune_nt_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, beta_is_one=False):
-    """First-call bench of the NT candidates, best (launch, cfg) cached by (M,N,K); each is
-    finite-checked before it is timed (see _pick_dense_candidate). The 8-wave tiles are joined
-    by the 4-wave whole-loop on the long-K shapes whose steady state pays for it."""
-    import torch as _torch
-
-    key = (M, N, K, cbsz, blgp, out_fp16)
-    tuned = _NT_AUTOTUNE_CACHE.get(key)
-    if tuned is not None:
-        return _dense_beta1_entry(_NT_AUTOTUNE_CACHE, key, tuned) if beta_is_one else tuned
-    bargs, out_view = _bench_dense_args(args)
-    cands = []
+    """NT candidates for the shape, raced on first call (see _dense_race). The 8-wave tiles are
+    joined by the 4-wave whole-loop on the long-K shapes whose steady state pays for it."""
     pair_n, col_safe = N % 2 == 0 and not out_fp16, N % 256 == 0
-
-    def add(build, cfg):
-        try:
-            launch = build(beta_is_one=False)
-            c = _get_compiled_dense(launch, bargs)
-            c(*bargs)
-            _torch.cuda.synchronize()
-            if not _torch.isfinite(out_view.view(-1)[:1024].float()).all().item():
-                return
-            cands.append([launch, cfg, c, build])  # c: compiled, reused eager
-        except Exception:
-            return
-
     w4 = K % _TN4_BLOCK_K == 0 and K // _TN4_BLOCK_K >= _NT4_MIN_K_ITERS
     wide = 4 * 256 * K > _NT_BAND_L2_BYTES  # GROUP_M * BLOCK_M * K of the leading cfg
-    for bm, gm, xcd, ag in _NT_CANDIDATES[(w4, wide)]:
-        add(
+    builders = [
+        (
+            (bm, gm, xcd, ag),
             functools.partial(
                 _compile_dense_nt,
                 K=K,
@@ -3005,11 +2966,13 @@ def _autotune_nt_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, beta_is
                 pair_n=pair_n,
                 col_safe=col_safe,
             ),
-            (bm, gm, xcd, ag),
         )
+        for bm, gm, xcd, ag in _NT_CANDIDATES[(w4, wide)]
+    ]
     if w4:
-        for gm, xcd in _NT4_BANDS:
-            add(
+        builders += [
+            (
+                ("nt4", gm, xcd),
                 functools.partial(
                     _compile_dense_nt_wave4,
                     M,
@@ -3023,13 +2986,11 @@ def _autotune_nt_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, beta_is
                     pair_n=pair_n,
                     col_safe=col_safe,
                 ),
-                ("nt4", gm, xcd),
             )
-    if not cands:
-        raise RuntimeError(f"NT autotune found no working cfg for ({M},{N},{K})")
-    best = _pick_dense_candidate(cands, bargs)
-    _NT_AUTOTUNE_CACHE[key] = best
-    return _dense_beta1_entry(_NT_AUTOTUNE_CACHE, key, best) if beta_is_one else best
+            for gm, xcd in _NT4_BANDS
+        ]
+    key = (M, N, K, cbsz, blgp, out_fp16)
+    return _dense_race(_NT_AUTOTUNE_CACHE, key, args, "NT", builders, beta_is_one)
 
 
 _TN_WAVE4_CACHE: dict = {}
@@ -3193,18 +3154,11 @@ def _autotune_tn_dispatch(
     L2-resident shapes pick num_xcd=1. ``i64_traverse`` re-bases A's and B's
     SRDs per load (lifts the k*m / k*n < 2^32 cap; threaded to _compile_dense_tn).
     """
-    import torch as _torch
-
-    key = (M, N, K, cbsz, blgp, out_fp16, i64_traverse)
-    tuned = _TN_AUTOTUNE_CACHE.get(key)
-    if tuned is not None:
-        return _dense_beta1_entry(_TN_AUTOTUNE_CACHE, key, tuned) if beta_is_one else tuned
     bm = 256
-    bargs, out_view = _bench_dense_args(args)
-    cands = []
-    for xcd in (8, 1):
-        try:
-            mk = functools.partial(
+    builders = [
+        (
+            (bm, 4, 0, xcd),
+            functools.partial(
                 _compile_dense_tn,
                 K=K,
                 BLOCK_M=bm,
@@ -3217,22 +3171,12 @@ def _autotune_tn_dispatch(
                 blgp=blgp,
                 out_fp16=out_fp16,
                 i64_traverse=i64_traverse,
-            )
-            launch = mk(beta_is_one=False)
-            c = _get_compiled_dense(launch, bargs)
-            c(*bargs)
-            _torch.cuda.synchronize()
-            sample = out_view.view(-1)[:1024].float()
-            if not _torch.isfinite(sample).all().item():
-                continue
-            cands.append([launch, (bm, 4, 0, xcd), c, mk])  # c: compiled, reused eager
-        except Exception:
-            continue
-    if not cands:
-        raise RuntimeError(f"TN autotune found no working cfg for ({M},{N},{K})")
-    best = _pick_dense_candidate(cands, bargs)
-    _TN_AUTOTUNE_CACHE[key] = best
-    return _dense_beta1_entry(_TN_AUTOTUNE_CACHE, key, best) if beta_is_one else best
+            ),
+        )
+        for xcd in (8, 1)
+    ]
+    key = (M, N, K, cbsz, blgp, out_fp16, i64_traverse)
+    return _dense_race(_TN_AUTOTUNE_CACHE, key, args, "TN", builders, beta_is_one)
 
 
 def gemm_fp8_tensorwise_flydsl_kernel(

--- a/primus_turbo/flydsl/utils/gemm_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_helper.py
@@ -68,6 +68,12 @@ def compile_with_scratch_out(launch, args, out_index=2):
     return flyc.compile(launch, *args[:out_index], scratch, *args[out_index + 1 :])
 
 
+def floordiv_pow2(a, b: int):
+    """``a // b`` for a power-of-two ``b``, shifting past what ``floordivsi`` would lower to."""
+    assert b > 0 and (b & (b - 1)) == 0
+    return a >> (b.bit_length() - 1)
+
+
 _PRESHUF_KT = 16  # scale-preshuffle k-tile (rows*KT dwords staged in LDS per workgroup)
 
 
@@ -187,19 +193,15 @@ def make_bf16_rebased_rsrc(arg, base_elems, num_records_bytes):
     return rsrc
 
 
+def lds_row_swizzle(row, chunks):
+    """XOR key spreading the column one ds_read_b64_tr_b8 gathers over the LDS banks, shared
+    by the write and transpose-read sides so the two cannot drift apart."""
+    return ((row % 16) // 2) & (chunks - 1)
+
+
 def swizzle_128(row, col, width=128):
-    """XOR bank-swizzle over a `width`=2**k logical row (width=128 is byte-identical to
-    the original fixed-128 form). The swizzle must stay within col's bits [0,k); for k<7
-    we extract fewer bits (k-4) from the `row%16` window so the result is always < width."""
-    k = width.bit_length() - 1
-    period = 16 * width
-    offset = row * width + col
-    nbits = k - 4
-    mask = (1 << nbits) - 1
-    extracted = (offset % period) >> (k + 1)
-    swizzle = (extracted & mask) << 4
-    swizzled_offset = offset ^ swizzle
-    return swizzled_offset // width, swizzled_offset % width
+    """Bank-swizzle a `width`=2**k row; only the chunks inside a row move, the index does not."""
+    return row, col ^ (lds_row_swizzle(row, width // 16) * 16)
 
 
 def compute_global_swizzle(lane_id, wave_id, K, n_rounds, preshuffled):
@@ -555,7 +557,12 @@ class StoreCPerTensor:
     element is read back through the same band SRD, widened to f32 and added
     before the single rounding to out_ty. Masked-out lanes read OOB (0) and
     their store is dropped, so the read-back needs no extra bounds logic.
+
+    ``col_safe`` drops the per-store OOB select; ``c_base`` re-points the tile at a
+    same-pitch scratch buffer.
     """
+
+    stages_lds = False  # subclasses that borrow LDS need the caller to fence its owner off
 
     def __init__(
         self,
@@ -569,20 +576,25 @@ class StoreCPerTensor:
         n_tiles_b,
         out_ty,
         elem_fn=None,
+        col_safe=False,
+        store_aux=0,
+        c_base=None,
         beta_is_one=False,
     ):
+        self.beta_is_one = beta_is_one
         self.c_rows = c_rows
         self.c_cols = c_cols
+        self.col_safe = col_safe
+        self.store_aux = store_aux
         self.lane_id = fx.thread_idx.x % 64
         self.c_idx_fn = c_idx_fn
         self.n_tiles_a = n_tiles_a
         self.n_tiles_b = n_tiles_b
         self.out_ty = out_ty
-        self.beta_is_one = beta_is_one
         # Optional f32->f32 epilogue node chain (bias/act), post-scale pre-cast.
         self.elem_fn = elem_fn
         self.scaled = A_scale is not None
-        self.c_base = _buffer_ops.extract_base_index(C)  # index = byte base address
+        self.c_base = _buffer_ops.extract_base_index(C) if c_base is None else c_base  # byte base address
         if self.scaled:
             gSA = fx.rocdl.make_buffer_tensor(A_scale, max_size=False, num_records_bytes=4)  # 1 fp32
             gSB = fx.rocdl.make_buffer_tensor(B_scale, max_size=False, num_records_bytes=4)  # 1 fp32
@@ -590,59 +602,288 @@ class StoreCPerTensor:
             self.sb_div = fx.logical_divide(gSB, fx.make_layout(1, 1))
             self.scale_atom_1 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Float32)
             self.reg_f32_1 = fx.make_rmem_tensor(fx.make_layout(1, 1), fx.Float32)
+        self._scale_v = None
 
     def _load_scalar(self, div):
         fx.copy(self.scale_atom_1, fx.slice(div, (None, fx.Int32(0))), self.reg_f32_1)
         return Vec(fx.memref_load_vec(self.reg_f32_1))[0]
 
-    def _addresses(self, base_col):
-        """(element offset, column-valid) per (ti, tj, i), in store order."""
-        out = []
-        for ti in range_constexpr(self.n_tiles_a):
-            row_local = ti * 16 + (self.lane_id // 16) * 4  # relative to base_row
-            for tj in range_constexpr(self.n_tiles_b):
-                col = base_col + tj * 16 + self.lane_id % 16
-                col_valid = col < self.c_cols
-                for i in range_constexpr(4):
-                    out.append(((row_local + i) * self.c_cols + col, col_valid))
-        return out
+    def _scale(self):
+        """a_scale*b_scale once per block: a value defined in one region cannot dominate
+        a use in another, so the key has to be the block."""
+        if not self.scaled:
+            return None
+        blk = ir.InsertionPoint.current.block
+        if self._scale_v is None or self._scale_v[0] != blk:
+            self._scale_v = (blk, self._load_scalar(self.sa_div) * self._load_scalar(self.sb_div))
+        return self._scale_v[1]
+
+    def flush(self):
+        """Emit whatever a subclass left queued; a store that lands in its own call has none."""
+
+    def _row_col(self, ti, i, tj, base_col):
+        """Element address of the value at fragment (ti, tj), row ``i`` of this lane's four."""
+        return (ti * 16 + (self.lane_id // 16) * 4 + i) * self.c_cols + base_col + tj * 16 + self.lane_id % 16
 
     def prefetch(self, base_row, base_col):
-        """Issue this sub-tile's beta=1 read-back; returns the handle ``store`` consumes.
-
-        Kept separate from ``store`` so a caller writing several sub-tiles (see
-        ``_store_quadrants``) can put every load in flight before the first store waits
-        on one -- the epilogue is latency-bound otherwise, not bandwidth-bound.
-        """
+        """Read C back in value order, so a subclass indexes it the way it indexes accumulators."""
         if not const_expr(self.beta_is_one):
             return None
         rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
+        col0 = base_col + self.lane_id % 16
         return [
-            _buffer_ops.buffer_load(rsrc, off_e, vec_width=1, dtype=self.out_ty.ir_type, mask=valid)
-            for off_e, valid in self._addresses(base_col)
+            [
+                [
+                    _buffer_ops.buffer_load(
+                        rsrc,
+                        self._row_col(ti, i, tj, base_col),
+                        vec_width=1,
+                        dtype=self.out_ty.ir_type,
+                        mask=None if self.col_safe else (col0 + tj * 16) < self.c_cols,
+                    )
+                    for i in range_constexpr(4)
+                ]
+                for tj in range_constexpr(self.n_tiles_b)
+            ]
+            for ti in range_constexpr(self.n_tiles_a)
         ]
 
+    def _accum(self, val, prev, ti, tj, i):
+        """Add the read-back before the cast, so the accumulate rounds exactly once."""
+        return val if prev is None else val + self.out_ty(prev[ti][tj][i]).to(fx.Float32)
+
     def store(self, c_frag, base_row, base_col, prev=None):
-        scale = self._load_scalar(self.sa_div) * self._load_scalar(self.sb_div) if self.scaled else None
-        # buffer_store row-band path (int64-safe); the band SRD is pinned to SGPRs inside.
-        rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
-        addrs = self._addresses(base_col)
+        scale = self._scale()
         if const_expr(self.beta_is_one) and prev is None:
             prev = self.prefetch(base_row, base_col)
-        n = 0
+        # buffer_store row-band path (int64-safe); the band SRD is pinned to SGPRs inside.
+        rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
+        col0 = base_col + self.lane_id % 16
         for ti in range_constexpr(self.n_tiles_a):
+            row_local = ti * 16 + (self.lane_id // 16) * 4  # relative to base_row
+            # One byte address per row: the fragment column step rides the store's 12-bit immediate.
+            row_off = [((row_local + i) * self.c_cols + col0) * 2 for i in range_constexpr(4)]
             for tj in range_constexpr(self.n_tiles_b):
+                col_valid = None if self.col_safe else (col0 + tj * 16) < self.c_cols
                 vec_f32 = Vec(c_frag[self.c_idx_fn(ti, tj)])
+                if self.scaled:
+                    vec_f32 = vec_f32 * scale  # wave-uniform scale packs to v_pk_mul_f32
                 for i in range_constexpr(4):
-                    off_e, col_valid = addrs[n]
-                    val = vec_f32[i] * scale if self.scaled else vec_f32[i]
+                    val = vec_f32[i]
                     if self.elem_fn is not None:
                         val = self.elem_fn(val)  # bias/act epilogue node chain
-                    if const_expr(self.beta_is_one):
-                        val = val + self.out_ty(prev[n]).to(fx.Float32)  # add in f32: one rounding
-                    val = val.to(self.out_ty)
-                    _buffer_ops.buffer_store(val, rsrc, off_e * 2, mask=col_valid, offset_is_bytes=True)
-                    n += 1
+                    val = self._accum(val, prev, ti, tj, i).to(self.out_ty)
+                    off = row_off[i] if tj == 0 else row_off[i] + tj * 16 * 2
+                    _buffer_ops.buffer_store(
+                        val,
+                        rsrc,
+                        off,
+                        mask=col_valid,
+                        cache_modifier=self.store_aux,
+                        offset_is_bytes=True,
+                    )
+
+
+_DPP_QUAD_SWAP1 = 0xB1  # quad_perm:[1,0,3,2] -- exchange with the neighbouring lane
+_PERM_LO_PAIR = 0x05040100  # {own low half, right neighbour's low half}
+_PERM_HI_PAIR = 0x03020706  # {left neighbour's high half, own high half}
+
+
+class StoreCPerTensorPairN(StoreCPerTensor):
+    """A row's two n-fragments folded into one dword store, widening the request a fragment
+    row's 16 lanes leave with; the pair comes from a lane and its DPP neighbour."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        assert self.n_tiles_b % 2 == 0, "the pair is written as a unit"
+        lane16 = self.lane_id % 16
+        hi = (lane16 % 2) > 0
+        # even lane e holds columns (e, e+1); odd lane o holds (16 + o - 1, 16 + o).
+        self.pair_col = arith.select(hi, lane16 + 15, lane16)
+        self.pair_sel = arith.select(hi, fx.Int32(_PERM_HI_PAIR), fx.Int32(_PERM_LO_PAIR))
+
+    def _pack(self, lo, hi):
+        """(lo, hi) as one dword of out_ty; bf16 takes the single packed convert."""
+        if const_expr(self.out_ty is fx.BFloat16):
+            return rocdl.cvt_pk_bf16_f32(lo, hi)
+        pair = Vec.from_elements([lo.to(self.out_ty), hi.to(self.out_ty)], self.out_ty)
+        return arith._to_raw(pair.bitcast(fx.Int32)[0])
+
+    def store(self, c_frag, base_row, base_col, prev=None):
+        scale = self._scale()
+        if const_expr(self.beta_is_one) and prev is None:
+            prev = self.prefetch(base_row, base_col)
+        rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
+        col0 = base_col + self.pair_col
+        zero = arith._to_raw(fx.Int32(0))
+        for ti in range_constexpr(self.n_tiles_a):
+            row_local = ti * 16 + (self.lane_id // 16) * 4  # relative to base_row
+            vecs = [
+                (Vec(c_frag[self.c_idx_fn(ti, tj)]) * scale)
+                if self.scaled
+                else Vec(c_frag[self.c_idx_fn(ti, tj)])
+                for tj in range_constexpr(self.n_tiles_b)
+            ]
+            for i in range_constexpr(4):
+                row_off = ((row_local + i) * self.c_cols + col0) * 2  # i32-small within band
+                for p in range_constexpr(self.n_tiles_b // 2):
+                    dcol = p * 32
+                    lo, hi = vecs[2 * p][i], vecs[2 * p + 1][i]
+                    if self.elem_fn is not None:
+                        lo, hi = self.elem_fn(lo), self.elem_fn(hi)
+                    lo = self._accum(lo, prev, ti, 2 * p, i)
+                    hi = self._accum(hi, prev, ti, 2 * p + 1, i)
+                    pk = self._pack(lo, hi)
+                    sw = rocdl.update_dpp(pk.type, zero, pk, _DPP_QUAD_SWAP1, 0xF, 0xF, True)
+                    pair_ok = None if self.col_safe else (col0 + dcol + 1) < self.c_cols
+                    _buffer_ops.buffer_store(
+                        rocdl.perm_b32(sw, pk, self.pair_sel),
+                        rsrc,
+                        row_off if dcol == 0 else row_off + dcol * 2,
+                        mask=pair_ok,
+                        cache_modifier=self.store_aux,
+                        offset_is_bytes=True,
+                    )
+
+
+XPOSE_SLOT = 512  # bytes one staged transpose takes: four lane groups, a 128 B block each
+XPOSE_SLOTS = 8  # slots the staging rotates over, so a slot is reused long after it retires
+_XPOSE_LAG = 4  # runs left in flight before the oldest is drained and stored
+
+
+def _wait_lgkmcnt_mem(n):
+    _llvm.inline_asm(
+        res=None,
+        operands_=[],
+        asm_string=f"s_waitcnt lgkmcnt({n})",
+        constraints="~{memory}",
+        has_side_effects=True,
+    )
+
+
+def load_per_tensor_scale(A_scale, B_scale):
+    atom = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Float32)
+    reg = fx.make_rmem_tensor(fx.make_layout(1, 1), fx.Float32)
+    vals = []
+    for t in (A_scale, B_scale):
+        g = fx.rocdl.make_buffer_tensor(t, max_size=False, num_records_bytes=4)  # 1 fp32
+        div = fx.logical_divide(g, fx.make_layout(1, 1))
+        fx.copy(atom, fx.slice(div, (None, fx.Int32(0))), reg)
+        vals.append(Vec(fx.memref_load_vec(reg))[0])
+    return vals[0] * vals[1]
+
+
+class StoreCPerTensorLineN(StoreCPerTensorPairN):
+    """PairN widened to a whole-line request per fragment row, via an LDS transpose whose
+    ``lds_xpose`` scratch the caller must fence against whatever it is borrowed from."""
+
+    stages_lds = True
+
+    def __init__(self, *args, lds_xpose, scale, **kwargs):
+        super().__init__(*args, **kwargs)
+        assert self.n_tiles_b % 4 == 0, "a line run gathers four n-fragments"
+        assert self.col_safe, "a whole-line run has no column mask"
+        lane16 = self.lane_id % 16
+        quad = lane16 % 4
+        self.line_col = quad * 16 + (lane16 // 4) * 4
+        self.scale = scale
+        blk = (self.lane_id // 16) * 128
+        self._xp_wr = _lds_ptr_from_i32(lds_xpose + blk + quad * 32 + (lane16 // 4) * 8)
+        self._xp_rd = _lds_ptr_from_i32(lds_xpose + blk + lane16 * 8)
+        self._slot = 0
+        self._pend = []
+
+    def _xpose(self, pk):
+        off = self._slot * XPOSE_SLOT
+        self._slot = (self._slot + 1) % XPOSE_SLOTS
+        return _lds_xpose_tr16(self._xp_wr, self._xp_rd, Vec.from_elements(pk, fx.Int32), off)
+
+    def _retire(self):
+        rsrc, off, run = self._pend.pop(0)
+        _wait_lgkmcnt_mem(2 * len(self._pend))  # a write and a read still queued per pending run
+        _buffer_ops.buffer_store(
+            run.bitcast(self.out_ty),
+            rsrc,
+            off,
+            cache_modifier=self.store_aux,
+            offset_is_bytes=True,
+        )
+
+    def flush(self):
+        while self._pend:
+            self._retire()
+
+    def store(self, c_frag, base_row, base_col, prev=None, tap=None):
+        scale = self.scale
+        if const_expr(self.beta_is_one) and prev is None:
+            prev = self.prefetch(base_row, base_col)
+        rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
+        col0 = base_col + self.line_col
+        for ti in range_constexpr(self.n_tiles_a):
+            if tap is not None:
+                tap()
+            row_local = ti * 16 + (self.lane_id // 16) * 4  # relative to base_row
+            vecs = [
+                (Vec(c_frag[self.c_idx_fn(ti, tj)]) * scale)
+                if self.scaled
+                else Vec(c_frag[self.c_idx_fn(ti, tj)])
+                for tj in range_constexpr(self.n_tiles_b)
+            ]
+            for i in range_constexpr(4):
+                if tap is not None:
+                    tap()
+                row_off = ((row_local + i) * self.c_cols + col0) * 2  # i32-small within band
+                for g in range_constexpr(self.n_tiles_b // 4):
+                    el = [vecs[4 * g + f][i] for f in range_constexpr(4)]
+                    if self.elem_fn is not None:
+                        el = [self.elem_fn(v) for v in el]
+                    el = [self._accum(v, prev, ti, 4 * g + f, i) for f, v in enumerate(el)]
+                    run = self._xpose([self._pack(el[0], el[1]), self._pack(el[2], el[3])])
+                    self._pend.append((rsrc, row_off if g == 0 else row_off + g * 128, run))
+                    if len(self._pend) > _XPOSE_LAG:
+                        self._retire()
+
+
+class StoreCPerTensorQuadN(StoreCPerTensorPairN):
+    """PairN for a kernel whose n-fragments arrived column-interleaved, so a lane already holds
+    the adjacent columns and one unmasked store folds them with no cross-lane step. The caller
+    owns the interleave; the tile must be column-safe."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        assert self.n_tiles_b in (4, 8), "the interleave folds four or eight n-fragments"
+        assert self.col_safe, "a partial fold has no column mask"
+
+    def _row_col(self, ti, i, tj, base_col):
+        """The fold hands this lane a whole run of columns, so tj steps by one, not by a tile."""
+        row = ti * 16 + (self.lane_id // 16) * 4 + i
+        return row * self.c_cols + base_col + (self.lane_id % 16) * self.n_tiles_b + tj
+
+    def store(self, c_frag, base_row, base_col, prev=None):
+        scale = self._scale()
+        if const_expr(self.beta_is_one) and prev is None:
+            prev = self.prefetch(base_row, base_col)
+        rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
+        col0 = base_col + (self.lane_id % 16) * self.n_tiles_b
+        for ti in range_constexpr(self.n_tiles_a):
+            row_local = ti * 16 + (self.lane_id // 16) * 4  # relative to base_row
+            vecs = [
+                (Vec(c_frag[self.c_idx_fn(ti, tj)]) * scale)
+                if self.scaled
+                else Vec(c_frag[self.c_idx_fn(ti, tj)])
+                for tj in range_constexpr(self.n_tiles_b)
+            ]
+            for i in range_constexpr(4):
+                el = [v[i] if self.elem_fn is None else self.elem_fn(v[i]) for v in vecs]
+                el = [self._accum(v, prev, ti, tj, i) for tj, v in enumerate(el)]
+                dw = [self._pack(el[2 * h], el[2 * h + 1]) for h in range_constexpr(self.n_tiles_b // 2)]
+                _buffer_ops.buffer_store(
+                    Vec.from_elements(dw, fx.Int32).bitcast(self.out_ty),
+                    rsrc,
+                    ((row_local + i) * self.c_cols + col0) * 2,  # i32-small within band
+                    cache_modifier=self.store_aux,
+                    offset_is_bytes=True,
+                )
 
 
 class StoreCPerTensorCShuffle:
@@ -999,9 +1240,8 @@ class S2RLoaderTr:
         r_step = K_log // KW
         W = (K_log % KW) // rows_per_wave
         K_local_row = K_log % rows_per_wave
-        # swz_K reproduces swizzle_128's own (extracted & mask) term: extracted =
-        # (K_log%16)//2 is width-independent; only the mask narrows with width.
-        swz_K = (((K_log % 16) // 2) & (chunks - 1)) * 16
+        # swz_K reproduces swizzle_128's own key over this buffer's chunk count.
+        swz_K = lds_row_swizzle(K_log, chunks) * 16
         coord_start = self.wave_idx * self.tile_stride + tile_i * 16
         j_chunk = (coord_start // 16) ^ (swz_K // 16)
         if self.wswz:
@@ -1017,9 +1257,8 @@ class S2RLoaderTr:
             + (L_in_sg % 2) * 8
         )
 
-    def _issue_one(self, lds_src, tile_i, base_off=None):
-        """Issue the 4 ds_read_b64_tr_b8 of one tile (no drain, no assemble).
-        Returns the 4 raw v2i32 Vec."""
+    def _issue_one(self, lds_src, tile_i, base_off=None, vmcnt=None):
+        """Issue one tile's 4 ds_read_b64_tr_b8, undrained; vmcnt overrides the g2s hint."""
         tr_type = Vec.make_type(2, fx.Int32)
         base_i32 = fx.Int32(fx.ptrtoint(lds_src.ptr))
         if base_off is not None:  # runtime LDS-stage byte offset (double-buffer parity)
@@ -1030,7 +1269,8 @@ class S2RLoaderTr:
         if self.inline_asm:
             p0 = _lds_ptr_from_i32(base_i32 + fx.Int32(self._ptr_off(0, tile_i, I, L_in_sg)))
             p1 = _lds_ptr_from_i32(base_i32 + fx.Int32(self._ptr_off(1, tile_i, I, L_in_sg)))
-            r02 = _packed_ds_read_tr_offsets(p0, [0, RS], vmcnt_hint=self.vmcnt_hint)
+            vm = self.vmcnt_hint if vmcnt is None else vmcnt
+            r02 = _packed_ds_read_tr_offsets(p0, [0, RS], vmcnt_hint=vm)
             r13 = _packed_ds_read_tr_offsets(p1, [0, RS], vmcnt_hint=None)
             # r02 = [c0, c2], r13 = [c1, c3] -> caller assembles as c0,c1,c2,c3
             return [Vec(r02[0]), Vec(r13[0]), Vec(r02[1]), Vec(r13[1])]
@@ -1061,15 +1301,12 @@ class S2RLoaderTr:
             has_side_effects=True,
         )
 
-    def load(self, lds_src, preshuffled=False, drain=True, base_off=None):
-        """Return all n_tiles operand frags. Inline-asm path issues every tile's
-        async reads then one trailing lgkmcnt(0) before the consuming mfma;
-        drain=False skips it when a later drain covers these reads. The intrinsic
-        path lets the backend insert the wait. base_off = runtime LDS-stage byte
-        offset (double-buffer parity)."""
+    def load(self, lds_src, preshuffled=False, drain=True, base_off=None, vmcnt=None):
+        """All n_tiles operand frags. The asm path drains once at the end unless a later drain
+        covers it; base_off is the double-buffer parity, vmcnt overrides the g2s hint."""
         assert not preshuffled, "S2RLoaderTr does not support preshuffled"
         if self.inline_asm:
-            all_calls = [self._issue_one(lds_src, t, base_off) for t in range_constexpr(self.n_tiles)]
+            all_calls = [self._issue_one(lds_src, t, base_off, vmcnt) for t in range_constexpr(self.n_tiles)]
             if drain:
                 self._wait_lgkmcnt(0)
             return [self._assemble(c) for c in all_calls]
@@ -1363,6 +1600,21 @@ def _packed_ds_read_tr16(base_ptr, byte_offsets):
         has_side_effects=True,
     )
     return [Vec(_llvm.extractvalue(v2i32, op.result, [k])).bitcast(fx.BFloat16) for k in range(n)]
+
+
+def _lds_xpose_tr16(wr_ptr, rd_ptr, val, byte_offset=0):
+    """Stage one lane's 8 B and take the 16-lane group's 128 B back transposed, async on lgkmcnt."""
+    v2i32 = ir.VectorType.get([2], ir.IntegerType.get_signless(32))
+    op = _llvm.InlineAsmOp(
+        res=v2i32,
+        operands_=[_raw(wr_ptr), _raw(rd_ptr), _raw(val)],
+        asm_string=(
+            f"ds_write_b64 $1, $3 offset:{byte_offset}\nds_read_b64_tr_b16 $0, $2 offset:{byte_offset}"
+        ),
+        constraints="=&v,v,v,v,~{memory}",
+        has_side_effects=True,
+    )
+    return Vec(op.result).bitcast(fx.BFloat16)
 
 
 def _read_tr16_sub(base_i32, sub16, row_off):


### PR DESCRIPTION
# Description

Ports the dense FP8 GEMM optimisations for the NN (dgrad) and TN (wgrad) layouts onto `main`. Both layouts of this GEMM sit on the board power limit, so the contest is energy per FLOP rather than cycles; every change here takes work off the memory side or out of the dispatch, and none of them touch the NT (fwd) tile or its ISA.

`main` had not moved `gemm_fp8_kernel.py` since this line forked, so that file transfers whole. `gemm_helper.py` is a three-way merge — `main`'s own additions there survive, and three primitives this kernel calls that had drifted on `main` come back with it: `StoreCPerTensor`'s `store_aux`, `S2RLoaderTr.load`'s `vmcnt`, and the pool addressing the whole-loop tile needs.

The campaign harness, probe scripts and the grouped/mxfp8 lines from the source branch are deliberately left behind — this PR is two files.

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

Non-breaking: existing entry points, signatures and defaults are unchanged; this adds a new TN tile path and new autotune candidates.

## Changes

**TN (wgrad)**

- A 4-wave whole-loop macro tile (`_compile_dense_tn_wave4`), one tile per workgroup at one wave per SIMD, with a split-K window and its reduce, gated by `_tn_wave4_supported` and raced per shape against the existing 8-wave kernel.
- Tile-level tuning on that carrier: cross-XCD partial handoff published at device scope, wait-state placement between the body's instruction groups, macro-tile/LDS-pool geometry (square and rectangular) with the mfma B step that spreads fragment refills, and band selection.

**NN (dgrad)**

- `StoreCPerTensorPairN`: a 16x16 mfma row of one n-fragment spans 16 lanes, so a scalar 2 B store leaves as a 32 B request. Packing the fragment pair with `v_cvt_pk_bf16_f32` and exchanging it with the neighbouring lane through a `quad_perm` DPP — no LDS, no barrier — lets each lane hold two adjacent columns, so the pair leaves as one 64 B request and the store count halves. Even `N`, bf16 output only.
- Store issued per accumulator group at that group's last mfma instead of joining one four-group burst after the last one; the exposed part of a tile's write drain is the tail of that burst.
- Removed one redundant LDS drain: the b0 loader's trailing `lgkmcnt(0)` is already covered by the following a0 load's own drain before `c00` consumes b0.
- Bands and XCD placement raced in the per-shape autotune, including the 2D band the NT path already used. An M-band reuses B's N-stripe, so once that stripe outgrows one XCD L2 slice the hardware round-robin beats clustering; narrow and wide grids want opposite bands, so both families are offered.

**Helper**

- Three-way merge of `gemm_helper.py`; no primitive is removed or re-signed, only extended.

## Measurements

MI355X (gfx950), one card, both arms materialised from git into isolated package
copies and md5-checked before the run, warmed once, then three interleaved passes;
medians below. Shapes are the forward `(M, K, N)` of `Y[M,N] = X[M,K] @ W[N,K]^T`:

(16384,  3072,  9216)   (16384,  3072,  3072)   (16384,  3072, 12288)
(16384, 12288,  3072)   (32768,  3072, 21504)   (32768, 15360,  3072)

Each metric is the geomean over the six cells of `torch._scaled_mm` time / ours.
NN and TN hand the reference a repacked operand and are not charged for the repack,
so those two are measured against a deliberately optimistic baseline; NT is the one
layout where neither side repacks (`W[N,K].t()` is already column-major).

| metric | `main` | this PR |
|---|---|---|
| `nt_gm` (NT / forward) | 0.958 | **1.085** |
| `nn_gm` (NN / dgrad)   | 0.937 | **1.068** |
| `tn_gm` (TN / wgrad)   | 0.815 | **1.057** |

Spread over the three passes was at most 0.71% on any arm. Correctness: SNR > 28 dB
on every cell; the accumulate (`beta=1`) epilogue is checked separately per store
class — output into a zeroed buffer is bit-identical to `beta=0`, and with `A = 0`
and a distinct value per element in `out` the result is bit-identical to that input.


The denominator is given row-major x column-major operands with no repack charged, so it is an optimistic baseline.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (n/a — no user-facing API or docs change)
- [x] My changes generate no new warnings (`ruff check` and `ruff format --check` clean; pre-commit passes)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
