### PR TITLE
feat: add grad accumulation fuse support for tensorwise (Part1)

### DIFF
--- a/csrc/include/primus_turbo/gemm.h
+++ b/csrc/include/primus_turbo/gemm.h
@@ -56,8 +56,8 @@ void hipblaslt_gemm_impl(const void *A, const hipDataType A_type, const int64_t 
                          const int64_t rows_b, const int64_t cols_b, const int64_t ldb,
                          const void *scaleB_inv, hipblasOperation_t transB, void *D,
                          const hipDataType D_type, const int64_t rows_d, const int64_t cols_d,
-                         const int64_t ldd, void *workspace, const int64_t workspace_size,
-                         const bool                         use_low_precision,
+                         const int64_t ldd, const float beta, void *workspace,
+                         const int64_t workspace_size, const bool use_low_precision,
                          const hipblasLtMatmulMatrixScale_t scale_mode, hipblasLtHandle_t handle,
                          hipStream_t stream);
 

--- a/csrc/include/primus_turbo/grouped_gemm.h
+++ b/csrc/include/primus_turbo/grouped_gemm.h
@@ -88,6 +88,8 @@ struct HipblasltGroupedGemmParams {
     hipDataType          c_type;
     std::vector<int64_t> c_shape;
 
+    float beta = 0.0f;
+
     const int64_t *group_lens_ptr = nullptr;
     const int64_t *group_offs_ptr = nullptr;
     bool           transA         = false;

--- a/csrc/kernels/gemm/hipblaslt_gemm.cu
+++ b/csrc/kernels/gemm/hipblaslt_gemm.cu
@@ -33,9 +33,10 @@ void hipblaslt_gemm_impl(const void *A, const hipDataType A_type, const int64_t 
                          const int64_t rows_b, const int64_t cols_b, const int64_t ldb,
                          const void *scaleB_inv, hipblasOperation_t transB, void *D,
                          const hipDataType D_type, const int64_t rows_d, const int64_t cols_d,
-                         const int64_t ldd, void *workspace, const int64_t workspace_size,
-                         const bool use_low_precision, hipblasLtMatmulMatrixScale_t scale_mode,
-                         hipblasLtHandle_t handle, hipStream_t stream) {
+                         const int64_t ldd, const float beta, void *workspace,
+                         const int64_t workspace_size, const bool use_low_precision,
+                         hipblasLtMatmulMatrixScale_t scale_mode, hipblasLtHandle_t handle,
+                         hipStream_t stream) {
     hipblasLtMatmulDesc_t       operation_desc = nullptr;
     hipblasLtMatrixLayout_t     A_desc = nullptr, B_desc = nullptr, D_desc = nullptr;
     hipblasLtMatmulPreference_t preference        = nullptr;
@@ -94,7 +95,6 @@ void hipblaslt_gemm_impl(const void *A, const hipDataType A_type, const int64_t 
                        "hipBLASLt: no valid algorithm found for current matmul config");
 
     const float alpha = 1.0;
-    const float beta  = 0.0;
     // clang-format off
     PRIMUS_TURBO_CHECK_HIPBLAS(hipblasLtMatmul(
         handle,

--- a/csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu
+++ b/csrc/kernels/grouped_gemm/hipblaslt_grouped_gemm.cu
@@ -135,6 +135,7 @@ public:
                     gemm_ptrs_[idx].a_scale_ptr,
                     params.transA ? HIPBLAS_OP_T : HIPBLAS_OP_N,
                     gemm_ptrs_[idx].c_ptr, params.c_type, rows_c_[idx], cols_c_[idx], ld_c_[idx],
+                    params.beta,
                     workspace, get_hipblaslt_workspace_size_in_byte(),
                     params.use_low_precision,
                     params.scale_mode,
@@ -197,11 +198,16 @@ private:
 
             // For grad_b (transA), if the group len is 0, set the output memory to 0
             // c shape is [group_num, k, n], so each group's c size is k * n
+            // NOTE: when accumulating (beta != 0) C already holds the caller's running
+            // sum, and an expert that got no tokens simply contributes nothing to it --
+            // zeroing the slice would instead wipe out what was accumulated before.
             if (params.transA && len == 0) {
                 int64_t c_rows_t = get_dim(params.c_shape, -1);
                 int64_t c_cols_t = get_dim(params.c_shape, -2);
                 int64_t c_size_t = c_rows_t * c_cols_t * hipblaslt_dtype_bytes(params.c_type);
-                PRIMUS_TURBO_CHECK_HIP(hipMemsetAsync(c_ptr, 0, c_size_t, params.stream));
+                if (params.beta == 0.0f) {
+                    PRIMUS_TURBO_CHECK_HIP(hipMemsetAsync(c_ptr, 0, c_size_t, params.stream));
+                }
                 c_ptr += c_size_t;
             }
 

--- a/csrc/pytorch/bindings_pytorch.cpp
+++ b/csrc/pytorch/bindings_pytorch.cpp
@@ -13,10 +13,11 @@ namespace primus_turbo::pytorch {
 TORCH_LIBRARY(primus_turbo_cpp_extension, m) {
     // ********* Gemm *********
     m.def("hipblaslt_gemm(Tensor A, Tensor B, "
-          "ScalarType out_dtype, bool transA, bool transB, bool transC) -> Tensor");
-    m.def(
-        "hipblaslt_gemm_fp8(Tensor A, Tensor scaleA_inv, Tensor B, Tensor scaleB_inv,"
-        "ScalarType out_dtype, bool transA, bool transB, bool transC, str granularity) -> Tensor");
+          "ScalarType out_dtype, bool transA, bool transB, bool transC,"
+          "float beta=0.0, Tensor(a!)? out=None) -> Tensor");
+    m.def("hipblaslt_gemm_fp8(Tensor A, Tensor scaleA_inv, Tensor B, Tensor scaleB_inv,"
+          "ScalarType out_dtype, bool transA, bool transB, bool transC, str granularity,"
+          "float beta=0.0, Tensor(a!)? out=None) -> Tensor");
     m.def(
         "hipblaslt_gemm_fp4(Tensor A, Tensor scaleA_inv, Tensor B, Tensor scaleB_inv,"
         "ScalarType out_dtype, bool transA, bool transB, bool transC, str granularity) -> Tensor");
@@ -122,10 +123,12 @@ TORCH_LIBRARY(primus_turbo_cpp_extension, m) {
           "Tensor group_lens, Tensor group_offs, bool transA, bool transB, "
           "ScalarType out_dtype, str granularity, int? num_cu) -> Tensor");
     m.def("hipblaslt_grouped_gemm(Tensor a, Tensor b, Tensor group_lens, Tensor group_offs, "
-          "bool transA, bool transB, bool pre_sync) -> Tensor");
+          "bool transA, bool transB, bool pre_sync,"
+          "float beta=0.0, Tensor(a!)? out=None) -> Tensor");
     m.def("hipblaslt_grouped_gemm_fp8(Tensor a, Tensor b, Tensor a_scales, Tensor b_scales, "
           "Tensor group_lens, Tensor group_offs, bool transA, bool transB, "
-          "ScalarType out_dtype, str granularity, bool pre_sync) -> Tensor");
+          "ScalarType out_dtype, str granularity, bool pre_sync,"
+          "float beta=0.0, Tensor(a!)? out=None) -> Tensor");
     m.def("grouped_gemm_compute_offs(Tensor group_lens) -> Tensor");
 }
 

--- a/csrc/pytorch/extensions.h
+++ b/csrc/pytorch/extensions.h
@@ -221,19 +221,23 @@ at::Tensor shuffle_weight_impl_meta(const at::Tensor weight, at::IntArrayRef lay
 //==================================================================
 
 at::Tensor hipblaslt_gemm(at::Tensor A, at::Tensor B, const at::ScalarType out_dtype, bool transA,
-                          bool transB, bool transC);
+                          bool transB, bool transC, const double beta,
+                          c10::optional<at::Tensor> out);
 
 at::Tensor hipblaslt_gemm_meta(at::Tensor A, at::Tensor B, const at::ScalarType out_dtype,
-                               bool transA, bool transB, bool transC);
+                               bool transA, bool transB, bool transC, const double beta,
+                               c10::optional<at::Tensor> out);
 
 at::Tensor hipblaslt_gemm_fp8(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
                               at::Tensor scaleB_inv, const at::ScalarType out_dtype, bool transA,
-                              bool transB, bool transC, const std::string &granularity);
+                              bool transB, bool transC, const std::string &granularity,
+                              const double beta, c10::optional<at::Tensor> out);
 
 at::Tensor hipblaslt_gemm_fp8_meta(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
                                    at::Tensor scaleB_inv, const at::ScalarType out_dtype,
                                    bool transA, bool transB, bool transC,
-                                   const std::string &granularity);
+                                   const std::string &granularity, const double beta,
+                                   c10::optional<at::Tensor> out);
 
 at::Tensor hipblaslt_gemm_fp4(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
                               at::Tensor scaleB_inv, const at::ScalarType out_dtype, bool transA,
@@ -314,23 +318,27 @@ at::Tensor ck_grouped_gemm_fp8_variable_k_meta(at::Tensor &a, at::Tensor &b, at:
 
 at::Tensor hipblaslt_grouped_gemm(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
                                   at::Tensor &group_offs, const bool transA, const bool transB,
-                                  const bool pre_sync);
+                                  const bool pre_sync, const double beta,
+                                  c10::optional<at::Tensor> out);
 
 at::Tensor hipblaslt_grouped_gemm_meta(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
                                        at::Tensor &group_offs, const bool transA, const bool transB,
-                                       const bool pre_sync);
+                                       const bool pre_sync, const double beta,
+                                       c10::optional<at::Tensor> out);
 
 at::Tensor hipblaslt_grouped_gemm_fp8(at::Tensor &a, at::Tensor &b, at::Tensor &a_scales,
                                       at::Tensor &b_scales, at::Tensor &group_lens,
                                       at::Tensor &group_offs, const bool transA, const bool transB,
                                       at::ScalarType out_dtype, const std::string &granularity,
-                                      const bool pre_sync);
+                                      const bool pre_sync, const double beta,
+                                      c10::optional<at::Tensor> out);
 
 at::Tensor hipblaslt_grouped_gemm_fp8_meta(at::Tensor &a, at::Tensor &b, at::Tensor &a_scales,
                                            at::Tensor &b_scales, at::Tensor &group_lens,
                                            at::Tensor &group_offs, const bool transA,
                                            const bool transB, at::ScalarType out_dtype,
-                                           const std::string &granularity, const bool pre_sync);
+                                           const std::string &granularity, const bool pre_sync,
+                                           const double beta, c10::optional<at::Tensor> out);
 
 at::Tensor grouped_gemm_compute_offs(at::Tensor &group_lens);
 

