### PR TITLE
feat: add grad accumulation fuse support for mxfp8/mxfp4 (Part2)

### DIFF
--- a/primus_turbo/flydsl/gemm/gemm_mxfp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_mxfp8_kernel.py
@@ -50,13 +50,16 @@ from primus_turbo.flydsl.utils.gemm_helper import (
     ScaleS2R,
     _PRESHUF_KT,
     _robust_time,
+    _store_quadrants,
     block_mn,
     build_preshuffle_ab_kernel,
     ceildiv,
+    compile_with_scratch_out,
     compute_global_swizzle,
     StoreCPerTensor,
     make_fp8_buffer_tensor_rebased,
     make_value_attrs,
+    resolve_accum_out,
     wait_barrier,
     xcd_remap_pid,
 )
@@ -80,6 +83,7 @@ def _build_mxfp8_nt_kernel(
     cbsz: int = 0,  # srcA fp8 format: 0=E4M3, 1=E5M2
     blgp: int = 0,  # srcB fp8 format: 0=E4M3, 1=E5M2
     out_fp16: bool = False,  # fp16 output (else bf16)
+    beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
 ):
     BLOCK_K = 128
     assert GROUP_M >= 1
@@ -187,7 +191,9 @@ def _build_mxfp8_nt_kernel(
         sa_s2r = ScaleS2R(A_scale, c_m, K, SA_TILES)
         sb_s2r = ScaleBComb(B_scale, c_n, K)  # one dwordx4 = b0+b1 scales
         _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
-        store_c = StoreCPerTensor(None, None, C, c_m, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty)
+        store_c = StoreCPerTensor(
+            None, None, C, c_m, c_n, mfma.idx, N_TILES_A, N_TILES_B, _out_ty, beta_is_one=beta_is_one
+        )
 
         # Global row/col bases for the two M / N regions (region1 = +LDS half).
         wave_m_offset = wave_m * (N_TILES_A * 16)
@@ -350,10 +356,17 @@ def _build_mxfp8_nt_kernel(
         base_row = block_m * BLOCK_M + wave_m_offset
         base_col = block_n * BLOCK_N + wave_n_offset
 
-        store_c.store(c00_frag, base_row + 0, base_col + 0)
-        store_c.store(c01_frag, base_row + 0, base_col + LDS_BLOCK_N)
-        store_c.store(c10_frag, base_row + LDS_BLOCK_M, base_col + 0)
-        store_c.store(c11_frag, base_row + LDS_BLOCK_M, base_col + LDS_BLOCK_N)
+        _store_quadrants(
+            store_c,
+            c00_frag,
+            c01_frag,
+            c10_frag,
+            c11_frag,
+            base_row,
+            base_col,
+            LDS_BLOCK_M,
+            LDS_BLOCK_N,
+        )
 
     # Bare kernel (NOT a launch): the fused factory issues it + the preshuffle kernel
     # from a single @flyc.jit host stub. BLOCK_M/BLOCK_N/waves_per_eu are returned so
@@ -367,9 +380,9 @@ _BLOCK_M = 256
 _BLOCK_N = 256
 _PRESHUF_BLK = 256  # preshuffle kernel block size (matches build_preshuffle_ab_kernel)
 
-# (K, bm, gm, xcd, gn, cbsz, blgp, out_fp16) -> launch_mxfp8_fused (preshuffle+gemm jit)
+# (K, bm, gm, xcd, gn, cbsz, blgp, out_fp16, beta1) -> launch_mxfp8_fused (preshuffle+gemm jit)
 _MXFP8_FUSED_CACHE: dict = {}
-_MXFP8_AT_CACHE: dict = {}  # (M,N,K,bm,gm,xcd,gn,cbsz,blgp,out_fp16) -> [raw_launch, compiled_or_None]
+_MXFP8_AT_CACHE: dict = {}  # (M,N,K,bm,gm,xcd,gn,cbsz,blgp,out_fp16,beta1) -> [raw_launch, compiled_or_None]
 # (M, N, K128, device, stream) -> (a_sp, b_sp, a_blocks, a_ngrp, b_ngrp). Caller-owned
 # scale workspace (turbo-style): the fused stub's preshuffle writes a_sp/b_sp then the
 # gemm reads them, in stream order, so reuse across same-shape calls on one stream is safe.
@@ -412,7 +425,7 @@ def _mx_nt_gn_cands(N):
     return [g for g in (4, 8, 16) if n_blocks >= 2 * g]
 
 
-def _compile_mxfp8_fused(K, bm, gm, xcd, gn=0, cbsz=0, blgp=0, out_fp16=False):
+def _compile_mxfp8_fused(K, bm, gm, xcd, gn=0, cbsz=0, blgp=0, out_fp16=False, beta_is_one=False):
     """Build the turbo-style fused @flyc.jit ``launch_mxfp8_fused``: ONE host stub
     that enqueues the A+B scale preshuffle kernel and then the NT mxfp8 GEMM kernel
     on the same stream (single Python dispatch, no separate preshuffle launch, no
@@ -436,6 +449,7 @@ def _compile_mxfp8_fused(K, bm, gm, xcd, gn=0, cbsz=0, blgp=0, out_fp16=False):
         cbsz=cbsz,
         blgp=blgp,
         out_fp16=out_fp16,
+        beta_is_one=beta_is_one,
     )
 
     @flyc.jit
@@ -474,11 +488,11 @@ def _compile_mxfp8_fused(K, bm, gm, xcd, gn=0, cbsz=0, blgp=0, out_fp16=False):
     return launch_mxfp8_fused
 
 
-def _get_mxfp8_fused_launch(K, bm, gm, xcd, gn=0, cbsz=0, blgp=0, out_fp16=False):
-    fk = (K, bm, gm, xcd, gn, cbsz, blgp, out_fp16)
+def _get_mxfp8_fused_launch(K, bm, gm, xcd, gn=0, cbsz=0, blgp=0, out_fp16=False, beta_is_one=False):
+    fk = (K, bm, gm, xcd, gn, cbsz, blgp, out_fp16, beta_is_one)
     launch = _MXFP8_FUSED_CACHE.get(fk)
     if launch is None:
-        launch = _compile_mxfp8_fused(K, bm, gm, xcd, gn, cbsz, blgp, out_fp16)
+        launch = _compile_mxfp8_fused(K, bm, gm, xcd, gn, cbsz, blgp, out_fp16, beta_is_one)
         _MXFP8_FUSED_CACHE[fk] = launch
     return launch
 
@@ -522,6 +536,9 @@ def _autotune_mxfp8(
         return cached
     cands = _MXFP8_NT_CANDIDATES
     stream = torch.cuda.current_stream()
+    # Race on a scratch: each candidate is run dozens of times, which a beta=1 build
+    # would fold into the caller's accumulation buffer.
+    out_view = torch.empty_like(out_view)
 
     def _time_cfg(bm, gm, xcd, gn):
         try:
@@ -579,10 +596,15 @@ def gemm_mxfp8_flydsl_kernel(
     trans_a: bool = False,
     trans_b: bool = True,
     out_dtype: torch.dtype = torch.bfloat16,
+    beta: float = 0.0,
+    out: "torch.Tensor | None" = None,
 ) -> torch.Tensor:
     """MXFP8 (per-1x32 E8M0 block-scaled) dense GEMM, gfx950. Returns C [M,N].
 
     NT only (trans_a=False, trans_b=True): A [M,K], B [N,K], C = a @ b^T.
+
+    ``beta=1.0`` accumulates into ``out`` (``out += a @ b^T``) in the epilogue instead
+    of overwriting it, and therefore requires ``out``.
 
     ``a_scale`` / ``b_scale`` are the RAW E8M0 block scales ([M, K//32] / [N, K//32],
     uint8/e8m0): this kernel preshuffles them to the broadcast int32 layout itself,
@@ -621,7 +643,8 @@ def gemm_mxfp8_flydsl_kernel(
     # kernel reads grow*K128+gk); contiguous straight out of quant, copy only if a view broke it.
     a_raw = (a_scale if a_scale.is_contiguous() else a_scale.contiguous()).view(torch.int32).reshape(-1)
     b_raw = (b_scale if b_scale.is_contiguous() else b_scale.contiguous()).view(torch.int32).reshape(-1)
-    out = torch.empty((M, N), dtype=out_dtype, device=a.device)
+    out = resolve_accum_out(out, beta, (M, N), a.device, out_dtype)
+    beta_is_one = beta == 1.0
     # Keep 2D int8 views (NOT flat 1D): FlyDSL marshals each shape dim as int32, so a
     # 1D [M*K] view overflows when M*K > 2^31. The kernel addresses via i64 SRD re-base
     # (extract_base_index reads only the base ptr), so the 2D shape is just metadata.
@@ -634,11 +657,13 @@ def gemm_mxfp8_flydsl_kernel(
     bm, gm, xcd, gn = _autotune_mxfp8(
         a8, b8, out, a_raw, b_raw, a_sp, b_sp, M, N, K, a_blocks, a_ngrp, b_ngrp, out_dtype, cbsz, blgp
     )
-    launch = _get_mxfp8_fused_launch(K, bm, gm, xcd, gn, cbsz=cbsz, blgp=blgp, out_fp16=out_fp16)
+    launch = _get_mxfp8_fused_launch(
+        K, bm, gm, xcd, gn, cbsz=cbsz, blgp=blgp, out_fp16=out_fp16, beta_is_one=beta_is_one
+    )
     args = (a8, b8, out, a_raw, b_raw, a_sp, b_sp, M, N, a_blocks, a_ngrp, b_ngrp, stream)
     # [raw, compiled]: raw for CUDA-graph capture (flyc.compile regresses under capture);
     # compiled for eager (skips per-call jit dispatch overhead). Mirrors _GROUPED_AT_CACHE.
-    at_key = (M, N, K, bm, gm, xcd, gn, cbsz, blgp, out_fp16)
+    at_key = (M, N, K, bm, gm, xcd, gn, cbsz, blgp, out_fp16, beta_is_one)
     entry = _MXFP8_AT_CACHE.get(at_key)
     if entry is None:
         entry = [launch, None]
@@ -648,7 +673,7 @@ def gemm_mxfp8_flydsl_kernel(
         raw(*args)
     else:
         if compiled is None:
-            compiled = flyc.compile(raw, *args)
+            compiled = compile_with_scratch_out(raw, args)
             entry[1] = compiled
         compiled(*args)
     return out

--- a/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -60,10 +60,12 @@ from primus_turbo.flydsl.utils.gemm_helper import (
     StoreCPerTensorCShuffle,
     _readfirstlane_i32,
     _robust_time,
+    _store_quadrants,
     asm_mma_do,
     ceildiv,
     compute_global_swizzle,
     compute_global_swizzle_nn,
+    lds_barrier,
     make_fp8_buffer_tensor_rebased,
     make_value_attrs,
     mask_a_tail,
@@ -109,29 +111,6 @@ def _build_mfma(N_TILES_A, N_TILES_B, cbsz, blgp, asm_mode=None):
     if asm_mode is not None:
         mfma._do_mma = lambda _a, _b, _c: asm_mma_do(_a, _b, _c, mode=asm_mode, cbsz=cbsz, blgp=blgp)
     return mfma
-
-
-def _store_quadrants(store_c, c00, c01, c10, c11, base_row, base_col, LDS_BLOCK_M, LDS_BLOCK_N):
-    """Store the four accumulator quadrants at their (row, col) sub-tile offsets.
-
-    A beta=1 epilogue read-back is software-pipelined by one quadrant: quadrant i+1's
-    loads go out before quadrant i stores, so they overlap without keeping all four
-    quadrants' worth of loaded values live at once. The 4-wave wgrad runs at occupancy
-    1, so it has neither a co-resident wave to hide the latency nor the registers to
-    spare for prefetching everything up front.
-    """
-    quads = (
-        (c00, base_row + 0, base_col + 0),
-        (c01, base_row + 0, base_col + LDS_BLOCK_N),
-        (c10, base_row + LDS_BLOCK_M, base_col + 0),
-        (c11, base_row + LDS_BLOCK_M, base_col + LDS_BLOCK_N),
-    )
-    nxt = store_c.prefetch(quads[0][1], quads[0][2])
-    for i, (frag, r, c) in enumerate(quads):
-        cur = nxt
-        if i + 1 < len(quads):
-            nxt = store_c.prefetch(quads[i + 1][1], quads[i + 1][2])
-        store_c.store(frag, r, c, prev=cur)
 
 
 # ── PERSISTENT grouped NN dgrad: a fixed grid of num_sms WGs strides the tile space
@@ -2364,7 +2343,11 @@ def _wholeloop_asm_3buf(
         for p in range(4):
             L.append(f"s_mov_b32 ${o_wsoff[p]}, ${i_soff0[p]}")
         L += [ds_line(refill0, tt) for tt in range(NT, NT + ntmp)]
+        # lgkmcnt(0) only retires THIS wave's prime reads; phase 0's g2s refills the very
+        # buffer they read, so without a barrier a wave that runs ahead can overwrite a
+        # lagging wave's source.
         L.append("s_waitcnt lgkmcnt(0)")
+        L.append("s_barrier")
         L.append("1:")
         for ph in range(n_phases):
             L += _emit_phase_block(ph, _ipend)
@@ -2632,6 +2615,9 @@ def _wave4_do_tile_tn(
     _cm,
     _cn,
     beta_is_one=False,
+    epi_cshuffle=False,
+    c_lds=None,
+    epi_lds_fence=False,
 ):
     tt = xcd_remap_pid(t, TOTAL, num_xcd)
     group_idx, block_m, block_n = _wgrad_block_mn(
@@ -2699,10 +2685,7 @@ def _wave4_do_tile_tn(
         wswz=_wswz,
     )
 
-    if (
-        os.environ.get("PT_EPI_PLAIN", "0") == "1"
-        or os.environ.get("PT_WL_2BPOOL", "1") == "1"  # 2bpool forces scalar store
-    ):
+    if const_expr(not epi_cshuffle):
         store_c = StoreCPerTensor(
             A_scale,
             B_scale,
@@ -2726,7 +2709,7 @@ def _wave4_do_tile_tn(
             N_TILES_A,
             N_TILES_B,
             _out_ty,
-            lds.C_lds_shuffle,
+            c_lds,
             wave_id,
             row_pad=4,  # must match epi_pad in _wave4_geometry's C_lds_shuffle sizing (cshuf_n)
             beta_is_one=beta_is_one,
@@ -2774,6 +2757,9 @@ def _wave4_do_tile_tn(
         tail_nval=tail_k_u,
         b0_extra_buf=_b0x,
     )
+    if const_expr(epi_lds_fence):
+        # c_lds aliases a loop buffer; fence before the next tile's prologue refills it.
+        lds_barrier()
 
 
 def _make_wave4_smem(*, a_lds_size, b_lds_size, cshuf_ty, cshuf_n, tail):
@@ -2902,6 +2888,12 @@ def _compile_grouped_tn_wgrad_4wave(
         cshuf_n=(16 if _2BPOOL else _cshuf_n),
         tail=["C", "B_extra_1"] + (["B_extra_0"] if _2BPOOL else []),
     )
+    # beta=1 always takes the CShuffle epilogue.
+    _epi_cshuffle = beta_is_one or not _2BPOOL
+    _epi_alias = _epi_cshuffle and _2BPOOL
+    assert not _epi_alias or a_lds_size >= _cshuf_n * 2, (
+        f"aliased C staging needs {_cshuf_n * 2}B, A_lds_cur_0 holds {a_lds_size}B"
+    )
 
     @flyc.kernel(known_block_size=[256, 1, 1])
     def kernel_grouped_tn_wgrad_4wave(
@@ -2981,6 +2973,9 @@ def _compile_grouped_tn_wgrad_4wave(
                 _cm=_cm,
                 _cn=_cn,
                 beta_is_one=beta_is_one,
+                epi_cshuffle=_epi_cshuffle,
+                c_lds=(lds.A_lds_cur_0 if _epi_alias else lds.C_lds_shuffle),
+                epi_lds_fence=_epi_alias,
             )
 
         # Persistent: a fixed grid of <=ncus WGs strides the tile space (scf.for).

--- a/primus_turbo/flydsl/grouped_gemm/grouped_gemm_mxfp4_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/grouped_gemm_mxfp4_kernel.py
@@ -39,6 +39,7 @@ from primus_turbo.flydsl.utils.gemm_helper import (
     _robust_time,
     ceildiv,
     make_fp8_rebased_tensor_and_srd,
+    resolve_accum_out,
     wait_barrier,
     xcd_remap_pid,
 )
@@ -724,7 +725,17 @@ def grouped_gemm_mxfp4_flydsl_kernel(
 
 
 def _build_grouped_mxfp4_wgrad_kernel(
-    OUT_M, OUT_N, G, M_total, group_m=4, num_xcds=8, group_n=0, wlv=10, elgk=9, out_fp16=False
+    OUT_M,
+    OUT_N,
+    G,
+    M_total,
+    group_m=4,
+    num_xcds=8,
+    group_n=0,
+    wlv=10,
+    elgk=9,
+    out_fp16=False,
+    beta_is_one=False,  # epilogue accumulates (C += acc) instead of overwriting
 ):
     BLOCK_M = BLOCK_N = BLOCK_K = _BLOCK
     swizzle = True
@@ -938,7 +949,14 @@ def _build_grouped_mxfp4_wgrad_kernel(
         base_col_r = b_row + I32(LDS_BN_HALF) + I32(wave_n_off)
         _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
         store_c = StoreCPlain(
-            C, (group_idx + I32(1)) * I32(OUT_M), OUT_N, mfma.idx, N_TILES_A, N_TILES_BH, _out_ty
+            C,
+            (group_idx + I32(1)) * I32(OUT_M),
+            OUT_N,
+            mfma.idx,
+            N_TILES_A,
+            N_TILES_BH,
+            _out_ty,
+            beta_is_one=beta_is_one,
         )
         store_c.store(accL, base_row, base_col_l, n_valid=_NV)
         store_c.store(accR, base_row, base_col_r, n_valid=_NV)
@@ -950,7 +968,7 @@ def _build_grouped_mxfp4_wgrad_kernel(
 
 _GMXFP4_WGRAD_LAUNCH_CACHE: dict = {}
 _GMXFP4_WGRAD_WS_CACHE: dict = {}
-_GMXFP4_WGRAD_AT_CACHE: dict = {}  # (OUT_M_p, OUT_N_p, M_alloc, G, out_fp16) -> [raw, compiled]
+_GMXFP4_WGRAD_AT_CACHE: dict = {}  # (OUT_M_p, OUT_N_p, M_alloc, G, out_fp16, beta1) -> [raw, compiled]
 
 
 def _get_grouped_mxfp4_wgrad_ws(OUT_M, OUT_N, K128m, device):
@@ -966,11 +984,23 @@ def _get_grouped_mxfp4_wgrad_ws(OUT_M, OUT_N, K128m, device):
     return e
 
 
-def _compile_grouped_mxfp4_wgrad_fused(OUT_M, OUT_N, G, M_total, gm, xcd, gn, wlv, elgk, out_fp16):
+def _compile_grouped_mxfp4_wgrad_fused(
+    OUT_M, OUT_N, G, M_total, gm, xcd, gn, wlv, elgk, out_fp16, beta_is_one=False
+):
     K128m = M_total // 128
     pre_ab = _build_mxfp4_preshuffle_kernel_ab()
     gemm_k, attrs, TOTAL = _build_grouped_mxfp4_wgrad_kernel(
-        OUT_M, OUT_N, G, M_total, group_m=gm, num_xcds=xcd, group_n=gn, wlv=wlv, elgk=elgk, out_fp16=out_fp16
+        OUT_M,
+        OUT_N,
+        G,
+        M_total,
+        group_m=gm,
+        num_xcds=xcd,
+        group_n=gn,
+        wlv=wlv,
+        elgk=elgk,
+        out_fp16=out_fp16,
+        beta_is_one=beta_is_one,
     )
     _PGRID = _MXFP4_PRESHUF_NG * _MXFP4_PRESHUF_BLK
 
@@ -999,14 +1029,28 @@ def _compile_grouped_mxfp4_wgrad_fused(OUT_M, OUT_N, G, M_total, gm, xcd, gn, wl
 
 
 def grouped_gemm_mxfp4_variable_k_flydsl_kernel(
-    lhs, lhs_scale, rhs, rhs_scale, group_offs, OUT_M, OUT_N, G, out_dtype=torch.bfloat16, num_cu=-1
+    lhs,
+    lhs_scale,
+    rhs,
+    rhs_scale,
+    group_offs,
+    OUT_M,
+    OUT_N,
+    G,
+    out_dtype=torch.bfloat16,
+    num_cu=-1,
+    beta=0.0,
+    out=None,
 ):
     """FlyDSL MXFP4 grouped variable-K wgrad (bare-asm whole-loop). lhs [OUT_M, M/2] /
     rhs [OUT_N, M/2] fp4 in the FlyDSL-quant colwise layout (each group's M already
     512-aligned), group_offs [G+1] the matching 512-padded per-group M offsets. Runs the
     NT whole-loop with a runtime nval directly -- no on-GPU repack, no free-dim pad (the
     non-256 OUT_M rows are SRD-dropped, OUT_N cols masked in the store). Returns
-    C [G, OUT_M, OUT_N]."""
+    C [G, OUT_M, OUT_N].
+
+    ``beta=1.0`` accumulates into ``out`` (``out[g] += lhs[:,g] @ rhs[:,g]^T``) in the
+    epilogue instead of overwriting it, and therefore requires ``out``."""
     assert lhs.ndim == 2 and rhs.ndim == 2
     assert lhs.shape[0] == OUT_M and rhs.shape[0] == OUT_N
     M_total = lhs.shape[1] * 2  # colwise contraction width (512-padded per group by the quant)
@@ -1027,7 +1071,8 @@ def grouped_gemm_mxfp4_variable_k_flydsl_kernel(
     a_sp, b_sp = _get_grouped_mxfp4_wgrad_ws(OUT_M, OUT_N, K128m, dev)
     # 3D C (NOT flattened): StoreCPlain re-bases per row band from C's base + OUT_N; a 1D
     # G*OUT_M*OUT_N view overflows the CABI for large-G MoE grad_b (> 2^31 elems).
-    out = torch.empty((G, OUT_M, OUT_N), dtype=out_dtype, device=dev)
+    out = resolve_accum_out(out, beta, (G, OUT_M, OUT_N), dev, out_dtype)
+    beta_is_one = beta == 1.0
 
     stream = torch.cuda.current_stream()
     wlv, elgk = 10, 9
@@ -1035,14 +1080,14 @@ def grouped_gemm_mxfp4_variable_k_flydsl_kernel(
 
     def _entry(cfg):
         gm, xcd, gn = cfg
-        lk = (OUT_M, OUT_N, G, M_total, gm, xcd, gn, wlv, elgk, out_fp16)
+        lk = (OUT_M, OUT_N, G, M_total, gm, xcd, gn, wlv, elgk, out_fp16, beta_is_one)
         ent = _GMXFP4_WGRAD_LAUNCH_CACHE.get(lk)
         if ent is None:
             ent = _compile_grouped_mxfp4_wgrad_fused(
-                OUT_M, OUT_N, G, M_total, gm, xcd, gn, wlv, elgk, out_fp16
+                OUT_M, OUT_N, G, M_total, gm, xcd, gn, wlv, elgk, out_fp16, beta_is_one
             )
             _GMXFP4_WGRAD_LAUNCH_CACHE[lk] = ent
-        atk = (OUT_M, OUT_N, M_total, G, gm, xcd, gn, out_fp16)
+        atk = (OUT_M, OUT_N, M_total, G, gm, xcd, gn, out_fp16, beta_is_one)
         e2 = _GMXFP4_WGRAD_AT_CACHE.get(atk)
         if e2 is None:
             e2 = [ent[0], None]

--- a/primus_turbo/flydsl/grouped_gemm/grouped_gemm_mxfp8_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/grouped_gemm_mxfp8_kernel.py
@@ -37,10 +37,13 @@ from primus_turbo.flydsl.utils.gemm_helper import (
     _emit_lds_repack,
     _readfirstlane_i32,
     _robust_time,
+    _store_quadrants,
     ceildiv,
+    compile_with_scratch_out,
     compute_global_swizzle,
     make_fp8_buffer_tensor_rebased,
     make_value_attrs,
+    resolve_accum_out,
     wait_barrier,
     xcd_remap_pid,
 )
@@ -69,7 +72,7 @@ def run_eager_or_capture(entry, args, compiled_idx):
         entry[0](*args)
     else:
         if entry[compiled_idx] is None:
-            entry[compiled_idx] = flyc.compile(entry[0], *args)
+            entry[compiled_idx] = compile_with_scratch_out(entry[0], args)
         entry[compiled_idx](*args)
 
 
@@ -1059,6 +1062,7 @@ def _build_grouped_mxfp8_wgrad_kernel(
     blgp: int = 0,
     out_fp16: bool = False,
     chunk: int = 8,
+    beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
 ):
     """Grouped MXFP8 variable-K wgrad (runtime per-group contraction M_g)."""
     BLOCK_K = 128
@@ -1163,7 +1167,16 @@ def _build_grouped_mxfp8_wgrad_kernel(
             sa_s2r = ScaleS2R(A_scale, OUT_M, m_total, SA_TILES, pack=1)  # wgrad: unpacked scales
             sb_s2r = ScaleBComb(B_scale, OUT_N, m_total, pack=1)
             store_c = StoreCPerTensor(
-                None, None, C, (group_idx + 1) * OUT_M, OUT_N, mfma.idx, N_TILES_A, N_TILES_B, _out_ty
+                None,
+                None,
+                C,
+                (group_idx + 1) * OUT_M,
+                OUT_N,
+                mfma.idx,
+                N_TILES_A,
+                N_TILES_B,
+                _out_ty,
+                beta_is_one=beta_is_one,
             )
 
             wave_m_offset = wave_m * (N_TILES_A * 16)
@@ -1282,10 +1295,17 @@ def _build_grouped_mxfp8_wgrad_kernel(
             c01_frag = [Vec(fx.memref_load_vec(r)) for r in acc01]
             c10_frag = [Vec(fx.memref_load_vec(r)) for r in acc10]
             c11_frag = [Vec(fx.memref_load_vec(r)) for r in acc11]
-            store_c.store(c00_frag, base_row + 0, base_col + 0)
-            store_c.store(c01_frag, base_row + 0, base_col + LDS_BLOCK_N)
-            store_c.store(c10_frag, base_row + LDS_BLOCK_M, base_col + 0)
-            store_c.store(c11_frag, base_row + LDS_BLOCK_M, base_col + LDS_BLOCK_N)
+            _store_quadrants(
+                store_c,
+                c00_frag,
+                c01_frag,
+                c10_frag,
+                c11_frag,
+                base_row,
+                base_col,
+                LDS_BLOCK_M,
+                LDS_BLOCK_N,
+            )
 
         _do_tile(pid)
 
@@ -1294,12 +1314,14 @@ def _build_grouped_mxfp8_wgrad_kernel(
 
 # ── wgrad host wrapper ───────────────────────────────────────────────────────
 
-_GWG_FUSED_CACHE: dict = {}  # (OUT_M, OUT_N, G, bm, bn, gm, xcd, gn, cbsz, blgp, out_fp16) -> launch
+_GWG_FUSED_CACHE: dict = {}  # (OUT_M, OUT_N, G, bm, bn, gm, xcd, gn, cbsz, blgp, out_fp16, beta1) -> launch
 _GWG_WS_CACHE: dict = {}  # (OUT_M, OUT_N, K128, device, stream) -> (a_sp, b_sp)
-_GWG_AT_CACHE: dict = {}  # (OUT_M, OUT_N, M_total, G, cbsz, blgp, out_fp16) -> [raw, compiled]
+_GWG_AT_CACHE: dict = {}  # (OUT_M, OUT_N, M_total, G, cbsz, blgp, out_fp16, beta1) -> [raw, compiled]
 
 
-def _compile_grouped_mxfp8_wgrad_fused(OUT_M, OUT_N, G, bm, bn, gm, xcd, gn, cbsz, blgp, out_fp16):
+def _compile_grouped_mxfp8_wgrad_fused(
+    OUT_M, OUT_N, G, bm, bn, gm, xcd, gn, cbsz, blgp, out_fp16, beta_is_one=False
+):
     pre_kern, a_ngrp, b_ngrp = _build_grouped_wgrad_preshuffle_kernel(OUT_M, OUT_N)
     gemm_kern, BM, BN, wpe, TOTAL = _build_grouped_mxfp8_wgrad_kernel(
         OUT_M=OUT_M,
@@ -1313,6 +1335,7 @@ def _compile_grouped_mxfp8_wgrad_fused(OUT_M, OUT_N, G, bm, bn, gm, xcd, gn, cbs
         cbsz=cbsz,
         blgp=blgp,
         out_fp16=out_fp16,
+        beta_is_one=beta_is_one,
     )
 
     @flyc.jit
@@ -1374,8 +1397,14 @@ def grouped_gemm_mxfp8_variable_k_flydsl_kernel(
     G: int,
     out_dtype: torch.dtype = torch.bfloat16,
     num_cu: "int | None" = -1,
+    beta: float = 0.0,
+    out: "torch.Tensor | None" = None,
 ) -> "torch.Tensor":
-    """FlyDSL MXFP8 grouped variable-K wgrad. Returns C [G, OUT_M, OUT_N]."""
+    """FlyDSL MXFP8 grouped variable-K wgrad. Returns C [G, OUT_M, OUT_N].
+
+    ``beta=1.0`` accumulates into ``out`` (``out[g] += lhs[:,g] @ rhs[:,g]^T``) in the
+    epilogue instead of overwriting it, and therefore requires ``out``.
+    """
     assert lhs.ndim == 2 and rhs.ndim == 2
     assert lhs.shape[0] == OUT_M and rhs.shape[0] == OUT_N
     M_total = lhs.shape[1]
@@ -1390,7 +1419,8 @@ def grouped_gemm_mxfp8_variable_k_flydsl_kernel(
     b_raw = (rhs_scale if rhs_scale.is_contiguous() else rhs_scale.contiguous()).view(torch.int32).reshape(-1)
     a8 = lhs.contiguous().view(torch.int8)
     b8 = rhs.contiguous().view(torch.int8)
-    out = torch.empty((G, OUT_M, OUT_N), dtype=out_dtype, device=lhs.device)
+    out = resolve_accum_out(out, beta, (G, OUT_M, OUT_N), lhs.device, out_dtype)
+    beta_is_one = beta == 1.0
 
     _go = group_offs if group_offs.dtype == torch.int64 else group_offs.to(torch.int64)
     go = _go.view(torch.int32)
@@ -1406,16 +1436,16 @@ def grouped_gemm_mxfp8_variable_k_flydsl_kernel(
 
     bm, bn, gm, xcd, gn = 256, 256, 4, 8, 0
     # Single universal variable-K kernel: chunk-local SSA accumulation, no balance detection.
-    fk = (OUT_M, OUT_N, G, bm, bn, gm, xcd, gn, cbsz, blgp, out_fp16)
+    fk = (OUT_M, OUT_N, G, bm, bn, gm, xcd, gn, cbsz, blgp, out_fp16, beta_is_one)
     launch = _GWG_FUSED_CACHE.get(fk)
     if launch is None:
         launch = _compile_grouped_mxfp8_wgrad_fused(
-            OUT_M, OUT_N, G, bm, bn, gm, xcd, gn, cbsz, blgp, out_fp16
+            OUT_M, OUT_N, G, bm, bn, gm, xcd, gn, cbsz, blgp, out_fp16, beta_is_one
         )
         _GWG_FUSED_CACHE[fk] = launch
 
     args = (a8, b8, out, a_raw, b_raw, a_sp, b_sp, go, M_total, K128, n_kt, a_blocks, pre_grid, stream)
-    at_key = (OUT_M, OUT_N, M_total, G, cbsz, blgp, out_fp16)
+    at_key = (OUT_M, OUT_N, M_total, G, cbsz, blgp, out_fp16, beta_is_one)
     entry = _GWG_AT_CACHE.get(at_key)
     if entry is None:
         entry = [launch, None]

--- a/primus_turbo/flydsl/utils/gemm_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_helper.py
@@ -351,6 +351,17 @@ def wait_barrier(count):
     )
 
 
+def lds_barrier():
+    """Drain this wave's LDS traffic, then sync the workgroup."""
+    _llvm.inline_asm(
+        res=None,
+        operands_=[],
+        asm_string="s_waitcnt lgkmcnt(0)\ns_barrier",
+        constraints="",
+        has_side_effects=True,
+    )
+
+
 class Mfma16x16x128:
     def __init__(self, n_tiles_a, n_tiles_b):
         self.atom = fx.make_mma_atom(fx.rocdl.cdna4.MFMA_Scale(16, 16, 128, fx.Float8E4M3FN))
@@ -806,6 +817,29 @@ class StoreCPerTensorCShuffle:
                     n += 1
                 _buffer_ops.buffer_store(vec, rsrc, off_e * out_b, mask=valid, offset_is_bytes=True)
             S2RLoaderTr._wait_lgkmcnt(0)  # drain re-read before next ti overwrites LDS
+
+
+def _store_quadrants(store_c, c00, c01, c10, c11, base_row, base_col, LDS_BLOCK_M, LDS_BLOCK_N):
+    """Store the four accumulator quadrants at their (row, col) sub-tile offsets.
+
+    A beta=1 epilogue read-back is software-pipelined by one quadrant: quadrant i+1's
+    loads go out before quadrant i stores, so they overlap without keeping all four
+    quadrants' worth of loaded values live at once. The 4-wave wgrad runs at occupancy
+    1, so it has neither a co-resident wave to hide the latency nor the registers to
+    spare for prefetching everything up front.
+    """
+    quads = (
+        (c00, base_row + 0, base_col + 0),
+        (c01, base_row + 0, base_col + LDS_BLOCK_N),
+        (c10, base_row + LDS_BLOCK_M, base_col + 0),
+        (c11, base_row + LDS_BLOCK_M, base_col + LDS_BLOCK_N),
+    )
+    nxt = store_c.prefetch(quads[0][1], quads[0][2])
+    for i, (frag, r, c) in enumerate(quads):
+        cur = nxt
+        if i + 1 < len(quads):
+            nxt = store_c.prefetch(quads[i + 1][1], quads[i + 1][2])
+        store_c.store(frag, r, c, prev=cur)
 
 
 def _a_tail_mask_vec(lane_id, r):

--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp8_impl.py
@@ -109,7 +109,6 @@ class GEMMFP8HipBLASLtBackend(KernelBackend):
         supported &= (a.dtype, b.dtype, out_dtype) in GEMMFP8HipBLASLtBackend.SUPPORTED_DTYPES
 
         if inplace_add_to_out:
-            supported &= granularity == ScalingGranularity.TENSORWISE
             supported &= out is not None and out.is_contiguous()
             supported &= out is not None and out.dtype in (
                 torch.float32,
@@ -425,7 +424,6 @@ class GEMMFP8FlyDSLBackend(KernelBackend):
     ) -> bool:
         supported = True
         if inplace_add_to_out:
-            supported &= granularity == ScalingGranularity.TENSORWISE
             supported &= out is not None and out.dtype == out_dtype
             supported &= out_dtype in (torch.bfloat16, torch.float16)
         # gfx950 (CDNA4) only: kernel uses mfma_f32_16x16x128_f8f6f4, absent on gfx942-.
@@ -440,6 +438,7 @@ class GEMMFP8FlyDSLBackend(KernelBackend):
             supported &= k % 128 == 0 and k >= 256
             supported &= a_scale_inv.shape == (m, k // 32) and b_scale_inv.shape == (n, k // 32)
             supported &= a_scale_inv.element_size() == 1 and b_scale_inv.element_size() == 1
+            supported &= not (inplace_add_to_out and trans_c)
             return supported
 
         # TENSORWISE: NT/NN/TN native (TT unsupported), scalar per-tensor scales.
@@ -464,9 +463,14 @@ class GEMMFP8FlyDSLBackend(KernelBackend):
         **kwargs,
     ):
         if granularity == ScalingGranularity.MX_BLOCKWISE:
-            assert not inplace_add_to_out, "MXFP8 dense FlyDSL has no accumulate epilogue"
             res = gemm_mxfp8_flydsl_kernel(
-                a, a_scale_inv.view(torch.uint8), b, b_scale_inv.view(torch.uint8), out_dtype=out_dtype
+                a,
+                a_scale_inv.view(torch.uint8),
+                b,
+                b_scale_inv.view(torch.uint8),
+                out_dtype=out_dtype,
+                beta=1.0 if inplace_add_to_out else 0.0,
+                out=out if inplace_add_to_out else None,
             )
             return res.t().contiguous() if trans_c else res
 

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
@@ -326,8 +326,8 @@ class GroupedGEMMFP4VariableKFlyDSLBackend(KernelBackend):
         **kwargs,
     ) -> bool:
         supported = True
-        # This backend has no beta=1 accumulate epilogue.
-        supported &= not inplace_add_to_out
+        if inplace_add_to_out:
+            supported &= out is not None and out.dtype == out_dtype
         supported &= a.dim() == 2 and b.dim() == 2
         supported &= granularity in GroupedGEMMFP4VariableKFlyDSLBackend.SUPPORTED_GRANULARITIES
         supported &= a.dtype == float4_e2m1fn_x2 and b.dtype == float4_e2m1fn_x2
@@ -385,6 +385,8 @@ class GroupedGEMMFP4VariableKFlyDSLBackend(KernelBackend):
             G,
             out_dtype=out_dtype,
             num_cu=num_cu if num_cu is not None else -1,
+            beta=1.0 if inplace_add_to_out else 0.0,
+            out=out if inplace_add_to_out else None,
         )
 
 

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -625,7 +625,10 @@ class GroupedGEMMFP8VariableKTritonBackend(KernelBackend):
         supported &= a.dim() == 2 and b.dim() == 2
         supported &= granularity in GroupedGEMMFP8VariableKTritonBackend.SUPPORTED_GRANULARITIES
         if inplace_add_to_out:
-            supported &= granularity == ScalingGranularity.TENSORWISE
+            supported &= granularity in (
+                ScalingGranularity.TENSORWISE,
+                ScalingGranularity.MX_BLOCKWISE,
+            )
         if granularity != ScalingGranularity.MX_BLOCKWISE:
             supported &= (
                 a.dtype,
@@ -757,7 +760,6 @@ class GroupedGEMMFP8VariableKFlyDSLBackend(KernelBackend):
     ) -> bool:
         supported = True
         if inplace_add_to_out:
-            supported &= granularity == ScalingGranularity.TENSORWISE
             supported &= out is not None and out.dtype == out_dtype
             supported &= out_dtype in (torch.bfloat16, torch.float16)
         supported &= a.dim() == 2 and b.dim() == 2
@@ -829,6 +831,8 @@ class GroupedGEMMFP8VariableKFlyDSLBackend(KernelBackend):
                 G,
                 out_dtype=out_dtype,
                 num_cu=num_cu,
+                beta=beta,
+                out=accum_out,
             )
 
         return grouped_gemm_fp8_variable_k_tensorwise_flydsl_kernel(

--- a/primus_turbo/pytorch/ops/gemm_fp4.py
+++ b/primus_turbo/pytorch/ops/gemm_fp4.py
@@ -349,7 +349,10 @@ def gemm_fp4(
             into the wgrad GEMM epilogue, so backward writes ``b.main_grad``
             directly instead of returning a gradient the framework then adds.
             ``"megatron"`` is the only supported pattern; ``b`` must carry
-            ``main_grad`` / ``grad_added_to_main_grad``. Defaults to None (no fusion).
+            ``main_grad`` / ``grad_added_to_main_grad``. FlyDSL is the only backend
+            with the FP4 accumulate epilogue, so this requires ``use_preshuffle=False``
+            and a ``main_grad`` in the weight's own dtype (its store is 16-bit).
+            Defaults to None (no fusion).
 
     Returns:
         torch.Tensor: Output matrix with shape (M, N)
@@ -391,8 +394,9 @@ def gemm_fp4(
     if out_dtype is None:
         out_dtype = torch.promote_types(a_data.dtype, b_data.dtype)
 
-    assert fuse_bgrad_accum_pattern is None, (
-        f"fuse_bgrad_accum_pattern is not supported for FP4, got {config.granularity}"
+    assert not (fuse_bgrad_accum_pattern is not None and config.use_preshuffle), (
+        "fuse_bgrad_accum_pattern requires use_preshuffle=False: only the FlyDSL backend "
+        "carries the FP4 beta=1 wgrad epilogue, and it takes raw (non-preshuffled) E8M0 scales."
     )
 
     if config.granularity == ScalingGranularity.MX_BLOCKWISE:

--- a/primus_turbo/pytorch/ops/gemm_fp8.py
+++ b/primus_turbo/pytorch/ops/gemm_fp8.py
@@ -565,11 +565,14 @@ class FP8GemmMXFunction(torch.autograd.Function):
         trans_b: bool,
         out_dtype: torch.dtype,
         config: Float8QuantConfig,
+        fuse_bgrad_accum_pattern: Union[None, str] = None,
     ):
         supported_mxfp8_backend, reason = check_mxfp8_support()
         assert supported_mxfp8_backend, reason
 
         assert trans_a == False and trans_b == True, "trans_a has to be False and trans_b has to be True"
+
+        fuse_bgrad_accum, main_grad = _setup_fused_grad_accum(b, fuse_bgrad_accum_pattern)
 
         # Scale preshuffle is NOT done here: the quant emits raw E8M0 [dim, K//32]
         # scales and each GEMM backend implicitly preshuffles right before its own
@@ -645,6 +648,8 @@ class FP8GemmMXFunction(torch.autograd.Function):
         ctx.save_for_backward(a_col, a_col_scale, b_col, b_col_scale)
         ctx.out_dtype = out_dtype
         ctx.config = config
+        ctx.fuse_bgrad_accum = fuse_bgrad_accum
+        ctx.main_grad = main_grad
 
         return out
 
@@ -682,7 +687,7 @@ class FP8GemmMXFunction(torch.autograd.Function):
             default_backend=BackendType.FLYDSL.value,
         )
 
-        grad_b = gemm_fp8_impl(
+        grad_b = _bgrad_gemm_fp8_impl_wrapper(
             g_col,
             g_col_scale,
             False,
@@ -692,7 +697,11 @@ class FP8GemmMXFunction(torch.autograd.Function):
             ctx.out_dtype,
             False,
             granularity=ctx.config.granularity.value,
-            default_backend=BackendType.FLYDSL.value,
+            default_backend=(
+                BackendType.HIPBLASLT.value if ctx.fuse_bgrad_accum else BackendType.FLYDSL.value
+            ),
+            inplace_add_to_out=ctx.fuse_bgrad_accum,
+            out=ctx.main_grad,
         )
 
         return (
@@ -704,6 +713,7 @@ class FP8GemmMXFunction(torch.autograd.Function):
             None,  # trans_b
             None,  # out_dtype
             None,  # config
+            None,  # fuse_bgrad_accum_pattern
         )
 
 
@@ -740,8 +750,8 @@ def gemm_fp8(
             into the wgrad GEMM epilogue, so backward writes ``b.main_grad``
             directly instead of returning a gradient the framework then adds.
             ``"megatron"`` is the only supported pattern; ``b`` must carry
-            ``main_grad`` / ``grad_added_to_main_grad``. TENSORWISE only.
-            Defaults to None (no fusion).
+            ``main_grad`` / ``grad_added_to_main_grad``. TENSORWISE and
+            MX_BLOCKWISE only. Defaults to None (no fusion).
 
     Returns:
         torch.Tensor: Output matrix with shape (M, N)
@@ -794,11 +804,15 @@ def gemm_fp8(
         return FP8GemmTensorFunction.apply(
             a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config, fuse_bgrad_accum_pattern
         )
+    elif config.granularity == ScalingGranularity.MX_BLOCKWISE:
+        return FP8GemmMXFunction.apply(
+            a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config, fuse_bgrad_accum_pattern
+        )
 
-    # The other granularities silently ignore the flag rather than fusing, which
+    # The remaining granularities silently ignore the flag rather than fusing, which
     # would leave main_grad unwritten and the weight without a gradient.
     assert fuse_bgrad_accum_pattern is None, (
-        f"fuse_bgrad_accum_pattern is only supported for TENSORWISE, got {config.granularity}"
+        f"fuse_bgrad_accum_pattern is not supported for {config.granularity}"
     )
     if config.granularity == ScalingGranularity.ROWWISE:
         return FP8GemmRowFunction.apply(
@@ -806,10 +820,6 @@ def gemm_fp8(
         )
     elif config.granularity == ScalingGranularity.BLOCKWISE:
         return FP8GemmBlockFunction.apply(
-            a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config
-        )
-    elif config.granularity == ScalingGranularity.MX_BLOCKWISE:
-        return FP8GemmMXFunction.apply(
             a_data, b_data, a_data_t, b_data_t, trans_a, trans_b, out_dtype, config
         )
     else:

--- a/primus_turbo/pytorch/ops/grouped_gemm_fp4.py
+++ b/primus_turbo/pytorch/ops/grouped_gemm_fp4.py
@@ -354,7 +354,9 @@ def grouped_gemm_fp4(
             into the wgrad GEMM epilogue, so backward writes ``b.main_grad``
             directly instead of returning a gradient the framework then adds.
             ``"megatron"`` is the only supported pattern; ``b`` must carry
-            ``main_grad`` / ``grad_added_to_main_grad``. Defaults to None (no fusion).
+            ``main_grad`` / ``grad_added_to_main_grad``. FlyDSL is the only backend
+            with the FP4 accumulate epilogue and its store is 16-bit, so ``main_grad``
+            must be in the weight's own dtype. Defaults to None (no fusion).
 
     Returns:
         Output [total_m, N].
@@ -379,10 +381,6 @@ def grouped_gemm_fp4(
 
     assert a_data.ndim == 2, "a must be 2D [total_m, K]"
     assert b_data.ndim == 3, "b must be 3D [G, N, K]"
-
-    assert fuse_bgrad_accum_pattern is None, (
-        f"fuse_bgrad_accum_pattern is not supported for FP4, got {config.granularity}"
-    )
 
     if config.granularity == ScalingGranularity.MX_BLOCKWISE:
         return FP4GroupedGemmMXFunc.apply(

--- a/tests/pytorch/ops/test_gemm_fp4.py
+++ b/tests/pytorch/ops/test_gemm_fp4.py
@@ -292,6 +292,85 @@ def test_gemm_fp4_mx_blockwise_quantized_tensor(m, n, k, layout, format, dtype, 
     )
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("backend", [None, BackendType.FLYDSL])
+def test_gemm_fp4_mx_fused_grad_accum(dtype, backend):
+    """``fuse_bgrad_accum_pattern`` must leave ``main_grad`` holding previous + wgrad.
+
+    FlyDSL is the only FP4 backend with the accumulate epilogue and its store is 16-bit,
+    so ``main_grad`` is allocated in the weight's own dtype rather than Megatron's fp32.
+    """
+    from primus_turbo.pytorch.core.low_precision import check_mxfp4_support
+
+    mxfp4_supported, reason = check_mxfp4_support()
+    if not mxfp4_supported:
+        pytest.skip(reason)
+
+    seed = 42
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    device = "cuda:0"
+    m, n, k = 256, 512, 256  # FlyDSL MXFP4 needs M/N/K all multiples of 256
+
+    GlobalBackendManager.set_gemm_backend(backend)
+    GlobalBackendManager.set_auto_tune(False)
+
+    config = Float4QuantConfig(
+        granularity=ScalingGranularity.MX_BLOCKWISE,
+        format=Format.E2M1_X2,
+        block_size=32,
+        scale_dtype=ScaleDtype.E8M0,
+        use_gradient_sr=False,  # the two runs must quantize grad_out identically
+    )
+
+    a = torch.randn((m, k), dtype=dtype, device=device, requires_grad=True)
+    b = torch.randn((n, k), dtype=dtype, device=device, requires_grad=True)
+    grad_out = torch.randn((m, n), dtype=dtype, device=device)
+    a_fused = a.detach().clone().requires_grad_(True)
+    b_fused = b.detach().clone().requires_grad_(True)
+    torch.cuda.synchronize()
+
+    # Baseline: ordinary autograd, b.grad holds the weight gradient.
+    out = gemm_fp4(a, b, trans_b=True, out_dtype=dtype, config=config)
+    out.backward(grad_out)
+    torch.cuda.synchronize()
+
+    # Fused: the wgrad is accumulated into a pre-seeded main_grad buffer.
+    previous = torch.randn(b_fused.shape, dtype=dtype, device=device)
+    b_fused.main_grad = previous.clone()
+    b_fused.grad_added_to_main_grad = False
+
+    out_fused = gemm_fp4(
+        a_fused,
+        b_fused,
+        trans_b=True,
+        out_dtype=dtype,
+        config=config,
+        fuse_bgrad_accum_pattern="megatron",
+    )
+    out_fused.backward(grad_out)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out_fused, out)
+    assert b_fused.grad_added_to_main_grad is True, "weight must be flagged during forward"
+    assert b_fused.grad.shape == b_fused.shape, "dummy wgrad must keep the weight's shape"
+    assert b_fused.grad.dtype == b_fused.dtype, "dummy wgrad must keep the weight's dtype"
+
+    snr_threshold = 10
+
+    a_grad_snr = compute_snr(a.grad, a_fused.grad)
+    print(f"AGrad-SNR: {a_grad_snr:.2f} dB")
+    assert a_grad_snr > snr_threshold, "a_grad_snr too low"
+
+    accumulated = b_fused.main_grad.float() - previous.float()
+    b_grad_snr = compute_snr(b.grad.float(), accumulated)
+    print(f"BGrad-SNR: {b_grad_snr:.2f} dB")
+    assert b_grad_snr > snr_threshold, "b_grad_snr too low"
+
+    GlobalBackendManager.reset()
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_use_gradient_sr_false():
     """Gradient quantization with use_gradient_sr=False should be deterministic (identical)."""

--- a/tests/pytorch/ops/test_gemm_fp8.py
+++ b/tests/pytorch/ops/test_gemm_fp8.py
@@ -10,6 +10,7 @@ import torch
 
 from primus_turbo.pytorch.core.backend import BackendType, GlobalBackendManager
 from primus_turbo.pytorch.core.low_precision import (
+    MXFP8_BLOCK_SIZE,
     Float8QuantConfig,
     Format,
     ScaleDtype,
@@ -662,7 +663,17 @@ def test_gemm_fp8_blockwise_triton_deterministic(m, n, k, layout, format, dtype,
 
 
 def _run_gemm_fp8_fused_grad_accum_test(
-    m, n, k, layout, dtype, format, backend, main_grad_dtype=torch.float32
+    m,
+    n,
+    k,
+    layout,
+    dtype,
+    format,
+    backend,
+    main_grad_dtype=torch.float32,
+    granularity=ScalingGranularity.TENSORWISE,
+    block_size=None,
+    scale_dtype=ScaleDtype.FP32,
 ):
     """``fuse_bgrad_accum_pattern`` must leave ``main_grad`` holding previous + wgrad.
 
@@ -678,7 +689,10 @@ def _run_gemm_fp8_fused_grad_accum_test(
     torch.cuda.manual_seed_all(seed)
 
     device = "cuda:0"
-    print(f"\nM={m}, N={n}, K={k}, layout={layout}, dtype={dtype}, format={format}, backend={backend}")
+    print(
+        f"\nM={m}, N={n}, K={k}, layout={layout}, dtype={dtype}, format={format}, "
+        f"granularity={granularity}, backend={backend}"
+    )
 
     # A pinned backend exercises that backend's beta=1 accumulate epilogue; ``None``
     # leaves the dispatcher to resolve one, which is how training actually runs.
@@ -690,7 +704,9 @@ def _run_gemm_fp8_fused_grad_accum_test(
     a_shape = (k, m) if trans_a else (m, k)
     b_shape = (n, k) if trans_b else (k, n)
 
-    config = Float8QuantConfig(format=format, granularity=ScalingGranularity.TENSORWISE)
+    config = Float8QuantConfig(
+        format=format, granularity=granularity, block_size=block_size, scale_dtype=scale_dtype
+    )
 
     a = torch.randn(a_shape, dtype=dtype, device=device, requires_grad=True)
     b = torch.randn(b_shape, dtype=dtype, device=device, requires_grad=True)
@@ -751,20 +767,11 @@ def _run_gemm_fp8_fused_grad_accum_test(
 @pytest.mark.parametrize("layout", ["NT", "NN", "TN"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("format", [Format.E4M3, Format.HYBRID])
-@pytest.mark.parametrize("backend", [None, BackendType.TRITON, BackendType.HIPBLASLT])
-def test_gemm_fp8_fused_grad_accum(layout, dtype, format, backend):
-    _run_gemm_fp8_fused_grad_accum_test(
-        m=256, n=512, k=256, layout=layout, dtype=dtype, format=format, backend=backend
-    )
-
-
-@pytest.mark.parametrize("layout", ["NT", "NN", "TN"])
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-@pytest.mark.parametrize("format", [Format.E4M3, Format.HYBRID])
-def test_gemm_fp8_fused_grad_accum_flydsl(layout, dtype, format):
-    """FlyDSL's beta=1 wgrad epilogue, against a main_grad in the weight's own dtype."""
-    if get_device_compute_capability() < (9, 5):
+@pytest.mark.parametrize("backend", [None, BackendType.TRITON, BackendType.HIPBLASLT, BackendType.FLYDSL])
+def test_gemm_fp8_tensorwise_fused_grad_accum(layout, dtype, format, backend):
+    if backend == BackendType.FLYDSL and get_device_compute_capability() < (9, 5):
         pytest.skip("FlyDSL fp8 GEMM is gfx950-only")
+    main_grad_dtype = dtype if backend == BackendType.FLYDSL else torch.float32
     _run_gemm_fp8_fused_grad_accum_test(
         m=256,
         n=512,
@@ -772,6 +779,30 @@ def test_gemm_fp8_fused_grad_accum_flydsl(layout, dtype, format):
         layout=layout,
         dtype=dtype,
         format=format,
-        backend=BackendType.FLYDSL,
-        main_grad_dtype=dtype,
+        backend=backend,
+        main_grad_dtype=main_grad_dtype,
+        granularity=ScalingGranularity.TENSORWISE,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("format", [Format.E4M3, Format.HYBRID])
+@pytest.mark.parametrize("backend", [None, BackendType.HIPBLASLT, BackendType.FLYDSL])
+def test_gemm_fp8_mx_fused_grad_accum(dtype, format, backend):
+    """MXFP8 is NT-only, so the layout sweep collapses to a single entry."""
+    if get_device_compute_capability() < (9, 5):
+        pytest.skip("MXFP8 GEMM is gfx950-only")
+    main_grad_dtype = dtype if backend == BackendType.FLYDSL else torch.float32
+    _run_gemm_fp8_fused_grad_accum_test(
+        m=256,
+        n=512,
+        k=256,
+        layout="NT",
+        dtype=dtype,
+        format=format,
+        backend=backend,
+        main_grad_dtype=main_grad_dtype,
+        granularity=ScalingGranularity.MX_BLOCKWISE,
+        block_size=MXFP8_BLOCK_SIZE,
+        scale_dtype=ScaleDtype.E8M0,
     )

--- a/tests/pytorch/ops/test_grouped_gemm_fp4.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp4.py
@@ -287,6 +287,73 @@ def test_grouped_gemm_fp4_zero_group_lens(dtype):
     assert b_grad_snr > SNR_THRESHOLD, f"b_grad_snr={b_grad_snr:.2f} too low"
 
 
+# ----------------------------------------------------------------------------
+# Fused gradient accumulation (Megatron main_grad written from the wgrad epilogue).
+# ----------------------------------------------------------------------------
+@pytest.mark.parametrize("dtype", DTYPE_VALUES)
+@pytest.mark.parametrize("balance", BALANCE_VALUES)
+def test_grouped_gemm_fp4_fused_grad_accum(dtype, balance):
+    """``fuse_bgrad_accum_pattern`` must leave ``main_grad`` holding previous + wgrad.
+
+    FlyDSL is the only FP4 variable-K backend with the accumulate epilogue and its store
+    is 16-bit, so ``main_grad`` is allocated in the weight's dtype, not Megatron's fp32.
+    """
+    supported, reason = check_mxfp4_support()
+    if not supported:
+        pytest.skip(reason)
+
+    seed = 42
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    device = "cuda:0"
+    B, M, N, K = 4, 256, 512, 256
+    group_lens = generate_grouped_gemm_group_lens(B, M, balance=balance).to(device)
+    print(f"\nB={B}, M={M}, N={N}, K={K}, dtype={dtype}, balance={balance}")
+
+    config = _make_config()
+
+    a = torch.randn((B * M, K), dtype=dtype, device=device, requires_grad=True)
+    b = torch.randn((B, N, K), dtype=dtype, device=device, requires_grad=True)
+    grad_out = torch.randn((B * M, N), dtype=dtype, device=device)
+    a_fused = a.detach().clone().requires_grad_(True)
+    b_fused = b.detach().clone().requires_grad_(True)
+    torch.cuda.synchronize()
+
+    # Baseline: ordinary autograd, b.grad holds the weight gradient.
+    out = grouped_gemm_fp4(a, b, group_lens, trans_b=True, config=config)
+    out.backward(grad_out)
+    torch.cuda.synchronize()
+
+    # Fused: the wgrad is accumulated into a pre-seeded main_grad buffer.
+    previous = torch.randn(b_fused.shape, dtype=dtype, device=device)
+    b_fused.main_grad = previous.clone()
+    b_fused.grad_added_to_main_grad = False
+
+    out_fused = grouped_gemm_fp4(
+        a_fused,
+        b_fused,
+        group_lens,
+        trans_b=True,
+        config=config,
+        fuse_bgrad_accum_pattern="megatron",
+    )
+    out_fused.backward(grad_out)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out_fused, out)
+    assert b_fused.grad_added_to_main_grad is True, "weight must be flagged during forward"
+    assert b_fused.grad.shape == b_fused.shape, "dummy wgrad must keep the weight's shape"
+    assert b_fused.grad.dtype == b_fused.dtype, "dummy wgrad must keep the weight's dtype"
+
+    a_grad_snr = compute_snr(a.grad, a_fused.grad)
+    accumulated = b_fused.main_grad.float() - previous.float()
+    b_grad_snr = compute_snr(b.grad.float(), accumulated)
+    print(f"AGrad-SNR={a_grad_snr:.2f} dB  BGrad-SNR={b_grad_snr:.2f} dB")
+    assert a_grad_snr > SNR_THRESHOLD, f"a_grad_snr={a_grad_snr:.2f} too low"
+    assert b_grad_snr > SNR_THRESHOLD, f"b_grad_snr={b_grad_snr:.2f} too low"
+
+
 # CUDA-graph capturability (forward). The forward uses no D2H sync, so it is
 # graph-capturable and a replay with in-place-updated group_lens must re-route.
 # Only the forward is captured: fwd+bwd through autograd segfaults at capture_end

--- a/tests/pytorch/ops/test_grouped_gemm_fp8.py
+++ b/tests/pytorch/ops/test_grouped_gemm_fp8.py
@@ -1335,15 +1335,9 @@ def _run_grouped_gemm_fp8_fused_grad_accum_test(
 
 
 @pytest.mark.parametrize("ori_dtype", ORI_DTYPE_VALUES)
-@pytest.mark.parametrize(
-    "granularity, trans_b",
-    [
-        (ScalingGranularity.TENSORWISE, True),
-        (ScalingGranularity.TENSORWISE, False),
-    ],
-)
+@pytest.mark.parametrize("trans_b", [True, False])
 @pytest.mark.parametrize("backend", [None, BackendType.TRITON, BackendType.HIPBLASLT, BackendType.FLYDSL])
-def test_grouped_gemm_fp8_fused_grad_accum(ori_dtype, granularity, trans_b, backend):
+def test_grouped_gemm_fp8_tensorwise_fused_grad_accum(ori_dtype, trans_b, backend):
     if backend == BackendType.FLYDSL and get_device_compute_capability() < (9, 5):
         pytest.skip("FlyDSL fp8 grouped GEMM is gfx950-only")
     # FlyDSL's accumulate epilogue stores 16-bit, so it only takes a main_grad matching
@@ -1355,8 +1349,28 @@ def test_grouped_gemm_fp8_fused_grad_accum(ori_dtype, granularity, trans_b, back
         N=512,
         K=256,
         ori_dtype=ori_dtype,
-        granularity=granularity,
+        granularity=ScalingGranularity.TENSORWISE,
         trans_b=trans_b,
+        backend=backend,
+        main_grad_dtype=main_grad_dtype,
+    )
+
+
+@pytest.mark.parametrize("ori_dtype", ORI_DTYPE_VALUES)
+@pytest.mark.parametrize("backend", [None, BackendType.TRITON, BackendType.FLYDSL])
+def test_grouped_gemm_fp8_mx_fused_grad_accum(ori_dtype, backend):
+    """MXFP8 grouped GEMM is NT-only, so trans_b is fixed rather than swept."""
+    if backend == BackendType.FLYDSL and get_device_compute_capability() < (9, 5):
+        pytest.skip("FlyDSL MXFP8 grouped GEMM is gfx950-only")
+    main_grad_dtype = ori_dtype if backend == BackendType.FLYDSL else torch.float32
+    _run_grouped_gemm_fp8_fused_grad_accum_test(
+        B=4,
+        M=256,
+        N=512,
+        K=256,
+        ori_dtype=ori_dtype,
+        granularity=ScalingGranularity.MX_BLOCKWISE,
+        trans_b=True,
         backend=backend,
         main_grad_dtype=main_grad_dtype,
     )


### PR DESCRIPTION
# Description

This PR extends Megatron-style fused weight-gradient accumulation (`fuse_bgrad_accum_pattern="megatron"`) to MXFP8 and MXFP4 operators (Part 2 of the grad-accum fusion work).

Instead of materializing a separate wgrad tensor and adding it into `main_grad` in a follow-up kernel, the backward GEMM epilogue now performs `out += matmul_result` in-place when `beta=1.0`.
This reduces memory traffic and kernel launch overhead during MoE/LLM training on gfx950 (CDNA4).

The change wires the fusion path end-to-end across FlyDSL kernels, PyTorch backend dispatch, and public ops APIs for dense and grouped GEMM in both FP8 and FP4 MX blockwise quantization.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `beta=1.0` accumulate epilogue support to FlyDSL MXFP8 dense GEMM (`gemm_mxfp8_flydsl_kernel`) and grouped variable-K wgrad kernels (`grouped_gemm_mxfp8_variable_k_flydsl_kernel`, `grouped_gemm_mxfp4_variable_k_flydsl_kernel`), including `beta_is_one` in kernel compilation caches and autotune keys.
- Introduce shared helpers in `gemm_helper.py`: `resolve_accum_out` (validate or allocate the caller-owned accumulation buffer), `compile_with_scratch_out` (compile FlyDSL kernels against a scratch output to avoid double-accumulating during `flyc.compile`), `_store_quadrants` (software-pipelined quadrant store for beta=1 read-modify-write), and `lds_barrier` (LDS drain + workgroup sync).
- Fix grouped FP8 wgrad beta=1 correctness: add an LDS barrier after the whole-loop prime phase, route beta=1 through the CShuffle epilogue with optional LDS aliasing/fencing in the 2-buffer-pool path, and refactor epilogue selection via `epi_cshuffle` / `epi_lds_fence` parameters.
- Extend PyTorch ops and backend dispatch so `fuse_bgrad_accum_pattern="megatron"` is supported for `ScalingGranularity.MX_BLOCKWISE` on `gemm_fp8`, `gemm_fp4`, and grouped FP8/FP4 variable-K paths; `FP8GemmMXFunction` now participates in the fused backward path and selects HipBLASLt vs FlyDSL appropriately.
- Relax backend capability checks: MX blockwise inplace accumulation is no longer restricted to tensorwise granularity; FlyDSL MXFP8 dense accumulation rejects `trans_c` layouts explicitly.
- Add and extend unit tests: `test_gemm_fp8_mx_fused_grad_accum`, `test_grouped_gemm_fp8_mx_fused_grad_accum`, `test_gemm_fp4_mx_fused_grad_accum`, and `test_grouped_gemm_fp4_fused_grad_accum`; rename existing tensorwise tests for clarity.

# Checklist:

- [x] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
