### PR TITLE
fix: primus-turbo link file arch not correct when use dockerfile build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -335,6 +335,8 @@ def get_common_flags():
     cxx_flags += offload_arch_list  # hipcc needs --offload-arch for CK headers in .cpp files
     nvcc_flags += macro_arch_list
     nvcc_flags += offload_arch_list
+    # -fgpu-rdc defers device codegen to the link, so the link needs the archs too.
+    extra_link_args += offload_arch_list
 
     # Composable-Kernel (ck_tile) GEMM backend: define the guard macro only when built.
     if ck_backend_enabled():


### PR DESCRIPTION
# Description

Primus-Turbo is compiled with `-fgpu-rdc`, which defers device code generation from the compile step to the link step.
The target architectures resolved by `get_offload_archs()` were only appended to `cxx_flags` and `nvcc_flags`, but never to `extra_link_args`, so the final `--hip-link` invocation ran without any `--offload-arch` option and fell back to the compiler default architecture.

On a machine whose local GPU happens to match the requested architecture this goes unnoticed, but inside a Dockerfile build there is usually no GPU visible (or a different one than the deployment target), and `GPU_ARCHS` is the only source of truth.
In that case the object files are generated for the requested architecture while the device link produces code for the wrong one, and the resulting extension fails to load or run on the target GPU.

This PR forwards the same `--offload-arch` list to the link step so that compile and link always agree on the target architectures.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- `setup.py`: append the `--offload-arch` list returned by `get_offload_archs()` to `extra_link_args` in `get_common_flags()`, so the `-fgpu-rdc` device link targets the same architectures as the compile step.
- Added a short comment explaining why the link step needs the architecture flags as well.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