--- a/csrc/pytorch/gemm/gemm_meta.cpp
+++ b/csrc/pytorch/gemm/gemm_meta.cpp
@@ -9,7 +9,12 @@
 namespace primus_turbo::pytorch {
 
 at::Tensor hipblaslt_gemm_meta(at::Tensor A, at::Tensor B, const at::ScalarType out_dtype,
-                               bool transA, bool transB, bool transC) {
+                               bool transA, bool transB, bool transC, const double beta,
+                               c10::optional<at::Tensor> out) {
+    if (out.has_value()) {
+        return out.value();
+    }
+
     const int64_t m = transA ? A.size(1) : A.size(0);
     const int64_t n = transB ? B.size(0) : B.size(1);
 
@@ -21,8 +26,9 @@ at::Tensor hipblaslt_gemm_meta(at::Tensor A, at::Tensor B, const at::ScalarType 
 at::Tensor hipblaslt_gemm_fp8_meta(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
                                    at::Tensor scaleB_inv, const at::ScalarType out_dtype,
                                    bool transA, bool transB, bool transC,
-                                   const std::string &granularity) {
-    return hipblaslt_gemm_meta(A, B, out_dtype, transA, transB, transC);
+                                   const std::string &granularity, const double beta,
+                                   c10::optional<at::Tensor> out) {
+    return hipblaslt_gemm_meta(A, B, out_dtype, transA, transB, transC, beta, out);
 }
 
 at::Tensor ck_gemm_fp8_meta(at::Tensor &a, at::Tensor &b, at::Tensor &a_scales,
@@ -37,7 +43,8 @@ at::Tensor ck_gemm_fp8_meta(at::Tensor &a, at::Tensor &b, at::Tensor &a_scales,
 at::Tensor turbo_gemm_fp8_meta(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
                                at::Tensor scaleB_inv, const at::ScalarType out_dtype, bool transA,
                                bool transB, bool transC, const std::string &granularity) {
-    return hipblaslt_gemm_meta(A, B, out_dtype, transA, transB, transC);
+    return hipblaslt_gemm_meta(A, B, out_dtype, transA, transB, transC, /*beta=*/0.0,
+                               /*out=*/c10::nullopt);
 }
 
 } // namespace primus_turbo::pytorch

--- a/csrc/pytorch/gemm/hipblaslt_gemm.cpp
+++ b/csrc/pytorch/gemm/hipblaslt_gemm.cpp
@@ -10,11 +10,18 @@
 namespace primus_turbo::pytorch {
 
 at::Tensor hipblaslt_gemm(at::Tensor A, at::Tensor B, const at::ScalarType out_dtype, bool transA,
-                          bool transB, bool transC) {
+                          bool transB, bool transC, const double beta,
+                          c10::optional<at::Tensor> out) {
     PRIMUS_TURBO_CHECK(is_floating_point_dtype(A.scalar_type()));
     PRIMUS_TURBO_CHECK(is_floating_point_dtype(B.scalar_type()));
     PRIMUS_TURBO_CHECK(A.scalar_type() == B.scalar_type(), "A and B dtype mismatch");
-    PRIMUS_TURBO_CHECK(is_floating_point_dtype(out_dtype));
+    if (out.has_value()) {
+        PRIMUS_TURBO_CHECK(is_floating_point_dtype(out->scalar_type()),
+                           "out must be a fp16/bf16/fp32 Tensor.");
+    } else {
+        PRIMUS_TURBO_CHECK(beta == 0.0, "beta != 0 requires an `out` Tensor to accumulate into.");
+        PRIMUS_TURBO_CHECK(is_floating_point_dtype(out_dtype));
+    }
 
     // contiguous check
     PRIMUS_TURBO_CHECK(A.is_contiguous(), "A must be contiguous");
@@ -61,7 +68,14 @@ at::Tensor hipblaslt_gemm(at::Tensor A, at::Tensor B, const at::ScalarType out_d
         PRIMUS_TURBO_ERROR("Not support layout.");
     }
 
-    at::Tensor C = at::empty({m, n}, torch::dtype(out_dtype).device(at::kCUDA));
+    at::Tensor C;
+    if (out.has_value()) {
+        C = out.value();
+        PRIMUS_TURBO_CHECK(C.is_contiguous(), "out must be contiguous");
+        PRIMUS_TURBO_CHECK(C.dim() == 2 && C.size(0) == m && C.size(1) == n, "out shape mismatch");
+    } else {
+        C = at::empty({m, n}, torch::dtype(out_dtype).device(at::kCUDA));
+    }
 
     auto stream = at::cuda::getCurrentCUDAStream();
     auto handle = at::cuda::getCurrentCUDABlasLtHandle();
@@ -89,6 +103,7 @@ at::Tensor hipblaslt_gemm(at::Tensor A, at::Tensor B, const at::ScalarType out_d
         trans_operation_A,
         static_cast<void *>(C.data_ptr()), C_type,
         rows_d, cols_d, ldd,
+        static_cast<float>(beta),
         static_cast<void *>(workspace.data_ptr()), workspace_size,
         false,
         HIPBLASLT_MATMUL_MATRIX_SCALE_END,
@@ -100,7 +115,8 @@ at::Tensor hipblaslt_gemm(at::Tensor A, at::Tensor B, const at::ScalarType out_d
 
 at::Tensor hipblaslt_gemm_fp8(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
                               at::Tensor scaleB_inv, const at::ScalarType out_dtype, bool transA,
-                              bool transB, bool transC, const std::string &granularity) {
+                              bool transB, bool transC, const std::string &granularity,
+                              const double beta, c10::optional<at::Tensor> out) {
     const bool use_fp8 = is_8bit_floating_point_dtype(A.scalar_type()) &&
                          is_8bit_floating_point_dtype(B.scalar_type());
 
@@ -118,7 +134,13 @@ at::Tensor hipblaslt_gemm_fp8(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
 
     PRIMUS_TURBO_CHECK(is_8bit_floating_point_dtype(A.scalar_type()));
     PRIMUS_TURBO_CHECK(is_8bit_floating_point_dtype(B.scalar_type()));
-    PRIMUS_TURBO_CHECK(is_16bit_floating_point_dtype(out_dtype));
+    if (out.has_value()) {
+        PRIMUS_TURBO_CHECK(is_floating_point_dtype(out->scalar_type()),
+                           "out must be a fp16/bf16/fp32 Tensor.");
+    } else {
+        PRIMUS_TURBO_CHECK(beta == 0.0, "beta != 0 requires an `out` Tensor to accumulate into.");
+        PRIMUS_TURBO_CHECK(is_16bit_floating_point_dtype(out_dtype));
+    }
     if (granularity != "MX_BLOCKWISE") {
         PRIMUS_TURBO_CHECK(scaleA_inv.scalar_type() == at::kFloat);
         PRIMUS_TURBO_CHECK(scaleB_inv.scalar_type() == at::kFloat);
@@ -187,7 +209,14 @@ at::Tensor hipblaslt_gemm_fp8(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
         PRIMUS_TURBO_CHECK(scaleB_inv.dim() == 2, "Scale B must be a 2-D tensor.");
     }
 
-    at::Tensor C = at::empty({m, n}, torch::dtype(out_dtype).device(at::kCUDA));
+    at::Tensor C;
+    if (out.has_value()) {
+        C = out.value();
+        PRIMUS_TURBO_CHECK(C.is_contiguous(), "out must be contiguous");
+        PRIMUS_TURBO_CHECK(C.dim() == 2 && C.size(0) == m && C.size(1) == n, "out shape mismatch");
+    } else {
+        C = at::empty({m, n}, torch::dtype(out_dtype).device(at::kCUDA));
+    }
 
     auto stream = at::cuda::getCurrentCUDAStream();
     auto handle = at::cuda::getCurrentCUDABlasLtHandle();
@@ -215,6 +244,7 @@ at::Tensor hipblaslt_gemm_fp8(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
         trans_operation_A,
         static_cast<void *>(C.data_ptr()), C_type,
         rows_d, cols_d, ldd,
+        static_cast<float>(beta),
         static_cast<void *>(workspace.data_ptr()), workspace_size,
         use_fp8,
         scale_mode,
@@ -338,6 +368,7 @@ at::Tensor hipblaslt_gemm_fp4(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
         trans_operation_A,
         static_cast<void *>(C.data_ptr()), C_type,
         rows_d, cols_d, ldd,
+        0.0f,
         static_cast<void *>(workspace.data_ptr()), workspace_size,
         use_fp4,
         scale_mode,

--- a/csrc/pytorch/grouped_gemm/grouped_gemm_meta.cpp
+++ b/csrc/pytorch/grouped_gemm/grouped_gemm_meta.cpp
@@ -64,7 +64,11 @@ at::Tensor ck_grouped_gemm_fp8_variable_k_meta(at::Tensor &a, at::Tensor &b, at:
 //==================================================================
 at::Tensor hipblaslt_grouped_gemm_meta(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
                                        at::Tensor &group_offs, const bool transA, const bool transB,
-                                       const bool pre_sync) {
+                                       const bool pre_sync, const double beta,
+                                       c10::optional<at::Tensor> out) {
+    if (out.has_value()) {
+        return out.value();
+    }
     if (transA) {
         const int64_t bs = group_lens.numel();
         const int64_t m  = transA ? a.size(1) : a.size(0);
@@ -81,7 +85,11 @@ at::Tensor hipblaslt_grouped_gemm_fp8_meta(at::Tensor &a, at::Tensor &b, at::Ten
                                            at::Tensor &b_scales, at::Tensor &group_lens,
                                            at::Tensor &group_offs, const bool transA,
                                            const bool transB, at::ScalarType out_dtype,
-                                           const std::string &granularity, const bool pre_sync) {
+                                           const std::string &granularity, const bool pre_sync,
+                                           const double beta, c10::optional<at::Tensor> out) {
+    if (out.has_value()) {
+        return out.value();
+    }
     if (transA) {
         const int64_t bs = group_lens.numel();
         const int64_t m  = a.size(1);

--- a/csrc/pytorch/grouped_gemm/hipblaslt_grouped_gemm.cpp
+++ b/csrc/pytorch/grouped_gemm/hipblaslt_grouped_gemm.cpp
@@ -16,6 +16,22 @@
 
 namespace primus_turbo::pytorch {
 
+inline at::Tensor resolve_grouped_gemm_out(const c10::optional<at::Tensor> &out,
+                                           const std::vector<int64_t>      &c_shape,
+                                           const at::TensorOptions &options, const double beta) {
+    if (!out.has_value()) {
+        PRIMUS_TURBO_CHECK(beta == 0.0, "beta != 0 requires an `out` Tensor to accumulate into.");
+        return at::empty(c_shape, options);
+    }
+
+    const at::Tensor &c = out.value();
+    PRIMUS_TURBO_CHECK(c.is_contiguous(), "out must be contiguous");
+    PRIMUS_TURBO_CHECK(is_floating_point_dtype(c.scalar_type()),
+                       "out must be a fp16/bf16/fp32 Tensor.");
+    PRIMUS_TURBO_CHECK(c.sizes().vec() == c_shape, "out shape mismatch");
+    return c;
+}
+
 inline HipblasltGroupedGemmParams
 make_hipblaslt_grouped_gemm_params(const at::Tensor &a, const at::Tensor &b, at::Tensor &c,
                                    const at::Tensor &group_lens, const at::Tensor &group_offs,
@@ -83,7 +99,8 @@ inline HipblasltGroupedGemmParams make_hipblaslt_grouped_gemm_fp8_params(
 
 at::Tensor hipblaslt_grouped_gemm(at::Tensor &a, at::Tensor &b, at::Tensor &group_lens,
                                   at::Tensor &group_offs, const bool transA, const bool transB,
-                                  const bool pre_sync) {
+                                  const bool pre_sync, const double beta,
+                                  c10::optional<at::Tensor> out) {
     // Check
     PRIMUS_TURBO_CHECK(is_16bit_floating_point_dtype(a.scalar_type()),
                        "hipblaslt_grouped_gemm only supports float16 and bfloat16");
@@ -94,17 +111,18 @@ at::Tensor hipblaslt_grouped_gemm(at::Tensor &a, at::Tensor &b, at::Tensor &grou
     PRIMUS_TURBO_CHECK(a.scalar_type() == b.scalar_type(), "a and b dtype mismatch");
 
     // Create output tensor
-    at::Tensor c;
+    std::vector<int64_t> c_shape;
     if (transA) {
         const int64_t bs = group_lens.numel();
         const int64_t m  = a.size(1);
         const int64_t n  = transB ? b.size(0) : b.size(1);
-        c                = at::empty({bs, m, n}, a.options());
+        c_shape          = {bs, m, n};
     } else {
         const int64_t m = a.size(0);
         const int64_t n = transB ? b.size(1) : b.size(2);
-        c               = at::empty({m, n}, a.options());
+        c_shape         = {m, n};
     }
+    at::Tensor c = resolve_grouped_gemm_out(out, c_shape, a.options(), beta);
 
     const int64_t workspace_size = primus_turbo::get_hipblaslt_grouped_gemm_workspace_size();
     at::Tensor    workspace =
@@ -112,6 +130,7 @@ at::Tensor hipblaslt_grouped_gemm(at::Tensor &a, at::Tensor &b, at::Tensor &grou
 
     auto params = make_hipblaslt_grouped_gemm_params(a, b, c, group_lens, group_offs, transA,
                                                      transB, workspace);
+    params.beta = static_cast<float>(beta);
     primus_turbo::hipblaslt_grouped_gemm(params, pre_sync);
     return c;
 }
@@ -120,7 +139,8 @@ at::Tensor hipblaslt_grouped_gemm_fp8(at::Tensor &a, at::Tensor &b, at::Tensor &
                                       at::Tensor &b_scales, at::Tensor &group_lens,
                                       at::Tensor &group_offs, const bool transA, const bool transB,
                                       at::ScalarType out_dtype, const std::string &granularity,
-                                      const bool pre_sync) {
+                                      const bool pre_sync, const double beta,
+                                      c10::optional<at::Tensor> out) {
     // Check
     PRIMUS_TURBO_CHECK(is_8bit_floating_point_dtype(a.scalar_type()));
     PRIMUS_TURBO_CHECK(is_8bit_floating_point_dtype(b.scalar_type()));
@@ -139,17 +159,18 @@ at::Tensor hipblaslt_grouped_gemm_fp8(at::Tensor &a, at::Tensor &b, at::Tensor &
     }
 
     // Create output tensor
-    at::Tensor c;
+    std::vector<int64_t> c_shape;
     if (transA) {
         const int64_t bs = group_lens.numel();
         const int64_t m  = a.size(1);
         const int64_t n  = transB ? b.size(0) : b.size(1);
-        c                = at::empty({bs, m, n}, a.options().dtype(out_dtype));
+        c_shape          = {bs, m, n};
     } else {
         const int64_t m = a.size(0);
         const int64_t n = transB ? b.size(1) : b.size(2);
-        c               = at::empty({m, n}, a.options().dtype(out_dtype));
+        c_shape         = {m, n};
     }
+    at::Tensor c = resolve_grouped_gemm_out(out, c_shape, a.options().dtype(out_dtype), beta);
 
     const int64_t workspace_size = primus_turbo::get_hipblaslt_grouped_gemm_workspace_size();
     at::Tensor    workspace =
@@ -157,6 +178,7 @@ at::Tensor hipblaslt_grouped_gemm_fp8(at::Tensor &a, at::Tensor &b, at::Tensor &
 
     auto params = make_hipblaslt_grouped_gemm_fp8_params(
         a, b, c, a_scales, b_scales, group_lens, group_offs, transA, transB, scale_mode, workspace);
+    params.beta = static_cast<float>(beta);
     primus_turbo::hipblaslt_grouped_gemm(params, pre_sync);
 
     return c;

--- a/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
@@ -33,11 +33,13 @@ from primus_turbo.flydsl.utils.gemm_helper import (
     StoreCPerTensor,
     asm_mma_do,
     ceildiv,
+    compile_with_scratch_out,
     compute_global_swizzle,
     compute_global_swizzle_nn,
     make_fp8_buffer_tensor_rebased,
     make_value_attrs,
     mask_a_tail,
+    resolve_accum_out,
     wait_barrier,
     xcd_remap_pid,
 )
@@ -64,6 +66,7 @@ def _compile_dense_nt(
     cbsz: int = 0,  # srcA fp8 fmt: 0=E4M3, 1=E5M2
     blgp: int = 0,  # srcB fp8 fmt: 0=E4M3, 1=E5M2
     out_fp16: bool = False,  # StoreCPerTensor out dtype: True -> fp16, else bf16
+    beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
 ):
     """Build & cache the (K, BLOCK_M, BLOCK_N, GROUP_M)-specialised NT launch.
 
@@ -186,7 +189,9 @@ def _compile_dense_nt(
         a_s2r = S2RLoader(wave_m, N_TILES_A)
         b_s2r = S2RLoader(wave_n, N_TILES_B)
         _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
-        store_c = StoreCPerTensor(A_scale, B_scale, C, c_m, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty)
+        store_c = StoreCPerTensor(
+            A_scale, B_scale, C, c_m, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty, beta_is_one=beta_is_one
+        )
 
         c00_frag = [mfma.zero_value] * N_ACCUMS
         c01_frag = [mfma.zero_value] * N_ACCUMS
@@ -392,6 +397,7 @@ def _compile_dense_nn(
     blgp: int = 0,  # srcB fp8 fmt: 0=E4M3, 1=E5M2
     out_fp16: bool = False,  # StoreCPerTensor out dtype: True -> fp16, else bf16
     i64_traverse: bool = False,  # B[K,N] traversal via per-load i64 SRD re-base (lifts k*n < 2^32 cap)
+    beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
 ):
     """NN-layout fp8 dense kernel. A [M, K], B [K, N], C [M, N].
 
@@ -516,7 +522,9 @@ def _compile_dense_nn(
         a_s2r = S2RLoader(wave_m, N_TILES_A)
         b_s2r = S2RLoaderTr(wave_n, N_TILES_B, 32, inline_asm=b_inline_asm_load, vmcnt_hint=vmcnt_hint)
         _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
-        store_c = StoreCPerTensor(A_scale, B_scale, C, c_m, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty)
+        store_c = StoreCPerTensor(
+            A_scale, B_scale, C, c_m, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty, beta_is_one=beta_is_one
+        )
 
         c00_frag = [mfma.zero_value] * N_ACCUMS
         c01_frag = [mfma.zero_value] * N_ACCUMS
@@ -703,6 +711,7 @@ def _compile_dense_tn(
     blgp: int = 0,  # srcB fp8 fmt: 0=E4M3, 1=E5M2
     out_fp16: bool = False,  # StoreCPerTensor out dtype: True -> fp16, else bf16
     i64_traverse: bool = False,  # A[K,M] & B[K,N] traversal via per-load i64 SRD re-base (lifts cap)
+    beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
 ):
     """TN-layout fp8 dense kernel: A [K, M], B [K, N], C [M, N] = A^T @ B.
     Both A and B are K-row strided, so both go through the wave-coop
@@ -867,7 +876,9 @@ def _compile_dense_tn(
             wave_n, N_TILES_B, 32, inline_asm=_b_inline, vmcnt_hint=vmcnt_hint, chunk_stride=_LDS_CS
         )
         _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
-        store_c = StoreCPerTensor(A_scale, B_scale, C, c_m, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty)
+        store_c = StoreCPerTensor(
+            A_scale, B_scale, C, c_m, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty, beta_is_one=beta_is_one
+        )
 
         c00_frag = [mfma.zero_value] * N_ACCUMS
         c01_frag = [mfma.zero_value] * N_ACCUMS
@@ -1043,9 +1054,34 @@ def _get_compiled_dense(launch, args):
     key = tuple(key_parts)
     cached = _COMPILED_DENSE_CACHE.get(key)
     if cached is None:
-        cached = flyc.compile(launch, *args)
+        cached = compile_with_scratch_out(launch, args)
         _COMPILED_DENSE_CACHE[key] = cached
     return cached
+
+
+def _bench_dense_args(args):
+    """Bench copy of the launch args with a scratch C, plus that scratch.
+
+    Each candidate is run 23 times while racing. Against a beta=1 build that would
+    fold 23 GEMMs into the caller's accumulation buffer, so the race never touches
+    it: the winning config is re-compiled with the accumulate epilogue afterwards.
+    """
+    bench_c = torch.empty_like(args[2])
+    return (args[0], args[1], bench_c) + tuple(args[3:]), bench_c
+
+
+def _dense_beta1_entry(cache, key, tuned):
+    """The beta=1 build of an already-tuned config (same config, accumulate epilogue).
+
+    ``tuned[3]`` is the config's compile factory; the compile functions are
+    lru_cached, so this only ever traces once per (shape, config).
+    """
+    bkey = key + (True,)
+    entry = cache.get(bkey)
+    if entry is None:
+        entry = [tuned[3](beta_is_one=True), tuned[1], None, tuned[3]]
+        cache[bkey] = entry
+    return entry
 
 
 def _run_dense(entry, args):
@@ -1057,7 +1093,7 @@ def _run_dense(entry, args):
         entry[0](*args)
     else:
         if entry[2] is None:
-            entry[2] = flyc.compile(entry[0], *args)
+            entry[2] = compile_with_scratch_out(entry[0], args)
         entry[2](*args)
 
 
@@ -1090,20 +1126,25 @@ _NN_CANDIDATES = [
 _NN_AUTOTUNE_CACHE: dict = {}
 
 
-def _autotune_nn_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, i64_traverse=False):
+def _autotune_nn_dispatch(
+    args, M, N, K, cbsz=0, blgp=0, out_fp16=False, i64_traverse=False, beta_is_one=False
+):
     """First-call bench NN candidates, cache best (launch, cfg) by (M,N,K).
 
     Runtime micro-benches each (BM, GROUP_M, num_xcd, AG) candidate,
     finite-checks the output, times 2-warmup + 20-iter, and caches the
     fastest by shape. ``i64_traverse`` re-bases B's SRD per load (lifts the
-    k*n < 2^32 cap; threaded to _compile_dense_nn).
+    k*n < 2^32 cap; threaded to _compile_dense_nn). The race always runs the
+    beta=0 build; ``beta_is_one`` re-compiles the winner with the accumulate
+    epilogue.
     """
     import torch as _torch
 
     key = (M, N, K, cbsz, blgp, out_fp16, i64_traverse)
-    if key in _NN_AUTOTUNE_CACHE:
-        return _NN_AUTOTUNE_CACHE[key]
-    out_view = args[2]
+    tuned = _NN_AUTOTUNE_CACHE.get(key)
+    if tuned is not None:
+        return _dense_beta1_entry(_NN_AUTOTUNE_CACHE, key, tuned) if beta_is_one else tuned
+    bargs, out_view = _bench_dense_args(args)
     best_us = float("inf")
     best = None
     for bm, gm, xcd, ag in _NN_CANDIDATES:
@@ -1113,7 +1154,8 @@ def _autotune_nn_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, i64_tra
         try:
             # inline-asm ds_read_b64_tr_b8 on by default (drops the per-K-iter
             # compiler-auto vmcnt(0) drains).
-            launch = _compile_dense_nn(
+            mk = functools.partial(
+                _compile_dense_nn,
                 K=K,
                 BLOCK_M=bm,
                 BLOCK_N=256,
@@ -1127,33 +1169,34 @@ def _autotune_nn_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, i64_tra
                 out_fp16=out_fp16,
                 i64_traverse=i64_traverse,
             )
-            c = _get_compiled_dense(launch, args)
-            c(*args)
+            launch = mk(beta_is_one=False)
+            c = _get_compiled_dense(launch, bargs)
+            c(*bargs)
             _torch.cuda.synchronize()
             sample = out_view.view(-1)[:1024].float()
             if not _torch.isfinite(sample).all().item():
                 continue
             for _ in range(2):
-                c(*args)
+                c(*bargs)
             _torch.cuda.synchronize()
             e0 = _torch.cuda.Event(enable_timing=True)
             e1 = _torch.cuda.Event(enable_timing=True)
             _torch.cuda.synchronize()
             e0.record()
             for _ in range(20):
-                c(*args)
+                c(*bargs)
             e1.record()
             _torch.cuda.synchronize()
             us = e0.elapsed_time(e1) * 1000.0 / 20
             if us < best_us:
                 best_us = us
-                best = [launch, (bm, gm, xcd, ag), c]  # c: compiled winner (reused eager)
+                best = [launch, (bm, gm, xcd, ag), c, mk]  # c: compiled winner (reused eager)
         except Exception:
             continue
     if best is None:
         raise RuntimeError(f"NN autotune found no working cfg for ({M},{N},{K})")
     _NN_AUTOTUNE_CACHE[key] = best
-    return best
+    return _dense_beta1_entry(_NN_AUTOTUNE_CACHE, key, best) if beta_is_one else best
 
 
 # NT per-shape autotune candidates (BLOCK_M, GROUP_M, num_xcd, AGPR). GROUP_M
@@ -1168,19 +1211,21 @@ _NT_CANDIDATES = [
 _NT_AUTOTUNE_CACHE: dict = {}
 
 
-def _autotune_nt_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False):
+def _autotune_nt_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, beta_is_one=False):
     """First-call bench NT candidates, cache best (launch, cfg) by (M,N,K).
 
     Runtime micro-benches each (BM, GROUP_M, num_xcd, AG) candidate,
     finite-checks the output, times 2-warmup + 20-iter, and caches the
-    fastest by shape.
+    fastest by shape. The race always runs the beta=0 build; ``beta_is_one``
+    re-compiles the winner with the accumulate epilogue.
     """
     import torch as _torch
 
     key = (M, N, K, cbsz, blgp, out_fp16)
-    if key in _NT_AUTOTUNE_CACHE:
-        return _NT_AUTOTUNE_CACHE[key]
-    out_view = args[2]
+    tuned = _NT_AUTOTUNE_CACHE.get(key)
+    if tuned is not None:
+        return _dense_beta1_entry(_NT_AUTOTUNE_CACHE, key, tuned) if beta_is_one else tuned
+    bargs, out_view = _bench_dense_args(args)
     best_us = float("inf")
     best = None
     for bm, gm, xcd, ag in _NT_CANDIDATES:
@@ -1188,7 +1233,8 @@ def _autotune_nt_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False):
         # bounded by c_m (StoreCPerTensor clamp) and the global SRD (HW OOB
         # clamp on the A G2S load), so no even-tiling filter is needed.
         try:
-            launch = _compile_dense_nt(
+            mk = functools.partial(
+                _compile_dense_nt,
                 K=K,
                 BLOCK_M=bm,
                 BLOCK_N=256,
@@ -1199,33 +1245,34 @@ def _autotune_nt_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False):
                 blgp=blgp,
                 out_fp16=out_fp16,
             )
-            c = _get_compiled_dense(launch, args)
-            c(*args)
+            launch = mk(beta_is_one=False)
+            c = _get_compiled_dense(launch, bargs)
+            c(*bargs)
             _torch.cuda.synchronize()
             sample = out_view.view(-1)[:1024].float()
             if not _torch.isfinite(sample).all().item():
                 continue
             for _ in range(2):
-                c(*args)
+                c(*bargs)
             _torch.cuda.synchronize()
             e0 = _torch.cuda.Event(enable_timing=True)
             e1 = _torch.cuda.Event(enable_timing=True)
             _torch.cuda.synchronize()
             e0.record()
             for _ in range(20):
-                c(*args)
+                c(*bargs)
             e1.record()
             _torch.cuda.synchronize()
             us = e0.elapsed_time(e1) * 1000.0 / 20
             if us < best_us:
                 best_us = us
-                best = [launch, (bm, gm, xcd, ag), c]  # c: compiled winner (reused eager)
+                best = [launch, (bm, gm, xcd, ag), c, mk]  # c: compiled winner (reused eager)
         except Exception:
             continue
     if best is None:
         raise RuntimeError(f"NT autotune found no working cfg for ({M},{N},{K})")
     _NT_AUTOTUNE_CACHE[key] = best
-    return best
+    return _dense_beta1_entry(_NT_AUTOTUNE_CACHE, key, best) if beta_is_one else best
 
 
 # TN dispatch: a single inplace-A kernel (inline-asm tr8 on both operands +
@@ -1237,31 +1284,37 @@ def _autotune_nt_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False):
 _TN_AUTOTUNE_CACHE: dict = {}
 
 
-def _autotune_tn_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, i64_traverse=False):
+def _autotune_tn_dispatch(
+    args, M, N, K, cbsz=0, blgp=0, out_fp16=False, i64_traverse=False, beta_is_one=False
+):
     """First-call bench TN candidates, cache best (launch, cfg) by (M,N,K).
 
     1D GROUP_M=4 with num_xcd 8 vs 1 (XCD-aware PID remap); large
     (HBM-streaming) shapes expose the per-XCD L2 reuse on the hot bench,
     L2-resident shapes pick num_xcd=1. ``i64_traverse`` re-bases A's and B's
     SRDs per load (lifts the k*m / k*n < 2^32 cap; threaded to _compile_dense_tn).
+    The race always runs the beta=0 build; ``beta_is_one`` re-compiles the winner
+    with the accumulate epilogue.
     """
     import torch as _torch
 
     key = (M, N, K, cbsz, blgp, out_fp16, i64_traverse)
-    if key in _TN_AUTOTUNE_CACHE:
-        return _TN_AUTOTUNE_CACHE[key]
+    tuned = _TN_AUTOTUNE_CACHE.get(key)
+    if tuned is not None:
+        return _dense_beta1_entry(_TN_AUTOTUNE_CACHE, key, tuned) if beta_is_one else tuned
     # Occupancy routing: BLOCK_M=BLOCK_N=256 yields ceil(M/256)*ceil(N/256)
     # tiles; below NUM_CUS the grid can't fill every CU, so BLOCK_M=128 doubles
     # the M-tile count. Above it the smaller block's per-tile overhead dominates.
     NUM_CUS = 256
     tiles_256 = ((M + 255) // 256) * ((N + 255) // 256)
     bm = 128 if tiles_256 < NUM_CUS else 256
-    out_view = args[2]
+    bargs, out_view = _bench_dense_args(args)
     best_us = float("inf")
     best = None
     for xcd in (8, 1):
         try:
-            launch = _compile_dense_tn(
+            mk = functools.partial(
+                _compile_dense_tn,
                 K=K,
                 BLOCK_M=bm,
                 BLOCK_N=256,
@@ -1274,33 +1327,34 @@ def _autotune_tn_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, i64_tra
                 out_fp16=out_fp16,
                 i64_traverse=i64_traverse,
             )
-            c = _get_compiled_dense(launch, args)
-            c(*args)
+            launch = mk(beta_is_one=False)
+            c = _get_compiled_dense(launch, bargs)
+            c(*bargs)
             _torch.cuda.synchronize()
             sample = out_view.view(-1)[:1024].float()
             if not _torch.isfinite(sample).all().item():
                 continue
             for _ in range(2):
-                c(*args)
+                c(*bargs)
             _torch.cuda.synchronize()
             e0 = _torch.cuda.Event(enable_timing=True)
             e1 = _torch.cuda.Event(enable_timing=True)
             _torch.cuda.synchronize()
             e0.record()
             for _ in range(20):
-                c(*args)
+                c(*bargs)
             e1.record()
             _torch.cuda.synchronize()
             us = e0.elapsed_time(e1) * 1000.0 / 20
             if us < best_us:
                 best_us = us
-                best = [launch, (bm, 4, 0, xcd), c]  # c: compiled winner (reused eager)
+                best = [launch, (bm, 4, 0, xcd), c, mk]  # c: compiled winner (reused eager)
         except Exception:
             continue
     if best is None:
         raise RuntimeError(f"TN autotune found no working cfg for ({M},{N},{K})")
     _TN_AUTOTUNE_CACHE[key] = best
-    return best
+    return _dense_beta1_entry(_TN_AUTOTUNE_CACHE, key, best) if beta_is_one else best
 
 
 def gemm_fp8_tensorwise_flydsl_kernel(
@@ -1312,14 +1366,26 @@ def gemm_fp8_tensorwise_flydsl_kernel(
     trans_b: bool = True,
     out_dtype: torch.dtype = torch.bfloat16,
     trans_c: bool = False,
+    beta: float = 0.0,
+    out: "torch.Tensor | None" = None,
 ) -> torch.Tensor:
     """Dense FP8 GEMM, per-tensor scaling. Inputs E4M3/E5M2/hybrid, out bf16/fp16,
     arbitrary K (native K-tail). Dispatch by (trans_a, trans_b): NT (F,T), NN
     (F,F, dgrad), TN (T,F) run native; TT (T,T) unsupported. trans_c=True returns
-    out.t().contiguous()."""
+    out.t().contiguous().
+
+    ``beta=1.0`` accumulates into ``out`` (``out += a @ b``) in the epilogue instead
+    of overwriting it, and therefore requires ``out``. It is incompatible with
+    ``trans_c``, whose transpose happens after the kernel has already written.
+    """
     if out_dtype not in (torch.bfloat16, torch.float16):
         raise NotImplementedError(f"FlyDSL wrapper emits bf16 or fp16. Got {out_dtype}.")
     assert a.dim() == 2 and b.dim() == 2
+    beta_is_one = beta == 1.0
+    assert not (beta_is_one and trans_c), (
+        "beta=1.0 cannot be combined with trans_c: the transpose is a post-kernel copy, "
+        "so the accumulation would land in a buffer the caller never sees."
+    )
     # Element-count threshold past which a contraction-traversal operand's 32-bit
     # soffset wraps (fp8 = 1 byte/elem). At/above it the kernel re-bases the SRD per
     # load in i64; below it the cheaper fixed-base + 32-bit soffset path is used.
@@ -1338,12 +1404,12 @@ def gemm_fp8_tensorwise_flydsl_kernel(
         K = K_a
         a_scale_v = _scalar_scale(a_scale_inv, a.device)
         b_scale_v = _scalar_scale(b_scale_inv, a.device)
-        out = torch.empty((M, N), dtype=out_dtype, device=a.device)
+        out = resolve_accum_out(out, beta, (M, N), a.device, out_dtype)
         # TN: per-shape autotune picks the best candidate cfg, cached by (M,N,K).
         args = (
             _as_i8_flat(a),
             _as_i8_flat(b),
-            out.contiguous(),
+            out,
             a_scale_v,
             b_scale_v,
             M,
@@ -1353,7 +1419,7 @@ def gemm_fp8_tensorwise_flydsl_kernel(
         # TN both operands traverse K: span k*m / k*n past 2^32 fp8 needs the
         # per-load i64 SRD re-base (else the 32-bit soffset wraps).
         i64_tr = (K * M >= cap) or (K * N >= cap)
-        _run_dense(_autotune_tn_dispatch(args, M, N, K, cbsz, blgp, out_fp16, i64_tr), args)
+        _run_dense(_autotune_tn_dispatch(args, M, N, K, cbsz, blgp, out_fp16, i64_tr, beta_is_one), args)
         if trans_c:
             return out.t().contiguous()
         return out
@@ -1367,13 +1433,13 @@ def gemm_fp8_tensorwise_flydsl_kernel(
         K = K_a
         a_scale_v = _scalar_scale(a_scale_inv, a.device)
         b_scale_v = _scalar_scale(b_scale_inv, a.device)
-        out = torch.empty((M, N), dtype=out_dtype, device=a.device)
+        out = resolve_accum_out(out, beta, (M, N), a.device, out_dtype)
         # NN: per-shape runtime autotune over the candidate tiles, caches by
         # (M,N,K). Build args before autotune (it benches against them).
         args = (
             _as_i8_flat(a),
             _as_i8_flat(b),
-            out.contiguous(),
+            out,
             a_scale_v,
             b_scale_v,
             M,
@@ -1382,7 +1448,7 @@ def gemm_fp8_tensorwise_flydsl_kernel(
         )
         # NN: only B[K,N] traverses K; k*n past 2^32 fp8 needs the i64 re-base.
         i64_tr = K * N >= cap
-        _run_dense(_autotune_nn_dispatch(args, M, N, K, cbsz, blgp, out_fp16, i64_tr), args)
+        _run_dense(_autotune_nn_dispatch(args, M, N, K, cbsz, blgp, out_fp16, i64_tr, beta_is_one), args)
     elif (not trans_a) and trans_b:
         # NT native: A [M, K], B [N, K] (B^T storage of [K, N]).
         M, K_a = a.shape
@@ -1391,20 +1457,20 @@ def gemm_fp8_tensorwise_flydsl_kernel(
         K = K_a
         a_scale_v = _scalar_scale(a_scale_inv, a.device)
         b_scale_v = _scalar_scale(b_scale_inv, a.device)
-        out = torch.empty((M, N), dtype=out_dtype, device=a.device)
+        out = resolve_accum_out(out, beta, (M, N), a.device, out_dtype)
         # NT: per-shape runtime autotune over the 8w/v3 candidate tiles, caches
         # by (M,N,K). Build args before autotune (it benches against them).
         args = (
             _as_i8_flat(a),
             _as_i8_flat(b),
-            out.contiguous(),
+            out,
             a_scale_v,
             b_scale_v,
             M,
             N,
             torch.cuda.current_stream(),
         )
-        _run_dense(_autotune_nt_dispatch(args, M, N, K, cbsz, blgp, out_fp16), args)
+        _run_dense(_autotune_nt_dispatch(args, M, N, K, cbsz, blgp, out_fp16, beta_is_one), args)
     else:
         raise NotImplementedError(
             f"FlyDSL fp8 GEMM does not support the TT layout (trans_a={trans_a}, trans_b={trans_b})."

--- a/primus_turbo/flydsl/gemm/gemm_mxfp4_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_mxfp4_kernel.py
@@ -44,9 +44,12 @@ import torch
 from primus_turbo.flydsl.utils.gemm_helper import (
     G2SLoader,
     ceildiv,
+    compile_with_scratch_out,
     make_fp8_rebased_tensor_and_srd,
     make_row_band_resource,
+    resolve_accum_out,
     wait_barrier,
+    xcd_remap_pid,
 )
 import flydsl.compiler as flyc
 import flydsl.expr as fx
@@ -116,14 +119,16 @@ def fp4_g2s_offsets(lane_id, wave_id, K, n_steps, bytes_per_row, swizzle=False):
 def grouped_xcd_pid(pid, c_m, c_n, BLOCK_M, BLOCK_N, group_m=4, num_xcds=8, group_n=0):
     """Map block_idx -> (block_m, block_n) with XCD-aware remap + GROUP_M tiling for
     L2 locality. group_n>0 enables a 2D super-block (N-band) swizzle on top (locks an
-    A-slab AND a B-slab into L2). Pure index math; exact bijection when
-    total_tiles % num_xcds == 0, falls back safely otherwise."""
+    A-slab AND a B-slab into L2). Pure index math, a bijection for any tile count.
+
+    The XCD remap must be exact: one workgroup owns one tile, so a mapping that
+    collides drops whichever tile lost the collision and leaves it at whatever the
+    output allocation happened to hold.
+    """
     num_pid_m = ceildiv(c_m, BLOCK_M)
     num_pid_n = ceildiv(c_n, BLOCK_N)
     total = num_pid_m * num_pid_n
-    pids_per_xcd = (total + num_xcds - 1) // num_xcds
-    pid_r = (pid % num_xcds) * pids_per_xcd + pid // num_xcds
-    pid_r = arith.select(pid_r < total, pid_r, pid)
+    pid_r = xcd_remap_pid(pid, total, num_xcds)
 
     if group_n and group_n > 0:
         band_tiles = num_pid_m * group_n  # tiles in one full band
@@ -208,9 +213,13 @@ class StoreCPlain:
 
     ``out_ty`` is bf16 or fp16 (both 2 bytes). The narrow ``store`` path uses a generic
     f32->out_ty ``.to()`` cast so it serves either; the wide ``store_tacc_wide`` fast
-    path packs through ``_pack_pair``, which serves either too."""
+    path packs through ``_pack_pair``, which serves either too.
 
-    def __init__(self, C, c_rows, c_cols, c_idx_fn, n_tiles_a, n_tiles_b, out_ty=None):
+    ``beta_is_one`` turns both paths into an accumulate (``C = C + acc``): the value is
+    read back through the same SRD and offset it is about to be stored to, widened to
+    f32 and added. Lanes whose store is masked/OOB read 0, so no extra bounds logic."""
+
+    def __init__(self, C, c_rows, c_cols, c_idx_fn, n_tiles_a, n_tiles_b, out_ty=None, beta_is_one=False):
         self.c_rows = c_rows
         self.c_cols = c_cols
         self.lane_id = fx.thread_idx.x % 64
@@ -218,6 +227,7 @@ class StoreCPlain:
         self.n_tiles_a = n_tiles_a
         self.n_tiles_b = n_tiles_b
         self.out_ty = out_ty if out_ty is not None else fx.BFloat16
+        self.beta_is_one = beta_is_one
         # int64 byte base: the store re-bases per row band (make_row_band_resource) so a
         # C whose flat rows*cols exceeds 2^31 (large-G wgrad grad_b [G,N,K]) addresses
         # correctly. Pass C as 2D so its shape packs within int32.
@@ -229,16 +239,34 @@ class StoreCPlain:
         # mask cols >= n_valid so the kernel runs the REAL N with no host N-pad.
         _mask = n_valid is not None
         rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
+        addrs = []
         for ti in range_constexpr(self.n_tiles_a):
             row_local = ti * 16 + (self.lane_id // 16) * 4  # relative to base_row
             for tj in range_constexpr(self.n_tiles_b):
                 col = base_col + tj * 16 + self.lane_id % 16
                 col_valid = (col < fx.Int32(n_valid)) if _mask else None
+                for i in range_constexpr(4):
+                    addrs.append(((row_local + i) * self.c_cols + col, col_valid))
+        prev = []
+        if const_expr(self.beta_is_one):
+            # Issue every read-back before the first store: one dependent load per store
+            # would leave the epilogue waiting on memory latency instead of overlapping.
+            prev = [
+                buffer_ops.buffer_load(rsrc, off_e, vec_width=1, dtype=self.out_ty.ir_type, mask=valid)
+                for off_e, valid in addrs
+            ]
+        n = 0
+        for ti in range_constexpr(self.n_tiles_a):
+            for tj in range_constexpr(self.n_tiles_b):
                 vec_f32 = Vec(c_frag[self.c_idx_fn(ti, tj)])
                 for i in range_constexpr(4):
-                    val = vec_f32[i].to(self.out_ty)
-                    off = ((row_local + i) * self.c_cols + col) * 2  # i32-small within band
-                    buffer_ops.buffer_store(val, rsrc, off, mask=col_valid, offset_is_bytes=True)
+                    off_e, col_valid = addrs[n]
+                    val = vec_f32[i]
+                    if const_expr(self.beta_is_one):
+                        val = val + self.out_ty(prev[n]).to(fx.Float32)  # add in f32: one rounding
+                    val = val.to(self.out_ty)
+                    buffer_ops.buffer_store(val, rsrc, off_e * 2, mask=col_valid, offset_is_bytes=True)
+                    n += 1
 
     def _pack_pair(self, x0, x1):
         if const_expr(self.out_ty is fx.Float16):
@@ -291,10 +319,10 @@ class StoreCPlain:
         # Hoisted per-lane base byte offset relative to base_row: (base_col + lane%16*c_cols
         # + col_off)*2. Per-store delta (ti*16*c_cols + tj*16)*2 is a compile-time constant ->
         # one v_add per store instead of recomputing r*c_cols (matches AITER's voffset+imm).
-        lane_base = (base_col + (self.lane_id % 16) * self.c_cols + col_off) * fx.Int32(2)
+        lane_base_e = base_col + (self.lane_id % 16) * self.c_cols + col_off
 
-        def _off(ti, tj):
-            return lane_base + fx.Int32((ti * 16 * self.c_cols + tj * 16) * 2)
+        def _off_e(ti, tj):
+            return lane_base_e + fx.Int32(ti * 16 * self.c_cols + tj * 16)
 
         def _xpose(ti, tj):
             A = Vec(c_frag[self.c_idx_fn(ti, tj)])
@@ -311,9 +339,23 @@ class StoreCPlain:
         # permlane16_swap->store RAW hazard (~80 exposed s_nop) is filled by independent
         # permlane work of later tiles instead of stalls.
         slots = [(ti, 2 * p) for ti in range_constexpr(nta) for p in range_constexpr(ntb // 2)]
+        # Read-backs first, then the cvt/permlane work, then the stores: the loads get
+        # the whole phase-1 shuffle to hide behind instead of stalling their own store.
+        prev = (
+            [
+                Vec(buffer_ops.buffer_load(rsrc, _off_e(ti, tj), vec_width=8, dtype=self.out_ty.ir_type))
+                for (ti, tj) in slots
+            ]
+            if const_expr(self.beta_is_one)
+            else []
+        )
         vecs = [_xpose(ti, tj) for (ti, tj) in slots]
-        for vec_out, (ti, tj) in zip(vecs, slots):
-            buffer_ops.buffer_store(vec_out, rsrc, _off(ti, tj), offset_is_bytes=True)
+        for n, (vec_out, (ti, tj)) in enumerate(zip(vecs, slots)):
+            if const_expr(self.beta_is_one):
+                # The packed value is already out_ty, so widen both sides and add in f32
+                # to keep the sum from rounding twice.
+                vec_out = (vec_out.to(fx.Float32) + prev[n].to(fx.Float32)).to(self.out_ty)
+            buffer_ops.buffer_store(vec_out, rsrc, _off_e(ti, tj) * 2, offset_is_bytes=True)
 
 
 # ── Scaled MFMA whole-loop emitter ───────────────────────────────────────────
@@ -926,10 +968,14 @@ def _build_mxfp4_gemm_kernel(
     ksplit: int = 1,
     taccw: bool = False,
     out_fp16: bool = False,
+    beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
 ):
     BLOCK_M = 256
     BLOCK_N = 256
     BLOCK_K = 256
+    # Split-K stores partials into a scratch row band that the host then reduces, so the
+    # accumulate belongs to that reduce, not to this store.
+    assert not (beta_is_one and ksplit > 1), "split-K accumulates in the host reduce, not the epilogue"
     # const_expr() resolves compile-time branches from LOCALS/params, not reliably from
     # module globals -> alias the per-shape epilogue selection to locals before traced use.
     _l_taccw = taccw  # autotune-selected per shape (never-regress epilogue variant axis)
@@ -1055,7 +1101,9 @@ def _build_mxfp4_gemm_kernel(
         # bf16/fp16 output: only the f32->out_ty cast in the store differs. Both the narrow
         # scalar store (generic ``.to``) and the wide TACCW store serve either dtype.
         _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
-        store_c = StoreCPlain(C, _c_store_rows, c_n, mfma.idx, N_TILES_A, N_TILES_BH, _out_ty)
+        store_c = StoreCPlain(
+            C, _c_store_rows, c_n, mfma.idx, N_TILES_A, N_TILES_BH, _out_ty, beta_is_one=beta_is_one
+        )
 
         wave_m_off = wave_m * (N_TILES_A * 16)  # 0 or 128
         wave_n_off = wave_n * (N_TILES_BH * 16)  # 0 or 64
@@ -1390,11 +1438,11 @@ def _autotune_mxfp4_config(M, N, K, args, out_fp16=False):
     for _wlv, _elgk in _wl_opts:
         for gm, gn, xcd in _mxfp4_swizzle_candidates(M, N, K):
             try:
-                at_key = (M, N, K, gm, xcd, gn, _wlv, _elgk, False, False, out_fp16)
+                at_key = (M, N, K, gm, xcd, gn, _wlv, _elgk, False, False, out_fp16, False)
                 entry = _MXFP4_AT_CACHE.get(at_key)
                 if entry is None:
                     raw = _get_mxfp4_fused_launch(K, gm, xcd, gn, _wlv, _elgk, coop=False, out_fp16=out_fp16)
-                    entry = [raw, flyc.compile(raw, *args)]
+                    entry = [raw, compile_with_scratch_out(raw, args)]
                     _MXFP4_AT_CACHE[at_key] = entry
                 compiled_cands.append(((gm, gn, xcd, _wlv, _elgk), entry[1]))
             except Exception:  # noqa: BLE001 -- a bad config must not break the GEMM
@@ -1445,16 +1493,16 @@ def _autotune_mxfp4_config(M, N, K, args, out_fp16=False):
     if _try_var:
         gm0, gn0, xcd0, w0, e0 = best[:5]
         try:
-            df_compiled = _MXFP4_AT_CACHE[(M, N, K, gm0, xcd0, gn0, w0, e0, False, False, out_fp16)][1]
+            df_compiled = _MXFP4_AT_CACHE[(M, N, K, gm0, xcd0, gn0, w0, e0, False, False, out_fp16, False)][1]
             variants = []  # (taccw, coop, compiled)
             for _cp, _tw in ((False, True), (True, False), (True, True)):
-                vkey = (M, N, K, gm0, xcd0, gn0, w0, e0, _tw, _cp, out_fp16)
+                vkey = (M, N, K, gm0, xcd0, gn0, w0, e0, _tw, _cp, out_fp16, False)
                 ventry = _MXFP4_AT_CACHE.get(vkey)
                 if ventry is None:
                     vraw = _get_mxfp4_fused_launch(
                         K, gm0, xcd0, gn0, w0, e0, taccw=_tw, coop=_cp, out_fp16=out_fp16
                     )
-                    ventry = [vraw, flyc.compile(vraw, *args)]
+                    ventry = [vraw, compile_with_scratch_out(vraw, args)]
                     _MXFP4_AT_CACHE[vkey] = ventry
                 variants.append((_tw, _cp, ventry[1]))
             for _ in range(5):  # warm every twin + the winner into the same L2/clock state
@@ -1517,7 +1565,9 @@ def _ksplit_candidates(M, N, K):
     return [1, *splits[-2:]]
 
 
-def _compile_mxfp4_fused(K, gm, xcd, gn, wlv=10, elgk=9, ksplit=1, taccw=False, coop=False, out_fp16=False):
+def _compile_mxfp4_fused(
+    K, gm, xcd, gn, wlv=10, elgk=9, ksplit=1, taccw=False, coop=False, out_fp16=False, beta_is_one=False
+):
     """Turbo/mxfp8-style fused @flyc.jit stub: ONE host dispatch enqueues the A scale
     preshuffle, the B scale preshuffle, then the NT GEMM on the same stream (no separate
     preshuffle launch, no CPU sync). The preshuffle kernels repack raw E8M0 (int32-viewed)
@@ -1537,6 +1587,7 @@ def _compile_mxfp4_fused(K, gm, xcd, gn, wlv=10, elgk=9, ksplit=1, taccw=False, 
         ksplit=ksplit,
         taccw=taccw,
         out_fp16=out_fp16,
+        beta_is_one=beta_is_one,
     )
     _PGRID = _MXFP4_PRESHUF_NG * _MXFP4_PRESHUF_BLK  # threads-per-block * fan-out
 
@@ -1577,17 +1628,27 @@ def _compile_mxfp4_fused(K, gm, xcd, gn, wlv=10, elgk=9, ksplit=1, taccw=False, 
 
 
 def _get_mxfp4_fused_launch(
-    K, gm, xcd, gn, wlv=10, elgk=9, ksplit=1, taccw=False, coop=False, out_fp16=False
+    K, gm, xcd, gn, wlv=10, elgk=9, ksplit=1, taccw=False, coop=False, out_fp16=False, beta_is_one=False
 ):
     # wlv/elgk pick the phase-barrier in-flight memory depth (autotuned per shape).
     # ksplit>1 compiles a K/ksplit slice kernel for few-tile large-K shapes.
     # coop/taccw are the never-regress scale-load / wide-store autotune axes.
     # out_fp16 selects the store cast dtype (fp16 vs bf16); fp16 implies taccw=False.
-    lk = (K, gm, xcd, gn, wlv, elgk, coop, ksplit, taccw, out_fp16)
+    lk = (K, gm, xcd, gn, wlv, elgk, coop, ksplit, taccw, out_fp16, beta_is_one)
     launch = _MXFP4_LAUNCH_CACHE.get(lk)
     if launch is None:
         launch = _compile_mxfp4_fused(
-            K, gm, xcd, gn, wlv=wlv, elgk=elgk, ksplit=ksplit, taccw=taccw, coop=coop, out_fp16=out_fp16
+            K,
+            gm,
+            xcd,
+            gn,
+            wlv=wlv,
+            elgk=elgk,
+            ksplit=ksplit,
+            taccw=taccw,
+            coop=coop,
+            out_fp16=out_fp16,
+            beta_is_one=beta_is_one,
         )
         _MXFP4_LAUNCH_CACHE[lk] = launch
     return launch
@@ -1711,6 +1772,8 @@ def gemm_mxfp4_flydsl_kernel(
     trans_b: bool = True,
     out_dtype: torch.dtype = torch.bfloat16,
     trans_c: bool = False,
+    beta: float = 0.0,
+    out: "torch.Tensor | None" = None,
 ) -> torch.Tensor:
     """MXFP4 (per-32-K E8M0 block-scaled) dense GEMM, gfx950 (4-wave whole-loop).
 
@@ -1729,13 +1792,21 @@ def gemm_mxfp4_flydsl_kernel(
     The whole-loop bare-asm body is an unroll-2 ping-pong that processes K in PAIRS
     of BLOCK_K=256. An odd number of 256-K blocks (K % 512 == 256) is handled by a
     single MFMA-only phase-A tail emitted after the hardware loop (see
-    ``call_mxfp4_wholeloop``'s ``ki``/tail path); the loop runs ``KI//2`` full pairs
+    ``call_mxfp4_wholeloop``'s ``ki``/tail path);     the loop runs ``KI//2`` full pairs
     and the trailing block is accumulated by the tail. K=256 (KI==1) omits the loop
     entirely and runs only the tail. No host-side K padding is required.
+
+    ``beta=1.0`` accumulates into ``out`` (``out += a @ b^T``) instead of overwriting it,
+    and therefore requires ``out``. It is incompatible with ``trans_c``, whose transpose
+    is a post-kernel copy.
     """
     assert a.dim() == 2 and b.dim() == 2, "a, b must be 2D"
     assert out_dtype in (torch.bfloat16, torch.float16), "mxfp4 FlyDSL store emits bf16/fp16"
     out_fp16 = out_dtype == torch.float16
+    assert not (beta == 1.0 and trans_c), (
+        "beta=1.0 cannot be combined with trans_c: the transpose is a post-kernel copy, "
+        "so the accumulation would land in a buffer the caller never sees."
+    )
     if not ((not trans_a) and trans_b):
         raise NotImplementedError(
             "mxfp4 FlyDSL GEMM is NT only (trans_a=False, trans_b=True); "
@@ -1762,7 +1833,8 @@ def gemm_mxfp4_flydsl_kernel(
     a_sp, b_sp = _get_mxfp4_scale_ws(M, N, K, a.device)
     a_raw = a_scale.contiguous().view(torch.int32).reshape(-1)
     b_raw = b_scale.contiguous().view(torch.int32).reshape(-1)
-    out = torch.empty((M, N), dtype=out_dtype, device=a.device)
+    out = resolve_accum_out(out, beta, (M, N), a.device, out_dtype)
+    beta_is_one = beta == 1.0
     # Keep the fp4 operands 2D (do NOT flatten): M*K/2 / N*K/2 exceed 2^31 int8s for
     # large M*K / N*K, which flydsl packs as an int32 dim (host CABI overflow). Both the
     # prologue G2S and the in-loop asm refill address off the rebased flat base
@@ -1773,15 +1845,37 @@ def gemm_mxfp4_flydsl_kernel(
     # Fused stub args: (A, B_T, C, A_raw, B_raw, A_scale_ws, B_scale_ws, c_m, c_n, stream).
     # C stays 2D (StoreCPlain re-bases per row band from C's base + c_n); a 1D M*N view
     # overflows the CABI for large M*N.
-    fused_args = (a8, b8, out, a_raw, b_raw, a_sp, b_sp, M, N, stream)
+    def _args_for(target):
+        return (a8, b8, target, a_raw, b_raw, a_sp, b_sp, M, N, stream)
 
-    def _exec_plain():
+    # Both autotunes launch the GEMM dozens of times. Against a beta=1 build that would
+    # fold every one of them into the caller's buffer, so tuning runs the beta=0 build
+    # into a scratch and only the final launch touches `out`. Allocated lazily: a warm
+    # cache never tunes and never needs it.
+    _tune_ws = []
+
+    def _tune_args():
+        if not beta_is_one:
+            return _args_for(out)
+        if not _tune_ws:
+            _tune_ws.append(torch.zeros_like(out))
+        return _args_for(_tune_ws[0])
+
+    def _tune_target():
+        return _tune_args()[2]
+
+    def _exec_plain(target=None, accum=False):
         # default one-WG-per-tile path (autotuned swizzle / pipe depth / scale-load / wide store).
-        gm, gn, xcd, _wlv, _elgk, _tw, _coop = _autotune_mxfp4_config(M, N, K, fused_args, out_fp16)
+        target = out if target is None else target
+        cfg = _MXFP4_CFG_CACHE.get((M, N, K, out_fp16))
+        if cfg is None:
+            cfg = _autotune_mxfp4_config(M, N, K, _tune_args(), out_fp16)
+        gm, gn, xcd, _wlv, _elgk, _tw, _coop = cfg
         launch = _get_mxfp4_fused_launch(
-            K, gm, xcd, gn, _wlv, _elgk, taccw=_tw, coop=_coop, out_fp16=out_fp16
+            K, gm, xcd, gn, _wlv, _elgk, taccw=_tw, coop=_coop, out_fp16=out_fp16, beta_is_one=accum
         )
-        at_key = (M, N, K, gm, xcd, gn, _wlv, _elgk, _tw, _coop, out_fp16)
+        at_key = (M, N, K, gm, xcd, gn, _wlv, _elgk, _tw, _coop, out_fp16, accum)
+        fused_args = _args_for(target)
         entry = _MXFP4_AT_CACHE.get(at_key)
         if entry is None:
             entry = [launch, None]
@@ -1791,12 +1885,12 @@ def gemm_mxfp4_flydsl_kernel(
             raw(*fused_args)
         else:
             if compiled is None:
-                compiled = flyc.compile(raw, *fused_args)
+                compiled = compile_with_scratch_out(raw, fused_args)
                 entry[1] = compiled
             compiled(*fused_args)
-        return out
+        return target
 
-    def _exec_split(ksplit):
+    def _exec_split(ksplit, target=None, accum=False):
         # split-K: grid x ksplit fills the CUs on few-tile large-K shapes. Each split writes
         # its K/ksplit partial into an out_dtype workspace[ksplit*M, N]; host sums the ksplit
         # row bands (BW-bound reduce, faster than an atomic-fused reduce for these shapes).
@@ -1816,10 +1910,15 @@ def gemm_mxfp4_flydsl_kernel(
             raw(*sk_args)
         else:
             if compiled is None:
-                compiled = flyc.compile(raw, *sk_args)
+                compiled = compile_with_scratch_out(raw, sk_args)
                 entry[1] = compiled
             compiled(*sk_args)
-        return ws.view(ksplit, M, N).sum(dim=0)
+        reduced = ws.view(ksplit, M, N).sum(dim=0)
+        if accum:
+            # The splits went to a scratch, so the epilogue could not accumulate; the
+            # reduce pass this path already runs absorbs it for free.
+            return (out if target is None else target).add_(reduced)
+        return reduced
 
     # ── Choose ksplit: cached timed pick > timed autotune.
     # The autotune times {plain, split+reduce} end-to-end on the real operands and takes the
@@ -1851,14 +1950,15 @@ def gemm_mxfp4_flydsl_kernel(
                 return best
 
             times = {}
+            tgt = _tune_target()
             for s in cands:
                 try:
-                    fn = _exec_plain if s == 1 else (lambda s=s: _exec_split(s))
+                    fn = (lambda: _exec_plain(tgt)) if s == 1 else (lambda s=s: _exec_split(s, tgt))
                     times[s] = _bench(fn)
                 except Exception:  # noqa: BLE001 -- a bad variant must not break the GEMM
                     continue
             ks = min(times, key=times.get) if times else 1
             _MXFP4_KSPLIT_CACHE[(M, N, K, out_fp16)] = ks
 
-    out2 = _exec_split(ks) if ks > 1 else _exec_plain()
+    out2 = _exec_split(ks, out, beta_is_one) if ks > 1 else _exec_plain(out, beta_is_one)
     return out2.t().contiguous() if trans_c else out2

--- a/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -37,6 +37,7 @@ Built on the dense kernel's primitives; see gemm_fp8_kernel.py for the K-loop /
 K-tail / barrier rationale (identical here).
 """
 
+import functools
 import os
 from collections import namedtuple
 
@@ -66,6 +67,7 @@ from primus_turbo.flydsl.utils.gemm_helper import (
     make_fp8_buffer_tensor_rebased,
     make_value_attrs,
     mask_a_tail,
+    resolve_accum_out,
     wait_barrier,
     xcd_remap_pid,
 )
@@ -110,12 +112,26 @@ def _build_mfma(N_TILES_A, N_TILES_B, cbsz, blgp, asm_mode=None):
 
 
 def _store_quadrants(store_c, c00, c01, c10, c11, base_row, base_col, LDS_BLOCK_M, LDS_BLOCK_N):
-    """Store the four output quadrants (shared by all 6 kernels; base_row/base_col are
-    computed per-kernel by the caller)."""
-    store_c.store(c00, base_row + 0, base_col + 0)
-    store_c.store(c01, base_row + 0, base_col + LDS_BLOCK_N)
-    store_c.store(c10, base_row + LDS_BLOCK_M, base_col + 0)
-    store_c.store(c11, base_row + LDS_BLOCK_M, base_col + LDS_BLOCK_N)
+    """Store the four accumulator quadrants at their (row, col) sub-tile offsets.
+
+    A beta=1 epilogue read-back is software-pipelined by one quadrant: quadrant i+1's
+    loads go out before quadrant i stores, so they overlap without keeping all four
+    quadrants' worth of loaded values live at once. The 4-wave wgrad runs at occupancy
+    1, so it has neither a co-resident wave to hide the latency nor the registers to
+    spare for prefetching everything up front.
+    """
+    quads = (
+        (c00, base_row + 0, base_col + 0),
+        (c01, base_row + 0, base_col + LDS_BLOCK_N),
+        (c10, base_row + LDS_BLOCK_M, base_col + 0),
+        (c11, base_row + LDS_BLOCK_M, base_col + LDS_BLOCK_N),
+    )
+    nxt = store_c.prefetch(quads[0][1], quads[0][2])
+    for i, (frag, r, c) in enumerate(quads):
+        cur = nxt
+        if i + 1 < len(quads):
+            nxt = store_c.prefetch(quads[i + 1][1], quads[i + 1][2])
+        store_c.store(frag, r, c, prev=cur)
 
 
 # ── PERSISTENT grouped NN dgrad: a fixed grid of num_sms WGs strides the tile space
@@ -1133,6 +1149,7 @@ def _compile_grouped_tn_wgrad_masked(
     # ceildiv(k_iters,chunk) x inner range_constexpr(chunk) of the 4-buffer body; even
     # chunk resets the ping-pong at the boundary; over-run is SRD-clamped (no host cap).
     i64_traverse: bool = False,  # A[m,OUT_M] & B[m,OUT_N] traversal via per-load i64 SRD re-base (lifts mg*OUT < 2^32 cap)
+    beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
 ):
     """Masked grouped TN wgrad: a CAPACITY-FREE chunked K-loop (outer runtime
     scf.for over ceildiv(k_iters,chunk) x inner range_constexpr(chunk) of the
@@ -1258,10 +1275,20 @@ def _compile_grouped_tn_wgrad_masked(
                 _out_ty,
                 lds.C_lds_shuffle,
                 wave_id,
+                beta_is_one=beta_is_one,
             )
         else:
             store_c = StoreCPerTensor(
-                A_scale, B_scale, C, (group_idx + 1) * OUT_M, OUT_N, mfma.idx, N_TILES_A, N_TILES_B, _out_ty
+                A_scale,
+                B_scale,
+                C,
+                (group_idx + 1) * OUT_M,
+                OUT_N,
+                mfma.idx,
+                N_TILES_A,
+                N_TILES_B,
+                _out_ty,
+                beta_is_one=beta_is_one,
             )
 
         # index (i64) so A0_off + (k+2)*AM doesn't truncate to i32 when the per-group
@@ -1838,6 +1865,7 @@ def _compile_grouped_tn_wgrad_persistent(
     unroll_n: int = -1,  # >=2: continuous-N chunk-unroll (dense-pipeline, capacity-free); -1 = use module env default
     cap_cu: int = -1,  # >0 caps grid to this many WGs (reserve CUs for comm overlap)
     i64_traverse: bool = False,  # A[m,OUT_M] & B[m,OUT_N] traversal via per-load i64 SRD re-base (lifts mg*OUT < 2^32 cap)
+    beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
 ):
     """PERSISTENT grouped TN wgrad (the production wgrad; fwd/dgrad are persistent
     so wgrad must be too). grid = min(G*TILES_PER_GROUP, num_cus); each WG
@@ -2060,6 +2088,7 @@ def _compile_grouped_tn_wgrad_persistent(
                     _out_ty,
                     lds.C_lds_shuffle,
                     wave_id,
+                    beta_is_one=beta_is_one,
                 )
             else:
                 store_c = StoreCPerTensor(
@@ -2072,6 +2101,7 @@ def _compile_grouped_tn_wgrad_persistent(
                     N_TILES_A,
                     N_TILES_B,
                     _out_ty,
+                    beta_is_one=beta_is_one,
                 )
             c00 = [Vec(fx.memref_load_vec(r)) for r in acc00]
             c01 = [Vec(fx.memref_load_vec(r)) for r in acc01]
@@ -2601,6 +2631,7 @@ def _wave4_do_tile_tn(
     lds,
     _cm,
     _cn,
+    beta_is_one=False,
 ):
     tt = xcd_remap_pid(t, TOTAL, num_xcd)
     group_idx, block_m, block_n = _wgrad_block_mn(
@@ -2682,6 +2713,7 @@ def _wave4_do_tile_tn(
             N_TILES_A,
             N_TILES_B,
             _out_ty,
+            beta_is_one=beta_is_one,
         )
     else:
         store_c = StoreCPerTensorCShuffle(
@@ -2697,6 +2729,7 @@ def _wave4_do_tile_tn(
             lds.C_lds_shuffle,
             wave_id,
             row_pad=4,  # must match epi_pad in _wave4_geometry's C_lds_shuffle sizing (cshuf_n)
+            beta_is_one=beta_is_one,
         )
     _common = dict(
         a_g2s=a_g2s,
@@ -2821,6 +2854,7 @@ def _compile_grouped_tn_wgrad_4wave(
     group_n: int = 0,
     vmcnt_hint: int = 2,
     cap_cu: int = -1,
+    beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
 ):
     """4-wave (occ=1) grouped TN wgrad dW[g]=A[g]^T@B[g], variable-K per group. 256x256
     whole-loop bare-asm body: runtime nval (floored to x6) + in-asm fused tail; partial
@@ -2946,6 +2980,7 @@ def _compile_grouped_tn_wgrad_4wave(
                 lds=lds,
                 _cm=_cm,
                 _cn=_cn,
+                beta_is_one=beta_is_one,
             )
 
         # Persistent: a fixed grid of <=ncus WGs strides the tile space (scf.for).
@@ -2992,9 +3027,11 @@ def _wgrad_compile_cfg(
     unroll_n=-1,
     cap_cu=-1,
     i64_traverse=False,
+    beta_is_one=False,
 ):
     """Compile (or cache-hit) an asm_mma wgrad for one config."""
     ck = (
+        "persist",
         OUT_M,
         OUT_N,
         G,
@@ -3007,6 +3044,7 @@ def _wgrad_compile_cfg(
         unroll_n,
         cap_cu,
         i64_traverse,
+        beta_is_one,
     )
     l = _GROUPED_WGRAD_LAUNCH_CACHE.get(ck)
     if l is None:
@@ -3027,14 +3065,17 @@ def _wgrad_compile_cfg(
             unroll_n=unroll_n,
             cap_cu=cap_cu,
             i64_traverse=i64_traverse,
+            beta_is_one=beta_is_one,
         )
         _GROUPED_WGRAD_LAUNCH_CACHE[ck] = l
     return l
 
 
-def _wgrad_masked_cfg(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, chunk, group_m, num_xcd, i64_traverse=False):
+def _wgrad_masked_cfg(
+    OUT_M, OUT_N, G, out_fp16, cbsz, blgp, chunk, group_m, num_xcd, i64_traverse=False, beta_is_one=False
+):
     """Compile (or cache-hit) the masked chunked wgrad for one (chunk, group_m, num_xcd)."""
-    ck = (OUT_M, OUT_N, G, out_fp16, cbsz, blgp, chunk, group_m, num_xcd, i64_traverse)
+    ck = ("masked", OUT_M, OUT_N, G, out_fp16, cbsz, blgp, chunk, group_m, num_xcd, i64_traverse, beta_is_one)
     l = _GROUPED_WGRAD_LAUNCH_CACHE.get(ck)
     if l is None:
         l = _compile_grouped_tn_wgrad_masked(
@@ -3051,6 +3092,28 @@ def _wgrad_masked_cfg(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, chunk, group_m, num
             store_cshuffle=True,
             chunk=chunk,
             i64_traverse=i64_traverse,
+            beta_is_one=beta_is_one,
+        )
+        _GROUPED_WGRAD_LAUNCH_CACHE[ck] = l
+    return l
+
+
+def _wgrad_4wave_cfg(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, group_m, group_n, num_xcd, beta_is_one=False):
+    """Compile (or cache-hit) the 4-wave whole-loop wgrad for one (group_m, group_n, num_xcd)."""
+    ck = ("4wave", OUT_M, OUT_N, G, out_fp16, cbsz, blgp, group_m, group_n, num_xcd, beta_is_one)
+    l = _GROUPED_WGRAD_LAUNCH_CACHE.get(ck)
+    if l is None:
+        l = _compile_grouped_tn_wgrad_4wave(
+            OUT_M=OUT_M,
+            OUT_N=OUT_N,
+            G=G,
+            out_fp16=out_fp16,
+            cbsz=cbsz,
+            blgp=blgp,
+            num_xcd=num_xcd,
+            group_m=group_m,
+            group_n=group_n,
+            beta_is_one=beta_is_one,
         )
         _GROUPED_WGRAD_LAUNCH_CACHE[ck] = l
     return l
@@ -3066,12 +3129,18 @@ _WGRAD_4WAVE_CANDS_LONG_BASE = ((8, 4, 4), (4, 4, 8))  # M_total>4096
 def _autotune_wgrad_dispatch(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, args, short, i64_traverse=False):
     """Race the wgrad candidates on synthetic balanced tensors at the live tokens/group and
     cache per static (OUT_M,OUT_N,G,dtype,short,i64), never per m_total. short -> persistent
-    8-wave pool; long -> masked ref + full 4-wave pool. cands[0] is the correctness ref."""
+    8-wave pool; long -> masked ref + full 4-wave pool. cands[0] is the correctness ref.
+
+    Returns a ``make(beta_is_one) -> launch`` factory rather than a launch: the race
+    always runs the beta=0 build into a scratch C, because a beta=1 build would fold
+    every warmup and timing iteration into the caller's accumulation buffer.
+    """
 
     lhs_live, rhs_live = args[0], args[1]
     M_total = lhs_live.shape[0]
     pms = (max(1, M_total // G),)
     mps = []
+    bench_c = torch.empty_like(args[2])
     for pm in pms:
         M_c = G * pm
         lhs_c = (torch.randn((M_c, OUT_M), device=lhs_live.device) * 0.1).to(lhs_live.dtype)
@@ -3079,8 +3148,8 @@ def _autotune_wgrad_dispatch(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, args, short,
         offs_c = _balanced_group_offs(M_c, G, lhs_live.device)
         mps.append(
             [
-                (lhs_c.view(torch.int8), rhs_c.view(torch.int8), args[2], args[3], args[4], offs_c, args[6]),
-                args[2],
+                (lhs_c.view(torch.int8), rhs_c.view(torch.int8), bench_c, args[3], args[4], offs_c, args[6]),
+                bench_c,
                 None,
                 None,
             ]
@@ -3088,23 +3157,47 @@ def _autotune_wgrad_dispatch(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, args, short,
 
     if short:
         cands = [
-            _wgrad_compile_cfg(
-                OUT_M, OUT_N, G, out_fp16, cbsz, blgp, 8, 4, 0, unroll_n=4, i64_traverse=i64_traverse
-            ),
-            _wgrad_compile_cfg(
-                OUT_M, OUT_N, G, out_fp16, cbsz, blgp, 8, 4, 8, unroll_n=4, i64_traverse=i64_traverse
-            ),
+            functools.partial(
+                _wgrad_compile_cfg,
+                OUT_M,
+                OUT_N,
+                G,
+                out_fp16,
+                cbsz,
+                blgp,
+                8,
+                4,
+                gn,
+                unroll_n=4,
+                i64_traverse=i64_traverse,
+            )
+            for gn in (0, 8)
         ]
     else:
         # Single masked candidate: 4-wave wins essentially every long-contraction shape
         # in the measured grid, so the masked pool's only real job here is the
         # correctness reference + fallback, not winning the race. chunk=8/group_m=4 is
         # the stronger of the two previously-raced masked configs.
-        cands = [_wgrad_masked_cfg(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, 8, 4, 8, i64_traverse=i64_traverse)]
+        cands = [
+            functools.partial(
+                _wgrad_masked_cfg,
+                OUT_M,
+                OUT_N,
+                G,
+                out_fp16,
+                cbsz,
+                blgp,
+                8,
+                4,
+                8,
+                i64_traverse=i64_traverse,
+            )
+        ]
 
     prod = cands[0]  # correctness reference + fallback
+    prod_l = prod(beta_is_one=False)
     for mp in mps:  # establish the per-M numeric reference from prod
-        prod(*mp[0])
+        prod_l(*mp[0])
         torch.cuda.synchronize()
         o = mp[1]
         if not torch.isfinite(o.view(-1)[:1024].float()).all().item():
@@ -3125,32 +3218,22 @@ def _autotune_wgrad_dispatch(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, args, short,
             prodt *= _robust_time(launch, targs)
         return prodt ** (1.0 / len(mps))
 
-    best_l, best_s = prod, _score(prod)
-    for l in cands[1:]:  # same-family pool: 1.5% hysteresis (geomean)
-        s = _score(l)
+    best_mk, best_s = prod, _score(prod_l)
+    for mk in cands[1:]:  # same-family pool: 1.5% hysteresis (geomean)
+        s = _score(mk(beta_is_one=False))
         if s is not None and s < best_s * 0.985:
-            best_l, best_s = l, s
+            best_mk, best_s = mk, s
 
     if short:
         wave4_cands = _WGRAD_4WAVE_CANDS_SHORT
     else:
         wave4_cands = _WGRAD_4WAVE_CANDS_LONG_BASE + ((0, 0, 2), (4, 16, 8))
     for gm, gn, xcd in wave4_cands:
-        l = _compile_grouped_tn_wgrad_4wave(
-            OUT_M=OUT_M,
-            OUT_N=OUT_N,
-            G=G,
-            out_fp16=out_fp16,
-            cbsz=cbsz,
-            blgp=blgp,
-            num_xcd=xcd,
-            group_m=gm,
-            group_n=gn,
-        )
-        s = _score(l)  # numeric guard folded in: None -> skip
+        mk = functools.partial(_wgrad_4wave_cfg, OUT_M, OUT_N, G, out_fp16, cbsz, blgp, gm, gn, xcd)
+        s = _score(mk(beta_is_one=False))  # numeric guard folded in: None -> skip
         if s is not None and s < best_s * 0.985:
-            best_l, best_s = l, s
-    return best_l
+            best_mk, best_s = mk, s
+    return best_mk
 
 
 def grouped_gemm_fp8_variable_k_tensorwise_flydsl_kernel(
@@ -3161,6 +3244,8 @@ def grouped_gemm_fp8_variable_k_tensorwise_flydsl_kernel(
     group_offs: "torch.Tensor",
     out_dtype=torch.bfloat16,
     num_cu: "int | None" = -1,
+    beta: float = 0.0,
+    out: "torch.Tensor | None" = None,
 ) -> "torch.Tensor":
     """FlyDSL per-tensor variable-K grouped fp8 GEMM (wgrad), matching the
     Triton variable-K entry.
@@ -3169,6 +3254,9 @@ def grouped_gemm_fp8_variable_k_tensorwise_flydsl_kernel(
     lhs [M_total, OUT_M] fp8, rhs [M_total, OUT_N] fp8, out [G, OUT_M, OUT_N].
     lhs_scale/rhs_scale scalar fp32; group_offs [G+1] int. The caller (backend)
     has already applied the trans_c lhs/rhs swap.
+
+    ``beta=1.0`` accumulates into ``out`` (``out += lhs^T @ rhs`` per group) in the
+    epilogue instead of overwriting it, and therefore requires ``out``.
     """
     assert lhs.ndim == 2 and rhs.ndim == 2
     assert lhs.shape[0] == rhs.shape[0], f"M_total mismatch lhs={lhs.shape[0]} rhs={rhs.shape[0]}"
@@ -3176,7 +3264,8 @@ def grouped_gemm_fp8_variable_k_tensorwise_flydsl_kernel(
     OUT_N = rhs.shape[1]
     G = group_offs.shape[0] - 1
 
-    out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)
+    out = resolve_accum_out(out, beta, (G, OUT_M, OUT_N), lhs.device, out_dtype)
+    beta_is_one = beta == 1.0
     # kernel reads group_offs as int64 low-words via a free int32-view (no .to(int32) cast).
     _go64 = group_offs if group_offs.dtype == torch.int64 else group_offs.to(torch.int64)
     go32 = _go64.view(torch.int32)
@@ -3198,11 +3287,14 @@ def grouped_gemm_fp8_variable_k_tensorwise_flydsl_kernel(
     at_key = (OUT_M, OUT_N, G, out_fp16, cbsz, blgp, short, i64_tr)
     # out as 2D [G*OUT_M, OUT_N] (the kernel's stacked-group view).
     wargs = (lhs_i8, rhs_i8, out.view(G * OUT_M, OUT_N), lsf, rsf, go32, stream)
-    launch = _GROUPED_WGRAD_AT_CACHE.get(at_key)
-    if launch is None:
-        launch = _autotune_wgrad_dispatch(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, wargs, short, i64_tr)
-        _GROUPED_WGRAD_AT_CACHE[at_key] = launch
-    launch(*wargs)
+    # The cached entry is the winning config, not a launch: the beta=0 and beta=1
+    # builds share a config but not a compiled kernel, and the race only ever runs
+    # the beta=0 one (see _autotune_wgrad_dispatch).
+    make_launch = _GROUPED_WGRAD_AT_CACHE.get(at_key)
+    if make_launch is None:
+        make_launch = _autotune_wgrad_dispatch(OUT_M, OUT_N, G, out_fp16, cbsz, blgp, wargs, short, i64_tr)
+        _GROUPED_WGRAD_AT_CACHE[at_key] = make_launch
+    make_launch(beta_is_one=beta_is_one)(*wargs)
     return out
 
 

--- a/primus_turbo/flydsl/utils/gemm_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_helper.py
@@ -32,6 +32,42 @@ def ceildiv(a: int, b: int) -> int:
     return (a + b - 1) // b
 
 
+def resolve_accum_out(out, beta, shape, device, out_dtype):
+    """Validate an optional caller-owned ``out``, or allocate one.
+
+    ``beta=0.0`` overwrites and is the default; ``beta=1.0`` makes the epilogue
+    accumulate, which only works against a buffer the caller supplies. The store
+    paths bake a 2-byte element into their address arithmetic, so an accumulate
+    target has to be 16-bit and contiguous -- a non-contiguous ``out`` would be
+    silently replaced by a ``.contiguous()`` copy and the accumulation would land
+    nowhere the caller can see.
+    """
+    assert beta in (0.0, 1.0), f"Only beta=0 (overwrite) or beta=1 (accumulate) supported, got {beta}"
+    if out is None:
+        assert beta == 0.0, "beta=1.0 requires an explicit `out` buffer to accumulate into"
+        return torch.empty(shape, device=device, dtype=out_dtype)
+    assert tuple(out.shape) == tuple(shape), f"out shape {tuple(out.shape)} must equal {tuple(shape)}"
+    assert out.dtype in (torch.bfloat16, torch.float16), (
+        f"FlyDSL accumulate epilogue writes bf16/fp16; got out dtype {out.dtype}"
+    )
+    assert out.dtype == out_dtype, f"out dtype {out.dtype} must match out_dtype {out_dtype}"
+    assert out.device == device, "out must be on the same device as the inputs"
+    assert out.is_contiguous(), "out must be contiguous to accumulate in place"
+    return out
+
+
+def compile_with_scratch_out(launch, args, out_index=2):
+    """``flyc.compile`` the launch, with the output argument pointed at a scratch buffer.
+
+    Compilation builds its artifact by running the kernel once (see ``_compile_impl``),
+    which an accumulate (beta=1) build would fold into the caller's buffer as a second
+    GEMM. The artifact is keyed on shapes, not pointers, so compiling against a scratch
+    of the same shape and then calling it on the real buffer runs exactly once.
+    """
+    scratch = torch.zeros_like(args[out_index])
+    return flyc.compile(launch, *args[:out_index], scratch, *args[out_index + 1 :])
+
+
 _PRESHUF_KT = 16  # scale-preshuffle k-tile (rows*KT dwords staged in LDS per workgroup)
 
 
@@ -514,10 +550,26 @@ class StoreCPerTensor:
     re-based per row band in 64-bit index (int64-safe, M*N > 4GB) via
     ``make_row_band_resource``; columns past c_cols clamp to an OOB index (HW SRD
     drop). out_ty bf16/fp16; pass C as 2D so its shape packs within int32.
+
+    ``beta_is_one`` turns the store into an accumulate (``C = C + acc``): each
+    element is read back through the same band SRD, widened to f32 and added
+    before the single rounding to out_ty. Masked-out lanes read OOB (0) and
+    their store is dropped, so the read-back needs no extra bounds logic.
     """
 
     def __init__(
-        self, A_scale, B_scale, C, c_rows, c_cols, c_idx_fn, n_tiles_a, n_tiles_b, out_ty, elem_fn=None
+        self,
+        A_scale,
+        B_scale,
+        C,
+        c_rows,
+        c_cols,
+        c_idx_fn,
+        n_tiles_a,
+        n_tiles_b,
+        out_ty,
+        elem_fn=None,
+        beta_is_one=False,
     ):
         self.c_rows = c_rows
         self.c_cols = c_cols
@@ -526,6 +578,7 @@ class StoreCPerTensor:
         self.n_tiles_a = n_tiles_a
         self.n_tiles_b = n_tiles_b
         self.out_ty = out_ty
+        self.beta_is_one = beta_is_one
         # Optional f32->f32 epilogue node chain (bias/act), post-scale pre-cast.
         self.elem_fn = elem_fn
         self.scaled = A_scale is not None
@@ -542,23 +595,54 @@ class StoreCPerTensor:
         fx.copy(self.scale_atom_1, fx.slice(div, (None, fx.Int32(0))), self.reg_f32_1)
         return Vec(fx.memref_load_vec(self.reg_f32_1))[0]
 
-    def store(self, c_frag, base_row, base_col):
-        scale = self._load_scalar(self.sa_div) * self._load_scalar(self.sb_div) if self.scaled else None
-        # buffer_store row-band path (int64-safe); the band SRD is pinned to SGPRs inside.
-        rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
+    def _addresses(self, base_col):
+        """(element offset, column-valid) per (ti, tj, i), in store order."""
+        out = []
         for ti in range_constexpr(self.n_tiles_a):
             row_local = ti * 16 + (self.lane_id // 16) * 4  # relative to base_row
             for tj in range_constexpr(self.n_tiles_b):
                 col = base_col + tj * 16 + self.lane_id % 16
                 col_valid = col < self.c_cols
+                for i in range_constexpr(4):
+                    out.append(((row_local + i) * self.c_cols + col, col_valid))
+        return out
+
+    def prefetch(self, base_row, base_col):
+        """Issue this sub-tile's beta=1 read-back; returns the handle ``store`` consumes.
+
+        Kept separate from ``store`` so a caller writing several sub-tiles (see
+        ``_store_quadrants``) can put every load in flight before the first store waits
+        on one -- the epilogue is latency-bound otherwise, not bandwidth-bound.
+        """
+        if not const_expr(self.beta_is_one):
+            return None
+        rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
+        return [
+            _buffer_ops.buffer_load(rsrc, off_e, vec_width=1, dtype=self.out_ty.ir_type, mask=valid)
+            for off_e, valid in self._addresses(base_col)
+        ]
+
+    def store(self, c_frag, base_row, base_col, prev=None):
+        scale = self._load_scalar(self.sa_div) * self._load_scalar(self.sb_div) if self.scaled else None
+        # buffer_store row-band path (int64-safe); the band SRD is pinned to SGPRs inside.
+        rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
+        addrs = self._addresses(base_col)
+        if const_expr(self.beta_is_one) and prev is None:
+            prev = self.prefetch(base_row, base_col)
+        n = 0
+        for ti in range_constexpr(self.n_tiles_a):
+            for tj in range_constexpr(self.n_tiles_b):
                 vec_f32 = Vec(c_frag[self.c_idx_fn(ti, tj)])
                 for i in range_constexpr(4):
+                    off_e, col_valid = addrs[n]
                     val = vec_f32[i] * scale if self.scaled else vec_f32[i]
                     if self.elem_fn is not None:
                         val = self.elem_fn(val)  # bias/act epilogue node chain
+                    if const_expr(self.beta_is_one):
+                        val = val + self.out_ty(prev[n]).to(fx.Float32)  # add in f32: one rounding
                     val = val.to(self.out_ty)
-                    off = ((row_local + i) * self.c_cols + col) * 2  # i32-small within band
-                    _buffer_ops.buffer_store(val, rsrc, off, mask=col_valid, offset_is_bytes=True)
+                    _buffer_ops.buffer_store(val, rsrc, off_e * 2, mask=col_valid, offset_is_bytes=True)
+                    n += 1
 
 
 class StoreCPerTensorCShuffle:
@@ -567,7 +651,10 @@ class StoreCPerTensorCShuffle:
     re-reads it N-contiguous, and emits one vectorized 128b global store per lane
     (vs 128 column-strided scalar buffer_store_short). Assumes BLOCK_N=256 (EPL=8
     out_ty/lane=128b) and c_cols % Cc == 0, base_col % Cc == 0 (true for FFN N dims);
-    invalid runs clamp to an OOB element index (HW SRD drop), as the scalar path does."""
+    invalid runs clamp to an OOB element index (HW SRD drop), as the scalar path does.
+
+    ``beta_is_one`` turns the store into an accumulate (``C = C + acc``) by loading
+    the same 128b run back before storing it; see ``store``."""
 
     def __init__(
         self,
@@ -583,6 +670,7 @@ class StoreCPerTensorCShuffle:
         c_lds,
         wave_id,
         row_pad=0,
+        beta_is_one=False,
     ):
         self.c_rows = c_rows
         self.c_cols = c_cols
@@ -592,6 +680,7 @@ class StoreCPerTensorCShuffle:
         self.n_tiles_a = n_tiles_a
         self.n_tiles_b = n_tiles_b
         self.out_ty = out_ty
+        self.beta_is_one = beta_is_one
         self.Cc = n_tiles_b * 16  # columns in one 16-row shuffle tile
         self.EPL = (16 * self.Cc) // 64  # out_ty elements each lane re-reads (16*Cc rows/cols / 64 lanes)
         # One coalesced global store is 128 bits = 8 x 16b (buffer_store_dwordx4). If a
@@ -628,13 +717,67 @@ class StoreCPerTensorCShuffle:
         fx.copy(self.scale_atom_1, fx.slice(div, (None, fx.Int32(0))), self.reg_f32_1)
         return Vec(fx.memref_load_vec(self.reg_f32_1))[0]
 
-    def store(self, c_frag, base_row, base_col):
+    def _band(self, base_row, ti, cols_i, rows_i, out_b):
+        """Output SRD re-based (i64) at the 16-row band this sub-tile writes."""
+        band_row = arith.index_cast(T.index, base_row + ti * 16)
+        row_c = arith.minui(band_row, rows_i)
+        band_base = self.c_base + row_c * cols_i * arith.index(out_b)
+        nrec = arith.minui((rows_i - row_c) * cols_i * arith.index(out_b), arith.index(0x7FFFFFFF))
+        band_base_i64 = _readfirstlane_i32(arith.index_cast(T.i64, band_base))
+        nrec_pinned = arith.index_cast(T.index, _readfirstlane_i32(arith.index_cast(T.i64, nrec)))
+        return _buffer_ops.create_buffer_resource_from_addr(band_base_i64, num_records_bytes=nrec_pinned)
+
+    def _runs(self, base_col):
+        """(sub-run column offset, global column, valid) per 128b run, in store order."""
+        row_in = (self.lane_id * self.EPL) // self.Cc
+        col0 = (self.lane_id * self.EPL) % self.Cc
+        runs = []
+        for sub in range_constexpr(self.EPL // self.elems_per_store):
+            col_in = col0 + sub * self.elems_per_store
+            gcol = base_col + col_in
+            runs.append((col_in, gcol, (gcol + fx.Int32(self.elems_per_store)) <= self.c_cols))
+        return row_in, runs
+
+    def prefetch(self, base_row, base_col):
+        """Issue this sub-tile's beta=1 read-back; returns the handle ``store`` consumes.
+
+        The addresses depend only on base_row/base_col, so the loads can go out before
+        the LDS staging runs -- and, via ``_store_quadrants``, before any other
+        sub-tile's store waits on one. A sub-tile only has n_tiles_a runs of them, which
+        is far too few to cover HBM latency on its own.
+        """
+        if not const_expr(self.beta_is_one):
+            return None
+        cols_i = _as_index(self.c_cols)
+        rows_i = _as_index(self.c_rows)
+        row_in, runs = self._runs(base_col)
+        prev = []
+        for ti in range_constexpr(self.n_tiles_a):
+            rsrc_i = self._band(base_row, ti, cols_i, rows_i, 2)
+            for _col_in, gcol, valid in runs:
+                prev.append(
+                    Vec(
+                        _buffer_ops.buffer_load(
+                            rsrc_i,
+                            row_in * self.c_cols + gcol,
+                            vec_width=self.elems_per_store,
+                            dtype=self.out_ty.ir_type,
+                            mask=valid,
+                        )
+                    )
+                )
+        return prev
+
+    def store(self, c_frag, base_row, base_col, prev=None):
         scale = self._load_scalar(self.sa_div) * self._load_scalar(self.sb_div)
         lds_base = fx.Int32(fx.ptrtoint(self.c_lds.ptr))
         wave_off = self.wave_id * self.wave_lds_elems  # element offset of this wave's region
         out_b = 2  # bf16/fp16 = 2 bytes
         cols_i = _as_index(self.c_cols)
         rows_i = _as_index(self.c_rows)
+        if const_expr(self.beta_is_one) and prev is None:
+            prev = self.prefetch(base_row, base_col)
+        n = 0
         for ti in range_constexpr(self.n_tiles_a):
             # --- stage this 16-row sub-tile row-major into the per-wave LDS region ---
             for tj in range_constexpr(self.n_tiles_b):
@@ -649,24 +792,19 @@ class StoreCPerTensorCShuffle:
             S2RLoaderTr._wait_lgkmcnt(0)
             # Re-base output at this 16-row band (i64), re-read N-contiguous (one EPL-col
             # run/lane) + one 128b store at a small in-band i32 offset; band num_records OOB-drops.
-            band_row = arith.index_cast(T.index, base_row + ti * 16)
-            row_c = arith.minui(band_row, rows_i)
-            band_base = self.c_base + row_c * cols_i * arith.index(out_b)
-            nrec = arith.minui((rows_i - row_c) * cols_i * arith.index(out_b), arith.index(0x7FFFFFFF))
-            band_base_i64 = _readfirstlane_i32(arith.index_cast(T.i64, band_base))
-            nrec_pinned = arith.index_cast(T.index, _readfirstlane_i32(arith.index_cast(T.i64, nrec)))
-            rsrc = _buffer_ops.create_buffer_resource_from_addr(band_base_i64, num_records_bytes=nrec_pinned)
-            row_in = (self.lane_id * self.EPL) // self.Cc
-            col0 = (self.lane_id * self.EPL) % self.Cc
-            for sub in range_constexpr(self.EPL // self.elems_per_store):
-                col_in = col0 + sub * self.elems_per_store
+            rsrc = self._band(base_row, ti, cols_i, rows_i, out_b)
+            row_in, runs = self._runs(base_col)
+            for col_in, gcol, valid in runs:
                 lane_e = wave_off + row_in * self.row_stride + col_in
                 rptr = fx.inttoptr(self._read_ptr_t, lds_base + lane_e * 2)
                 vec = fx.make_view(rptr, fx.make_layout(self.elems_per_store, 1)).load()
-                gcol = base_col + col_in
-                valid = (gcol + fx.Int32(self.elems_per_store)) <= self.c_cols
-                off = (row_in * self.c_cols + gcol) * out_b  # i32-small within band
-                _buffer_ops.buffer_store(vec, rsrc, off, mask=valid, offset_is_bytes=True)
+                off_e = row_in * self.c_cols + gcol  # elements, i32-small within band
+                if const_expr(self.beta_is_one):
+                    # The staged value is already rounded to out_ty, so the add runs in
+                    # f32 to keep the sum from rounding a second time in the narrow type.
+                    vec = (vec.to(fx.Float32) + prev[n].to(fx.Float32)).to(self.out_ty)
+                    n += 1
+                _buffer_ops.buffer_store(vec, rsrc, off_e * out_b, mask=valid, offset_is_bytes=True)
             S2RLoaderTr._wait_lgkmcnt(0)  # drain re-read before next ti overwrites LDS
 
 

--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
@@ -77,6 +77,8 @@ class GEMMFP4HipBLASLtBackend(KernelBackend):
         trans_c: bool,
         granularity: ScalingGranularity,
         preshuffled: bool = False,
+        inplace_add_to_out: bool = False,
+        **kwargs,
     ) -> bool:
         # HipBLASLt vendor wrapper has no preshuffle plumbing (see
         # csrc/kernels/gemm/hipblaslt_gemm.cu) and would silently produce
@@ -85,6 +87,8 @@ class GEMMFP4HipBLASLtBackend(KernelBackend):
             return False
 
         supported = True
+        # TODO: this backend has no beta=1 accumulate epilogue yet.
+        supported &= not inplace_add_to_out
         supported &= not is_gfx942()
         # check ScalingGranularity
         supported &= granularity in GEMMFP4HipBLASLtBackend.SUPPORTED_GRANULARITIES
@@ -155,9 +159,13 @@ class GEMMFP4AITERBackend(KernelBackend):
         trans_c: bool,
         granularity: ScalingGranularity,
         preshuffled: bool = False,
+        inplace_add_to_out: bool = False,
+        **kwargs,
     ) -> bool:
         del preshuffled  # AITER handles both layouts
         supported = True
+        # TODO: this backend has no beta=1 accumulate epilogue yet.
+        supported &= not inplace_add_to_out
         # TODO(ruibin): add gfx1250 support for aiter backend.
         supported &= is_gfx950()
         # check ScalingGranularity
@@ -239,6 +247,9 @@ class GEMMFP4FlyDSLBackend(KernelBackend):
         trans_c: bool,
         granularity: ScalingGranularity,
         preshuffled: bool = False,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
+        **kwargs,
     ) -> bool:
 
         # No path for AITER-preshuffled inputs (this backend preshuffles raw E8M0 itself).
@@ -246,6 +257,10 @@ class GEMMFP4FlyDSLBackend(KernelBackend):
             return False
 
         supported = True
+        if inplace_add_to_out:
+            supported &= out is not None and out.dtype == out_dtype
+            supported &= out_dtype in (torch.bfloat16, torch.float16)
+            supported &= not trans_c
         # gfx950 (CDNA4) only: mfma_scale_f32_16x16x128_f8f6f4 is absent below.
         supported &= is_gfx950()
         supported &= granularity in GEMMFP4FlyDSLBackend.SUPPORTED_GRANULARITIES
@@ -281,6 +296,9 @@ class GEMMFP4FlyDSLBackend(KernelBackend):
         trans_c: bool,
         granularity: ScalingGranularity,
         preshuffled: bool = False,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
+        **kwargs,
     ):
         # preshuffled accepted only so the dispatcher's uniform execute(**kwargs)
         # call works; can_handle already rejected the preshuffled=True case.
@@ -289,7 +307,16 @@ class GEMMFP4FlyDSLBackend(KernelBackend):
         # the FlyDSL GEMM wrapper repacks them into its lane-contiguous layout via a
         # separate preshuffle kernel on the same stream (quant stays generic). The
         # whole-loop kernel consumes any K % 256 (KI//2 pairs + MFMA-only odd tail).
-        return gemm_mxfp4_flydsl_kernel(a, a_scale_inv, b, b_scale_inv, out_dtype=out_dtype, trans_c=trans_c)
+        return gemm_mxfp4_flydsl_kernel(
+            a,
+            a_scale_inv,
+            b,
+            b_scale_inv,
+            out_dtype=out_dtype,
+            trans_c=trans_c,
+            beta=1.0 if inplace_add_to_out else 0.0,
+            out=out if inplace_add_to_out else None,
+        )
 
 
 _GEMM_FP4_BACKENDS = {
@@ -361,3 +388,75 @@ def gemm_fp4_impl_meta(
     if trans_c:
         m, n = n, m
     return torch.empty(m, n, dtype=out_dtype, device=a.device)
+
+
+@_torch_custom_op_wrapper("primus_turbo::gemm_fp4_accum_impl", mutates_args={"out"}, device_types="cuda")
+def gemm_fp4_accum_impl(
+    a: torch.Tensor,
+    a_scale_inv: torch.Tensor,
+    trans_a: bool,
+    b: torch.Tensor,
+    b_scale_inv: torch.Tensor,
+    trans_b: bool,
+    out_dtype: torch.dtype,
+    trans_c: bool,
+    granularity: int,
+    out: torch.Tensor,
+    default_backend: int,
+    preshuffled: bool = False,
+) -> None:
+    """Dense FP4 GEMM that accumulates into ``out`` instead of returning.
+
+    Computes ``out += op(A) @ op(B)``, folding the accumulation into the GEMM
+    epilogue (beta=1)
+    """
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_gemm_backend(PrecisionType.FP4)
+    granularity_enum = ScalingGranularity(granularity)
+
+    kwargs = dict(
+        a=a,
+        b=b,
+        a_scale_inv=a_scale_inv,
+        b_scale_inv=b_scale_inv,
+        out_dtype=out_dtype,
+        trans_a=trans_a,
+        trans_b=trans_b,
+        trans_c=trans_c,
+        granularity=granularity_enum,
+        preshuffled=preshuffled,
+        inplace_add_to_out=True,
+        out=out,
+    )
+
+    # The tuner benchmarks a backend by launching it repeatedly, so letting it tune on
+    # the caller's buffer would accumulate the wgrad once per warmup and timing
+    # iteration. Prime the cache on a scratch buffer first: the tune key ignores `out`,
+    # so the dispatch below hits that cache and runs exactly once on the real buffer.
+    # Zeroed, not empty -- beta=1 reads the buffer back and NaNs would skew the timings.
+    if GlobalBackendManager.auto_tune_enabled() and not GEMMFP4KernelDispatcher._is_graph_capturing():
+        GEMMFP4KernelDispatcher.tune(**{**kwargs, "out": torch.zeros_like(out)})
+
+    GEMMFP4KernelDispatcher.dispatch(default_backend_choice, user_backend_choice, **kwargs)
+
+
+@gemm_fp4_accum_impl.register_fake
+def gemm_fp4_accum_impl_meta(
+    a: torch.Tensor,
+    a_scale_inv: torch.Tensor,
+    trans_a: bool,
+    b: torch.Tensor,
+    b_scale_inv: torch.Tensor,
+    trans_b: bool,
+    out_dtype: torch.dtype,
+    trans_c: bool,
+    granularity: int,
+    out: torch.Tensor,
+    default_backend: int,
+    preshuffled: bool = False,
+) -> None:
+    m, n, _ = get_gemm_logical_shape(a, b, trans_a, trans_b)
+    if trans_c:
+        m, n = n, m
+    assert tuple(out.shape) == (m, n), f"out shape {tuple(out.shape)} must equal {(m, n)}"
+    return None

--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
@@ -96,6 +96,9 @@ class GEMMFP8HipBLASLtBackend(KernelBackend):
         out_dtype: torch.dtype,
         trans_c: bool,
         granularity: ScalingGranularity,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
+        **kwargs,
     ) -> bool:
         supported = True
         if granularity == ScalingGranularity.MX_BLOCKWISE:
@@ -104,6 +107,15 @@ class GEMMFP8HipBLASLtBackend(KernelBackend):
         supported &= granularity in GEMMFP8HipBLASLtBackend.SUPPORTED_GRANULARITIES
         # check dtype
         supported &= (a.dtype, b.dtype, out_dtype) in GEMMFP8HipBLASLtBackend.SUPPORTED_DTYPES
+
+        if inplace_add_to_out:
+            supported &= granularity == ScalingGranularity.TENSORWISE
+            supported &= out is not None and out.is_contiguous()
+            supported &= out is not None and out.dtype in (
+                torch.float32,
+                torch.bfloat16,
+                torch.float16,
+            )
 
         # TODO:
         # check layout
@@ -124,9 +136,23 @@ class GEMMFP8HipBLASLtBackend(KernelBackend):
         out_dtype: torch.dtype,
         trans_c: bool,
         granularity: ScalingGranularity,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
+        **kwargs,
     ):
+        beta = 1.0 if inplace_add_to_out else 0.0
         return torch.ops.primus_turbo_cpp_extension.hipblaslt_gemm_fp8(
-            a, a_scale_inv, b, b_scale_inv, out_dtype, trans_a, trans_b, trans_c, granularity.name
+            a,
+            a_scale_inv,
+            b,
+            b_scale_inv,
+            out_dtype,
+            trans_a,
+            trans_b,
+            trans_c,
+            granularity.name,
+            beta,
+            out,
         )
 
 
@@ -150,8 +176,12 @@ class GEMMFP8CKBackend(KernelBackend):
         out_dtype: torch.dtype,
         trans_c: bool,
         granularity: ScalingGranularity,
+        inplace_add_to_out: bool = False,
+        **kwargs,
     ) -> bool:
         supported = True
+        # This backend has no beta=1 accumulate epilogue.
+        supported &= not inplace_add_to_out
         # check the CK backend was compiled into this build
         supported &= build_ck()
         supported &= not is_gfx1250()
@@ -237,10 +267,16 @@ class GEMMFP8TritonBackend(KernelBackend):
         out_dtype: torch.dtype,
         trans_c: bool,
         granularity: ScalingGranularity,
+        inplace_add_to_out: bool = False,
+        **kwargs,
     ) -> bool:
         supported = True
         supported &= granularity in GEMMFP8TritonBackend.SUPPORTED_GRANULARITIES
         supported &= (a.dtype, b.dtype, out_dtype) in GEMMFP8TritonBackend.SUPPORTED_DTYPES
+        # Only the TENSORWISE kernel implements the beta=1 epilogue; the ROWWISE /
+        # BLOCKWISE ones would ignore `out` and silently produce no gradient.
+        if inplace_add_to_out:
+            supported &= granularity == ScalingGranularity.TENSORWISE
         return supported
 
     @staticmethod
@@ -254,7 +290,12 @@ class GEMMFP8TritonBackend(KernelBackend):
         out_dtype: torch.dtype,
         trans_c: bool,
         granularity: ScalingGranularity,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
+        **kwargs,
     ):
+        beta = 1.0 if inplace_add_to_out else 0.0
+
         if granularity == ScalingGranularity.TENSORWISE:
             return gemm_fp8_tensorwise_triton_kernel(
                 a,
@@ -265,8 +306,14 @@ class GEMMFP8TritonBackend(KernelBackend):
                 trans_b=trans_b,
                 out_dtype=out_dtype,
                 trans_c=trans_c,
+                beta=beta,
+                out=out,
             )
-        elif granularity == ScalingGranularity.ROWWISE:
+
+        assert not inplace_add_to_out, (
+            f"Fused accumulation into `out` is only implemented for TENSORWISE, got {granularity}"
+        )
+        if granularity == ScalingGranularity.ROWWISE:
             return gemm_fp8_rowwise_triton_kernel(
                 a,
                 a_scale_inv,
@@ -316,8 +363,12 @@ class GEMMFP8TurboBackend(KernelBackend):
         out_dtype: torch.dtype,
         trans_c: bool,
         granularity: ScalingGranularity,
+        inplace_add_to_out: bool = False,
+        **kwargs,
     ) -> bool:
         supported = True
+        # This backend has no beta=1 accumulate epilogue.
+        supported &= not inplace_add_to_out
         supported &= is_gfx950()
         supported &= granularity in GEMMFP8TurboBackend.SUPPORTED_GRANULARITIES
         supported &= (a.dtype, b.dtype, out_dtype) in GEMMFP8TurboBackend.SUPPORTED_DTYPES
@@ -368,8 +419,15 @@ class GEMMFP8FlyDSLBackend(KernelBackend):
         out_dtype: torch.dtype,
         trans_c: bool,
         granularity: ScalingGranularity,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
+        **kwargs,
     ) -> bool:
         supported = True
+        if inplace_add_to_out:
+            supported &= granularity == ScalingGranularity.TENSORWISE
+            supported &= out is not None and out.dtype == out_dtype
+            supported &= out_dtype in (torch.bfloat16, torch.float16)
         # gfx950 (CDNA4) only: kernel uses mfma_f32_16x16x128_f8f6f4, absent on gfx942-.
         supported &= is_gfx950()
         supported &= granularity in GEMMFP8FlyDSLBackend.SUPPORTED_GRANULARITIES
@@ -401,12 +459,16 @@ class GEMMFP8FlyDSLBackend(KernelBackend):
         out_dtype: torch.dtype,
         trans_c: bool,
         granularity: ScalingGranularity,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
+        **kwargs,
     ):
         if granularity == ScalingGranularity.MX_BLOCKWISE:
-            out = gemm_mxfp8_flydsl_kernel(
+            assert not inplace_add_to_out, "MXFP8 dense FlyDSL has no accumulate epilogue"
+            res = gemm_mxfp8_flydsl_kernel(
                 a, a_scale_inv.view(torch.uint8), b, b_scale_inv.view(torch.uint8), out_dtype=out_dtype
             )
-            return out.t().contiguous() if trans_c else out
+            return res.t().contiguous() if trans_c else res
 
         if trans_c:
             lhs, rhs = b, a
@@ -425,6 +487,8 @@ class GEMMFP8FlyDSLBackend(KernelBackend):
             trans_b=trans_rhs,
             out_dtype=out_dtype,
             trans_c=False,
+            beta=1.0 if inplace_add_to_out else 0.0,
+            out=out if inplace_add_to_out else None,
         )
 
 
@@ -479,6 +543,52 @@ def gemm_fp8_impl(
     return GEMMFP8KernelDispatcher.dispatch(default_backend_choice, user_backend_choice, **kwargs)
 
 
+@_torch_custom_op_wrapper("primus_turbo::gemm_fp8_accum_impl", mutates_args={"out"}, device_types="cuda")
+def gemm_fp8_accum_impl(
+    a: torch.Tensor,
+    a_scale_inv: torch.Tensor,
+    trans_a: bool,
+    b: torch.Tensor,
+    b_scale_inv: torch.Tensor,
+    trans_b: bool,
+    out_dtype: torch.dtype,
+    trans_c: bool,
+    granularity: int,
+    out: torch.Tensor,
+    default_backend: int,
+) -> None:
+    """Dense FP8 GEMM that accumulates into ``out`` instead of returning.
+
+    Computes ``out += op(A) @ op(B)``, folding the accumulation into the GEMM
+    epilogue (beta=1)
+    """
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_gemm_backend(PrecisionType.FP8)
+    granularity_enum = ScalingGranularity(granularity)
+
+    kwargs = dict(
+        a=a,
+        b=b,
+        a_scale_inv=a_scale_inv,
+        b_scale_inv=b_scale_inv,
+        out_dtype=out_dtype,
+        trans_a=trans_a,
+        trans_b=trans_b,
+        trans_c=trans_c,
+        granularity=granularity_enum,
+        inplace_add_to_out=True,
+        out=out,
+    )
+
+    # The tuner benchmarks a backend by launching it repeatedly, so letting it tune on
+    # the caller's buffer would accumulate the wgrad once per warmup and timing
+    # iteration.
+    if GlobalBackendManager.auto_tune_enabled() and not GEMMFP8KernelDispatcher._is_graph_capturing():
+        GEMMFP8KernelDispatcher.tune(**{**kwargs, "out": torch.zeros_like(out)})
+
+    GEMMFP8KernelDispatcher.dispatch(default_backend_choice, user_backend_choice, **kwargs)
+
+
 @gemm_fp8_impl.register_fake
 def gemm_fp8_impl_meta(
     a: torch.Tensor,
@@ -496,3 +606,24 @@ def gemm_fp8_impl_meta(
     if trans_c:
         m, n = n, m
     return torch.empty(m, n, dtype=out_dtype, device=a.device)
+
+
+@gemm_fp8_accum_impl.register_fake
+def gemm_fp8_accum_impl_meta(
+    a: torch.Tensor,
+    a_scale_inv: torch.Tensor,
+    trans_a: bool,
+    b: torch.Tensor,
+    b_scale_inv: torch.Tensor,
+    trans_b: bool,
+    out_dtype: torch.dtype,
+    trans_c: bool,
+    granularity: int,
+    out: torch.Tensor,
+    default_backend: int,
+) -> None:
+    m, n, _ = get_gemm_logical_shape(a, b, trans_a, trans_b)
+    if trans_c:
+        m, n = n, m
+    assert tuple(out.shape) == (m, n), f"out shape {tuple(out.shape)} must equal {(m, n)}"
+    return None

--- a/primus_turbo/pytorch/kernels/gemm/gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_impl.py
@@ -33,11 +33,20 @@ class GEMMHipBLASLtBackend(KernelBackend):
         trans_b: bool,
         out_dtype: torch.dtype,
         trans_c: bool,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ) -> bool:
         supported = True
         supported &= a.ndim == 2 and b.ndim == 2
-        supported &= a.dtype in _HIPBLASLT_SUPPORTED_DTYPES and b.dtype in _HIPBLASLT_SUPPORTED_DTYPES
+        supported &= a.dtype in _HIPBLASLT_SUPPORTED_DTYPES and a.dtype == b.dtype
+
+        d_dtype = out.dtype if (inplace_add_to_out and out is not None) else out_dtype
+        supported &= d_dtype == a.dtype or d_dtype == torch.float32
+
+        if inplace_add_to_out:
+            supported &= out is not None and out.is_contiguous()
+
         return supported
 
     @staticmethod
@@ -48,9 +57,14 @@ class GEMMHipBLASLtBackend(KernelBackend):
         trans_b: bool,
         out_dtype: torch.dtype,
         trans_c: bool,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor:
-        return torch.ops.primus_turbo_cpp_extension.hipblaslt_gemm(a, b, out_dtype, trans_a, trans_b, trans_c)
+        beta = 1.0 if inplace_add_to_out else 0.0
+        return torch.ops.primus_turbo_cpp_extension.hipblaslt_gemm(
+            a, b, out_dtype, trans_a, trans_b, trans_c, beta, out
+        )
 
 
 class GEMMTritonBackend(KernelBackend):
@@ -77,9 +91,12 @@ class GEMMTritonBackend(KernelBackend):
         trans_b: bool,
         out_dtype: torch.dtype,
         trans_c: bool,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor:
-        return gemm_triton_kernel(a, b, trans_a, trans_b, out_dtype, trans_c)
+        beta = 1.0 if inplace_add_to_out else 0.0
+        return gemm_triton_kernel(a, b, trans_a, trans_b, out_dtype, trans_c, beta=beta, out=out)
 
 
 _GEMM_BACKENDS = {
@@ -143,3 +160,66 @@ def gemm_impl_meta(
     if trans_c:
         M, N = N, M
     return torch.empty(M, N, dtype=out_dtype, device=a.device)
+
+
+@_torch_custom_op_wrapper("primus_turbo::gemm_accum_impl", mutates_args={"out"}, device_types="cuda")
+def gemm_accum_impl(
+    a: torch.Tensor,
+    trans_a: bool,
+    b: torch.Tensor,
+    trans_b: bool,
+    out_dtype: torch.dtype,
+    trans_c: bool,
+    out: torch.Tensor,
+    default_backend: int,
+) -> None:
+    """BF16/FP16 GEMM that accumulates into ``out`` instead of returning.
+
+    Computes ``out += op(A) @ op(B)``, folding the accumulation into the GEMM
+    epilogue (beta=1)
+    """
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_gemm_backend(PrecisionType.BF16_FP16_FP32)
+
+    kwargs = dict(
+        a=a,
+        trans_a=trans_a,
+        b=b,
+        trans_b=trans_b,
+        out_dtype=out_dtype,
+        trans_c=trans_c,
+        inplace_add_to_out=True,
+        out=out,
+    )
+
+    # The tuner benchmarks a backend by launching it repeatedly, so letting it tune on
+    # the caller's buffer would accumulate the wgrad once per warmup and timing
+    # iteration. Prime the cache on a scratch buffer first: the tune key ignores `out`,
+    # so the dispatch below hits that cache and runs exactly once on the real buffer.
+    # Zeroed, not empty -- beta=1 reads the buffer back and NaNs would skew the timings.
+    if GlobalBackendManager.auto_tune_enabled() and not GEMMKernelDispatcher._is_graph_capturing():
+        GEMMKernelDispatcher.tune(**{**kwargs, "out": torch.zeros_like(out)})
+
+    GEMMKernelDispatcher.dispatch(default_backend_choice, user_backend_choice, **kwargs)
+
+
+@gemm_accum_impl.register_fake
+def gemm_accum_impl_meta(
+    a: torch.Tensor,
+    trans_a: bool,
+    b: torch.Tensor,
+    trans_b: bool,
+    out_dtype: torch.dtype,
+    trans_c: bool,
+    out: torch.Tensor,
+    default_backend: int,
+) -> None:
+    assert a.ndim == 2 and b.ndim == 2, (
+        f"Expected both a and b to be 2D tensors, but got a.ndim={a.ndim}, b.ndim={b.ndim}"
+    )
+    M = a.shape[1] if trans_a else a.shape[0]
+    N = b.shape[0] if trans_b else b.shape[1]
+    if trans_c:
+        M, N = N, M
+    assert tuple(out.shape) == (M, N), f"out shape {tuple(out.shape)} must equal {(M, N)}"
+    return None

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
@@ -242,9 +242,12 @@ class GroupedGEMMFP4VariableKTritonBackend(KernelBackend):
         out_dtype: torch.dtype,
         granularity: ScalingGranularity,
         num_cu: int | None,
+        inplace_add_to_out: bool = False,
         **kwargs,
     ) -> bool:
         supported = True
+        # TODO: this backend has no beta=1 accumulate epilogue yet.
+        supported &= not inplace_add_to_out
         supported &= not is_gfx942()
         supported &= a.dim() == 2 and b.dim() == 2
         supported &= granularity in GroupedGEMMFP4VariableKTritonBackend.SUPPORTED_GRANULARITIES
@@ -318,9 +321,13 @@ class GroupedGEMMFP4VariableKFlyDSLBackend(KernelBackend):
         out_dtype: torch.dtype,
         granularity: ScalingGranularity,
         num_cu: int | None,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ) -> bool:
         supported = True
+        # This backend has no beta=1 accumulate epilogue.
+        supported &= not inplace_add_to_out
         supported &= a.dim() == 2 and b.dim() == 2
         supported &= granularity in GroupedGEMMFP4VariableKFlyDSLBackend.SUPPORTED_GRANULARITIES
         supported &= a.dtype == float4_e2m1fn_x2 and b.dtype == float4_e2m1fn_x2
@@ -348,6 +355,8 @@ class GroupedGEMMFP4VariableKFlyDSLBackend(KernelBackend):
         out_dtype: torch.dtype,
         granularity: ScalingGranularity,
         num_cu: int | None,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ):
         from primus_turbo.flydsl.grouped_gemm.grouped_gemm_mxfp4_kernel import (
@@ -504,6 +513,89 @@ def grouped_gemm_fp4_variable_k_impl(
     return GroupedGEMMFP4VariableKKernelDispatcher.dispatch(
         default_backend_choice, user_backend_choice, **kwargs
     )
+
+
+@_torch_custom_op_wrapper(
+    "primus_turbo::grouped_gemm_fp4_variable_k_accum_impl", mutates_args={"out"}, device_types="cuda"
+)
+def grouped_gemm_fp4_variable_k_accum_impl(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    trans_c: bool,
+    out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: int | None,
+    default_backend: int,
+    out: torch.Tensor,
+    maybe_pre_sync: bool = False,
+) -> None:
+    """Variable-K grouped MXFP4 GEMM that accumulates into ``out`` instead of returning.
+
+    Computes ``out += lhs[:,g] @ rhs[:,g]^T`` per group, folding the accumulation into
+    the GEMM epilogue (beta=1)
+    """
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP4)
+    granularity_enum = ScalingGranularity(granularity)
+
+    kwargs = dict(
+        a=a,
+        b=b,
+        a_scales=a_scales,
+        b_scales=b_scales,
+        group_lens=group_lens,
+        group_offs=group_offs,
+        trans_a=trans_a,
+        trans_b=trans_b,
+        trans_c=trans_c,
+        out_dtype=out_dtype,
+        granularity=granularity_enum,
+        num_cu=num_cu,
+        maybe_pre_sync=maybe_pre_sync,
+        inplace_add_to_out=True,
+        out=out,
+    )
+
+    # The tuner benchmarks a backend by launching it repeatedly, so letting it tune on
+    # the caller's buffer would accumulate the wgrad once per warmup and timing
+    # iteration.
+    if (
+        GlobalBackendManager.auto_tune_enabled()
+        and not GroupedGEMMFP4VariableKKernelDispatcher._is_graph_capturing()
+    ):
+        GroupedGEMMFP4VariableKKernelDispatcher.tune(**{**kwargs, "out": torch.zeros_like(out)})
+
+    GroupedGEMMFP4VariableKKernelDispatcher.dispatch(default_backend_choice, user_backend_choice, **kwargs)
+
+
+@grouped_gemm_fp4_variable_k_accum_impl.register_fake
+def grouped_gemm_fp4_variable_k_accum_impl_meta(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    trans_c: bool,
+    out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: int | None,
+    default_backend: int,
+    out: torch.Tensor,
+    maybe_pre_sync: bool = False,
+) -> None:
+    assert a.dim() == 2, f"a must be 2D, got {a.shape}"
+    assert b.dim() == 2, f"b must be 2D, got {b.shape}"
+    assert out.dim() == 3, f"out must be 3D, got {out.shape}"
+    return None
 
 
 @grouped_gemm_fp4_impl.register_fake

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -4,6 +4,7 @@
 # See LICENSE for license information.
 ###############################################################################
 
+
 import torch
 
 from primus_turbo.pytorch.core.backend import (
@@ -147,9 +148,12 @@ class GroupedGEMMFP8VariableKCKBackend(KernelBackend):
         out_dtype: torch.dtype,
         granularity: ScalingGranularity,
         num_cu: int | None,
+        inplace_add_to_out: bool = False,
         **kwargs,
     ) -> bool:
         supported = True
+        # This backend has no beta=1 accumulate epilogue.
+        supported &= not inplace_add_to_out
         # check the CK backend was compiled into this build
         supported &= build_ck()
         supported &= not is_gfx1250()
@@ -279,6 +283,8 @@ class GroupedGEMMFP8VariableKHipblasltBackend(KernelBackend):
         out_dtype: torch.dtype,
         granularity: ScalingGranularity,
         num_cu: int | None,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ) -> bool:
         supported = True
@@ -286,6 +292,15 @@ class GroupedGEMMFP8VariableKHipblasltBackend(KernelBackend):
         supported &= (a.dtype, b.dtype, out_dtype) in GroupedGEMMFP8VariableKHipblasltBackend.SUPPORTED_DTYPES
         supported &= granularity in GroupedGEMMFP8VariableKHipblasltBackend.SUPPORTED_GRANULARITIES
         supported &= trans_a and not trans_b
+
+        if inplace_add_to_out:
+            supported &= out is not None and out.is_contiguous()
+            supported &= out is not None and out.dtype in (
+                torch.float32,
+                torch.bfloat16,
+                torch.float16,
+            )
+
         return supported
 
     @staticmethod
@@ -303,6 +318,8 @@ class GroupedGEMMFP8VariableKHipblasltBackend(KernelBackend):
         granularity: ScalingGranularity,
         num_cu: int | None,
         maybe_pre_sync: bool = False,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ):
         if trans_c:
@@ -313,6 +330,7 @@ class GroupedGEMMFP8VariableKHipblasltBackend(KernelBackend):
             lhs, rhs = a, b
             lhs_scales, rhs_scales = a_scales, b_scales
             trans_lhs, trans_rhs = trans_a, trans_b
+        beta = 1.0 if inplace_add_to_out else 0.0
         return torch.ops.primus_turbo_cpp_extension.hipblaslt_grouped_gemm_fp8(
             lhs,
             rhs,
@@ -325,6 +343,8 @@ class GroupedGEMMFP8VariableKHipblasltBackend(KernelBackend):
             out_dtype,
             granularity.name,
             maybe_pre_sync,
+            beta,
+            out,
         )
 
 
@@ -598,11 +618,14 @@ class GroupedGEMMFP8VariableKTritonBackend(KernelBackend):
         out_dtype: torch.dtype,
         granularity: ScalingGranularity,
         num_cu: int | None,
+        inplace_add_to_out: bool = False,
         **kwargs,
     ) -> bool:
         supported = True
         supported &= a.dim() == 2 and b.dim() == 2
         supported &= granularity in GroupedGEMMFP8VariableKTritonBackend.SUPPORTED_GRANULARITIES
+        if inplace_add_to_out:
+            supported &= granularity == ScalingGranularity.TENSORWISE
         if granularity != ScalingGranularity.MX_BLOCKWISE:
             supported &= (
                 a.dtype,
@@ -634,6 +657,8 @@ class GroupedGEMMFP8VariableKTritonBackend(KernelBackend):
         out_dtype: torch.dtype,
         granularity: ScalingGranularity,
         num_cu: int | None,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ):
         if trans_c:
@@ -642,6 +667,8 @@ class GroupedGEMMFP8VariableKTritonBackend(KernelBackend):
         else:
             lhs, rhs = a, b
             lhs_scales, rhs_scales = a_scales, b_scales
+
+        beta = 1.0 if inplace_add_to_out else 0.0
 
         if granularity == ScalingGranularity.MX_BLOCKWISE:
             # wgrad: C[g](OUT_M,OUT_N) = lhs[:,g](OUT_M,M_g) @ rhs[:,g](OUT_N,M_g)^T
@@ -661,6 +688,8 @@ class GroupedGEMMFP8VariableKTritonBackend(KernelBackend):
                 G,
                 out_dtype=out_dtype,
                 num_cu=num_cu,
+                out=out,
+                beta=beta,
             )
         if granularity == ScalingGranularity.BLOCKWISE:
             return grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
@@ -670,6 +699,8 @@ class GroupedGEMMFP8VariableKTritonBackend(KernelBackend):
                 rhs_scales,
                 group_offs,
                 out_dtype=out_dtype,
+                out=out,
+                beta=beta,
             )
         elif granularity == ScalingGranularity.ROWWISE:
             return grouped_gemm_fp8_rowwise_variable_k_triton_kernel(
@@ -679,6 +710,8 @@ class GroupedGEMMFP8VariableKTritonBackend(KernelBackend):
                 rhs_scales,
                 group_offs,
                 out_dtype=out_dtype,
+                out=out,
+                beta=beta,
             )
         return grouped_gemm_fp8_tensorwise_variable_k_triton_kernel(
             lhs,
@@ -687,6 +720,8 @@ class GroupedGEMMFP8VariableKTritonBackend(KernelBackend):
             rhs_scales,
             group_offs,
             out_dtype=out_dtype,
+            out=out,
+            beta=beta,
         )
 
 
@@ -716,9 +751,15 @@ class GroupedGEMMFP8VariableKFlyDSLBackend(KernelBackend):
         out_dtype: torch.dtype,
         granularity: ScalingGranularity,
         num_cu: int | None,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ) -> bool:
         supported = True
+        if inplace_add_to_out:
+            supported &= granularity == ScalingGranularity.TENSORWISE
+            supported &= out is not None and out.dtype == out_dtype
+            supported &= out_dtype in (torch.bfloat16, torch.float16)
         supported &= a.dim() == 2 and b.dim() == 2
         supported &= (a.dtype, b.dtype, out_dtype) in GroupedGEMMFP8VariableKFlyDSLBackend.SUPPORTED_DTYPES
         supported &= granularity in GroupedGEMMFP8VariableKFlyDSLBackend.SUPPORTED_GRANULARITIES
@@ -750,6 +791,8 @@ class GroupedGEMMFP8VariableKFlyDSLBackend(KernelBackend):
         out_dtype: torch.dtype,
         granularity: ScalingGranularity,
         num_cu: int | None,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ):
         from primus_turbo.flydsl.grouped_gemm.grouped_gemm_fp8_kernel import (
@@ -763,6 +806,9 @@ class GroupedGEMMFP8VariableKFlyDSLBackend(KernelBackend):
         else:
             lhs, rhs = a, b
             lhs_scales, rhs_scales = a_scales, b_scales
+
+        beta = 1.0 if inplace_add_to_out else 0.0
+        accum_out = out if inplace_add_to_out else None
 
         if granularity == ScalingGranularity.MX_BLOCKWISE:
             from primus_turbo.flydsl.grouped_gemm.grouped_gemm_mxfp8_kernel import (
@@ -786,7 +832,15 @@ class GroupedGEMMFP8VariableKFlyDSLBackend(KernelBackend):
             )
 
         return grouped_gemm_fp8_variable_k_tensorwise_flydsl_kernel(
-            lhs, rhs, lhs_scales, rhs_scales, group_offs, out_dtype=out_dtype, num_cu=num_cu
+            lhs,
+            rhs,
+            lhs_scales,
+            rhs_scales,
+            group_offs,
+            out_dtype=out_dtype,
+            num_cu=num_cu,
+            beta=beta,
+            out=accum_out,
         )
 
 
@@ -915,6 +969,86 @@ def grouped_gemm_fp8_variable_k_impl(
     return GroupedGEMMFP8VariableKKernelDispatcher.dispatch(
         default_backend_choice, user_backend_choice, **kwargs
     )
+
+
+@_torch_custom_op_wrapper(
+    "primus_turbo::grouped_gemm_fp8_variable_k_accum_impl", mutates_args={"out"}, device_types="cuda"
+)
+def grouped_gemm_fp8_variable_k_accum_impl(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    trans_c: bool,
+    out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: int | None,
+    default_backend: int,
+    out: torch.Tensor,
+    maybe_pre_sync: bool = False,
+) -> None:
+    """Variable-K grouped FP8 GEMM that accumulates into ``out`` instead of returning.
+
+    Computes ``out += A^T @ B`` per group, folding the accumulation into the GEMM
+    epilogue (beta=1)
+    """
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.FP8)
+    granularity_enum = ScalingGranularity(granularity)
+
+    kwargs = dict(
+        a=a,
+        b=b,
+        a_scales=a_scales,
+        b_scales=b_scales,
+        group_lens=group_lens,
+        group_offs=group_offs,
+        trans_a=trans_a,
+        trans_b=trans_b,
+        trans_c=trans_c,
+        out_dtype=out_dtype,
+        granularity=granularity_enum,
+        num_cu=num_cu,
+        maybe_pre_sync=maybe_pre_sync,
+        inplace_add_to_out=True,
+        out=out,
+    )
+
+    if (
+        GlobalBackendManager.auto_tune_enabled()
+        and not GroupedGEMMFP8VariableKKernelDispatcher._is_graph_capturing()
+    ):
+        GroupedGEMMFP8VariableKKernelDispatcher.tune(**{**kwargs, "out": torch.zeros_like(out)})
+
+    GroupedGEMMFP8VariableKKernelDispatcher.dispatch(default_backend_choice, user_backend_choice, **kwargs)
+
+
+@grouped_gemm_fp8_variable_k_accum_impl.register_fake
+def grouped_gemm_fp8_variable_k_accum_impl_meta(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    trans_c: bool,
+    out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: int | None,
+    default_backend: int,
+    out: torch.Tensor,
+    maybe_pre_sync: bool = False,
+) -> None:
+    assert a.dim() == 2, f"a must be 2D, got {a.shape}"
+    assert b.dim() == 2, f"b must be 2D, got {b.shape}"
+    assert out.dim() == 3, f"out must be 3D, got {out.shape}"
+    return None
 
 
 @grouped_gemm_fp8_impl.register_fake

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
@@ -160,9 +160,12 @@ class GroupedGEMMVariableKCKBackend(KernelBackend):
         trans_c: bool,
         num_cu: int | None,
         schedule: str = "static",
+        inplace_add_to_out: bool = False,
         **kwargs,
     ) -> bool:
         supported = True
+        # This backend has no beta=1 accumulate epilogue.
+        supported &= not inplace_add_to_out
         supported &= build_ck()
         supported &= not is_gfx1250()
         supported &= a.dim() == 2 and b.dim() == 2
@@ -278,6 +281,8 @@ class GroupedGEMMVariableKHipblasltBackend(KernelBackend):
         trans_c: bool,
         num_cu: int | None,
         schedule: str = "static",
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ) -> bool:
         supported = True
@@ -285,6 +290,11 @@ class GroupedGEMMVariableKHipblasltBackend(KernelBackend):
         supported &= a.dtype in _COMMON_SUPPORTED_DTYPES and b.dtype in _COMMON_SUPPORTED_DTYPES
         supported &= trans_a and not trans_b
         supported &= schedule in _NON_WS_SUPPORTED_SCHEDULES
+
+        if inplace_add_to_out:
+            supported &= out is not None and out.is_contiguous()
+            supported &= out is not None and (out.dtype == a.dtype or out.dtype == torch.float32)
+
         return supported
 
     @staticmethod
@@ -299,6 +309,8 @@ class GroupedGEMMVariableKHipblasltBackend(KernelBackend):
         num_cu: int | None,
         maybe_pre_sync: bool = False,
         schedule: str = "static",
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor:
         if trans_c:
@@ -308,8 +320,9 @@ class GroupedGEMMVariableKHipblasltBackend(KernelBackend):
             lhs, rhs = a, b
             trans_lhs, trans_rhs = trans_a, trans_b
 
+        beta = 1.0 if inplace_add_to_out else 0.0
         return torch.ops.primus_turbo_cpp_extension.hipblaslt_grouped_gemm(
-            lhs, rhs, group_lens, group_offs, trans_lhs, trans_rhs, maybe_pre_sync
+            lhs, rhs, group_lens, group_offs, trans_lhs, trans_rhs, maybe_pre_sync, beta, out
         )
 
 
@@ -399,6 +412,8 @@ class GroupedGEMMVariableKTritonBackend(KernelBackend):
         trans_c: bool,
         num_cu: int | None,
         schedule: str = "static",
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor:
         if trans_c:
@@ -412,6 +427,8 @@ class GroupedGEMMVariableKTritonBackend(KernelBackend):
             num_cu=num_cu,
             work_steal=(schedule == "work_steal"),
             ws_mode="auto",
+            beta=(1.0 if inplace_add_to_out else 0.0),
+            out=out,
         )
 
 
@@ -544,6 +561,78 @@ def grouped_gemm_impl_meta(
     m = a.shape[1] if trans_a else a.shape[0]
     n = b.shape[-2] if trans_b else b.shape[-1]
     return torch.empty((m, n), device=a.device, dtype=a.dtype)
+
+
+@_torch_custom_op_wrapper(
+    "primus_turbo::grouped_gemm_variable_k_accum_impl", mutates_args={"out"}, device_types="cuda"
+)
+def grouped_gemm_variable_k_accum_impl(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    trans_c: bool,
+    num_cu: int | None,
+    default_backend: int,
+    out: torch.Tensor,
+    maybe_pre_sync: bool = False,
+    schedule: str = "static",
+) -> None:
+    """Variable-K grouped BF16/FP16 GEMM that accumulates into ``out``.
+
+    Computes ``out += A^T @ B`` per group, folding the accumulation into the GEMM
+    epilogue (beta=1)
+    """
+    default_backend_choice = BackendChoice(backend=BackendType(default_backend))
+    user_backend_choice = GlobalBackendManager.get_grouped_gemm_backend(PrecisionType.BF16_FP16_FP32)
+    kwargs = dict(
+        a=a,
+        b=b,
+        group_lens=group_lens,
+        group_offs=group_offs,
+        trans_a=trans_a,
+        trans_b=trans_b,
+        trans_c=trans_c,
+        num_cu=num_cu,
+        maybe_pre_sync=maybe_pre_sync,
+        schedule=schedule,
+        inplace_add_to_out=True,
+        out=out,
+    )
+
+    # The tuner benchmarks a backend by launching it repeatedly, so letting it tune on
+    # the caller's buffer would accumulate the wgrad once per warmup and timing
+    # iteration.
+    if (
+        GlobalBackendManager.auto_tune_enabled()
+        and not GroupedGEMMVariableKKernelDispatcher._is_graph_capturing()
+    ):
+        GroupedGEMMVariableKKernelDispatcher.tune(**{**kwargs, "out": torch.zeros_like(out)})
+
+    GroupedGEMMVariableKKernelDispatcher.dispatch(default_backend_choice, user_backend_choice, **kwargs)
+
+
+@grouped_gemm_variable_k_accum_impl.register_fake
+def grouped_gemm_variable_k_accum_impl_meta(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    trans_c: bool,
+    num_cu: int | None,
+    default_backend: int,
+    out: torch.Tensor,
+    maybe_pre_sync: bool = False,
+    schedule: str = "static",
+) -> None:
+    assert a.dim() == 2, f"a must be 2D, got {a.shape}"
+    assert b.dim() == 2, f"b must be 2D, got {b.shape}"
+    assert out.dim() == 3, f"out must be 3D, got {out.shape}"
+    return None
 
 
 @grouped_gemm_variable_k_impl.register_fake

--- a/primus_turbo/pytorch/ops/gemm.py
+++ b/primus_turbo/pytorch/ops/gemm.py
@@ -4,12 +4,50 @@
 # See LICENSE for license information.
 ###############################################################################
 
+from typing import Optional, Union
+
 import torch
 
 from primus_turbo.pytorch.core.backend import BackendType
-from primus_turbo.pytorch.kernels.gemm.gemm_impl import gemm_impl
+from primus_turbo.pytorch.kernels.gemm.gemm_impl import gemm_accum_impl, gemm_impl
+from primus_turbo.pytorch.ops.utils import _get_dummy_wgrad, _setup_fused_grad_accum
 
 __all__ = ["gemm"]
+
+
+def _bgrad_gemm_impl_wrapper(
+    a: torch.Tensor,
+    trans_a: bool,
+    b: torch.Tensor,
+    trans_b: bool,
+    out_dtype: torch.dtype,
+    trans_c: bool,
+    default_backend: int,
+    inplace_add_to_out: bool = False,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run the wgrad GEMM, accumulating into ``out`` when asked to.
+
+    Returns the weight gradient for autograd, or a dummy buffer when the wgrad went
+    straight into ``out``: forward already flagged the weight, so the training
+    framework's own accumulation step stands down. Megatron still expects a tensor
+    rather than None there, so its backward hooks stay on the main thread; the
+    contents are never read. It is handed back in the weight's own dtype, since a
+    mismatch would make autograd allocate and cast a full-size copy.
+    """
+    inputs = (a, trans_a, b, trans_b, out_dtype, trans_c)
+
+    if not inplace_add_to_out:
+        return gemm_impl(*inputs, default_backend=default_backend)
+
+    assert out is not None, "out should not be None when inplace_add_to_out is True"
+    # The wgrad keeps the caller's default backend: hipBLASLt and Triton both carry the
+    # beta=1 epilogue. Backends without it report `inplace_add_to_out` as unsupported,
+    # which keeps an explicitly pinned backend or auto-tune from silently landing
+    # somewhere that ignores `out`.
+    gemm_accum_impl(*inputs, out=out, default_backend=default_backend)
+
+    return _get_dummy_wgrad(out.shape, out_dtype)
 
 
 class GemmFunction(torch.autograd.Function):
@@ -21,8 +59,10 @@ class GemmFunction(torch.autograd.Function):
         trans_a: bool,
         trans_b: bool,
         out_dtype: torch.dtype,
+        fuse_bgrad_accum_pattern: Union[None, str] = None,
     ):
         assert a.dim() == 2 and b.dim() == 2, "Only 2D GEMM is supported"
+        fuse_bgrad_accum, main_grad = _setup_fused_grad_accum(b, fuse_bgrad_accum_pattern)
         # FWD
         # out    = a * b
         # [M, N] = [M, K] * [K, N]
@@ -32,6 +72,8 @@ class GemmFunction(torch.autograd.Function):
             ctx.save_for_backward(a, b)
             ctx.trans_a = trans_a
             ctx.trans_b = trans_b
+            ctx.fuse_bgrad_accum = fuse_bgrad_accum
+            ctx.main_grad = main_grad
         return out
 
     @staticmethod
@@ -52,7 +94,7 @@ class GemmFunction(torch.autograd.Function):
 
         # BGrad
         # grad_b = a^T * grad_out
-        grad_b = gemm_impl(
+        grad_b = _bgrad_gemm_impl_wrapper(
             a,
             not ctx.trans_a,
             grad_out,
@@ -60,9 +102,11 @@ class GemmFunction(torch.autograd.Function):
             b.dtype,
             ctx.trans_b,
             default_backend=BackendType.HIPBLASLT.value,
+            inplace_add_to_out=ctx.fuse_bgrad_accum,
+            out=ctx.main_grad,
         )
 
-        return grad_a, grad_b, None, None, None
+        return grad_a, grad_b, None, None, None, None
 
 
 def gemm(
@@ -71,8 +115,26 @@ def gemm(
     trans_a: bool = False,
     trans_b: bool = False,
     out_dtype: torch.dtype | None = None,
+    fuse_bgrad_accum_pattern: Union[None, str] = None,
 ) -> torch.Tensor:
+    """General matrix multiplication (GEMM) for BF16/FP16, supporting autograd.
+
+    Args:
+        a: Input matrix A with shape (M, K), must be 2D tensor
+        b: Input matrix B with shape (K, N) or (N, K), must be 2D tensor
+        trans_a: Whether to transpose matrix A
+        trans_b: Whether to transpose matrix B, if True B shape is (N, K)
+        out_dtype: Output data type, defaults to None (auto-inferred)
+        fuse_bgrad_accum_pattern: Enables fusing the weight-gradient accumulation
+            into the wgrad GEMM epilogue, so backward writes ``b.main_grad``
+            directly instead of returning a gradient the framework then adds.
+            ``"megatron"`` is the only supported pattern; ``b`` must carry
+            ``main_grad`` / ``grad_added_to_main_grad``. Defaults to None (no fusion).
+
+    Returns:
+        torch.Tensor: Output matrix with shape (M, N)
+    """
     assert a.ndim == 2 and b.ndim == 2, "Only 2D tensors are supported"
     if out_dtype is None:
         out_dtype = torch.promote_types(a.dtype, b.dtype)
-    return GemmFunction.apply(a, b, trans_a, trans_b, out_dtype)
+    return GemmFunction.apply(a, b, trans_a, trans_b, out_dtype, fuse_bgrad_accum_pattern)

--- a/primus_turbo/pytorch/ops/gemm_fp4.py
+++ b/primus_turbo/pytorch/ops/gemm_fp4.py
@@ -21,10 +21,56 @@ from primus_turbo.pytorch.core.quantized_tensor import (
     QuantizedTensorPair,
     check_quantized_tensor,
 )
-from primus_turbo.pytorch.kernels.gemm.gemm_fp4_impl import gemm_fp4_impl
+from primus_turbo.pytorch.kernels.gemm.gemm_fp4_impl import (
+    gemm_fp4_accum_impl,
+    gemm_fp4_impl,
+)
 from primus_turbo.pytorch.ops.quantization import quantize_fp4_with_trans
+from primus_turbo.pytorch.ops.utils import _get_dummy_wgrad, _setup_fused_grad_accum
 
 __all__ = ["gemm_fp4"]
+
+
+def _bgrad_gemm_fp4_impl_wrapper(
+    a: torch.Tensor,
+    a_scale_inv: torch.Tensor,
+    trans_a: bool,
+    b: torch.Tensor,
+    b_scale_inv: torch.Tensor,
+    trans_b: bool,
+    out_dtype: torch.dtype,
+    trans_c: bool,
+    granularity: int,
+    default_backend: int,
+    preshuffled: bool = False,
+    inplace_add_to_out: bool = False,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run the wgrad GEMM, accumulating into ``out`` when asked to.
+
+    Returns the weight gradient for autograd, or a dummy buffer when the wgrad went
+    straight into ``out``: forward already flagged the weight, so the training
+    framework's own accumulation step stands down. Megatron still expects a tensor
+    rather than None there, so its backward hooks stay on the main thread; the
+    contents are never read. It is handed back in the weight's own dtype, since a
+    mismatch would make autograd allocate and cast a full-size copy.
+    """
+    inputs = (a, a_scale_inv, trans_a, b, b_scale_inv, trans_b)
+    options = dict(
+        out_dtype=out_dtype,
+        trans_c=trans_c,
+        granularity=granularity,
+        default_backend=default_backend,
+        preshuffled=preshuffled,
+    )
+
+    if not inplace_add_to_out:
+        return gemm_fp4_impl(*inputs, **options)
+
+    assert out is not None, "out should not be None when inplace_add_to_out is True"
+    gemm_fp4_accum_impl(*inputs, out=out, **options)
+
+    return _get_dummy_wgrad(out.shape, out_dtype)
 
 
 class FP4GemmMXFunction(torch.autograd.Function):
@@ -50,9 +96,12 @@ class FP4GemmMXFunction(torch.autograd.Function):
         trans_b: bool,
         out_dtype: torch.dtype,
         config: Float4QuantConfig,
+        fuse_bgrad_accum_pattern: Union[None, str] = None,
     ):
         supported_mxfp4_backend, reason = check_mxfp4_support()
         assert supported_mxfp4_backend, reason
+
+        fuse_bgrad_accum, main_grad = _setup_fused_grad_accum(b, fuse_bgrad_accum_pattern)
 
         dest_dtype = FP4GemmMXFunction.get_fp4_dtype(
             config.format,
@@ -155,6 +204,8 @@ class FP4GemmMXFunction(torch.autograd.Function):
         ctx.trans_b = trans_b
         ctx.out_dtype = out_dtype
         ctx.config = config
+        ctx.fuse_bgrad_accum = fuse_bgrad_accum
+        ctx.main_grad = main_grad
 
         return out
 
@@ -210,7 +261,7 @@ class FP4GemmMXFunction(torch.autograd.Function):
         )
 
         # NOTE: convert TN layout to NT layout because MXFP4 only supports NT layout on hipblaslt.
-        grad_b = gemm_fp4_impl(
+        grad_b = _bgrad_gemm_fp4_impl_wrapper(
             g_col,
             g_col_scale,
             False,
@@ -222,6 +273,8 @@ class FP4GemmMXFunction(torch.autograd.Function):
             granularity=ctx.config.granularity.value,
             default_backend=default_backend,
             preshuffled=preshuffle,
+            inplace_add_to_out=ctx.fuse_bgrad_accum,
+            out=ctx.main_grad,
         )
 
         return (
@@ -233,6 +286,7 @@ class FP4GemmMXFunction(torch.autograd.Function):
             None,  # trans_b
             None,  # out_dtype
             None,  # config
+            None,  # fuse_bgrad_accum_pattern
         )
 
 
@@ -251,6 +305,7 @@ def gemm_fp4(
     trans_b: bool = False,
     out_dtype: Union[torch.dtype, None] = None,
     config: Union[Float4QuantConfig, None] = None,
+    fuse_bgrad_accum_pattern: Union[None, str] = None,
 ) -> torch.Tensor:
     """General matrix multiplication (GEMM) with FP4 quantization, supporting autograd.
 
@@ -290,6 +345,11 @@ def gemm_fp4(
         trans_b: Whether to transpose matrix b, if True b shape is (N, K)
         out_dtype: Output data type, defaults to None (auto-inferred)
         config: FP4 quantization config
+        fuse_bgrad_accum_pattern: Enables fusing the weight-gradient accumulation
+            into the wgrad GEMM epilogue, so backward writes ``b.main_grad``
+            directly instead of returning a gradient the framework then adds.
+            ``"megatron"`` is the only supported pattern; ``b`` must carry
+            ``main_grad`` / ``grad_added_to_main_grad``. Defaults to None (no fusion).
 
     Returns:
         torch.Tensor: Output matrix with shape (M, N)
@@ -331,9 +391,13 @@ def gemm_fp4(
     if out_dtype is None:
         out_dtype = torch.promote_types(a_data.dtype, b_data.dtype)
 
+    assert fuse_bgrad_accum_pattern is None, (
+        f"fuse_bgrad_accum_pattern is not supported for FP4, got {config.granularity}"
+    )
+
     if config.granularity == ScalingGranularity.MX_BLOCKWISE:
         return FP4GemmMXFunction.apply(
-            a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config
+            a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config, fuse_bgrad_accum_pattern
         )
     else:
         raise ValueError(f"Unsupported FP4 ScalingGranularity: {config.granularity}")

--- a/primus_turbo/pytorch/ops/gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/gemm_fp8.py
@@ -13,12 +13,9 @@ from primus_turbo.pytorch.core.backend import (
 )
 from primus_turbo.pytorch.core.low_precision import (
     Float8QuantConfig,
-    Format,
     ScalingGranularity,
     ScalingRecipe,
     check_mxfp8_support,
-    float8_e4m3,
-    float8_e5m2,
 )
 from primus_turbo.pytorch.core.quantized_tensor import (
     QuantizedTensor,
@@ -26,25 +23,22 @@ from primus_turbo.pytorch.core.quantized_tensor import (
     check_quantized_tensor,
 )
 from primus_turbo.pytorch.core.utils import is_gfx942
-from primus_turbo.pytorch.kernels.gemm.gemm_fp8_impl import gemm_fp8_impl
+from primus_turbo.pytorch.kernels.gemm.gemm_fp8_impl import (
+    gemm_fp8_accum_impl,
+    gemm_fp8_impl,
+)
 from primus_turbo.pytorch.kernels.quantization.quantization_impl import quantize_mxfp8_impl
 from primus_turbo.pytorch.ops.quantization import (
     quantize_fp8,
     quantize_fp8_with_trans,
 )
+from primus_turbo.pytorch.ops.utils import (
+    _get_dummy_wgrad,
+    _get_fp8_dtype,
+    _setup_fused_grad_accum,
+)
 
 __all__ = ["gemm_fp8"]
-
-
-def _get_fp8_dtype(format: Format, is_fwd_stage: bool):
-    if format == Format.E4M3:
-        return float8_e4m3
-    elif format == Format.E5M2:
-        return float8_e5m2
-    elif format == Format.HYBRID:
-        return float8_e4m3 if is_fwd_stage else float8_e5m2
-    else:
-        raise ValueError(f"Unsupported FP8 format: {format}")
 
 
 def _deter_use_nt_layout_gemm_in_bwd(trans_a: bool, trans_b: bool):
@@ -54,6 +48,49 @@ def _deter_use_nt_layout_gemm_in_bwd(trans_a: bool, trans_b: bool):
     # NOTE: the non-NT layout gemm is not optimized for mi350/mi450.
     # Force to use NT layout GEMM in backward for now.
     return trans_a == False and trans_b == True
+
+
+def _bgrad_gemm_fp8_impl_wrapper(
+    a: torch.Tensor,
+    a_scale_inv: torch.Tensor,
+    trans_a: bool,
+    b: torch.Tensor,
+    b_scale_inv: torch.Tensor,
+    trans_b: bool,
+    out_dtype: torch.dtype,
+    trans_c: bool,
+    granularity: int,
+    default_backend: int,
+    inplace_add_to_out: bool = False,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run the wgrad GEMM, accumulating into ``out`` when asked to.
+
+    Returns the weight gradient for autograd, or a dummy buffer when the wgrad went
+    straight into ``out``: forward already flagged the weight, so the training
+    framework's own accumulation step stands down. Megatron still expects a tensor
+    rather than None there, so its backward hooks stay on the main thread; the
+    contents are never read. It is handed back in the weight's own dtype, since a
+    mismatch would make autograd allocate and cast a full-size copy.
+    """
+    inputs = (a, a_scale_inv, trans_a, b, b_scale_inv, trans_b)
+    options = dict(
+        out_dtype=out_dtype,
+        trans_c=trans_c,
+        granularity=granularity,
+    )
+
+    if not inplace_add_to_out:
+        return gemm_fp8_impl(*inputs, default_backend=default_backend, **options)
+
+    assert out is not None, "out should not be None when inplace_add_to_out is True"
+    # The wgrad keeps the caller's default backend: hipBLASLt and Triton both carry the
+    # beta=1 epilogue. Backends without it report `inplace_add_to_out` as unsupported,
+    # which keeps an explicitly pinned backend or auto-tune from silently landing
+    # somewhere that ignores `out`.
+    gemm_fp8_accum_impl(*inputs, out=out, default_backend=default_backend, **options)
+
+    return _get_dummy_wgrad(out.shape, out_dtype)
 
 
 class FP8GemmTensorFunction(torch.autograd.Function):
@@ -68,8 +105,10 @@ class FP8GemmTensorFunction(torch.autograd.Function):
         trans_b: bool,
         out_dtype: torch.dtype,
         config: Float8QuantConfig,
+        fuse_bgrad_accum_pattern: Union[None, str] = None,
     ):
         use_nt_layout_gemm_in_bwd = _deter_use_nt_layout_gemm_in_bwd(trans_a, trans_b)
+        fuse_bgrad_accum, main_grad = _setup_fused_grad_accum(b, fuse_bgrad_accum_pattern)
 
         if isinstance(a, QuantizedTensor):
             quantized_a = a
@@ -139,6 +178,8 @@ class FP8GemmTensorFunction(torch.autograd.Function):
         ctx.out_dtype = out_dtype
         ctx.config = config
         ctx.use_nt_layout_gemm_in_bwd = use_nt_layout_gemm_in_bwd
+        ctx.fuse_bgrad_accum = fuse_bgrad_accum
+        ctx.main_grad = main_grad
 
         return out
 
@@ -191,7 +232,7 @@ class FP8GemmTensorFunction(torch.autograd.Function):
         if ctx.use_nt_layout_gemm_in_bwd:
             quantized_grad_out_t = quantized_grad_out.t().contiguous()
 
-            b_grad = gemm_fp8_impl(
+            b_grad = _bgrad_gemm_fp8_impl_wrapper(
                 a_fp8_t,
                 a_t_scale_inv,
                 False,
@@ -202,9 +243,11 @@ class FP8GemmTensorFunction(torch.autograd.Function):
                 ctx.trans_b,
                 granularity=ctx.config.granularity.value,
                 default_backend=BackendType.HIPBLASLT.value,
+                inplace_add_to_out=ctx.fuse_bgrad_accum,
+                out=ctx.main_grad,
             )
         else:
-            b_grad = gemm_fp8_impl(
+            b_grad = _bgrad_gemm_fp8_impl_wrapper(
                 a_fp8,
                 a_scale_inv,
                 not ctx.trans_a,
@@ -215,6 +258,8 @@ class FP8GemmTensorFunction(torch.autograd.Function):
                 ctx.trans_b,
                 granularity=ctx.config.granularity.value,
                 default_backend=BackendType.HIPBLASLT.value,
+                inplace_add_to_out=ctx.fuse_bgrad_accum,
+                out=ctx.main_grad,
             )
 
         return (
@@ -226,6 +271,7 @@ class FP8GemmTensorFunction(torch.autograd.Function):
             None,  # trans_b
             None,  # out_dtype
             None,  # config
+            None,  # fuse_bgrad_accum_pattern
         )
 
 
@@ -676,6 +722,7 @@ def gemm_fp8(
     trans_b: bool = False,
     out_dtype: Union[torch.dtype, None] = None,
     config: Union[Float8QuantConfig, None] = None,
+    fuse_bgrad_accum_pattern: Union[None, str] = None,
 ) -> torch.Tensor:
     """General matrix multiplication (GEMM) with FP8 quantization, supporting autograd.
 
@@ -689,6 +736,12 @@ def gemm_fp8(
         trans_b: Whether to transpose matrix B, if True B shape is (N, K)
         out_dtype: Output data type, defaults to None (auto-inferred)
         config: FP8 quantization config, defaults to None (uses TENSORWISE + E4M3)
+        fuse_bgrad_accum_pattern: Enables fusing the weight-gradient accumulation
+            into the wgrad GEMM epilogue, so backward writes ``b.main_grad``
+            directly instead of returning a gradient the framework then adds.
+            ``"megatron"`` is the only supported pattern; ``b`` must carry
+            ``main_grad`` / ``grad_added_to_main_grad``. TENSORWISE only.
+            Defaults to None (no fusion).
 
     Returns:
         torch.Tensor: Output matrix with shape (M, N)
@@ -739,9 +792,15 @@ def gemm_fp8(
 
     if config.granularity == ScalingGranularity.TENSORWISE:
         return FP8GemmTensorFunction.apply(
-            a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config
+            a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config, fuse_bgrad_accum_pattern
         )
-    elif config.granularity == ScalingGranularity.ROWWISE:
+
+    # The other granularities silently ignore the flag rather than fusing, which
+    # would leave main_grad unwritten and the weight without a gradient.
+    assert fuse_bgrad_accum_pattern is None, (
+        f"fuse_bgrad_accum_pattern is only supported for TENSORWISE, got {config.granularity}"
+    )
+    if config.granularity == ScalingGranularity.ROWWISE:
         return FP8GemmRowFunction.apply(
             a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config
         )

--- a/primus_turbo/pytorch/ops/grouped_gemm.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm.py
@@ -4,19 +4,68 @@
 # See LICENSE for license information.
 ###############################################################################
 
+from typing import Optional, Union
+
 import torch
 
 from primus_turbo.pytorch.core.backend import BackendType
-from primus_turbo.pytorch.kernels.gemm.gemm_impl import gemm_impl
+from primus_turbo.pytorch.kernels.gemm.gemm_impl import gemm_accum_impl, gemm_impl
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_impl import (
     grouped_gemm_impl,
+    grouped_gemm_variable_k_accum_impl,
     grouped_gemm_variable_k_impl,
 )
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
     group_offs_from_lens,
 )
+from primus_turbo.pytorch.ops.utils import _get_dummy_wgrad, _setup_fused_grad_accum
 
 __all__ = ["grouped_gemm"]
+
+
+def _bgrad_grouped_gemm_impl_wrapper(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    trans_c: bool,
+    num_cu: int | None,
+    default_backend: int,
+    schedule: str = "static",
+    inplace_add_to_out: bool = False,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run the variable-K wgrad GEMM, accumulating into ``out`` when asked to.
+
+    Returns the weight gradient for autograd, or a dummy buffer when the wgrad went
+    straight into ``out``: forward already flagged the weight, so the training
+    framework's own accumulation step stands down. Megatron still expects a tensor
+    rather than None there, so its backward hooks stay on the main thread; the
+    contents are never read. It is handed back in the weight's own dtype, since a
+    mismatch would make autograd allocate and cast a full-size copy.
+    """
+    inputs = (a, b, group_lens, group_offs)
+    options = dict(
+        trans_a=trans_a,
+        trans_b=trans_b,
+        trans_c=trans_c,
+        num_cu=num_cu,
+        schedule=schedule,
+    )
+
+    if not inplace_add_to_out:
+        return grouped_gemm_variable_k_impl(*inputs, default_backend=default_backend, **options)
+
+    assert out is not None, "out should not be None when inplace_add_to_out is True"
+    # The wgrad keeps the caller's default backend: hipBLASLt and Triton both carry the
+    # beta=1 epilogue. Backends without it report `inplace_add_to_out` as unsupported,
+    # which keeps an explicitly pinned backend or auto-tune from silently landing
+    # somewhere that ignores `out`.
+    grouped_gemm_variable_k_accum_impl(*inputs, default_backend=default_backend, out=out, **options)
+
+    return _get_dummy_wgrad(out.shape, b.dtype)
 
 
 class GroupedGemmFunc(torch.autograd.Function):
@@ -30,7 +79,9 @@ class GroupedGemmFunc(torch.autograd.Function):
         trans_b: bool,
         num_cu: int | None,
         schedule: str = "static",
+        fuse_bgrad_accum_pattern: Union[None, str] = None,
     ):
+        fuse_bgrad_accum, main_grad = _setup_fused_grad_accum(b, fuse_bgrad_accum_pattern)
         if len(group_lens) == 1:
             assert b.size(0) == 1, f"Expected first dimension to be 1, got {b.size(0)}"
             b_2d = b.squeeze(0)
@@ -55,6 +106,8 @@ class GroupedGemmFunc(torch.autograd.Function):
         ctx.trans_b = trans_b
         ctx.num_cu = num_cu
         ctx.schedule = schedule
+        ctx.fuse_bgrad_accum = fuse_bgrad_accum
+        ctx.main_grad = main_grad
         return out
 
     @staticmethod
@@ -75,15 +128,30 @@ class GroupedGemmFunc(torch.autograd.Function):
                 ctx.trans_a,
                 default_backend=BackendType.HIPBLASLT.value,
             )
-            grad_b = gemm_impl(
-                a,
-                True,
-                grad_out,
-                False,
-                b.dtype,
-                ctx.trans_b,
-                default_backend=BackendType.HIPBLASLT.value,
-            ).view(b.size())
+            if ctx.fuse_bgrad_accum:
+                # main_grad matches b's [1, ...] shape; the dense GEMM writes 2D, and
+                # squeeze(0) is a view so the accumulation lands in the real buffer.
+                gemm_accum_impl(
+                    a,
+                    True,
+                    grad_out,
+                    False,
+                    b.dtype,
+                    ctx.trans_b,
+                    out=ctx.main_grad.squeeze(0),
+                    default_backend=BackendType.HIPBLASLT.value,
+                )
+                grad_b = _get_dummy_wgrad(b.shape, b.dtype)
+            else:
+                grad_b = gemm_impl(
+                    a,
+                    True,
+                    grad_out,
+                    False,
+                    b.dtype,
+                    ctx.trans_b,
+                    default_backend=BackendType.HIPBLASLT.value,
+                ).view(b.size())
         else:
             grad_a = grouped_gemm_impl(
                 grad_out,
@@ -96,7 +164,7 @@ class GroupedGemmFunc(torch.autograd.Function):
                 default_backend=BackendType.TRITON.value,
                 schedule=ctx.schedule,
             )
-            grad_b = grouped_gemm_variable_k_impl(
+            grad_b = _bgrad_grouped_gemm_impl_wrapper(
                 a,
                 grad_out,
                 group_lens,
@@ -107,8 +175,10 @@ class GroupedGemmFunc(torch.autograd.Function):
                 num_cu=ctx.num_cu,
                 default_backend=BackendType.TRITON.value,
                 schedule=ctx.schedule,
+                inplace_add_to_out=ctx.fuse_bgrad_accum,
+                out=ctx.main_grad,
             )
-        return grad_a, grad_b, None, None, None, None, None
+        return grad_a, grad_b, None, None, None, None, None, None
 
 
 def grouped_gemm(
@@ -119,6 +189,7 @@ def grouped_gemm(
     trans_b: bool = False,
     num_cu: int | None = None,
     schedule: str = "static",
+    fuse_bgrad_accum_pattern: Union[None, str] = None,
 ) -> torch.Tensor:
     """
     Grouped GEMM.
@@ -144,6 +215,12 @@ def grouped_gemm(
               sub-modes are not exposed at this layer; tune via the kernel-
               level entry points when needed. Requires ``num_cu=None`` (see
               ``num_cu`` above).
+        fuse_bgrad_accum_pattern (str | None): Enables fusing the weight-gradient
+            accumulation into the wgrad GEMM epilogue, so backward writes
+            ``b.main_grad`` directly instead of returning a gradient the framework
+            then adds. ``"megatron"`` is the only supported pattern; ``b`` must
+            carry ``main_grad`` / ``grad_added_to_main_grad``. Defaults to None
+            (no fusion).
 
     Returns:
         torch.Tensor: Output of shape [sum(group_lens), N], same dtype/device as `a`.
@@ -176,4 +253,5 @@ def grouped_gemm(
         trans_b,
         num_cu,
         schedule,
+        fuse_bgrad_accum_pattern,
     )

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp4.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp4.py
@@ -36,20 +36,66 @@ from primus_turbo.pytorch.core.quantized_tensor import (
 )
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_fp4_impl import (
     grouped_gemm_fp4_impl,
+    grouped_gemm_fp4_variable_k_accum_impl,
     grouped_gemm_fp4_variable_k_impl,
 )
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
     group_offs_from_lens,
 )
 from primus_turbo.pytorch.ops.quantization import grouped_quantize_fp4_with_trans, quantize_fp4_with_trans
+from primus_turbo.pytorch.ops.utils import (
+    _ensure_contiguous_grad_out,
+    _get_dummy_wgrad,
+    _setup_fused_grad_accum,
+)
 
 __all__ = ["grouped_gemm_fp4"]
 
 
-def _ensure_contiguous_grad_out(grad_out: torch.Tensor) -> torch.Tensor:
-    # Some upstream reductions can produce expanded zero-stride grad_out views.
-    # Custom grouped GEMM kernels expect dense layouts.
-    return grad_out if grad_out.is_contiguous() else grad_out.contiguous()
+def _bgrad_grouped_gemm_fp4_impl_wrapper(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    trans_c: bool,
+    out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: int | None,
+    default_backend: int,
+    inplace_add_to_out: bool = False,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run the variable-K wgrad GEMM, accumulating into ``out`` when asked to.
+
+    Returns the weight gradient for autograd, or a dummy buffer when the wgrad went
+    straight into ``out``: forward already flagged the weight, so the training
+    framework's own accumulation step stands down. Megatron still expects a tensor
+    rather than None there, so its backward hooks stay on the main thread; the
+    contents are never read. It is handed back in the weight's own dtype, since a
+    mismatch would make autograd allocate and cast a full-size copy.
+    """
+    inputs = (a, b, a_scales, b_scales, group_lens, group_offs)
+    options = dict(
+        trans_a=trans_a,
+        trans_b=trans_b,
+        trans_c=trans_c,
+        out_dtype=out_dtype,
+        granularity=granularity,
+        num_cu=num_cu,
+        default_backend=default_backend,
+    )
+
+    if not inplace_add_to_out:
+        return grouped_gemm_fp4_variable_k_impl(*inputs, **options)
+
+    assert out is not None, "out should not be None when inplace_add_to_out is True"
+    grouped_gemm_fp4_variable_k_accum_impl(*inputs, out=out, **options)
+
+    return _get_dummy_wgrad(out.shape, out_dtype)
 
 
 class FP4GroupedGemmMXFunc(torch.autograd.Function):
@@ -68,7 +114,10 @@ class FP4GroupedGemmMXFunc(torch.autograd.Function):
         out_dtype: torch.dtype,
         config: Float4QuantConfig,
         num_cu: int | None,
+        fuse_bgrad_accum_pattern: Union[None, str] = None,
     ):
+        fuse_bgrad_accum, main_grad = _setup_fused_grad_accum(b, fuse_bgrad_accum_pattern)
+
         assert config.granularity == ScalingGranularity.MX_BLOCKWISE
         assert a.ndim == 2 and b.ndim == 3
         assert out_dtype in (torch.float16, torch.bfloat16)
@@ -178,6 +227,8 @@ class FP4GroupedGemmMXFunc(torch.autograd.Function):
         ctx.config = config
         ctx.out_dtype = out_dtype
         ctx.num_cu = num_cu
+        ctx.fuse_bgrad_accum = fuse_bgrad_accum
+        ctx.main_grad = main_grad
         return out
 
     @staticmethod
@@ -232,7 +283,7 @@ class FP4GroupedGemmMXFunc(torch.autograd.Function):
         grad_a = grad_a[: ctx.total_m]
 
         # --- wgrad: grad_b[g] = gradO_col(rht=T) @ A_col(rht=T)^T, contract M_g -> [G, N, K] ---
-        grad_b = grouped_gemm_fp4_variable_k_impl(
+        grad_b = _bgrad_grouped_gemm_fp4_impl_wrapper(
             grad_out_t_fp4,
             a_col,
             grad_out_t_scale,
@@ -246,6 +297,8 @@ class FP4GroupedGemmMXFunc(torch.autograd.Function):
             granularity=ScalingGranularity.MX_BLOCKWISE.value,
             num_cu=ctx.num_cu,
             default_backend=BackendType.FLYDSL.value,
+            inplace_add_to_out=ctx.fuse_bgrad_accum,
+            out=ctx.main_grad,
         )
 
         return (
@@ -259,6 +312,7 @@ class FP4GroupedGemmMXFunc(torch.autograd.Function):
             None,  # out_dtype
             None,  # config
             None,  # num_cu
+            None,  # fuse_bgrad_accum_pattern
         )
 
 
@@ -279,6 +333,7 @@ def grouped_gemm_fp4(
     out_dtype: Union[torch.dtype, None] = None,
     config: Union[Float4QuantConfig, None] = None,
     num_cu: int | None = None,
+    fuse_bgrad_accum_pattern: Union[None, str] = None,
 ) -> torch.Tensor:
     """Grouped GEMM with MXFP4 (E2M1) quantization, supporting autograd.
 
@@ -295,6 +350,11 @@ def grouped_gemm_fp4(
         out_dtype: Output dtype (defaults to promote(a, b)).
         config: Float4QuantConfig (MX_BLOCKWISE). use_preshuffle must be False.
         num_cu: Optional cap on compute units for the persistent grid.
+        fuse_bgrad_accum_pattern: Enables fusing the weight-gradient accumulation
+            into the wgrad GEMM epilogue, so backward writes ``b.main_grad``
+            directly instead of returning a gradient the framework then adds.
+            ``"megatron"`` is the only supported pattern; ``b`` must carry
+            ``main_grad`` / ``grad_added_to_main_grad``. Defaults to None (no fusion).
 
     Returns:
         Output [total_m, N].
@@ -320,6 +380,10 @@ def grouped_gemm_fp4(
     assert a_data.ndim == 2, "a must be 2D [total_m, K]"
     assert b_data.ndim == 3, "b must be 3D [G, N, K]"
 
+    assert fuse_bgrad_accum_pattern is None, (
+        f"fuse_bgrad_accum_pattern is not supported for FP4, got {config.granularity}"
+    )
+
     if config.granularity == ScalingGranularity.MX_BLOCKWISE:
         return FP4GroupedGemmMXFunc.apply(
             a_data,
@@ -332,5 +396,6 @@ def grouped_gemm_fp4(
             out_dtype,
             config,
             num_cu,
+            fuse_bgrad_accum_pattern,
         )
     raise ValueError(f"Unsupported FP4 ScalingGranularity: {config.granularity}")

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp8.py
@@ -12,12 +12,9 @@ from primus_turbo.pytorch.core.backend import (
 )
 from primus_turbo.pytorch.core.low_precision import (
     Float8QuantConfig,
-    Format,
     ScalingGranularity,
     ScalingRecipe,
     check_mxfp8_support,
-    float8_e4m3,
-    float8_e5m2,
 )
 from primus_turbo.pytorch.core.quantized_tensor import (
     QuantizedTensor,
@@ -26,6 +23,7 @@ from primus_turbo.pytorch.core.quantized_tensor import (
 )
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_fp8_impl import (
     grouped_gemm_fp8_impl,
+    grouped_gemm_fp8_variable_k_accum_impl,
     grouped_gemm_fp8_variable_k_impl,
 )
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
@@ -39,27 +37,62 @@ from primus_turbo.pytorch.ops.quantization import (
     grouped_quantize_fp8_with_trans,
     quantize_fp8_with_trans,
 )
+from primus_turbo.pytorch.ops.utils import (
+    _ensure_contiguous_grad_out,
+    _get_dummy_wgrad,
+    _get_fp8_dtype,
+    _setup_fused_grad_accum,
+)
 
 __all__ = [
     "grouped_gemm_fp8",
 ]
 
 
-def _get_fp8_dtype(format: Format, is_fwd_stage: bool):
-    if format == Format.E4M3:
-        return float8_e4m3
-    elif format == Format.E5M2:
-        return float8_e5m2
-    elif format == Format.HYBRID:
-        return float8_e4m3 if is_fwd_stage else float8_e5m2
-    else:
-        raise ValueError(f"Unsupported FP8 format: {format}")
+def _grouped_gemm_fp8_variable_k_impl_wrapper(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    trans_c: bool,
+    out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: Optional[int],
+    default_backend: int,
+    inplace_add_to_out: bool = False,
+    out: Optional[torch.Tensor] = None,
+) -> Optional[torch.Tensor]:
+    """Run the variable-K wgrad GEMM, accumulating into ``out`` when asked to.
 
+    Returns the weight gradient for autograd, or a dummy buffer when the wgrad went
+    straight into ``out``: forward already flagged the weight, so the training
+    framework's own accumulation step stands down. Megatron still expects a tensor
+    rather than None there, so its backward hooks stay on the main thread; the
+    contents are never read. It is handed back in the weight's own dtype, since a
+    mismatch would make autograd allocate and cast a full-size copy.
+    """
+    inputs = (a, b, a_scales, b_scales, group_lens, group_offs)
+    options = dict(
+        trans_a=trans_a,
+        trans_b=trans_b,
+        trans_c=trans_c,
+        out_dtype=out_dtype,
+        granularity=granularity,
+        num_cu=num_cu,
+        default_backend=default_backend,
+    )
 
-def _ensure_contiguous_grad_out(grad_out: torch.Tensor) -> torch.Tensor:
-    # Some upstream reductions can produce expanded zero-stride grad_out views.
-    # Custom grouped GEMM kernels expect dense layouts.
-    return grad_out if grad_out.is_contiguous() else grad_out.contiguous()
+    if not inplace_add_to_out:
+        return grouped_gemm_fp8_variable_k_impl(*inputs, **options)
+
+    assert out is not None, "out should not be None when inplace_add_to_out is True"
+    grouped_gemm_fp8_variable_k_accum_impl(*inputs, out=out, **options)
+
+    return _get_dummy_wgrad(out.shape, out_dtype)
 
 
 class FP8GroupedGemmBlockFunc(torch.autograd.Function):
@@ -78,7 +111,10 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
         out_dtype: torch.dtype,
         config: Float8QuantConfig,
         num_cu: int | None,
+        fuse_bgrad_accum_pattern: Union[None, str] = None,
     ):
+        fuse_bgrad_accum, main_grad = _setup_fused_grad_accum(b, fuse_bgrad_accum_pattern)
+
         assert config.granularity == ScalingGranularity.BLOCKWISE
         assert config.block_size in [128], "Only block_size 128 is supported currently."
         if isinstance(a, QuantizedTensor):
@@ -137,6 +173,8 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
         ctx.config = config
         ctx.out_dtype = out_dtype
         ctx.num_cu = num_cu
+        ctx.fuse_bgrad_accum = fuse_bgrad_accum
+        ctx.main_grad = main_grad
 
         return out
 
@@ -184,7 +222,7 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
             default_backend=BackendType.TRITON.value,
         )
 
-        grad_b = grouped_gemm_fp8_variable_k_impl(
+        grad_b = _grouped_gemm_fp8_variable_k_impl_wrapper(
             a_fp8_col,
             grad_out_fp8_col,
             a_scale_col,
@@ -198,6 +236,8 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
             granularity=ctx.config.granularity.value,
             num_cu=ctx.num_cu,
             default_backend=BackendType.TRITON.value,
+            inplace_add_to_out=ctx.fuse_bgrad_accum,
+            out=ctx.main_grad,
         )
 
         return (
@@ -211,6 +251,7 @@ class FP8GroupedGemmBlockFunc(torch.autograd.Function):
             None,  # out_dtype
             None,  # config
             None,  # num_cu
+            None,  # fuse_bgrad_accum_pattern
         )
 
 
@@ -228,7 +269,10 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
         out_dtype: torch.dtype,
         config: Float8QuantConfig,
         num_cu: int | None,
+        fuse_bgrad_accum_pattern: Union[None, str] = None,
     ):
+        fuse_bgrad_accum, main_grad = _setup_fused_grad_accum(b, fuse_bgrad_accum_pattern)
+
         assert config.granularity == ScalingGranularity.ROWWISE
 
         # --- A side: [total_m, k] grouped activation, row-wise scale on axis=-1 (K) ---
@@ -322,6 +366,8 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
         ctx.config = config
         ctx.out_dtype = out_dtype
         ctx.num_cu = num_cu
+        ctx.fuse_bgrad_accum = fuse_bgrad_accum
+        ctx.main_grad = main_grad
         return out
 
     @staticmethod
@@ -366,7 +412,7 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
             group_lens=group_lens,
         )
 
-        grad_b = grouped_gemm_fp8_variable_k_impl(
+        grad_b = _grouped_gemm_fp8_variable_k_impl_wrapper(
             a_fp8_col,
             quantized_grad_out_t.qdata,
             a_scale_inv_col,
@@ -380,6 +426,8 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
             granularity=ctx.config.granularity.value,
             num_cu=ctx.num_cu,
             default_backend=BackendType.TRITON.value,
+            inplace_add_to_out=ctx.fuse_bgrad_accum,
+            out=ctx.main_grad,
         )
 
         return (
@@ -393,6 +441,7 @@ class FP8GroupedGemmRowFunc(torch.autograd.Function):
             None,  # out_dtype
             None,  # config
             None,  # num_cu
+            None,  # fuse_bgrad_accum_pattern
         )
 
 
@@ -410,7 +459,10 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
         out_dtype: torch.dtype,
         config: Float8QuantConfig,
         num_cu: int | None,
+        fuse_bgrad_accum_pattern: Union[None, str] = None,
     ):
+        fuse_bgrad_accum, main_grad = _setup_fused_grad_accum(b, fuse_bgrad_accum_pattern)
+
         assert config.granularity == ScalingGranularity.TENSORWISE
 
         if isinstance(a, QuantizedTensor):
@@ -472,6 +524,11 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
         ctx.config = config
         ctx.out_dtype = out_dtype
         ctx.num_cu = num_cu
+        ctx.fuse_bgrad_accum = fuse_bgrad_accum
+        # Kept off save_for_backward on purpose: the wgrad GEMM writes into this
+        # buffer in place, which would bump the version counter that saved tensors
+        # are checked against.
+        ctx.main_grad = main_grad
 
         return out
 
@@ -505,7 +562,7 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
             default_backend=BackendType.TRITON.value,
         )
 
-        grad_b = grouped_gemm_fp8_variable_k_impl(
+        grad_b = _grouped_gemm_fp8_variable_k_impl_wrapper(
             a_fp8,
             quantized_grad_out.qdata,
             a_scale_inv,
@@ -519,6 +576,8 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
             granularity=ctx.config.granularity.value,
             num_cu=ctx.num_cu,
             default_backend=BackendType.TRITON.value,
+            inplace_add_to_out=ctx.fuse_bgrad_accum,
+            out=ctx.main_grad,
         )
 
         return (
@@ -532,6 +591,7 @@ class FP8GroupedGemmTensorFunc(torch.autograd.Function):
             None,  # out_dtype
             None,  # config
             None,  # num_cu
+            None,  # fuse_bgrad_accum_pattern
         )
 
 
@@ -561,7 +621,10 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
         out_dtype: torch.dtype,
         config: Float8QuantConfig,
         num_cu: int | None,
+        fuse_bgrad_accum_pattern: Union[None, str] = None,
     ):
+        fuse_bgrad_accum, main_grad = _setup_fused_grad_accum(b, fuse_bgrad_accum_pattern)
+
         supported_mxfp8_backend, reason = check_mxfp8_support()
         assert supported_mxfp8_backend, reason
 
@@ -685,6 +748,8 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
         ctx.out_dtype = out_dtype
         ctx.num_cu = num_cu
         ctx.total_m = total_m
+        ctx.fuse_bgrad_accum = fuse_bgrad_accum
+        ctx.main_grad = main_grad
         return out
 
     @staticmethod
@@ -732,7 +797,11 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
         grad_a = grad_a[: ctx.total_m]
 
         # wgrad: grad_b[g] = grad_out_col[g] @ a_col[g]^T  (variable-K over colwise-128 M_g)
-        grad_b = grouped_gemm_fp8_variable_k_impl(
+        # FlyDSL is the default for the ordinary path, where it is faster. Its beta=1
+        # epilogue only writes 16-bit, so the fused path defaults to Triton, which also
+        # covers the fp32 main_grad Megatron allocates by default; pin FlyDSL through
+        # GlobalBackendManager when main_grad matches the weight's own bf16/fp16 dtype.
+        grad_b = _grouped_gemm_fp8_variable_k_impl_wrapper(
             grad_out_t_fp8,
             a_fp8_col,
             grad_out_t_scale,
@@ -745,7 +814,9 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
             out_dtype=ctx.out_dtype,
             granularity=ScalingGranularity.MX_BLOCKWISE.value,
             num_cu=ctx.num_cu,
-            default_backend=BackendType.FLYDSL.value,
+            default_backend=(BackendType.TRITON.value if ctx.fuse_bgrad_accum else BackendType.FLYDSL.value),
+            inplace_add_to_out=ctx.fuse_bgrad_accum,
+            out=ctx.main_grad,
         )
         # NT-only: wgrad already produces grad_b as (G, N, K) matching b.
         return (
@@ -759,6 +830,7 @@ class FP8GroupedGemmMXFunc(torch.autograd.Function):
             None,  # out_dtype
             None,  # config
             None,  # num_cu
+            None,  # fuse_bgrad_accum_pattern
         )
 
 
@@ -781,6 +853,7 @@ def grouped_gemm_fp8(
     out_dtype: Union[torch.dtype, None] = None,
     config: Union[Float8QuantConfig, None] = None,
     num_cu: int | None = None,
+    fuse_bgrad_accum_pattern: Union[None, str] = None,
 ) -> torch.Tensor:
     """Grouped GEMM with FP8 quantization.
 
@@ -836,6 +909,7 @@ def grouped_gemm_fp8(
             out_dtype,
             config,
             num_cu,
+            fuse_bgrad_accum_pattern,
         )
     elif config.granularity == ScalingGranularity.ROWWISE:
         return FP8GroupedGemmRowFunc.apply(
@@ -849,6 +923,7 @@ def grouped_gemm_fp8(
             out_dtype,
             config,
             num_cu,
+            fuse_bgrad_accum_pattern,
         )
     elif config.granularity == ScalingGranularity.BLOCKWISE:
         # BLOCKWISE accepts a pre-quantized 2D-block weight (``b``); the activation
@@ -865,6 +940,7 @@ def grouped_gemm_fp8(
             out_dtype,
             config,
             num_cu,
+            fuse_bgrad_accum_pattern,
         )
     elif config.granularity == ScalingGranularity.MX_BLOCKWISE:
         return FP8GroupedGemmMXFunc.apply(
@@ -878,6 +954,7 @@ def grouped_gemm_fp8(
             out_dtype,
             config,
             num_cu,
+            fuse_bgrad_accum_pattern,
         )
     else:
         raise ValueError(f"Unsupported FP8 ScalingGranularity: {config.granularity}")

--- a/primus_turbo/pytorch/ops/utils.py
+++ b/primus_turbo/pytorch/ops/utils.py
@@ -1,0 +1,88 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+"""Helpers shared across the GEMM / grouped-GEMM op implementations."""
+
+from typing import Optional
+
+import torch
+
+from primus_turbo.pytorch.core.low_precision import (
+    Format,
+    float8_e4m3,
+    float8_e5m2,
+)
+
+
+def _get_fp8_dtype(format: Format, is_fwd_stage: bool):
+    if format == Format.E4M3:
+        return float8_e4m3
+    elif format == Format.E5M2:
+        return float8_e5m2
+    elif format == Format.HYBRID:
+        return float8_e4m3 if is_fwd_stage else float8_e5m2
+    else:
+        raise ValueError(f"Unsupported FP8 format: {format}")
+
+
+def _ensure_contiguous_grad_out(grad_out: torch.Tensor) -> torch.Tensor:
+    # Some upstream reductions can produce expanded zero-stride grad_out views.
+    # Custom grouped GEMM kernels expect dense layouts.
+    return grad_out if grad_out.is_contiguous() else grad_out.contiguous()
+
+
+def _setup_fused_grad_accum(b, fuse_bgrad_accum_pattern: Optional[str]):
+    """Resolve the weight's gradient-accumulation buffer for the fused wgrad path.
+
+    Returns ``(enabled, main_grad)``. When enabled, the wgrad GEMM writes straight
+    into ``main_grad`` and the Function must return no gradient for ``b``.
+
+    Call this at the top of ``forward``: the flag has to be set while the weight
+    object is still in hand, because the backward pass only sees the saved tensors.
+    """
+    if fuse_bgrad_accum_pattern is None:
+        return False, None
+
+    assert fuse_bgrad_accum_pattern in ["megatron"], (
+        "Only megatron support gradient accumulation fusion currently"
+    )
+
+    assert hasattr(b, "grad_added_to_main_grad"), (
+        "b.grad_added_to_main_grad must be set up before the backward pass."
+    )
+    assert hasattr(b, "main_grad"), "b.main_grad must be set up before the backward pass."
+    assert isinstance(b.main_grad, torch.Tensor) and (b.main_grad.shape == b.shape), (
+        "b.main_grad must be a tensor with the same shape as b"
+    )
+
+    # Set in forward, not backward: autograd hands backward the saved tensors, not
+    # the parameter object that carries this attribute.
+    b.grad_added_to_main_grad = True
+    return True, b.main_grad
+
+
+_dummy_wgrads = {}
+
+
+def _get_dummy_wgrad(shape: list, dtype: torch.dtype, zero=False) -> torch.Tensor:
+    """Returns a dummy tensor of given shape.
+
+    Supports arbitrary rank (2D for plain Linear weights, 3D for stacked
+    grouped-linear weights ``(num_gemms, out_features, in_features)``, etc.).
+    Tensors are cached by ``(shape, dtype)`` so each distinct weight layout
+    only allocates one persistent buffer that gets reused across steps.
+    """
+    global _dummy_wgrads
+    key = (tuple(shape), dtype)
+    if key not in _dummy_wgrads:
+        _dummy_wgrads[key] = torch.empty(
+            shape,
+            dtype=dtype,
+            device="cuda",
+            requires_grad=False,
+        )
+    if zero:
+        _dummy_wgrads[key].fill_(0)
+    return _dummy_wgrads[key].detach()

--- a/primus_turbo/triton/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_fp8_kernel.py
@@ -146,7 +146,9 @@ def _fp8_persistent_gemm_kernel(
     EVEN_K: tl.constexpr,
     CACHE_MODIFIER_A: tl.constexpr,
     CACHE_MODIFIER_B: tl.constexpr,
+    BETA_IS_ONE: tl.constexpr = False,
 ):
+    """Persistent per-tensor-scaled FP8 GEMM."""
     pid = tl.program_id(0)
     if NUM_XCDS != 1:
         pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
@@ -227,7 +229,6 @@ def _fp8_persistent_gemm_kernel(
 
         # Apply per-tensor scale
         acc *= scale
-        c = acc.to(C.type.element_ty)
 
         rm = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
         rn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
@@ -235,6 +236,9 @@ def _fp8_persistent_gemm_kernel(
         rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
         c_mask = (rm[:, None] < M) & (rn[None, :] < N)
         C_ = C + rm[:, None].to(tl.int64) * stride_cm + rn[None, :].to(tl.int64) * stride_cn
+        if BETA_IS_ONE:
+            acc += tl.load(C_, mask=c_mask, other=0.0).to(acc_dtype)
+        c = acc.to(C.type.element_ty)
         tl.store(C_, c, c_mask)
 
 
@@ -253,10 +257,12 @@ def gemm_fp8_tensorwise_triton_kernel(
     trans_b: bool = True,
     out_dtype: torch.dtype = torch.bfloat16,
     trans_c: bool = False,
+    beta: float = 0.0,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """General-purpose FP8 GEMM with per-tensor scaling.
 
-    Computes: C = op(A) @ op(B) * a_scale_inv * b_scale_inv
+    Computes: C = beta * C + op(A) @ op(B) * a_scale_inv * b_scale_inv
     If trans_c=True, returns C^T (contiguous, shape N×M).
 
     Args:
@@ -266,12 +272,32 @@ def gemm_fp8_tensorwise_triton_kernel(
         b_scale_inv: Per-tensor dequantization scale for B, shape (1,), fp32.
         trans_a: Whether A is transposed.
         trans_b: Whether B is transposed.
-        out_dtype: Output dtype (default bfloat16).
+        out_dtype: Output dtype (default bfloat16). Ignored when ``out`` is given,
+            since the kernel then writes in whatever dtype ``out`` has.
         trans_c: If True, return transposed output C^T (shape N×M).
+        beta: Either ``0.0`` (overwrite, the default) or ``1.0`` (accumulate:
+            ``out += op(A) @ op(B)``); no other value is supported. ``beta=1.0``
+            requires ``out`` and folds the accumulation into the GEMM epilogue,
+            removing the separate elementwise add the caller would otherwise run
+            over the whole output.
+        out: Optional pre-allocated output buffer, shape (N, M) if ``trans_c``
+            else (M, N). When given, the kernel writes (or accumulates, see
+            ``beta``) into it instead of allocating. Strides are read off the
+            tensor, so non-contiguous views are fine.
 
     Returns:
         C of shape (M, N) if trans_c=False, or (N, M) if trans_c=True.
     """
+    # C^T = (op(A) @ op(B))^T = op(B)^T @ op(A)^T, so swapping the operands lets the
+    # kernel write the transposed result directly. Everything below then works on a
+    # plain row-major store: no swapped output strides, which would make the beta=1
+    # read-back column-major and force Triton to stage it through LDS (a 256x256 fp32
+    # tile needs 256KB, over the 160KB limit).
+    if trans_c:
+        a, b = b, a
+        a_scale_inv, b_scale_inv = b_scale_inv, a_scale_inv
+        trans_a, trans_b = not trans_b, not trans_a
+
     if trans_a:
         K, M = a.shape
         A_view = a.T
@@ -294,15 +320,17 @@ def gemm_fp8_tensorwise_triton_kernel(
     if B_view.stride(0) == 0 or B_view.stride(1) == 0:
         B_view = B_view.contiguous()
 
-    # Handle trans_c by writing to (N, M) buffer with swapped strides
-    if trans_c:
-        out = torch.empty((N, M), device=a.device, dtype=out_dtype)
-        stride_cm = out.stride(1)  # = 1
-        stride_cn = out.stride(0)  # = M
+    out_shape = (M, N)
+    assert beta in (0.0, 1.0), f"Only beta=0 (overwrite) or beta=1 (accumulate) supported, got {beta}"
+    if out is None:
+        assert beta == 0.0, "beta=1.0 requires an explicit `out` buffer to accumulate into"
+        out = torch.empty(out_shape, device=a.device, dtype=out_dtype)
     else:
-        out = torch.empty((M, N), device=a.device, dtype=out_dtype)
-        stride_cm = out.stride(0)  # = N
-        stride_cn = out.stride(1)  # = 1
+        assert tuple(out.shape) == out_shape, f"out shape {tuple(out.shape)} must equal {out_shape}"
+        assert out.device == a.device, "out must be on same device as a"
+
+    stride_cm = out.stride(0)
+    stride_cn = out.stride(1)
 
     # Stride constexprs for compiler optimisation
     s_ak = A_view.stride(1)
@@ -389,6 +417,7 @@ def gemm_fp8_tensorwise_triton_kernel(
         EVEN_K=even_k,
         CACHE_MODIFIER_A=cache_a,
         CACHE_MODIFIER_B=cache_b,
+        BETA_IS_ONE=(beta == 1.0),
         num_warps=8,
         num_stages=2,
         waves_per_eu=waves_per_eu,

--- a/primus_turbo/triton/gemm/gemm_kernel.py
+++ b/primus_turbo/triton/gemm/gemm_kernel.py
@@ -141,7 +141,9 @@ def _bf16_persistent_gemm_kernel(
     CACHE_MODIFIER_A: tl.constexpr,
     CACHE_MODIFIER_B: tl.constexpr,
     ALLOW_TF32: tl.constexpr = torch.backends.cuda.matmul.allow_tf32,
+    BETA_IS_ONE: tl.constexpr = False,
 ):
+    """Persistent BF16/FP16 GEMM."""
     pid = tl.program_id(0)
     if NUM_XCDS != 1:
         pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
@@ -229,7 +231,6 @@ def _bf16_persistent_gemm_kernel(
             b = tl.load(B_BASE, mask=b_mask_k, other=0.0, cache_modifier=CACHE_MODIFIER_B)
             acc += tl.dot(a, b, allow_tf32=ALLOW_TF32)
 
-        c = acc.to(C.type.element_ty)
         c_mask = (rm_raw[:, None] < M) & (rn_raw[None, :] < N)
         rm_s = rm_raw % M
         rn_s = rn_raw % N
@@ -238,6 +239,9 @@ def _bf16_persistent_gemm_kernel(
         if EVEN_N:
             rn_s = tl.max_contiguous(tl.multiple_of(rn_s, BLOCK_SIZE_N), BLOCK_SIZE_N)
         C_ = C + rm_s[:, None].to(tl.int64) * stride_cm + rn_s[None, :].to(tl.int64) * stride_cn
+        if BETA_IS_ONE:
+            acc += tl.load(C_, mask=c_mask, other=0.0).to(acc_dtype)
+        c = acc.to(C.type.element_ty)
         tl.store(C_, c, c_mask)
 
 
@@ -254,13 +258,15 @@ def gemm_triton_kernel(
     trans_b: bool = True,
     out_dtype: torch.dtype = torch.bfloat16,
     trans_c: bool = False,
+    beta: float = 0.0,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """General-purpose BF16/FP16 GEMM using optimized persistent kernel.
 
     Uses offline heuristic for block sizes / NUM_SMS, then origami analytical
     model to override GROUP_SIZE_M and cache modifiers.
 
-    Computes: C = op(A) @ op(B), where op(X) = X^T if trans else X.
+    Computes: C = beta * C + op(A) @ op(B), where op(X) = X^T if trans else X.
     If trans_c=True, returns C^T (contiguous, shape N×M).
 
     Args:
@@ -268,14 +274,34 @@ def gemm_triton_kernel(
         b: Input matrix (BF16 or FP16).
         trans_a: Whether A is transposed.
         trans_b: Whether B is transposed.
-        out_dtype: Output dtype (default bfloat16).
+        out_dtype: Output dtype (default bfloat16). Ignored when ``out`` is given,
+            since the kernel then writes in whatever dtype ``out`` has.
         trans_c: If True, return transposed output C^T (shape N×M).
+        beta: Either ``0.0`` (overwrite, the default) or ``1.0`` (accumulate:
+            ``out += op(A) @ op(B)``); no other value is supported. ``beta=1.0``
+            requires ``out`` and folds the accumulation into the GEMM epilogue,
+            removing the separate elementwise add the caller would otherwise run
+            over the whole output.
+        out: Optional pre-allocated output buffer, shape (N, M) if ``trans_c``
+            else (M, N). When given, the kernel writes (or accumulates, see
+            ``beta``) into it instead of allocating. Strides are read off the
+            tensor, so non-contiguous views are fine.
 
     Returns:
         C of shape (M, N) if trans_c=False, or (N, M) if trans_c=True.
     """
     assert a.dtype in (torch.bfloat16, torch.float16), f"Unsupported dtype: {a.dtype}"
     assert b.dtype in (torch.bfloat16, torch.float16), f"Unsupported dtype: {b.dtype}"
+
+    # C^T = (op(A) @ op(B))^T = op(B)^T @ op(A)^T, so swapping the operands lets the
+    # kernel write the transposed result directly. Everything below then works on a
+    # plain row-major store: no swapped output strides, which would make the beta=1
+    # read-back column-major and force Triton to stage it through LDS (a 256x256 fp32
+    # tile needs 256KB, over the 160KB limit).
+    if trans_c:
+        a, b = b, a
+        trans_a, trans_b = not trans_b, not trans_a
+
     # Determine logical (M, K) and (K, N) views
     if trans_a:
         K, M = a.shape
@@ -299,15 +325,17 @@ def gemm_triton_kernel(
     if B_view.stride(0) == 0 or B_view.stride(1) == 0:
         B_view = B_view.contiguous()
 
-    # Handle trans_c by writing to a (N, M) buffer with swapped strides
-    if trans_c:
-        out = torch.empty((N, M), device=a.device, dtype=out_dtype)
-        stride_cm = out.stride(1)  # = 1
-        stride_cn = out.stride(0)  # = M
+    out_shape = (M, N)
+    assert beta in (0.0, 1.0), f"Only beta=0 (overwrite) or beta=1 (accumulate) supported, got {beta}"
+    if out is None:
+        assert beta == 0.0, "beta=1.0 requires an explicit `out` buffer to accumulate into"
+        out = torch.empty(out_shape, device=a.device, dtype=out_dtype)
     else:
-        out = torch.empty((M, N), device=a.device, dtype=out_dtype)
-        stride_cm = out.stride(0)  # = N
-        stride_cn = out.stride(1)  # = 1
+        assert tuple(out.shape) == out_shape, f"out shape {tuple(out.shape)} must equal {out_shape}"
+        assert out.device == a.device, "out must be on same device as a"
+
+    stride_cm = out.stride(0)
+    stride_cn = out.stride(1)
 
     # Stride constexprs for compiler optimisation
     s_ak = A_view.stride(1)
@@ -436,6 +464,7 @@ def gemm_triton_kernel(
         B_LOAD_ALIGNED=b_load_aligned,
         CACHE_MODIFIER_A=cache_a,
         CACHE_MODIFIER_B=cache_b,
+        BETA_IS_ONE=(beta == 1.0),
         num_warps=8,
         num_stages=num_stages,
         waves_per_eu=waves_per_eu,

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -60,6 +60,30 @@ _grouped_blockwise_warmed: set = set()
 _grouped_blockwise_vk_warmed: set = set()
 
 
+def _resolve_variable_k_out(
+    out: torch.Tensor | None,
+    beta: float,
+    shape: tuple[int, int, int],
+    device: torch.device,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Validate a variable-K wrapper's optional ``out`` buffer, or allocate one.
+
+    ``beta=0.0`` overwrites the output and is the default; ``beta=1.0`` accumulates
+    (``out += lhs^T @ rhs``) inside the GEMM epilogue and therefore needs the caller
+    to supply the buffer to accumulate into. Strides are read off ``out`` at launch,
+    so non-contiguous views are fine.
+    """
+    assert beta in (0.0, 1.0), f"Only beta=0 (overwrite) or beta=1 (accumulate) supported, got {beta}"
+    if out is None:
+        assert beta == 0.0, "beta=1.0 requires an explicit `out` buffer to accumulate into"
+        return torch.empty(shape, device=device, dtype=out_dtype)
+
+    assert tuple(out.shape) == shape, f"out shape {tuple(out.shape)} must equal (G, OUT_M, OUT_N) = {shape}"
+    assert out.device == device, "out must be on same device as lhs"
+    return out
+
+
 def offline_select_gg_fp8(M_total, G, N, K, s_ak, s_bk):
     """FP8 grouped GEMM config from MI300X bench (out_gg_fp8_persistent_full.yaml).
 
@@ -608,10 +632,12 @@ def grouped_gemm_fp8_tensorwise_variable_k_triton_kernel(
     rhs_scale: torch.Tensor,
     group_offs: torch.Tensor,
     out_dtype: torch.dtype = torch.bfloat16,
+    beta: float = 0.0,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Variable-K grouped FP8 GEMM (backward, per-tensor scaling) using Triton.
 
-    Computes C[g] = lhs[offs[g]:offs[g+1]]^T @ rhs[offs[g]:offs[g+1]] * lhs_scale * rhs_scale
+    Computes C[g] = beta * C[g] + lhs[offs[g]:offs[g+1]]^T @ rhs[offs[g]:offs[g+1]] * lhs_scale * rhs_scale
     Output: [G, OUT_M, OUT_N].
 
     Args:
@@ -620,10 +646,20 @@ def grouped_gemm_fp8_tensorwise_variable_k_triton_kernel(
         lhs_scale: Per-tensor scale for LHS, scalar fp32.
         rhs_scale: Per-tensor scale for RHS, scalar fp32.
         group_offs: [G+1] int64 prefix sum.
-        out_dtype: Output dtype (default bfloat16).
+        out_dtype: Output dtype (default bfloat16). Ignored when ``out`` is given,
+            since the kernel then writes in whatever dtype ``out`` has.
+        beta: Either ``0.0`` (overwrite, the default) or ``1.0`` (accumulate:
+            ``out += lhs^T @ rhs``); no other value is supported. ``beta=1.0``
+            requires ``out`` and folds the accumulation into the GEMM epilogue,
+            removing the separate elementwise add the caller would otherwise run
+            over the whole output.
+        out: Optional pre-allocated output buffer of shape ``(G, OUT_M, OUT_N)``.
+            When given, the kernel writes (or accumulates, see ``beta``) into it
+            instead of allocating. Strides are read off the tensor, so
+            non-contiguous views are fine.
 
     Returns:
-        [G, OUT_M, OUT_N] output.
+        [G, OUT_M, OUT_N] output (the same tensor as ``out`` when it was given).
     """
     assert lhs.ndim == 2 and rhs.ndim == 2
     assert lhs.shape[0] == rhs.shape[0]
@@ -631,7 +667,7 @@ def grouped_gemm_fp8_tensorwise_variable_k_triton_kernel(
     OUT_N = rhs.shape[1]
     G = group_offs.shape[0] - 1
 
-    out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)
+    out = _resolve_variable_k_out(out, beta, (G, OUT_M, OUT_N), lhs.device, out_dtype)
     num_sms = get_num_cus()
 
     avg_m_g = max(lhs.shape[0] // max(G, 1), 256)
@@ -666,6 +702,7 @@ def grouped_gemm_fp8_tensorwise_variable_k_triton_kernel(
         IS_FP8=True,
         CACHE_MODIFIER_A=cache_a,
         CACHE_MODIFIER_B=cache_b,
+        BETA_IS_ONE=(beta == 1.0),
         num_warps=8,
         num_stages=num_stages_val,
         waves_per_eu=0,
@@ -989,8 +1026,13 @@ def _grouped_fp8_rowwise_variable_k_gemm_kernel(
     CHUNK_SIZE: tl.constexpr,
     CACHE_MODIFIER_A: tl.constexpr,
     CACHE_MODIFIER_B: tl.constexpr,
+    BETA_IS_ONE: tl.constexpr = False,
 ):
-    """Persistent grouped variable-K FP8 GEMM kernel (backward, per-row/per-col vector scaling)."""
+    """Persistent grouped variable-K FP8 GEMM kernel (backward, per-row/per-col vector scaling).
+
+    With ``BETA_IS_ONE=True`` the kernel computes ``C = C + LHS_g^T @ RHS_g``, folding a
+    gradient accumulation into the epilogue instead of leaving it to the caller.
+    """
     pid = tl.program_id(0)
     if NUM_XCDS != 1:
         pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
@@ -1087,13 +1129,15 @@ def _grouped_fp8_rowwise_variable_k_gemm_kernel(
         lhs_scale = tl.load(LHS_scale_ptr + rm)
         rhs_scale = tl.load(RHS_scale_ptr + rn)
         acc *= lhs_scale[:, None] * rhs_scale[None, :]
-        c = acc.to(C.type.element_ty)
         rm_s = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
         rn_s = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
         rn_s = tl.max_contiguous(tl.multiple_of(rn_s % OUT_N, BLOCK_SIZE_N), BLOCK_SIZE_N)
         c_mask = (rm_s[:, None] < OUT_M) & (rn_s[None, :] < OUT_N)
         # Cast group_idx to int64 to prevent overflow in C group offset
         C_ = C + group_idx.to(tl.int64) * stride_cg + rm_s[:, None] * stride_cm + rn_s[None, :] * stride_cn
+        if BETA_IS_ONE:
+            acc += tl.load(C_, mask=c_mask, other=0.0).to(acc_dtype)
+        c = acc.to(C.type.element_ty)
         tl.store(C_, c, c_mask)
 
 
@@ -1105,6 +1149,8 @@ def grouped_gemm_fp8_rowwise_variable_k_triton_kernel(
     rhs_scale: torch.Tensor,
     group_offs: torch.Tensor,
     out_dtype: torch.dtype = torch.bfloat16,
+    beta: float = 0.0,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Variable-K grouped FP8 GEMM (backward, per-row/per-col scaling) using Triton.
 
@@ -1121,10 +1167,13 @@ def grouped_gemm_fp8_rowwise_variable_k_triton_kernel(
         lhs_scale: (OUT_M,) per-row scale for LHS, fp32.
         rhs_scale: (OUT_N,) per-col scale for RHS, fp32.
         group_offs: [G+1] int64 prefix sum.
-        out_dtype: Output dtype (default bfloat16).
+        out_dtype: Output dtype (default bfloat16). Ignored when ``out`` is given.
+        beta: ``0.0`` (overwrite) or ``1.0`` (accumulate into ``out``).
+        out: Optional pre-allocated ``(G, OUT_M, OUT_N)`` output buffer. See
+            ``grouped_gemm_fp8_tensorwise_variable_k_triton_kernel``.
 
     Returns:
-        [G, OUT_M, OUT_N] output.
+        [G, OUT_M, OUT_N] output (the same tensor as ``out`` when it was given).
     """
     assert lhs.ndim == 2 and rhs.ndim == 2
     assert lhs.shape[0] == rhs.shape[0]
@@ -1132,7 +1181,7 @@ def grouped_gemm_fp8_rowwise_variable_k_triton_kernel(
     OUT_N = rhs.shape[1]
     G = group_offs.shape[0] - 1
 
-    out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)
+    out = _resolve_variable_k_out(out, beta, (G, OUT_M, OUT_N), lhs.device, out_dtype)
     num_sms = get_num_cus()
 
     avg_m_g = max(lhs.shape[0] // max(G, 1), 256)
@@ -1166,6 +1215,7 @@ def grouped_gemm_fp8_rowwise_variable_k_triton_kernel(
         CHUNK_SIZE=chunk_size,
         CACHE_MODIFIER_A=cache_a,
         CACHE_MODIFIER_B=cache_b,
+        BETA_IS_ONE=(beta == 1.0),
         num_warps=8,
         num_stages=num_stages_val,
         waves_per_eu=0,
@@ -1582,9 +1632,13 @@ def _grouped_blockwise_fp8_variable_k_gemm_kernel(
     NUM_XCDS: tl.constexpr,
     CHUNK_SIZE: tl.constexpr,
     CACHE_MODIFIER: tl.constexpr,
+    BETA_IS_ONE: tl.constexpr = False,
 ):
     """Variable-K BWD: C[g] = LHS_g^T @ RHS_g. M_g is segment-padded to BLOCK_SIZE_K
-    by quant_fp8_blockwise_segment_m_row_col_impl, so no K-loop masking is needed."""
+    by quant_fp8_blockwise_segment_m_row_col_impl, so no K-loop masking is needed.
+
+    With ``BETA_IS_ONE=True`` the kernel computes ``C = C + LHS_g^T @ RHS_g``, folding a
+    gradient accumulation into the epilogue instead of leaving it to the caller."""
     pid = tl.program_id(0)
     if NUM_XCDS != 1:
         pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
@@ -1680,12 +1734,14 @@ def _grouped_blockwise_fp8_variable_k_gemm_kernel(
                 RHS_BASE += BLOCK_SIZE_K * stride_rhs_m
 
         # ── Store output ──
-        c = acc.to(C.type.element_ty)
         rm_s = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
         rn_s = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
         rn_s = tl.max_contiguous(tl.multiple_of(rn_s % OUT_N, BLOCK_SIZE_N), BLOCK_SIZE_N)
         c_mask = (rm_s[:, None] < OUT_M) & (rn_s[None, :] < OUT_N)
         C_ = C + group_idx.to(tl.int64) * stride_cg + rm_s[:, None] * stride_cm + rn_s[None, :] * stride_cn
+        if BETA_IS_ONE:
+            acc += tl.load(C_, mask=c_mask, other=0.0).to(acc_dtype)
+        c = acc.to(C.type.element_ty)
         tl.store(C_, c, c_mask)
 
 
@@ -1846,6 +1902,8 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
     b_k_contig: bool = False,
     out_M: int = -1,
     out_N: int = -1,
+    beta: float = 0.0,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Variable-K grouped block-wise FP8 GEMM (backward, 1D+1D scaling) using Triton.
 
@@ -1869,9 +1927,12 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
         b_k_contig: Same for rhs.
         out_M, out_N: Required when *_k_contig=True (cannot infer from transposed
                       shape because it equals OUT_M/N).
+        beta: ``0.0`` (overwrite) or ``1.0`` (accumulate into ``out``).
+        out: Optional pre-allocated ``(G, OUT_M, OUT_N)`` output buffer. See
+            ``grouped_gemm_fp8_tensorwise_variable_k_triton_kernel``.
 
     Returns:
-        [G, OUT_M, OUT_N] output.
+        [G, OUT_M, OUT_N] output (the same tensor as ``out`` when it was given).
     """
     assert lhs.ndim == 2 and rhs.ndim == 2
     G = group_offs.shape[0] - 1
@@ -1885,7 +1946,7 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
     else:
         OUT_N = rhs.shape[1]
 
-    out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=out_dtype)
+    out = _resolve_variable_k_out(out, beta, (G, OUT_M, OUT_N), lhs.device, out_dtype)
     num_sms = get_num_cus()
 
     # K-axis stride: for K-contig, dim 1 of [OUT_M, M_padded_max] = 1.
@@ -1900,7 +1961,14 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
     # (G, OUT_M, OUT_N, A_K_CONTIGUOUS, B_K_CONTIGUOUS) — group_offs is not part
     # of the key, so prime the cache once with a balanced distribution so the
     # chosen config generalizes across MoE per-step routing variation.
-    warm_key = (G, OUT_M, OUT_N, a_k_contig, b_k_contig)
+    #
+    # The output dtype and BETA_IS_ONE belong in the warm key too. Triton's autotuner
+    # folds tensor dtypes into its own cache key and benchmarks every candidate config
+    # by launching the kernel on the arguments it was given, so a beta=1 launch that
+    # still has to tune would accumulate into the caller's buffer once per benchmark
+    # iteration. Priming on a scratch buffer first keeps the real launch a cache hit.
+    beta_is_one = beta == 1.0
+    warm_key = (G, OUT_M, OUT_N, a_k_contig, b_k_contig, out.dtype, beta_is_one)
     if warm_key not in _grouped_blockwise_vk_warmed:
         _grouped_blockwise_vk_warmed.add(warm_key)
         # Padded segment lens for variable-K need to respect BLOCK_K alignment;
@@ -1909,7 +1977,9 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
         per = max((M_padded // G) // 128 * 128, 128)
         bal_offs = torch.arange(G + 1, device=group_offs.device, dtype=group_offs.dtype) * per
         bal_offs[-1] = M_padded
-        out_warm = torch.empty_like(out)
+        # Zeroed, not empty: with beta=1 the kernel reads this buffer back, and
+        # uninitialized NaNs would skew the benchmark.
+        out_warm = torch.zeros_like(out)
         _grouped_blockwise_fp8_variable_k_gemm_kernel[(num_sms,)](
             lhs,
             rhs,
@@ -1936,6 +2006,7 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
             NUM_SMS=num_sms,
             NUM_XCDS=NUM_XCDS,
             CACHE_MODIFIER=".ca",
+            BETA_IS_ONE=beta_is_one,
             waves_per_eu=2,
             matrix_instr_nonkdim=16,
             kpack=2,
@@ -1967,6 +2038,7 @@ def grouped_gemm_fp8_blockwise_variable_k_triton_kernel(
         NUM_SMS=num_sms,
         NUM_XCDS=NUM_XCDS,
         CACHE_MODIFIER=".ca",
+        BETA_IS_ONE=beta_is_one,
         waves_per_eu=2,
         matrix_instr_nonkdim=16,
         kpack=2,
@@ -2265,7 +2337,10 @@ def _grouped_mxfp8_variable_k_gemm_kernel(
     VEC: tl.constexpr,
     LHS_FMT: tl.constexpr,  # "e4m3"/"e5m2" — independent (HYBRID wgrad is
     RHS_FMT: tl.constexpr,  # e5m2 grad_out x e4m3 activation)
+    BETA_IS_ONE: tl.constexpr = False,
 ):
+    """With ``BETA_IS_ONE=True`` the kernel computes ``C = C + LHS[g] @ RHS[g]^T``,
+    folding a gradient accumulation into the epilogue."""
     pid = tl.program_id(0)
     if NUM_XCDS != 1:
         pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
@@ -2313,7 +2388,8 @@ def _grouped_mxfp8_variable_k_gemm_kernel(
         LS_BASE = LHS_scale + (sk0 + rks[:, None]) * stride_lsk + rm[None, :] * stride_lsm
         RS_BASE = RHS_scale + (sk0 + rks[:, None]) * stride_rsk + rn[None, :] * stride_rsm
 
-        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        acc_dtype = tl.float32
+        acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
         loop_k = M_g // BLOCK_SIZE_K  # padded → no mask
         for _ in range(loop_k):
             l = tl.load(tl.multiple_of(L_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER)  # (BM, BK)
@@ -2326,20 +2402,37 @@ def _grouped_mxfp8_variable_k_gemm_kernel(
             LS_BASE += (BLOCK_SIZE_K // VEC) * stride_lsk
             RS_BASE += (BLOCK_SIZE_K // VEC) * stride_rsk
 
-        c = acc.to(C.type.element_ty)
         rm_s = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
         rn_s = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
         cmask = (rm_s[:, None] < OUT_M) & (rn_s[None, :] < OUT_N)
         C_ = C + group_idx.to(tl.int64) * stride_cg + rm_s[:, None] * stride_cm + rn_s[None, :] * stride_cn
+        if BETA_IS_ONE:
+            acc += tl.load(C_, mask=cmask, other=0.0).to(acc_dtype)
+        c = acc.to(C.type.element_ty)
         tl.store(C_, c, cmask)
 
 
 @scoped_amd_knobs
 def grouped_gemm_mxfp8_variable_k_triton_kernel(
-    lhs, lhs_scale, rhs, rhs_scale, go_pad, OUT_M, OUT_N, G, out_dtype=torch.bfloat16, num_cu=None
+    lhs,
+    lhs_scale,
+    rhs,
+    rhs_scale,
+    go_pad,
+    OUT_M,
+    OUT_N,
+    G,
+    out_dtype=torch.bfloat16,
+    num_cu=None,
+    beta: float = 0.0,
+    out=None,
 ):
-    """C[g] (OUT_M,OUT_N) = lhs[:,g] @ rhs[:,g]^T. lhs (OUT_M,M_total), rhs (OUT_N,M_total)."""
-    c = torch.empty((G, OUT_M, OUT_N), dtype=out_dtype, device=lhs.device)
+    """C[g] (OUT_M,OUT_N) = beta * C[g] + lhs[:,g] @ rhs[:,g]^T.
+
+    lhs (OUT_M,M_total), rhs (OUT_N,M_total). ``out`` / ``beta`` behave as in
+    ``grouped_gemm_fp8_tensorwise_variable_k_triton_kernel``.
+    """
+    c = _resolve_variable_k_out(out, beta, (G, OUT_M, OUT_N), lhs.device, out_dtype)
     ls = lhs_scale.view(torch.uint8)
     rs = rhs_scale.view(torch.uint8)
     # Per-operand format (independent) — HYBRID wgrad pairs e5m2 grad_out with
@@ -2389,6 +2482,7 @@ def grouped_gemm_mxfp8_variable_k_triton_kernel(
         VEC=VEC_SIZE,
         LHS_FMT=lhs_fmt,
         RHS_FMT=rhs_fmt,
+        BETA_IS_ONE=(beta == 1.0),
         num_warps=8,
         num_stages=3,
         waves_per_eu=2,

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
@@ -793,8 +793,14 @@ def _process_variable_k_tile(
     CACHE_MODIFIER_A: tl.constexpr,
     CACHE_MODIFIER_B: tl.constexpr,
     ALLOW_TF32: tl.constexpr,
+    BETA_IS_ONE: tl.constexpr,
 ):
-    """Compute one variable-K output tile given its global tile id."""
+    """Compute one variable-K output tile given its global tile id.
+
+    With ``BETA_IS_ONE=True`` the tile is accumulated into whatever ``C`` already
+    holds (``C += LHS_g^T @ RHS_g``) instead of overwriting it, which is the
+    ``D = beta*D + alpha*A*B`` pattern with beta=1.
+    """
     # -- Map to (group, local_tile) -- simple div/mod, O(1) --
     group_idx = global_tile // tiles_per_group
     local_tile = global_tile - group_idx * tiles_per_group
@@ -825,7 +831,8 @@ def _process_variable_k_tile(
 
     # -- K-loop over M_g (variable per group, always masked) --
     loop_k = tl.cdiv(M_g, BLOCK_SIZE_K)
-    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    acc_dtype = tl.float32
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=acc_dtype)
 
     for k in range(loop_k):
         k_start = k * BLOCK_SIZE_K
@@ -871,12 +878,19 @@ def _process_variable_k_tile(
     # -- Apply scaling and store --
     if IS_FP8:
         acc *= scale
-    c = acc.to(C.type.element_ty)
     rm_s = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
     rn_s = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     rn_s = tl.max_contiguous(tl.multiple_of(rn_s % OUT_N, BLOCK_SIZE_N), BLOCK_SIZE_N)
     c_mask = (rm_s[:, None] < OUT_M) & (rn_s[None, :] < OUT_N)
     C_ = C + group_idx.to(tl.int64) * stride_cg + rm_s[:, None] * stride_cm + rn_s[None, :] * stride_cn
+    if BETA_IS_ONE:
+        # Read the previous value of this tile and fold it into the FP32
+        # accumulator before the cast. Costs one extra HBM read per output tile,
+        # which is nearly free in the bandwidth-bound regime since the tile is
+        # written anyway, and it removes the standalone accumulation kernel the
+        # caller would otherwise have to launch over the whole output.
+        acc += tl.load(C_, mask=c_mask, other=0.0).to(acc_dtype)
+    c = acc.to(C.type.element_ty)
     tl.store(C_, c, c_mask)
 
 
@@ -911,8 +925,14 @@ def _grouped_variable_k_gemm_kernel(
     CACHE_MODIFIER_A: tl.constexpr,
     CACHE_MODIFIER_B: tl.constexpr,
     ALLOW_TF32: tl.constexpr = torch.backends.cuda.matmul.allow_tf32,
+    BETA_IS_ONE: tl.constexpr = False,
 ):
-    """Persistent grouped variable-K GEMM kernel for backward (static stride)."""
+    """Persistent grouped variable-K GEMM kernel for backward (static stride).
+
+    With ``BETA_IS_ONE=True`` the kernel computes ``C = C + LHS_g^T @ RHS_g``, so a
+    caller holding a gradient-accumulation buffer can pass it as ``C`` and have the
+    accumulation folded into the GEMM's epilogue.
+    """
     pid = tl.program_id(0)
     if NUM_XCDS != 1:
         pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
@@ -961,6 +981,7 @@ def _grouped_variable_k_gemm_kernel(
             CACHE_MODIFIER_A=CACHE_MODIFIER_A,
             CACHE_MODIFIER_B=CACHE_MODIFIER_B,
             ALLOW_TF32=ALLOW_TF32,
+            BETA_IS_ONE=BETA_IS_ONE,
         )
 
 
@@ -1002,8 +1023,12 @@ def _grouped_variable_k_gemm_kernel_ws(
     CACHE_MODIFIER_B: tl.constexpr,
     COUNTER_STRIDE: tl.constexpr,
     ALLOW_TF32: tl.constexpr = torch.backends.cuda.matmul.allow_tf32,
+    BETA_IS_ONE: tl.constexpr = False,
 ):
-    """Variable-K persistent GEMM with per-XCD + global-fallback work stealing."""
+    """Variable-K persistent GEMM with per-XCD + global-fallback work stealing.
+
+    ``BETA_IS_ONE`` behaves as in :func:`_grouped_variable_k_gemm_kernel`.
+    """
     pid = tl.program_id(0)
     tiles_m = tl.cdiv(OUT_M, BLOCK_SIZE_M)
     tiles_n = tl.cdiv(OUT_N, BLOCK_SIZE_N)
@@ -1067,6 +1092,7 @@ def _grouped_variable_k_gemm_kernel_ws(
             CACHE_MODIFIER_A=CACHE_MODIFIER_A,
             CACHE_MODIFIER_B=CACHE_MODIFIER_B,
             ALLOW_TF32=ALLOW_TF32,
+            BETA_IS_ONE=BETA_IS_ONE,
         )
         if in_phase2:
             g_idx = tl.atomic_add(global_counter_ptr, 1, sem="relaxed", scope="gpu")
@@ -1094,10 +1120,12 @@ def grouped_gemm_variable_k_triton_kernel(
     work_steal: bool = False,
     ws_mode: str = "auto",
     ws_counter: torch.Tensor | None = None,
+    beta: float = 0.0,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Variable-K grouped BF16/FP16 GEMM (backward) using Triton.
 
-    Computes C[g] = lhs[offs[g]:offs[g+1]]^T @ rhs[offs[g]:offs[g+1]]
+    Computes C[g] = beta * C[g] + lhs[offs[g]:offs[g+1]]^T @ rhs[offs[g]:offs[g+1]]
     Output: [G, OUT_M, OUT_N].
 
     Args:
@@ -1112,9 +1140,18 @@ def grouped_gemm_variable_k_triton_kernel(
         ws_counter: Optional int32 buffer (per-device singleton managed by
             the higher-level wrapper when None). See
             ``grouped_gemm_triton_kernel`` for the single-stream caveat.
+        beta: Either ``0.0`` (overwrite, the default) or ``1.0`` (accumulate:
+            ``out += lhs^T @ rhs``); no other value is supported. ``beta=1.0``
+            requires ``out`` and folds the accumulation into the GEMM epilogue,
+            removing the separate elementwise add the caller would otherwise run
+            over the whole output.
+        out: Optional pre-allocated output buffer of shape ``(G, OUT_M, OUT_N)``.
+            When given, the kernel writes (or accumulates, see ``beta``) into it
+            instead of allocating, and its dtype decides the output dtype. Strides
+            are read off the tensor, so non-contiguous views are fine.
 
     Returns:
-        [G, OUT_M, OUT_N] output.
+        [G, OUT_M, OUT_N] output (the same tensor as ``out`` when it was given).
     """
     assert lhs.ndim == 2 and rhs.ndim == 2
     assert lhs.shape[0] == rhs.shape[0]
@@ -1122,7 +1159,17 @@ def grouped_gemm_variable_k_triton_kernel(
     OUT_N = rhs.shape[1]
     G = group_offs.shape[0] - 1
 
-    out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=lhs.dtype)
+    assert beta in (0.0, 1.0), f"Only beta=0 (overwrite) or beta=1 (accumulate) supported, got {beta}"
+    if out is None:
+        assert beta == 0.0, "beta=1.0 requires an explicit `out` buffer to accumulate into"
+        out = torch.empty((G, OUT_M, OUT_N), device=lhs.device, dtype=lhs.dtype)
+    else:
+        expected_shape = (G, OUT_M, OUT_N)
+        assert tuple(out.shape) == expected_shape, (
+            f"out shape {tuple(out.shape)} must equal (G, OUT_M, OUT_N) = {expected_shape}"
+        )
+        assert out.device == lhs.device, "out must be on same device as lhs"
+
     device_num_cus = get_num_cus()
     num_sms = min(num_cu, device_num_cus) if num_cu is not None and num_cu > 0 else device_num_cus
     dummy_scale = torch.empty(1, device=lhs.device, dtype=torch.float32)
@@ -1193,6 +1240,7 @@ def grouped_gemm_variable_k_triton_kernel(
             CACHE_MODIFIER_A=cache_a,
             CACHE_MODIFIER_B=cache_b,
             COUNTER_STRIDE=COUNTER_STRIDE,
+            BETA_IS_ONE=(beta == 1.0),
             num_warps=8,
             num_stages=num_stages_val,
             waves_per_eu=0,
@@ -1228,6 +1276,7 @@ def grouped_gemm_variable_k_triton_kernel(
         IS_FP8=False,
         CACHE_MODIFIER_A=cache_a,
         CACHE_MODIFIER_B=cache_b,
+        BETA_IS_ONE=(beta == 1.0),
         num_warps=8,
         num_stages=num_stages_val,
         waves_per_eu=0,

--- a/tests/pytorch/ops/test_gemm.py
+++ b/tests/pytorch/ops/test_gemm.py
@@ -148,6 +148,79 @@ def test_gemm_deterministic(m, n, k, layout, dtype, backend):
     GlobalBackendManager.reset()
 
 
+@pytest.mark.parametrize("layout", ["TN", "NN", "NT"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("main_grad_dtype", [torch.float32, None])
+@pytest.mark.parametrize("backend", [None, BackendType.TRITON, BackendType.HIPBLASLT])
+def test_gemm_fused_grad_accum(layout, dtype, main_grad_dtype, backend):
+    """``fuse_bgrad_accum_pattern`` must leave ``main_grad`` holding previous + wgrad.
+
+    The fused path hands the weight's ``main_grad`` to the wgrad GEMM as a beta=1
+    accumulate target instead of returning a gradient for autograd to add on top, so
+    the check is that the buffer moved by exactly the wgrad the ordinary path produces.
+    ``main_grad_dtype=None`` keeps the accumulator in the weight's own dtype; Megatron
+    uses FP32.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    m, n, k = 256, 512, 256
+    accum_dtype = main_grad_dtype if main_grad_dtype is not None else dtype
+
+    # A pinned backend exercises that backend's beta=1 accumulate epilogue; ``None``
+    # leaves the dispatcher to resolve one, which is how training actually runs.
+    GlobalBackendManager.set_gemm_backend(backend)
+    GlobalBackendManager.set_auto_tune(False)
+
+    device = "cuda"
+    torch.manual_seed(42)
+
+    trans_a = layout[0] == "T"
+    trans_b = layout[1] == "T"
+    a_shape = (k, m) if trans_a else (m, k)
+    b_shape = (n, k) if trans_b else (k, n)
+
+    a = torch.randn(a_shape, dtype=dtype, device=device, requires_grad=True)
+    b = torch.randn(b_shape, dtype=dtype, device=device, requires_grad=True)
+    grad_out = torch.randn((m, n), dtype=dtype, device=device)
+    a_fused = a.detach().clone().requires_grad_(True)
+    b_fused = b.detach().clone().requires_grad_(True)
+    torch.cuda.synchronize()
+
+    # Baseline: ordinary autograd, b.grad holds the weight gradient.
+    out = turbo.ops.gemm(a, b, trans_a, trans_b, dtype)
+    out.backward(grad_out)
+
+    # Fused: the wgrad is accumulated into a pre-seeded main_grad buffer.
+    previous = torch.randn(b_fused.shape, dtype=accum_dtype, device=device)
+    b_fused.main_grad = previous.clone()
+    b_fused.grad_added_to_main_grad = False
+
+    out_fused = turbo.ops.gemm(a_fused, b_fused, trans_a, trans_b, dtype, fuse_bgrad_accum_pattern="megatron")
+    out_fused.backward(grad_out)
+    torch.cuda.synchronize()
+
+    # The forward is untouched, and the weight is flagged so the training framework's
+    # own accumulation step stands down. Following Megatron, backward still hands back
+    # a dummy tensor rather than None (it keeps the DDP hooks on the main thread), so
+    # what matters is the flag plus the dummy matching the weight's shape and dtype --
+    # a dtype mismatch would make autograd allocate and cast a full-size copy.
+    torch.testing.assert_close(out_fused, out)
+    assert b_fused.grad_added_to_main_grad is True, "weight must be flagged during forward"
+    assert b_fused.grad.shape == b_fused.shape, "dummy wgrad must keep the weight's shape"
+    assert b_fused.grad.dtype == b_fused.dtype, "dummy wgrad must keep the weight's dtype"
+
+    torch.testing.assert_close(a.grad, a_fused.grad, **get_tolerances(dtype))
+    # Compare the accumulated buffer rather than the wgrad recovered by subtracting
+    # `previous`: that subtraction cancels the leading digits and blows the rounding of
+    # a low-precision accumulator up past any sensible tolerance. Tolerances follow the
+    # GEMM's dtype, since the baseline wgrad was rounded to it before autograd stored it.
+    expected = (previous.float() + b.grad.float()).to(accum_dtype)
+    torch.testing.assert_close(b_fused.main_grad, expected, **get_tolerances(dtype))
+
+    GlobalBackendManager.reset()
+
+
 @pytest.mark.parametrize(
     "m, n, k, layout",
     [

--- a/tests/pytorch/ops/test_gemm_fp8.py
+++ b/tests/pytorch/ops/test_gemm_fp8.py
@@ -659,3 +659,119 @@ def test_gemm_fp8_blockwise_triton_deterministic(m, n, k, layout, format, dtype,
         backend=backend,
         block_size=128,
     )
+
+
+def _run_gemm_fp8_fused_grad_accum_test(
+    m, n, k, layout, dtype, format, backend, main_grad_dtype=torch.float32
+):
+    """``fuse_bgrad_accum_pattern`` must leave ``main_grad`` holding previous + wgrad.
+
+    The fused path hands the weight's ``main_grad`` to the wgrad GEMM as a beta=1
+    accumulate target instead of returning a gradient for autograd to add on top, so
+    the check is that the buffer moved by exactly the wgrad the ordinary path produces.
+
+    ``main_grad_dtype`` is fp32 as Megatron allocates it; FlyDSL's accumulate epilogue
+    writes 16-bit only, so its coverage passes the weight's own dtype instead.
+    """
+    seed = 42
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    device = "cuda:0"
+    print(f"\nM={m}, N={n}, K={k}, layout={layout}, dtype={dtype}, format={format}, backend={backend}")
+
+    # A pinned backend exercises that backend's beta=1 accumulate epilogue; ``None``
+    # leaves the dispatcher to resolve one, which is how training actually runs.
+    GlobalBackendManager.set_gemm_backend(backend)
+    GlobalBackendManager.set_auto_tune(False)
+
+    trans_a = layout[0] == "T"
+    trans_b = layout[1] == "T"
+    a_shape = (k, m) if trans_a else (m, k)
+    b_shape = (n, k) if trans_b else (k, n)
+
+    config = Float8QuantConfig(format=format, granularity=ScalingGranularity.TENSORWISE)
+
+    a = torch.randn(a_shape, dtype=dtype, device=device, requires_grad=True)
+    b = torch.randn(b_shape, dtype=dtype, device=device, requires_grad=True)
+    grad_out = torch.randn((m, n), dtype=dtype, device=device)
+    a_fused = a.detach().clone().requires_grad_(True)
+    b_fused = b.detach().clone().requires_grad_(True)
+    torch.cuda.synchronize()
+
+    # Baseline: ordinary autograd, b.grad holds the weight gradient.
+    out = gemm_fp8(a, b, trans_a, trans_b, dtype, config)
+    out.backward(grad_out)
+    torch.cuda.synchronize()
+
+    # Fused: the wgrad is accumulated into a pre-seeded main_grad buffer.
+    previous = torch.randn(b_fused.shape, dtype=main_grad_dtype, device=device)
+    b_fused.main_grad = previous.clone()
+    b_fused.grad_added_to_main_grad = False
+
+    out_fused = gemm_fp8(
+        a_fused,
+        b_fused,
+        trans_a,
+        trans_b,
+        dtype,
+        config,
+        fuse_bgrad_accum_pattern="megatron",
+    )
+    out_fused.backward(grad_out)
+    torch.cuda.synchronize()
+
+    # The forward is untouched, and the weight is flagged so the training framework's
+    # own accumulation step stands down. Following Megatron, backward still hands back
+    # a dummy tensor rather than None (it keeps the DDP hooks on the main thread), so
+    # what matters is the flag plus the dummy matching the weight's shape and dtype --
+    # a dtype mismatch would make autograd allocate and cast a full-size copy.
+    torch.testing.assert_close(out_fused, out)
+    assert b_fused.grad_added_to_main_grad is True, "weight must be flagged during forward"
+    assert b_fused.grad.shape == b_fused.shape, "dummy wgrad must keep the weight's shape"
+    assert b_fused.grad.dtype == b_fused.dtype, "dummy wgrad must keep the weight's dtype"
+
+    snr_threshold = 25 if format == Format.E4M3 else 20
+
+    a_grad_snr = compute_snr(a.grad, a_fused.grad)
+    print(f"AGrad-SNR: {a_grad_snr:.2f} dB")
+    assert a_grad_snr > snr_threshold, "a_grad_snr too low"
+
+    # The baseline rounds the wgrad to dtype before autograd stores it while the fused
+    # path carries the fp32 accumulator all the way into main_grad, so the two differ
+    # by that rounding -- compare by SNR rather than exactly.
+    accumulated = b_fused.main_grad.float() - previous.float()
+    b_grad_snr = compute_snr(b.grad.float(), accumulated)
+    print(f"BGrad-SNR: {b_grad_snr:.2f} dB")
+    assert b_grad_snr > snr_threshold, "b_grad_snr too low"
+
+    GlobalBackendManager.reset()
+
+
+@pytest.mark.parametrize("layout", ["NT", "NN", "TN"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("format", [Format.E4M3, Format.HYBRID])
+@pytest.mark.parametrize("backend", [None, BackendType.TRITON, BackendType.HIPBLASLT])
+def test_gemm_fp8_fused_grad_accum(layout, dtype, format, backend):
+    _run_gemm_fp8_fused_grad_accum_test(
+        m=256, n=512, k=256, layout=layout, dtype=dtype, format=format, backend=backend
+    )
+
+
+@pytest.mark.parametrize("layout", ["NT", "NN", "TN"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("format", [Format.E4M3, Format.HYBRID])
+def test_gemm_fp8_fused_grad_accum_flydsl(layout, dtype, format):
+    """FlyDSL's beta=1 wgrad epilogue, against a main_grad in the weight's own dtype."""
+    if get_device_compute_capability() < (9, 5):
+        pytest.skip("FlyDSL fp8 GEMM is gfx950-only")
+    _run_gemm_fp8_fused_grad_accum_test(
+        m=256,
+        n=512,
+        k=256,
+        layout=layout,
+        dtype=dtype,
+        format=format,
+        backend=BackendType.FLYDSL,
+        main_grad_dtype=dtype,
+    )

--- a/tests/pytorch/ops/test_grouped_gemm.py
+++ b/tests/pytorch/ops/test_grouped_gemm.py
@@ -209,6 +209,69 @@ def generate_grouped_gemm_group_lens_with_zeros(b, m, num_zero):
     return group_lens
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("trans_b", [True, False])
+@pytest.mark.parametrize("num_zero", [0, 2])
+@pytest.mark.parametrize("backend", [None, BackendType.TRITON, BackendType.HIPBLASLT])
+def test_grouped_gemm_fused_grad_accum(dtype, trans_b, num_zero, backend):
+    """``fuse_bgrad_accum_pattern`` must leave ``main_grad`` holding previous + wgrad.
+
+    The fused path hands the weight's ``main_grad`` to the wgrad GEMM as a beta=1
+    accumulate target instead of returning a gradient for autograd to add on top, so
+    the check is that the buffer moved by exactly the wgrad the ordinary path produces.
+    Experts that got no tokens must come out untouched rather than zeroed -- zeroing
+    an empty group's slice is right for a fresh output buffer but would wipe the
+    caller's running sum here.
+    """
+    B, M, N, K = 4, 256, 512, 256
+    device = "cuda"
+
+    # A pinned backend exercises that backend's beta=1 accumulate epilogue; ``None``
+    # leaves the dispatcher to resolve one, which is how training actually runs.
+    GlobalBackendManager.set_grouped_gemm_backend(backend)
+    GlobalBackendManager.set_auto_tune(False)
+    torch.manual_seed(42)
+
+    if num_zero:
+        group_lens = generate_grouped_gemm_group_lens_with_zeros(B, M, num_zero=num_zero).to(device)
+    else:
+        group_lens = generate_grouped_gemm_group_lens(B, M, balance=False).to(device)
+
+    b_shape = (B, N, K) if trans_b else (B, K, N)
+    a = torch.randn((B * M, K), dtype=dtype, device=device, requires_grad=True)
+    b = torch.randn(b_shape, dtype=dtype, device=device, requires_grad=True)
+    grad_out = torch.randn((B * M, N), dtype=dtype, device=device)
+    a_fused = a.detach().clone().requires_grad_(True)
+    b_fused = b.detach().clone().requires_grad_(True)
+
+    # Baseline: ordinary autograd, b.grad holds the weight gradient.
+    out = grouped_gemm(a, b, group_lens, trans_b=trans_b)
+    out.backward(grad_out)
+
+    # Fused: the wgrad is accumulated into a pre-seeded main_grad buffer.
+    previous = torch.randn(b_fused.shape, dtype=torch.float32, device=device)
+    b_fused.main_grad = previous.clone()
+    b_fused.grad_added_to_main_grad = False
+
+    out_fused = grouped_gemm(
+        a_fused, b_fused, group_lens, trans_b=trans_b, fuse_bgrad_accum_pattern="megatron"
+    )
+    out_fused.backward(grad_out)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out_fused, out)
+    assert b_fused.grad_added_to_main_grad is True, "weight must be flagged during forward"
+    torch.testing.assert_close(a.grad, a_fused.grad, **get_tolerances(dtype))
+
+    # Compare the accumulated buffer rather than the wgrad recovered by subtracting
+    # `previous`: that subtraction cancels the leading digits and blows the rounding up
+    # past any sensible tolerance. Tolerances follow the GEMM's dtype, since the
+    # baseline wgrad was rounded to it before autograd stored it.
+    expected = previous + b.grad.float()
+    torch.testing.assert_close(b_fused.main_grad, expected, **get_tolerances(dtype))
+    GlobalBackendManager.reset()
+
+
 @pytest.mark.parametrize("B", [8])
 @pytest.mark.parametrize("M", [2048])
 @pytest.mark.parametrize("N_K", [(4096, 4096)])

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -1226,3 +1226,137 @@ def test_grouped_gemm_fp8_padded_tail_zeroed(ori_dtype, trans_b, backend):
     )
 
     GlobalBackendManager.reset()
+
+
+def _run_grouped_gemm_fp8_fused_grad_accum_test(
+    B, M, N, K, ori_dtype, granularity, trans_b, backend, main_grad_dtype=torch.float32
+):
+    """``fuse_bgrad_accum_pattern`` must leave ``main_grad`` holding previous + wgrad.
+
+    The fused path hands the weight's ``main_grad`` to the wgrad GEMM as a beta=1
+    accumulate target instead of returning a gradient for autograd to add on top, so
+    the check is that the buffer moved by exactly the wgrad the ordinary path produces.
+
+    ``main_grad_dtype`` is fp32 as Megatron allocates it; FlyDSL's accumulate epilogue
+    writes 16-bit only, so its coverage passes the weight's own dtype instead.
+    """
+    seed = 42
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    if granularity == ScalingGranularity.MX_BLOCKWISE:
+        supported, reason = check_mxfp8_support()
+        if not supported:
+            pytest.skip(reason)
+
+    if backend == BackendType.HIPBLASLT and granularity != ScalingGranularity.TENSORWISE:
+        pytest.skip("The hipBLASLt grouped GEMM only scales per tensor")
+
+    device = "cuda:0"
+    print(
+        f"\nB={B}, M={M}, N={N}, K={K}, ori_dtype={ori_dtype}, granularity={granularity}, "
+        f"trans_b={trans_b}, backend={backend}"
+    )
+
+    # A pinned backend exercises that backend's beta=1 accumulate epilogue; ``None``
+    # leaves the dispatcher to resolve one, which is how training actually runs.
+    GlobalBackendManager.set_grouped_gemm_backend(backend)
+    GlobalBackendManager.set_auto_tune(False)
+
+    if granularity == ScalingGranularity.BLOCKWISE:
+        config = Float8QuantConfig(format=Format.E4M3, granularity=granularity, block_size=128)
+    elif granularity == ScalingGranularity.MX_BLOCKWISE:
+        config = Float8QuantConfig(
+            format=Format.E4M3,
+            granularity=granularity,
+            block_size=MXFP8_BLOCK_SIZE,
+            scale_dtype=ScaleDtype.E8M0,
+        )
+    else:
+        config = Float8QuantConfig(format=Format.E4M3, granularity=granularity)
+
+    group_lens = generate_grouped_gemm_group_lens(B, M, balance=False).to(device)
+    b_shape = (B, N, K) if trans_b else (B, K, N)
+
+    a = torch.randn((B * M, K), dtype=ori_dtype, device=device, requires_grad=True)
+    b = torch.randn(b_shape, dtype=ori_dtype, device=device, requires_grad=True)
+    grad_out = torch.randn((B * M, N), dtype=ori_dtype, device=device)
+    a_fused = a.detach().clone().requires_grad_(True)
+    b_fused = b.detach().clone().requires_grad_(True)
+    torch.cuda.synchronize()
+
+    # Baseline: ordinary autograd, b.grad holds the weight gradient.
+    out = grouped_gemm_fp8(a, b, group_lens, trans_b=trans_b, config=config)
+    out.backward(grad_out)
+    torch.cuda.synchronize()
+
+    # Fused: the wgrad is accumulated into a pre-seeded main_grad buffer.
+    previous = torch.randn(b_fused.shape, dtype=main_grad_dtype, device=device)
+    b_fused.main_grad = previous.clone()
+    b_fused.grad_added_to_main_grad = False
+
+    out_fused = grouped_gemm_fp8(
+        a_fused,
+        b_fused,
+        group_lens,
+        trans_b=trans_b,
+        config=config,
+        fuse_bgrad_accum_pattern="megatron",
+    )
+    out_fused.backward(grad_out)
+    torch.cuda.synchronize()
+
+    # The forward is untouched, and the weight is flagged so the training framework's
+    # own accumulation step stands down. Following Megatron, backward still hands back
+    # a dummy tensor rather than None (it keeps the DDP hooks on the main thread), so
+    # what matters is the flag plus the dummy matching the weight's shape and dtype --
+    # a dtype mismatch would make autograd allocate and cast a full-size copy.
+    torch.testing.assert_close(out_fused, out)
+    assert b_fused.grad_added_to_main_grad is True, "weight must be flagged during forward"
+    assert b_fused.grad.shape == b_fused.shape, "dummy wgrad must keep the weight's shape"
+    assert b_fused.grad.dtype == b_fused.dtype, "dummy wgrad must keep the weight's dtype"
+
+    snr_threshold = 25
+
+    a_grad_snr = compute_snr(a.grad, a_fused.grad)
+    print(f"AGrad-SNR: {a_grad_snr:.2f} dB")
+    assert a_grad_snr > snr_threshold, "a_grad_snr too low"
+
+    # The baseline rounds the wgrad to ori_dtype before autograd stores it while the
+    # fused path carries the fp32 accumulator all the way into main_grad, so the two
+    # differ by that rounding -- compare by SNR rather than exactly.
+    accumulated = b_fused.main_grad.float() - previous.float()
+    b_grad_snr = compute_snr(b.grad.float(), accumulated)
+    print(f"BGrad-SNR: {b_grad_snr:.2f} dB")
+    assert b_grad_snr > snr_threshold, "b_grad_snr too low"
+
+    GlobalBackendManager.reset()
+
+
+@pytest.mark.parametrize("ori_dtype", ORI_DTYPE_VALUES)
+@pytest.mark.parametrize(
+    "granularity, trans_b",
+    [
+        (ScalingGranularity.TENSORWISE, True),
+        (ScalingGranularity.TENSORWISE, False),
+    ],
+)
+@pytest.mark.parametrize("backend", [None, BackendType.TRITON, BackendType.HIPBLASLT, BackendType.FLYDSL])
+def test_grouped_gemm_fp8_fused_grad_accum(ori_dtype, granularity, trans_b, backend):
+    if backend == BackendType.FLYDSL and get_device_compute_capability() < (9, 5):
+        pytest.skip("FlyDSL fp8 grouped GEMM is gfx950-only")
+    # FlyDSL's accumulate epilogue stores 16-bit, so it only takes a main_grad matching
+    # the weight; the others take the fp32 one Megatron allocates by default.
+    main_grad_dtype = ori_dtype if backend == BackendType.FLYDSL else torch.float32
+    _run_grouped_gemm_fp8_fused_grad_accum_test(
+        B=4,
+        M=256,
+        N=512,
+        K=256,
+        ori_dtype=ori_dtype,
+        granularity=granularity,
+        trans_b=trans_b,
+        backend=backend,
+        main_grad_dtype=main_grad_dtype,
+    )


### PR DESCRIPTION
# Description

Megatron-style training with gradient accumulation keeps a separate `main_grad` buffer (FP32 by default) for every weight.
Today Primus-Turbo returns the weight gradient (wgrad) from backward and the framework adds it into that buffer in a second, elementwise pass, so every weight pays for a full-size wgrad allocation plus a read-modify-write over a weight-sized buffer on every microbatch.

This PR folds that accumulation into the wgrad GEMM epilogue (`D = beta * C + op(A) @ op(B)` with `beta = 1`), so backward writes `b.main_grad` directly and the framework's own accumulation step stands down.
Ops opt in through a new `fuse_bgrad_accum_pattern` argument, with `"megatron"` as the only pattern currently recognized; when it is `None` (the default) every code path behaves exactly as before.

This is Part 1 and covers the tensorwise recipes: dense BF16/FP16 GEMM, dense FP8 tensorwise GEMM, grouped BF16/FP16 GEMM, and grouped FP8 tensorwise GEMM, on the hipBLASLt, Triton and FlyDSL backends.
FP4 gets the kernel-level plumbing but stays gated off at the op level, and the remaining FP8 granularities (rowwise / blockwise / MX-blockwise) are left for a follow-up.

Fixes # (no linked issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

**Public op API**

- Add `fuse_bgrad_accum_pattern` to `gemm`, `gemm_fp8`, `grouped_gemm`, `grouped_gemm_fp8`, `gemm_fp4` and `grouped_gemm_fp4`, documented in each public docstring.
- When the pattern is set, forward validates that the weight carries `main_grad` / `grad_added_to_main_grad`, sets `grad_added_to_main_grad = True` while the parameter object is still in hand, and stashes `main_grad` on the ctx (deliberately not through `save_for_backward`, since the in-place write would bump the version counter saved tensors are checked against).
- Backward then hands autograd a cached dummy tensor in the weight's own shape and dtype instead of `None`, which is what Megatron's backward hooks expect; the contents are never read, and matching the dtype avoids autograd allocating and casting a full-size copy.
- `gemm_fp8` asserts the pattern is `None` for non-TENSORWISE granularities, and the FP4 entry points assert it is `None` altogether, so an unsupported combination fails loudly instead of silently leaving `main_grad` unwritten.

**New shared helpers in `primus_turbo/pytorch/ops/utils.py`**

- Add `_setup_fused_grad_accum` (resolves and validates the accumulation buffer) and `_get_dummy_wgrad` (one persistent buffer per `(shape, dtype)`, reused across steps and arbitrary rank).
- Move `_get_fp8_dtype` and `_ensure_contiguous_grad_out` here from `ops/gemm_fp8.py` and `ops/grouped_gemm_fp8.py`, since three op modules now need them.

**New accumulate entry points in the kernel layer**

- Add `gemm_accum_impl`, `gemm_fp8_accum_impl`, `gemm_fp4_accum_impl`, `grouped_gemm_variable_k_accum_impl`, `grouped_gemm_fp8_variable_k_accum_impl` and `grouped_gemm_fp4_variable_k_accum_impl`, each registered as a custom op with `mutates_args={"out"}` and paired with a `register_fake` meta implementation.
- Auto-tune primes its cache on a zeroed scratch buffer of the same shape before dispatching on the caller's buffer: the tuner benchmarks a backend by launching it repeatedly, which with `beta=1` would otherwise accumulate the wgrad once per warmup and timing iteration.

**Backend capability gating**

- `can_handle` now receives `inplace_add_to_out` / `out`; backends without a `beta=1` epilogue (dense FP8 CK and Turbo, FP4 hipBLASLt and AITER, grouped CK, grouped FP4 Triton and FlyDSL) report the request as unsupported, so a pinned backend or auto-tune can never land somewhere that quietly ignores `out`.
- hipBLASLt and Triton carry the epilogue for the tensorwise paths and accept an FP32, BF16 or FP16 `main_grad`; FlyDSL's store epilogue is 16-bit only, so it requires `main_grad` to match the weight's own BF16/FP16 dtype.
- The grouped MXFP8 wgrad switches its default backend from FlyDSL to Triton when fusing, because Megatron allocates `main_grad` in FP32; FlyDSL can still be pinned through `GlobalBackendManager` when the accumulator matches the weight dtype.

**C++ / hipBLASLt layer**

- `hipblaslt_gemm`, `hipblaslt_gemm_fp8`, `hipblaslt_grouped_gemm` and `hipblaslt_grouped_gemm_fp8` take `float beta=0.0` and an optional `Tensor(a!) out`; both are defaulted, so existing callers and schemas are unaffected.
- `beta != 0` requires an `out` tensor, which is checked for contiguity, floating-point dtype and shape; otherwise the op allocates as before.
- `hipblaslt_gemm_impl` takes `beta` as a parameter instead of hardcoding `0.0`.
- In the grouped kernel, an expert that received no tokens no longer zeroes its output slice when `beta != 0`: that slice holds the caller's running sum, and zeroing it would wipe out everything accumulated so far.

**Triton kernels**

- Add a `BETA_IS_ONE` constexpr to the dense BF16/FP16 kernel, the dense FP8 tensorwise kernel and the variable-K grouped kernels; the epilogue loads `C` back and adds into the FP32 accumulator before the single rounding to the output dtype.
- The dense BF16/FP16 and FP8 kernels now handle `trans_c` by swapping the operands rather than swapping the output strides, which keeps the `beta=1` read-back row-major; a column-major read-back would force Triton to stage a 256x256 FP32 tile through LDS, well over the 160KB limit.
- The grouped tensorwise warm-cache key includes the output dtype and `BETA_IS_ONE`, and warmup runs against a zeroed scratch buffer so autotuning cannot accumulate into the real one.

**FlyDSL kernels**

- `StoreCPerTensor`, `StoreCPerTensorCShuffle` and the MXFP4 store paths gain a `beta_is_one` mode that reads `C` back through the same row-band SRD, adds in FP32 and rounds once; masked-out lanes read OOB and drop their store, so no extra bounds logic is needed.
- Read-backs are issued through a separate `prefetch` step so a caller writing several sub-tiles can put every load in flight before the first store waits on one, since the epilogue is latency-bound rather than bandwidth-bound.
- Add `resolve_accum_out` (validates a caller-owned `out` or allocates one) and `compile_with_scratch_out` (compilation runs the kernel once, so an accumulate build is compiled against scratch to avoid folding an extra GEMM into the caller's buffer) to `flydsl/utils/gemm_helper.py`.
- Auto-tune always races the `beta=0` build and then re-compiles the winning config with the accumulate epilogue, keeping the tuning result and the accumulate path on the same config.

**Tests**

- Add `test_gemm_fused_grad_accum`, `test_gemm_fp8_fused_grad_accum`, `test_gemm_fp8_fused_grad_accum_flydsl`, `test_grouped_gemm_fused_grad_accum` and `test_grouped_gemm_fp8_fused_grad_accum`.
- Each test seeds `main_grad` with random previous values, runs the ordinary and the fused path on identical inputs, and checks that the forward output and dgrad are unchanged, that the weight is flagged during forward, that the dummy wgrad keeps the weight's shape and dtype, and that `main_grad` moved by exactly the wgrad the ordinary path produces.
- Coverage spans TN/NN/NT layouts, BF16 and FP16, E4M3 and HYBRID FP8 formats, `main_grad` in FP32 and in the weight's own dtype, backend `None` (dispatcher-resolved) as well as Triton, hipBLASLt and FlyDSL pinned explicitly, and, for the grouped cases, groups with zero tokens.
- The accumulated buffer is compared directly rather than by subtracting the seed, because that subtraction cancels the leading digits and inflates the rounding error of a low-precision accumulator past any sensible tolerance.
- The FP8 grouped test compares by SNR instead, since the baseline rounds the wgrad to the original dtype while the fused path carries the FP32 accumulator all the way into `main_grad`.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
