### PR TITLE
perf(flydsl): tune the MXFP4 GEMM for gpt-oss-20b MoE on gfx950

### DIFF
--- a/primus_turbo/flydsl/gemm/gemm_mxfp4_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_mxfp4_kernel.py
@@ -11,31 +11,9 @@
 # not the MIT license that covers the rest of Primus-Turbo (see LICENSE).
 ###############################################################################
 
-"""4-wave MXFP4 dense GEMM (per-32-K E8M0 block scaling) for AMD CDNA4 (gfx950).
-
-NT only: A [M, K] fp4 (packed 2/byte), B [N, K] fp4, C = a @ b^T (bf16 or fp16).
-
-The 4-wave (2x2 wave)
-topology gives 1 wave/SIMD so the full 256-AGPR file holds one wave's N-sliced
-accumulator (acc_left + acc_right) cleanly, freeing arch-VGPR for operand prefetch.
-
-This file carries the production code path. The standalone source's tuning/debug
-knobs are hardcoded to their production value; per-shape launch swizzle,
-workload-depth and epilogue variant are chosen by the timed autotune:
-
-  * whole-loop bare-asm compute (the entire K-loop is one inline-asm hw-loop),
-  * 2 LDS ping-pong buffers (unroll-2), NEXT-K in-place operand refill,
-  * blocked-diagonal MFMA emission (4 A-rows x 8 N-cols) with the K-sub innermost,
-  * GAVOID g2s placement (loads only in refill-free MFMA slots),
-  * VGPR-direct scales (buffer_load lane-contiguous straight to VGPR; no LDS/ds_read
-    for scales), interleaved into the MFMA stream,
-  * pinned operand/scale VGPRs (PINBASE=8) to dodge the LLVM RA cascade crash,
-  * per-phase s_barrier with vmcnt(10) lgkmcnt(9) drain,
-  * agpr-alloc=256, waves_per_eu=1, BLOCK_M=BLOCK_N=BLOCK_K=256, packed E8M0 scales.
-
-Scale tensors are passed pre-shuffled into the lane-contiguous layout produced
-directly by the fused MXFP4 quant kernel (VGPR-direct scale read; no host repack).
-"""
+"""4-wave MXFP4 dense NT GEMM (per-32-K E8M0 block scaling) for AMD CDNA4 (gfx950).
+A [M, K] fp4 (packed 2/byte), B [N, K] fp4, C = a @ b^T. One wave per SIMD lets the
+256-AGPR file hold the N-sliced accumulator; swizzle/depth/epilogue are autotuned."""
 
 import torch
 
@@ -47,7 +25,6 @@ from primus_turbo.flydsl.utils.gemm_helper import (
     make_fp8_rebased_tensor_and_srd,
     make_row_band_resource,
     resolve_accum_out,
-    wait_barrier,
     xcd_remap_pid,
 )
 import flydsl.compiler as flyc
@@ -81,38 +58,105 @@ class ScaleS2RPacked:
         self.rsrc = buffer_ops.create_buffer_resource(sp_tensor, max_size=False, num_records_bytes=nbytes)
 
 
-def _swz_fwd(c):
-    """LDS bank-swizzle, logical chunk -> physical slot. Modular-add rotate within
-    each 1024B block: phase = c//8, rotate the low 3 bits (128B bank period) by phase
-    so the 8 same-bank rows of one ds_read_b128 land on all 8 bank-groups. Bijection."""
+def _swz_fwd(c, d=0):
+    """LDS bank-swizzle (bijection): rotate each block's rows so one ds_read spreads
+    across all bank-groups, avoiding conflicts. ``d`` offsets the rotation so two
+    parity-split regions read in the same ds_read stay on disjoint bank-groups."""
     ph = c // 8
-    return ph * 8 + (c % 8 + ph) % 8
+    return ph * 8 + (c % 8 + ph + d) % 8
 
 
-def _swz_inv(c):
-    """Inverse of _swz_fwd (physical slot -> logical chunk). G2S lane L writes the
-    contiguous physical slot L, so it must fetch the gmem of logical chunk _swz_inv(L)
-    for S2R's _swz_fwd read to land on it."""
-    ph = c // 8
-    return ph * 8 + (c % 8 + 8 - ph) % 8
-
-
-def fp4_g2s_offsets(lane_id, wave_id, K, n_steps, bytes_per_row, swizzle=False):
-    """Per-lane gmem byte offsets for fp4 G2S. Lane L (wave w) copies 16 bytes from
-    gmem [row*(K/2)+chunk*16] into its contiguous LDS slot (w*1024 + L*16), which
-    algebraically equals row*bpr + chunk*16 -> S2R reads it back at identity
-    row*bpr + g*16. ``swizzle`` applies the inverse bank-swizzle so the write lands
-    where S2RLoaderFp4's _swz_fwd read expects."""
+def fp4_g2s_offsets(lane_id, wave_id, K, n_steps, bytes_per_row, swizzle=False, ilv=0):
+    """Per-lane gmem byte offsets for fp4 G2S into identity LDS slots (S2R reads back
+    at the same address). ``swizzle`` pre-applies the inverse bank-swizzle; ``ilv``
+    column-interleaves source rows so a lane owns adjacent columns, LDS image intact."""
     n_waves = fx.block_dim.x // 64
     lpr = bytes_per_row // 16  # lanes per row
     rows_per_step = 64 // lpr
+    assert not ilv or (bytes_per_row == 128 and ilv == 4)
     offs = []
     for r in range_constexpr(n_steps):
-        cib = _swz_inv(lane_id) if swizzle else lane_id  # physical slot -> logical chunk
-        row = cib // lpr + wave_id * rows_per_step + r * (n_waves * rows_per_step)
-        chunk = cib % lpr
-        offs.append(row * (K // 2) + chunk * 16)
+        ph = lane_id // lpr  # physical row slot in this lane's LDS block
+        row = ph + wave_id * rows_per_step + r * (n_waves * rows_per_step)
+        chunk = (lane_id % lpr + lpr - row % lpr) % lpr if swizzle else lane_id % lpr
+        src = row
+        if ilv:
+            q = row % 64
+            src = (row // 64) * 64 + ilv * (q % 16) + q // 16
+        offs.append(src * (K // 2) + chunk * 16)
     return offs
+
+
+def fp4_g2s_offsets_split(lane_id, wave_id, K, n_steps, row_par, shift, ilv=0):
+    """Per-lane gmem byte offsets for ONE parity region of the split fp4 G2S: a region
+    holds alternate operand rows so a whole request stays inside one cache line. ``ilv``
+    column-interleaves across both regions so a lane owns adjacent output columns."""
+    n_waves = fx.block_dim.x // 64
+    offs = []
+    for r in range_constexpr(n_steps):
+        ph = lane_id // 8  # physical row slot in this lane's 1024B block
+        u = ph + wave_id * 8 + r * (n_waves * 8)  # region row
+        if ilv:
+            u = r * (n_waves * 8) + (ph + (wave_id % 2) * 8) * 2 + wave_id // 2
+        k = (lane_id % 8 + 8 - ph) % 8  # physical 16B slot -> logical chunk
+        offs.append((u * 2 + row_par) * (K // 2) + k * 16 + shift)
+    return offs
+
+
+class S2RLoaderFp4Split:
+    """LDS->reg fp4 fragment loader for the parity-split cache-line-aligned layout so no
+    g2s crosses a cache-line boundary or reads a buffer being refilled. ``skew``/``f_base``
+    drive the odd-phase rotating ring; ``ilv`` column-interleaves across both regions."""
+
+    def __init__(self, wave_idx, n_tiles, n_rows, par, skew, ilv=0):
+        self.lane16 = fx.thread_idx.x % 16
+        self.g = (fx.thread_idx.x % 64) // 16
+        self.wave_idx = wave_idx
+        self.n_tiles = n_tiles
+        self.slot = (n_rows // 2) * 128  # bytes per ring slot (one region)
+        self.par = par  # 128B phase of tile row 0
+        self.skew = skew
+        self.ilv = ilv
+        assert not ilv or ilv == n_tiles
+
+    def _phys(self, lds, u, k, slot_off):
+        off = u * 128 + ((k + u % 8) % 8) * 16 + slot_off
+        i8 = fx.recast_iter(fx.Uint8, fx.add_offset(lds.ptr, fx.make_int_tuple(off)))
+        return fx.ptrtoint(i8)
+
+    def _row(self):
+        return self.wave_idx * (self.n_tiles * 16) + self.lane16
+
+    def _pair(self, lds_e, lds_o, u, buf, s):
+        ae = self._phys(lds_e, u, s * 4 + self.g, buf * self.slot)
+        if const_expr(self.skew):
+            ko = (4 + self.g) if s == 0 else self.g  # top of line c, bottom of line c+1
+            ao = self._phys(lds_o, u, ko, 0)
+        else:
+            ao = self._phys(lds_o, u, s * 4 + self.g, buf * self.slot)
+        return ae, ao
+
+    def f_base(self, lds_e, lds_o, buf, s):
+        """Per-lane LDS read address for ring slot ``buf``, 128-K sub-step ``s``."""
+        ae, ao = self._pair(lds_e, lds_o, self._row() // 2, buf, s)
+        return arith.select((self._row() + self.par) % 2 == fx.Int32(1), ao, ae)
+
+    def f_base_ilv(self, lds_e, lds_o, buf, s):
+        """Both regions' addresses, for the column-interleaved fragment. The lane reads
+        region rows wave*ntb*8 + lane%16 (+ tile_stride per tile PAIR) of each region."""
+        u = self.wave_idx * (self.n_tiles * 8) + self.lane16
+        return self._pair(lds_e, lds_o, u, buf, s)
+
+    def q_unit(self):
+        """Odd-ring slot stride for this lane (0 on even-phase rows)."""
+        if const_expr(bool(self.ilv)):
+            return fx.Int32(self.slot)  # interleaved: every lane reads the odd region
+        odd = (self._row() + self.par) % 2 == fx.Int32(1)
+        return arith.select(odd, fx.Int32(self.slot), fx.Int32(0))
+
+    @property
+    def tile_stride(self):
+        return (self.n_tiles * 4 if self.ilv else 8) * 128
 
 
 def grouped_xcd_pid(pid, c_m, c_n, BLOCK_M, BLOCK_N, group_m=4, num_xcds=8, group_n=0):
@@ -183,10 +227,9 @@ class S2RLoaderFp4:
 
     def base_addr(self, lds_src, s=0):
         """Single base LDS address (tile 0, sub-block s). Per-tile fragments are at
-        base + i*tile_stride (tile_stride = 16*row_stride bytes) -> the asm uses ONE
-        address reg per region + a ds_read offset immediate."""
-        row0 = self.wave_idx * (self.n_tiles * 16) + self.lane16
-        off_nat = row0 * self.row_stride + s * 64 + self.g * 16
+        base + i*tile_stride -> the asm uses ONE address reg per region + a ds_read
+        offset immediate."""
+        off_nat = (self.wave_idx * (self.n_tiles * 16) + self.lane16) * self.row_stride + s * 64 + self.g * 16
         if const_expr(self.swizzle):  # tile i = base + i*tile_stride stays swz-correct
             cib = (off_nat % 1024) // 16  # (tile_stride is a 1024-multiple -> %1024 const)
             off = (off_nat // 1024) * 1024 + _swz_fwd(cib) * 16
@@ -201,30 +244,21 @@ class S2RLoaderFp4:
 
 
 class StoreCPlain:
-    """Plain FP32 accumulator -> bf16/fp16 store (no scaling; scales folded in MMA).
+    """Plain FP32 accumulator -> BF16/FP16 store (scales folded in MMA), using an
+    OOB-index redirect for the column-edge mask to avoid per-store EXEC save/restore.
+    ``out_ty`` fp16 forces the narrow path; ``ilv`` maps a lane to adjacent columns."""
 
-    Uses ``fx.copy`` over a single divided output view + OOB-index redirect for the
-    column-edge mask (``arith.select(col_valid, c_index, oob)``), which the backend
-    lowers WITHOUT per-store EXEC-mask save/restore -> a tight store epilogue (the
-    masked ``buffer_store`` path emits ~1.8k extra scalar ops, a fixed per-WG cost).
-    M, N are multiples of 256 here so every tile is in-bounds; the redirect is just a
-    cheap safety net. C is a flat 1D out_ty buffer (num_records bounds the SRD).
-
-    ``out_ty`` is bf16 or fp16 (both 2 bytes). The narrow ``store`` path uses a generic
-    f32->out_ty ``.to()`` cast so it serves either; the wide ``store_tacc_wide`` fast
-    path packs through ``_pack_pair``, which serves either too.
-
-    ``beta_is_one`` turns both paths into an accumulate (``C = C + acc``): the value is
-    read back through the same SRD and offset it is about to be stored to, widened to
-    f32 and added. Lanes whose store is masked/OOB read 0, so no extra bounds logic."""
-
-    def __init__(self, C, c_rows, c_cols, c_idx_fn, n_tiles_a, n_tiles_b, out_ty=None, beta_is_one=False):
+    def __init__(
+        self, C, c_rows, c_cols, c_idx_fn, n_tiles_a, n_tiles_b, out_ty=None, ilv=0, beta_is_one=False
+    ):
+        assert not ilv or ilv == n_tiles_b
         self.c_rows = c_rows
         self.c_cols = c_cols
         self.lane_id = fx.thread_idx.x % 64
         self.c_idx_fn = c_idx_fn
         self.n_tiles_a = n_tiles_a
         self.n_tiles_b = n_tiles_b
+        self.ilv = ilv
         self.out_ty = out_ty if out_ty is not None else fx.BFloat16
         self.beta_is_one = beta_is_one
         # int64 byte base: the store re-bases per row band (make_row_band_resource) so a
@@ -233,23 +267,27 @@ class StoreCPlain:
         self.c_base = buffer_ops.extract_base_index(C)
 
     def store(self, c_frag, base_row, base_col, n_valid=None):
-        # Re-base at this tile's row band in int64; intra-band voffsets stay int32. Rows
-        # past c_rows OOB-drop via the band SRD's num_records. n_valid (non-256 free dim):
-        # mask cols >= n_valid so the kernel runs the REAL N with no host N-pad.
-        _mask = n_valid is not None
-        rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
+        # n_valid drops whole out-of-range column spans via band SRD num_records (no per-store mask).
+        c_rows = self.c_rows
+        if n_valid is not None and n_valid % (16 * self.n_tiles_b) == 0:
+            c_rows = arith.select(base_col < fx.Int32(n_valid), c_rows, base_row)
+            n_valid = None
+        rsrc = make_row_band_resource(self.c_base, base_row, c_rows, self.c_cols, 2)
+        if n_valid is None and const_expr(not self.beta_is_one):
+            # Fast path writes only; beta=1 needs the read-back, so it falls through below.
+            self._store_rowaddr(c_frag, base_col, rsrc)
+            return
+        # beta=1 issues every read-back before the first store so the loads pipeline.
         addrs = []
         for ti in range_constexpr(self.n_tiles_a):
             row_local = ti * 16 + (self.lane_id // 16) * 4  # relative to base_row
             for tj in range_constexpr(self.n_tiles_b):
-                col = base_col + tj * 16 + self.lane_id % 16
-                col_valid = (col < fx.Int32(n_valid)) if _mask else None
+                col = base_col + self._col(tj)
+                col_valid = (col < fx.Int32(n_valid)) if n_valid is not None else None
                 for i in range_constexpr(4):
                     addrs.append(((row_local + i) * self.c_cols + col, col_valid))
         prev = []
         if const_expr(self.beta_is_one):
-            # Issue every read-back before the first store: one dependent load per store
-            # would leave the epilogue waiting on memory latency instead of overlapping.
             prev = [
                 buffer_ops.buffer_load(rsrc, off_e, vec_width=1, dtype=self.out_ty.ir_type, mask=valid)
                 for off_e, valid in addrs
@@ -273,6 +311,43 @@ class StoreCPlain:
             return halves.bitcast(fx.Int32)[0]
         return rocdl.cvt_pk_bf16_f32(x0, x1)
 
+    def _col(self, tj):
+        """Column of N sub-block ``tj`` for this lane, relative to the wave's column base."""
+        if const_expr(bool(self.ilv)):
+            return self.ilv * (self.lane_id % 16) + tj
+        return tj * 16 + self.lane_id % 16
+
+    def fused_operands(self, base_row, base_col_l, base_col_r, n_valid=None):
+        """SRDs + per-lane voffset for a C store emitted INSIDE the whole-loop asm,
+        addressed like ``_store_rowaddr`` (one address per row/lane). Both halves share
+        the row band and differ only in num_records dropping an all-padding R half."""
+        rsrc = []
+        for col in (base_col_l, base_col_r):
+            rows = self.c_rows
+            if n_valid is not None:
+                assert n_valid % (16 * self.n_tiles_b) == 0
+                rows = arith.select(col < fx.Int32(n_valid), rows, base_row)
+            rsrc.append(make_row_band_resource(self.c_base, base_row, rows, self.c_cols, 2))
+        row_b = self.c_cols * fx.Int32(2)
+        voff = (base_col_l + self._col(0)) * fx.Int32(2) + (self.lane_id // 16) * (row_b * fx.Int32(4))
+        return rsrc[0], rsrc[1], voff, rocdl.readfirstlane(T.i32, row_b)
+
+    def _store_rowaddr(self, c_frag, base_col, rsrc):
+        """Unmasked store: ONE address per (row, lane) shared by the row's N sub-blocks,
+        which ride the store's offset immediate so the per-store address VALU disappears.
+        Rows past c_rows still OOB-drop through the band SRD's num_records."""
+        row_b = self.c_cols * fx.Int32(2)  # C row stride in bytes
+        base = (base_col + self._col(0)) * fx.Int32(2) + (self.lane_id // 16) * (row_b * fx.Int32(4))
+        step = 2 if self.ilv else 32  # interleaved: sub-blocks are adjacent columns
+        for ti in range_constexpr(self.n_tiles_a):
+            for i in range_constexpr(4):
+                off = base + row_b * fx.Int32(ti * 16 + i)
+                for tj in range_constexpr(self.n_tiles_b):
+                    val = Vec(c_frag[self.c_idx_fn(ti, tj)])[i].to(self.out_ty)
+                    buffer_ops.buffer_store(
+                        val, rsrc, off if tj == 0 else off + tj * step, offset_is_bytes=True
+                    )
+
     @staticmethod
     def _permlane16_swap(a_i32, b_i32):
         """v_permlane16_swap_b32 a, b -- swap 16-lane row-groups between two regs
@@ -294,20 +369,9 @@ class StoreCPlain:
         return _llvm.extractvalue(i32t, r, [0]), _llvm.extractvalue(i32t, r, [1])
 
     def store_tacc_wide(self, c_frag, base_row, base_col):
-        """TACC + AITER permlane16_swap WIDE store (autotune-selected TACCW variant). Combines TWO
-        adjacent N sub-blocks (tj, tj+1) into a 16-row x 32-col region written with
-        ONE ``buffer_store_dwordx4`` (8 out_ty = 16B) per lane.
-
-        With acc = Cᵀ a lane's 4 f32 are 4 CONSECUTIVE columns. Pack them to 2 out_ty
-        dwords (``_pack_pair``), then 2x ``v_permlane16_swap`` reshuffle the 4 row-groups so
-        each lane ends up holding 8 CONTIGUOUS columns (AITER's exact recipe):
-            rg0 -> tj   cols 0..7    rg1 -> tj+1 cols 0..7
-            rg2 -> tj   cols 8..15   rg3 -> tj+1 cols 8..15
-        Addressing: row = base_row + ti*16 + lane%16 (lane->row, scattered by row);
-        col = base_col + tj*16 + coloff(rg), coloff=[0,16,8,24] -> the 4 row-groups
-        of a row write 4 contiguous 16B blocks = 64B-coalesced burst. 16 wide stores
-        per half (vs 256 narrow shorts). No LDS, no barrier. Host guarantees
-        M%256==N%256==0 so all tiles are in-bounds (SRD num_records is the safety net)."""
+        """TACC + permlane16_swap wide store: two adjacent N sub-blocks become one
+        16-row x 32-col region per lane, written with a single buffer_store_dwordx4.
+        With acc = C^T a lane holds 4 consecutive columns; two swaps make them 8 contiguous."""
         nta, ntb = self.n_tiles_a, self.n_tiles_b
         assert ntb % 2 == 0, "store_tacc_wide pairs N sub-blocks (ntb must be even)"
         # Re-base at this tile's row band in int64 (rows*cols may exceed 2^31); the per-lane
@@ -374,14 +438,8 @@ class MfmaScaleFp4:
         self.n_tiles_a = n_tiles_a
         self.n_tiles_b = n_tiles_b
         self.packed = packed
-        # tacc: swap MMA operands (src0<->src1, scales, op_sel) so the native
-        # accumulator holds Cᵀ -> per sub-block a lane's 4 f32 are 4 CONSECUTIVE
-        # columns, enabling a wide buffer_store_dwordx2/4 epilogue (AITER's method).
+        # tacc: swap MMA operands so the accumulator holds C^T (4 consecutive columns/lane) for a wide store.
         self.tacc = tacc
-        # phase-barrier in-flight memory depth (autotuned per shape): deeper (e.g.
-        # 16/15) hides more steady-state g2s latency -> faster high-K; shallower (10/9)
-        # is better on low/mid-trip-K where a deep pipeline can't fill. ELGK<=15 (4-bit
-        # lgkmcnt HW field).
         self.wlv = wlv
         self.elgk = elgk
         self.coop = coop
@@ -422,12 +480,20 @@ class MfmaScaleFp4:
         sc_soff0,
         ki=None,
         sc_buf_stride=0,
+        half_n=None,
+        half_g2s=True,
+        half_k=False,
+        split=None,
+        cst=None,
+        cst_gap=0,
+        cst_ilv=0,
+        cst_nt=False,
+        b_base_even=None,
         _cache={},  # noqa: B006 -- deliberate cross-call asm compile cache
     ):
-        """WHOLE-LOOP bare-asm: the entire K-loop is one inline-asm hw-loop, unroll-2 with
-        buf0/buf1 ping-pong. Each phase: ds_read operands + 128 MFMA (L+R, n_sub, packed
-        scale) + G2S buffer_load_lds refill (next-K in-place) + s_barrier. Scales are
-        VGPR-direct (default) or COOP LDS-staged. Returns (accL, accR)."""
+        """WHOLE-LOOP bare-asm K-loop: one inline-asm hw-loop, unroll-2 ping-pong with
+        VGPR-direct or COOP scales. half_n/half_k/split/cst/half_g2s select boundary/odd-K/
+        parity-split/fused-store/live-R-half variants; returns (accL, accR)."""
         assert self.packed
         nta, ntb = self.n_tiles_a, self.n_tiles_b
         nq = nta * ntb
@@ -441,12 +507,9 @@ class MfmaScaleFp4:
         NSET = 1
         _WLV = self.wlv  # vmcnt kept in flight at the phase barrier (deep g2s pipeline)
         _ELGK = self.elgk  # lgkmcnt left at the phase barrier (late refills stay in flight)
-        # Cooperative LDS scale staging (_COOP, vs default per-wave VGPR-direct): the 4 waves
-        # each load ONE of the 4 unique scale groups into SC_lds once, s_barrier, then each
-        # ds_reads the A/B groups it needs -- avoids the 2x redundant HBM scale fetch when
-        # waves share wave_m/wave_n. Per-wave rsrc/soffset selected host-side (arith.select).
+        # Cooperative LDS scale staging (vs per-wave VGPR-direct): 4 waves co-load the 4 groups once.
         _COOP = self.coop
-        _TACC = self.tacc  # transposed accumulator: swap MMA operands -> acc = Cᵀ
+        _TACC = self.tacc  # transposed accumulator: swap MMA operands -> acc = C^T
         _PINBASE = 8
         key = (
             nta,
@@ -465,7 +528,29 @@ class MfmaScaleFp4:
             self.coop,
             _TACC,
             ki,
+            half_n is not None,
+            half_g2s,
+            half_k,
+            split is not None and len(split[0]),
+            cst is not None,
+            cst_gap,
+            cst_ilv,
+            cst_nt,
         )
+        _SPLIT = split is not None
+        _CST = cst is not None
+        _CILV = cst_ilv
+        assert not _CILV or (_CST and _CILV == ntb and ntb == 4)
+        _BSPL = bool(_CILV) and _SPLIT
+        assert _BSPL == (b_base_even is not None)
+        # The fused store needs a g2s-free tail phase to ride (unified vmcnt): a peel or odd KI.
+        assert not _CST or (not self.coop and (ki is None or (half_k and ((ki & 1) or ki >= 4))))
+        _RTPEEL = _CST and ki is None
+        # 3-slot odd ring (skewed rows) rotates ds_read bases; a 2-slot ring is byte-exact/static.
+        _ROT = _SPLIT and len(split[0]) == 3
+        _NOD = len(split[0]) if _SPLIT else 0
+        if _SPLIT:
+            assert n_sub == 2 and nbuf == 2 and nbuf_b == 2 and nsa % 2 == 0 and nsb % 2 == 0
         if key not in _cache:
             o_acc = list(range(NT))
             t_a = NT
@@ -476,7 +561,12 @@ class MfmaScaleFp4:
             _scextra = nsct  # VGPR-direct 2nd scale set (ping-pong)
             set_sz = ntmp + nsct + _scextra
             ntmp2 = NSET * set_sz
-            o_cnt = NT + ntmp2  # =&s loop counter
+            _nvx = 19 if _ROT else 0  # split: 12 rotating ds_read bases + 2x3 ring offsets + scratch
+            _nbase = NT + ntmp2
+            o_nb = [[[_nbase + t * 4 + b * 2 + s for s in range(2)] for b in range(2)] for t in range(3)]
+            o_nq = [[_nbase + 12 + t * 3 + j for j in range(3)] for t in range(2)]
+            o_vtm = _nbase + 18
+            o_cnt = NT + ntmp2 + _nvx  # =&s loop counter
             o_sa = o_cnt + 1
             o_sbl = o_sa + 1
             o_sbr = o_sbl + 1  # advancing gmem soffsets A/BL/BR
@@ -485,7 +575,21 @@ class MfmaScaleFp4:
             o_tbr = o_tbl + 1  # buf1 (=+kstep) scratch soffsets
             o_sca = [o_tbr + 1 + g for g in range(4)]  # 4 scale soffsets (A-g0, A-g1, BL, BR)
             o_sct = o_sca[3] + 1  # scale scratch soffset
-            nout = o_sct + 1
+            o_pod = [
+                [o_sct + 1 + t * 3 + j for j in range(3)] for t in range(3)
+            ]  # 3 odd-ring g2s dests/operand
+            o_stm = o_sct + 10
+            nout = o_sct + 1 + (10 if _ROT else 0)
+            o_csc = nout
+            o_crw = [[nout + 1 + p * 4 + e for e in range(4)] for p in range(2)]
+            if _CST:
+                nout += 9
+            _CDV = _PINBASE + NSET * (2 * nsct + 4 * ntmp)
+            _NCDV = 18 if _CILV else 0
+            nout += _NCDV
+            o_npv = nout  # runtime peel: hw-loop bound = trip count - 2
+            if _RTPEEL:
+                nout += 1
             # scale temp accessors (group: 0=A-g0, 1=A-g1, 2=BL, 3=BR; slot=grp*n_sub+s)
             # _scb[0] = ping-pong scale-set base (0 or nsct), set per phase.
             _scb = [0]
@@ -544,6 +648,28 @@ class MfmaScaleFp4:
             i += 1  # scale per-lane gmem voffset
             i_sca0 = [i + g for g in range(4)]
             i += 4  # scale soffset inits (A-g0, A-g1, BL, BR)
+            i_hn = i
+            i += 1 if half_n is not None else 0  # half-N variant selector
+            i_od = [[i + t * _NOD + j for j in range(_NOD)] for t in range(3)]  # odd g2s dest
+            i += 3 * _NOD
+            i_qu = [i, i + 1]  # per-lane odd-ring slot stride (0 on aligned rows)
+            i += 2 if _ROT else 0
+            i_cl, i_cr, i_cvo, i_crb = i, i + 1, i + 2, i + 3  # fused store: SRDs, voff, row bytes
+            i += 4 if _CST else 0
+            i_ble = [[i + b * n_sub + s for s in range(n_sub)] for b in range(nbuf_b)]
+            i += nbuf_b * n_sub if _BSPL else 0
+            i_bre = [[i + b * n_sub + s for s in range(n_sub)] for b in range(nbuf_b)]
+            i += nbuf_b * n_sub if _BSPL else 0
+            if _ROT:
+                f_ab, f_blb, f_brb = i_ab, i_blb, i_brb
+                i_ab, i_blb, i_brb = o_nb[0], o_nb[1], o_nb[2]
+
+            def b_rd(sl, buf, s, ji):
+                """LDS read operands of B's N sub-block ``ji`` (base register, byte offset)."""
+                if _BSPL:
+                    odd, even = (i_blb, i_ble) if sl == 0 else (i_brb, i_bre)
+                    return (odd if ji % 2 else even)[buf][s], (ji // 2) * ts_b
+                return (i_blb if sl == 0 else i_brb)[buf][s], ji * ts_b
 
             def emit_ds(buf, off=0):
                 # operands only; scales are VGPR-direct (emit_sc_vgpr in the loop).
@@ -553,21 +679,35 @@ class MfmaScaleFp4:
                         r.append(
                             f"ds_read_b128 ${t_a + ii * n_sub + s + off}, ${i_ab[buf][s]} offset:{ii * ts_a}"
                         )
-                for ji in range(ntb):
-                    for s in range(n_sub):
-                        r.append(
-                            f"ds_read_b128 ${t_bl + ji * n_sub + s + off}, ${i_blb[buf][s]} offset:{ji * ts_b}"
-                        )
-                for ji in range(ntb):
-                    for s in range(n_sub):
-                        r.append(
-                            f"ds_read_b128 ${t_br + ji * n_sub + s + off}, ${i_brb[buf][s]} offset:{ji * ts_b}"
-                        )
+                for sl, tb in ((0, t_bl), (1, t_br)):
+                    for ji in range(ntb):
+                        for s in range(n_sub):
+                            bb, bo = b_rd(sl, buf, s, ji)
+                            r.append(f"ds_read_b128 ${tb + ji * n_sub + s + off}, ${bb} offset:{bo}")
                 return r
 
-            def emit_g2s(buf, sa_op, sbl_op, sbr_op):
+            def emit_g2s(buf, sa_op, sbl_op, sbr_op, half=False, only_rg=None, b_only=False):
+                if _SPLIT:
+                    # Two streams/operand: aligned rows into slot buf, skewed rows into the 3-slot ring head.
+                    ne, nbe = nsa // 2, nsb // 2
+                    od = o_pod if _ROT else i_od
+                    r = []
+                    for de, do, gl, rs, so, n in (
+                        (i_g_ab[buf], od[0][buf], i_gla, i_rsa, sa_op, 0 if b_only else ne),
+                        (i_g_blb[buf], od[1][buf], i_glb, i_rsb, sbl_op, nbe),
+                        (i_g_brb[buf], od[2][buf], i_glb, i_rsb, sbl_op if half else sbr_op, nbe),
+                    ):
+                        for st in range(n):
+                            for rg, dst in enumerate((de, do)):
+                                if only_rg is not None and rg != only_rg:
+                                    continue
+                                r.append(
+                                    f"s_add_u32 m0, ${dst}, {st * _NWc * 1024}\n"
+                                    f"buffer_load_dwordx4 ${gl[rg * n + st]}, ${rs}, ${so} offen lds"
+                                )
+                    return r
                 r = []
-                for st in range(nsa):
+                for st in range(0 if b_only else nsa):
                     r.append(
                         f"s_add_u32 m0, ${i_g_ab[buf]}, {st * _NWc * 1024}\n"
                         f"buffer_load_dwordx4 ${i_gla[st]}, ${i_rsa}, ${sa_op} offen lds"
@@ -580,9 +720,52 @@ class MfmaScaleFp4:
                 for st in range(nsb):
                     r.append(
                         f"s_add_u32 m0, ${i_g_brb[buf]}, {st * _NWc * 1024}\n"
-                        f"buffer_load_dwordx4 ${i_glb[st]}, ${i_rsb}, ${sbr_op} offen lds"
+                        f"buffer_load_dwordx4 ${i_glb[st]}, ${i_rsb}, ${sbl_op if half else sbr_op} offen lds"
                     )
                 return r
+
+            def emit_rot():
+                mv = []
+                for t in range(2):
+                    q = o_nq[t]
+                    mv += [
+                        f"v_mov_b32 ${o_vtm}, ${q[1]}",
+                        f"v_mov_b32 ${q[1]}, ${q[0]}",
+                        f"v_mov_b32 ${q[0]}, ${q[2]}",
+                        f"v_mov_b32 ${q[2]}, ${o_vtm}",
+                    ]
+                sv = []
+                for t in range(3):
+                    p = o_pod[t]
+                    sv += [
+                        f"s_mov_b32 ${o_stm}, ${p[1]}",
+                        f"s_mov_b32 ${p[1]}, ${p[0]}",
+                        f"s_mov_b32 ${p[0]}, ${p[2]}",
+                        f"s_mov_b32 ${p[2]}, ${o_stm}",
+                    ]
+                return ["\n".join(mv), "\n".join(sv)]
+
+            def emit_bases(buf):
+                jj = (2, 0) if buf == 0 else (0, 1)
+                r = []
+                for t, fr in enumerate((f_ab, f_blb, f_brb)):
+                    q = o_nq[0 if t == 0 else 1]
+                    for s in range(2):
+                        r.append(f"v_add_u32 ${o_nb[t][buf][s]}, ${fr[buf][s]}, ${q[jj[s]]}")
+                return r
+
+            def mix_g2s(g2s, extra):
+                if not extra:
+                    return g2s
+                out = []
+                gap = max(len(g2s) // len(extra), 1)
+                ei = 0
+                for k, ln in enumerate(g2s):
+                    out.append(ln)
+                    if ei < len(extra) and k % gap == gap - 1:
+                        out.append(extra[ei])
+                        ei += 1
+                return out + extra[ei:]
 
             def ds_line(buf, tt):
                 # per-temp ds_read for the in-place refill stream. Scale temps
@@ -592,39 +775,142 @@ class MfmaScaleFp4:
                     ii = rel // n_sub
                     s = rel % n_sub
                     return f"ds_read_b128 ${tt}, ${i_ab[buf][s]} offset:{ii * ts_a}"
-                if tt < t_br:
-                    rel = tt - t_bl
-                    ji = rel // n_sub
-                    s = rel % n_sub
-                    return f"ds_read_b128 ${tt}, ${i_blb[buf][s]} offset:{ji * ts_b}"
                 if tt < t_sc:
-                    rel = tt - t_br
-                    ji = rel // n_sub
-                    s = rel % n_sub
-                    return f"ds_read_b128 ${tt}, ${i_brb[buf][s]} offset:{ji * ts_b}"
+                    sl = 0 if tt < t_br else 1
+                    rel = tt - (t_bl if sl == 0 else t_br)
+                    bb, bo = b_rd(sl, buf, rel % n_sub, rel // n_sub)
+                    return f"ds_read_b128 ${tt}, ${bb} offset:{bo}"
                 return ""
 
-            def emit_inplace(nxt_buf, g2sl):
-                # NEXT-K in-place refill, blocked-diagonal (4 A-rows x 8 N-cols) with the
-                # K-sub (s) innermost so each acc's n_sub MFMA are consecutive. Both operands
-                # free progressively (ds_read of nxt_buf overlaps the MFMA tail); scales are
-                # VGPR-direct so their refill is a no-op. GAVOID: g2s only at no-ds-refill
-                # slots; the 4x8 block spacing avoids the accumulator RAW stall.
+            # fused C store folded into the g2s-free tail MFMA stream, paced _CRATE lines/MFMA per acc.
+            _CAGE = 4
+            _CRATE = 6 if _CILV else 2
+            _CST_HAZ = ["s_nop 15", "s_nop 15"]
+            _ARD = 8
+
+            def cst_rows(ii, p):
+                r = o_crw[p]
+                if ii:
+                    ls = [
+                        f"s_mul_i32 ${o_csc}, ${i_crb}, {ii * 16}",
+                        f"v_add_u32 ${r[0]}, ${o_csc}, ${i_cvo}",
+                    ]
+                else:
+                    ls = [f"v_mov_b32 ${r[0]}, ${i_cvo}"]
+                for e in range(1, 4):
+                    ls.append(f"v_add_u32 ${r[e]}, ${i_crb}, ${r[e - 1]}")
+                return ls
+
+            # C is write-only and evicts shared operand lines; ``nt`` keeps operands resident.
+            _CNT = " nt" if cst_nt else ""
+
+            def cst_group(ii, sl, ji, p):
+                # bf16 is the accumulator's high half, so the store sources the AGPR directly.
+                q = sl * nq + ii * ntb + ji
+                imm = (cst_gap if sl else 0) + ji * 32
+                rs = i_cr if sl else i_cl
+                return [
+                    f"buffer_store_short_d16_hi a{4 * q + e}, ${o_crw[p][e]}, ${rs}, 0 offen"
+                    + (f" offset:{imm}" if imm else "")
+                    + _CNT
+                    for e in range(4)
+                ]
+
+            def cst_wide(ii, sl, p, u):
+                # Interleaved: each C row packs to a dwordx2 via v_accvgpr_read + v_cvt_pk_bf16_f32.
+                q0 = sl * nq + ii * ntb
+                imm = cst_gap if sl else 0
+                rs = i_cr if sl else i_cl
+                b = _CDV + (u & 1) * 8
+                s0, s1 = _CDV + 16, _CDV + 17
+                ls = []
+                for e in range(4):
+                    d = b + 2 * e
+                    ls += [
+                        f"v_accvgpr_read_b32 v{d}, a{4 * q0 + e}",
+                        f"v_accvgpr_read_b32 v{s0}, a{4 * (q0 + 1) + e}",
+                        f"v_cvt_pk_bf16_f32 v{d}, v{d}, v{s0}",
+                        f"v_accvgpr_read_b32 v{d + 1}, a{4 * (q0 + 2) + e}",
+                        f"v_accvgpr_read_b32 v{s1}, a{4 * (q0 + 3) + e}",
+                        f"v_cvt_pk_bf16_f32 v{d + 1}, v{d + 1}, v{s1}",
+                    ]
+                for e in range(4):
+                    d = b + 2 * e
+                    ls.append(
+                        f"buffer_store_dwordx2 v[{d}:{d + 1}], ${o_crw[p][e]}, ${rs}, 0 offen"
+                        + (f" offset:{imm}" if imm else "")
+                        + _CNT
+                    )
+                return ls
+
+            class CstSched:
+                """Paced FIFO of the accumulators the tail's MFMA stream has finished."""
+
+                def __init__(self):
+                    self.q = []  # finished store units, in MFMA order
+                    self.ln = []  # store lines of the unit being drained
+                    self.cur = None
+                    self.pend = {}  # interleaved: (ii, sl) -> accumulators finished
+                    self.u = 0  # interleaved: store-unit counter (data-VGPR bank)
+
+                def done(self, mi, ii, sl, ji):
+                    if _CILV:
+                        n = self.pend.get((ii, sl), 0) + 1
+                        self.pend[(ii, sl)] = n
+                        if n == ntb:
+                            self.q.append((mi, ii, sl, None))
+                        return
+                    self.q.append((mi, ii, sl, ji))
+
+                def emit(self, mi, n=_CRATE):
+                    out = []
+                    while n > 0:
+                        if not self.ln:
+                            if not self.q or (mi is not None and self.q[0][0] + _CAGE > mi):
+                                break
+                            _, ii, sl, ji = self.q.pop(0)
+                            if _CILV:
+                                self.ln.append("s_waitcnt vmcnt(4)")
+                            if ii != self.cur:
+                                self.ln += cst_rows(ii, ii % 2)
+                                self.cur = ii
+                            if _CILV:
+                                self.ln += cst_wide(ii, sl, ii % 2, self.u)
+                                self.u += 1
+                            else:
+                                self.ln += cst_group(ii, sl, ji, ii % 2)
+                        k = min(n, len(self.ln))
+                        out += self.ln[:k]
+                        self.ln = self.ln[k:]
+                        n -= k
+                    return out
+
+                def flush(self):
+                    return self.emit(None, 1 << 30)
+
+            def emit_inplace(nxt_buf, g2sl, half=False, drop_s=False, refill=True, cstq=None):
+                # NEXT-K in-place refill, blocked-diagonal (4 A-rows x 8 N-cols); GAVOID: g2s in no-refill slots.
                 bm, bn = 4, 8
                 ncol = 2 * ntb
                 nib = nta // bm
                 ncb = ncol // bn
-                cells = []
+                quads = []
                 for D in range(nib + ncb - 1):
                     for iib in range(nib):
                         cb = D - iib
                         if 0 <= cb < ncb:
                             for di in range(bm):
                                 for dj in range(bn):
-                                    for s in range(n_sub):
-                                        ii = iib * bm + di
-                                        col = cb * bn + dj
-                                        cells.append((ii, col // ntb, col % ntb, s))
+                                    ii = iib * bm + di
+                                    col = cb * bn + dj
+                                    if half and col // ntb:
+                                        continue  # R half: padding columns
+                                    quads.append((ii, col // ntb, col % ntb))
+                nsub_e = n_sub - 1 if drop_s else n_sub
+                cells = []
+                for q in quads:
+                    for s in range(nsub_e):
+                        cells.append(q + (s,))
                 mlist = []
                 for ii, sl, ji, s in cells:
                     tb = t_bl if sl == 0 else t_br
@@ -635,7 +921,7 @@ class MfmaScaleFp4:
                     bt = tb + ji * n_sub + s
                     sat = sa_t(s, ii // 4)
                     sbt = sbfn(s)
-                    if _TACC:  # acc = Cᵀ: src0<->src1, scales, op_sel[0]<->op_sel[1]
+                    if _TACC:  # acc = C^T: src0<->src1, scales, op_sel[0]<->op_sel[1]
                         osel = f"op_sel:[{ob & 1},{oa & 1},0] op_sel_hi:[{(ob >> 1) & 1},{(oa >> 1) & 1},0]"
                         mline = (
                             f"v_mfma_scale_f32_16x16x128_f8f6f4 ${q}, ${bt}, ${at}, ${q}, "
@@ -665,39 +951,45 @@ class MfmaScaleFp4:
                                 _rfslot.add(mi)
                                 _rf.add(rt)
                     _free = [mi for mi in range(len(mlist)) if mi not in _rfslot]
-                    _fgap = max(len(_free) // max(len(g2sl), 1), 1)
+                    _n = len(g2sl)
+                    _fgap = max(len(_free) // max(_n, 1), 1)
                     for _k, _fi in enumerate(_free):
-                        if (_k % _fgap == 0) and len(_gset) < len(g2sl):
+                        if (_k % _fgap == 0) and len(_gset) < _n:
                             _gset[_fi] = len(_gset)
                 out = []
                 gi = 0
                 refilled = set()
                 for mi, (ml, at, bt, sat, sbt) in enumerate(mlist):
                     out.append(ml)
-                    for rt in (at, bt, sat, sbt):
-                        if rt in mid and last[rt] == mi and rt not in refilled:
-                            out.append(ds_line(nxt_buf, rt))
-                            refilled.add(rt)
+                    if refill:
+                        for rt in (at, bt, sat, sbt):
+                            if rt in mid and last[rt] == mi and rt not in refilled:
+                                out.append(ds_line(nxt_buf, rt))
+                                refilled.add(rt)
                     if g2sl and mi in _gset and gi < len(g2sl):
                         out.append(g2sl[gi])
                         gi += 1
+                    if cstq is not None:
+                        _ii, _sl, _ji, _s = cells[mi]
+                        if _s == nsub_e - 1:
+                            cstq.done(mi, _ii, _sl, _ji)
+                        out += cstq.emit(mi)
                 while gi < len(g2sl):
                     out.append(g2sl[gi])
                     gi += 1
-                # end drain: refill the still-pending operand temps (used till end).
-                for tt in range(t_a, NT + set_sz):
-                    if tt not in refilled:
-                        out.append(ds_line(nxt_buf, tt))
+                if refill:
+                    for tt in range(t_a, NT + set_sz):  # end drain: refill still-pending temps
+                        if half and t_br <= tt < t_sc:
+                            continue  # R half: the variant never reads these fragments
+                        if tt not in refilled:
+                            out.append(ds_line(nxt_buf, tt))
+                if cstq is not None:
+                    out += _CST_HAZ + cstq.flush()
                 return out
 
-            # ── phase boundary drains ─────────────────────────────────────────
             _ipend = f"s_waitcnt vmcnt({_WLV}) lgkmcnt({_ELGK})\ns_barrier"
-            _ipenda = f"s_waitcnt vmcnt({_WLV}) lgkmcnt({_ELGK})\ns_barrier"
 
-            # ── VGPR-direct scale prefetch (lane-contiguous buffer_load to VGPR) ──
-            # emit_sc_vgpr(tb) loads this kk's 2*n_sub*2 scale dwords DIRECT to the
-            # pinned scale set (A -> v[p:..], B -> v[p+scw:..]); no LDS / ds_read. NO
-            # vmcnt here (in flight, drained by the phase barrier) -> overlaps mfma.
+            # VGPR-direct scale prefetch: emit_sc_vgpr loads scale dwords to the pinned set (no LDS/ds_read).
             _pbsc = _PINBASE  # scale VGPRs pinned first (PINSC), at PINBASE
             _scw = 2 * n_sub  # scale dwords per operand (2 region groups x n_sub subs)
             _scwx = {1: "", 2: "x2", 4: "x4"}.get(_scw, f"x{_scw}")  # buffer_load width suffix
@@ -717,10 +1009,7 @@ class MfmaScaleFp4:
                     f"s_add_u32 ${o_sca[2]}, ${o_sca[2]}, {_scvstep}",
                 ]
 
-            # COOP 2-deep pipeline: the 4 waves each buffer_load ONE unique scale group to
-            # its SC_lds slot, s_barrier, then each ds_reads the A group (slot=wave_m) + B
-            # (slot=2+wave_n) into the pinned scale VGPRs. g2s 2-ahead, ds_read 1-ahead
-            # (VGPR set + LDS buf ping-pong). Per-wave rsrc/soffset host-side (arith.select).
+            # COOP 2-deep pipeline: each wave loads one group to SC_lds, s_barrier, then ds_reads A+B.
             def emit_sc_coop_g2s(buf):
                 # one wave -> one group (4 dwords/lane) into SC_lds[buf] slot=wave_id.
                 return [
@@ -744,24 +1033,57 @@ class MfmaScaleFp4:
             # phase's first MFMA.
             _ipend_coop = "s_waitcnt vmcnt(0) lgkmcnt(0)\ns_barrier"
 
-            # ── prologue (before the hw-loop label) ───────────────────────────
+            # deferred tail of the operand prefill: last ring slot issued after k=0 scale loads (hides latency).
+            _APRE = _SPLIT  # the split ring also defers A's last slot
+            _NPRE = (nsa if _APRE else 0) + 2 * nsb
+
+            def emit_g2s_pre():
+                _bo = not _APRE
+                _sb = [
+                    f"s_sub_u32 ${o_ta}, ${i_sa0}, ${i_kstep}",
+                    f"s_sub_u32 ${o_tbl}, ${i_sbl0}, ${i_kstep}",
+                    f"s_sub_u32 ${o_tbr}, ${i_sbr0}, ${i_kstep}",
+                ]
+                if not _SPLIT:
+                    return _sb + emit_g2s(1, o_ta, o_tbl, o_tbr, b_only=_bo)
+                r = _sb + emit_g2s(1, o_ta, o_tbl, o_tbr, only_rg=0, b_only=_bo)
+                if _NOD == 3:
+                    r += [
+                        f"s_sub_u32 ${o_ta}, ${i_sa0}, 128",
+                        f"s_sub_u32 ${o_tbl}, ${i_sbl0}, 128",
+                        f"s_sub_u32 ${o_tbr}, ${i_sbr0}, 128",
+                    ]
+                return r + emit_g2s(1, o_ta, o_tbl, o_tbr, only_rg=1, b_only=_bo)
+
+            # prologue: half_k + even trip count peels the final unroll-2 iteration (loop stops two phases early).
+            _KPEEL = half_k and not _COOP and (ki is not None) and (ki >= 4) and not (ki & 1)
+            _OPEEL = _CST and half_k and not _COOP and (ki is not None) and (ki >= 5) and bool(ki & 1)
             L = [
-                f"s_mov_b32 ${o_cnt}, 0",
+                f"s_mov_b32 ${o_cnt}, {2 if (_KPEEL or _OPEEL) else 0}",
                 f"s_mov_b32 ${o_sa}, ${i_sa0}",
                 f"s_mov_b32 ${o_sbl}, ${i_sbl0}",
                 f"s_mov_b32 ${o_sbr}, ${i_sbr0}",
             ]
             for g in range(4):
                 L.append(f"s_mov_b32 ${o_sca[g]}, ${i_sca0[g]}")
+            if _RTPEEL:
+                L.append(f"s_sub_u32 ${o_npv}, ${i_nval}, 2")
+            if _ROT:
+                for t in range(3):
+                    for j in range(3):
+                        L.append(f"s_mov_b32 ${o_pod[t][j]}, ${i_od[t][(j + 1) % 3]}")
+                for t in range(2):
+                    q = o_nq[t]
+                    L.append(f"v_mov_b32 ${q[0]}, ${i_qu[t]}")
+                    L.append(f"v_lshlrev_b32 ${q[1]}, 1, ${i_qu[t]}")
+                    L.append(f"v_mov_b32 ${q[2]}, 0")
+                L += emit_bases(0) + emit_bases(1)
             # in-place double-buffer prologue: read buf0 (k=0) into set0 before the loop.
-            # operand ds_read (lgkmcnt) and scale buffer_load (vmcnt) write disjoint VGPRs
-            # and are independent -> issue both then drain with ONE combined wait so their
-            # latencies overlap. Removes a prologue wait edge from the fixed launch cost
-            # (bigger relative win on low-trip K where the prologue dominates).
-            L += emit_ds(0, 0)
             if _COOP:
-                # 2-deep prime: g2s P0->LDS0 (+P1->LDS1 when a loop follows), barrier
-                # (cross-wave LDS visible), then ds_read LDS0->set0 for the P0 consume.
+                L += emit_g2s_pre()
+                L.append("s_waitcnt vmcnt(0) lgkmcnt(0)")
+                L.append("s_barrier")
+                L += emit_ds(0, 0)
                 L += emit_sc_coop_g2s(0)
                 L += _scv_adv()
                 if (ki is None) or (ki >= 2):
@@ -774,59 +1096,192 @@ class MfmaScaleFp4:
             else:
                 # VGPR-direct scale prologue: set A = phase-A iter0 scales.
                 L += emit_sc_vgpr(0) + _scv_adv()
+                L += emit_g2s_pre()
+                L.append(f"s_waitcnt vmcnt({_NPRE}) lgkmcnt(0)")
+                L.append("s_barrier")
+                L += emit_ds(0, 0)
                 L.append("s_waitcnt vmcnt(0) lgkmcnt(0)")
-            # K%256 (odd KI) support: the unroll-2 do-while processes K in PAIRS of
-            # 256-blocks. ``i_nval`` is the floor-even count ((KI//2)*2); an odd
-            # trailing 256-block is handled by a single MFMA-only phase-A tail after
-            # the loop. KI==1 (K=256) has zero full pairs, so the do-while (which runs
-            # >=1 trip) is omitted entirely and the prologue feeds the tail directly.
+                L.append("s_barrier")
+            # K%256 (odd KI): the do-while processes 256-blocks in PAIRS; an odd trailing block is an MFMA tail (or _OPEEL).
             _has_loop = (ki is None) or (ki >= 2)
-            _has_tail = (ki is not None) and bool(ki & 1)
+            _has_tail = (ki is not None) and bool(ki & 1) and not _OPEEL
 
             if _has_loop:
-                L.append("1:")
+                # unroll-2 body (phase A even-k, phase B odd-k); scale loads lead the mfma stream.
+                def emit_phase_a(half):
+                    # phase A: consume set0; g2s P+2 -> LDS0, ds_read P+1 (LDS1) -> set1.
+                    _scb[0] = 0
+                    if _COOP:
+                        _scA = emit_sc_coop_g2s(0) + emit_sc_coop_ds(nsct, 1)
+                    else:
+                        _scA = emit_sc_vgpr(nsct)
+                    _gA = emit_g2s(0, o_sa, o_sbl, o_sbr, half and half_g2s)
+                    if _ROT:  # rotate first (phase A's own g2s dest is the new head)
+                        _gA = emit_rot() + mix_g2s(_gA, emit_bases(0))
+                    return _scA + emit_inplace(1, _gA, half) + _scv_adv()
 
-                # ── unroll-2 body (phase A even-k, phase B odd-k) ─────────────────
-                # SCV_ILV: the scale buffer_load is interleaved INTO the mfma stream
-                # (prepended to g2sl) so it overlaps the MFMA and stops competing with g2s
-                # for the boundary VMEM slot; _scv_adv (o_sca advance) is emitted AFTER
-                # emit_inplace so the interleaved loads read the un-advanced offset.
-                _g2sA = emit_g2s(0, o_sa, o_sbl, o_sbr)
-                _g2sB = emit_g2s(1, o_ta, o_tbl, o_tbr)
-                # phase A: consume set0; g2s P+2 -> LDS0, ds_read P+1 (LDS1) -> set1.
-                _scb[0] = 0
-                if _COOP:
-                    _scA = emit_sc_coop_g2s(0) + emit_sc_coop_ds(nsct, 1)
-                else:
-                    _scA = emit_sc_vgpr(nsct)
-                L += emit_inplace(1, _scA + _g2sA)
-                L += _scv_adv()
-                L.append(_ipenda)
-                L.append(f"s_add_u32 ${o_ta}, ${o_sa}, ${i_kstep}")
-                L.append(f"s_add_u32 ${o_tbl}, ${o_sbl}, ${i_kstep}")
-                L.append(f"s_add_u32 ${o_tbr}, ${o_sbr}, ${i_kstep}")
-                # phase B: consume set1; g2s P+2 -> LDS1, ds_read P+1 (LDS0) -> set0.
-                _scb[0] = nsct
-                if _COOP:
-                    _scB = emit_sc_coop_g2s(1) + emit_sc_coop_ds(0, 0)
-                else:
-                    _scB = emit_sc_vgpr(0)
-                L += emit_inplace(0, _scB + _g2sB)
-                L += _scv_adv()
-                L.append(_ipend)
-                for _so in (o_sa, o_sbl, o_sbr):
-                    L.append(f"s_add_u32 ${_so}, ${_so}, ${i_kstep}")
-                    L.append(f"s_add_u32 ${_so}, ${_so}, ${i_kstep}")
-                L.append(f"s_add_u32 ${o_cnt}, ${o_cnt}, 2")
-                L.append(f"s_cmp_lt_u32 ${o_cnt}, ${i_nval}")
-                L.append("s_cbranch_scc1 1b")
+                def emit_loop(lbl, half):
+                    B = [f"{lbl}:"]
+                    B += emit_phase_a(half)
+                    B.append(_ipend)
+                    B.append(f"s_add_u32 ${o_ta}, ${o_sa}, ${i_kstep}")
+                    B.append(f"s_add_u32 ${o_tbl}, ${o_sbl}, ${i_kstep}")
+                    B.append(f"s_add_u32 ${o_tbr}, ${o_sbr}, ${i_kstep}")
+                    # phase B: consume set1; g2s P+2 -> LDS1, ds_read P+1 (LDS0) -> set0.
+                    _scb[0] = nsct
+                    if _COOP:
+                        _scB = emit_sc_coop_g2s(1) + emit_sc_coop_ds(0, 0)
+                    else:
+                        _scB = emit_sc_vgpr(0)
+                    _gB = emit_g2s(1, o_ta, o_tbl, o_tbr, half and half_g2s)
+                    if _ROT:
+                        _gB = mix_g2s(_gB, emit_bases(1))
+                    B += _scB + emit_inplace(0, _gB, half)
+                    B += _scv_adv()
+                    B.append(_ipend)
+                    for _so in (o_sa, o_sbl, o_sbr):
+                        B.append(f"s_add_u32 ${_so}, ${_so}, ${i_kstep}")
+                        B.append(f"s_add_u32 ${_so}, ${_so}, ${i_kstep}")
+                    B.append(f"s_add_u32 ${o_cnt}, ${o_cnt}, 2")
+                    B.append(f"s_cmp_lt_u32 ${o_cnt}, ${o_npv if _RTPEEL else i_nval}")
+                    B.append(f"s_cbranch_scc1 {lbl}b")
+                    return B
+
+                def emit_peel(half):
+                    # Peeled last iteration: keeps phase A's refill + scale prefetch, drops the g2s (past K's end).
+                    B = [f"s_waitcnt vmcnt(0) lgkmcnt({_ELGK})", "s_barrier"]
+                    _scb[0] = 0
+                    B += emit_sc_vgpr(nsct) + emit_inplace(1, [], half)
+                    B.append(f"s_waitcnt vmcnt(0) lgkmcnt({_ELGK})")
+                    _scb[0] = nsct
+                    B += emit_inplace(0, [], half, drop_s=True, refill=False)
+                    return B
+
+                def emit_peel_fold(half, sw=0):
+                    """Peeled last iteration with the C store folded into its MFMA stream, so each
+                    accumulator is final after 3 MFMAs and its stores ride the later ones.
+                    Per-accumulator MFMA order is unchanged, so C is bit-identical."""
+                    nsl = 1 if half else 2
+                    cq = CstSched()
+                    sc_f, sc_t = (0, nsct) if sw == 0 else (nsct, 0)
+
+                    def aw(ii, s):  # rolling A window: k sub-steps + the trailing block's
+                        return t_a + (ii % 2) * (n_sub + 2) + s
+
+                    def b1(sl, ji):  # trailing block's B, in the A slots left over
+                        return t_a + 2 * (n_sub + 2) + sl * ntb + ji
+
+                    def rd_a(ii, s):
+                        buf, ss = (sw, s) if s < n_sub else (1 - sw, 0)
+                        return f"ds_read_b128 ${aw(ii, s)}, ${i_ab[buf][ss]} offset:{ii * ts_a}"
+
+                    def rd_b1(sl, ji):
+                        bb, bo = b_rd(sl, 1 - sw, 0, ji)
+                        return f"ds_read_b128 ${b1(sl, ji)}, ${bb} offset:{bo}"
+
+                    def mfl(ii, sl, ji, s):
+                        q = sl * nq + ii * ntb + ji
+                        oa, ob = ii % 4, ji
+                        se = s if s < n_sub else 0
+                        scb = sc_f if s < n_sub else sc_t
+                        at = aw(ii, s)
+                        bt = (t_bl if sl == 0 else t_br) + ji * n_sub + se if s < n_sub else b1(sl, ji)
+                        sat = t_sc + scb + (ii // 4) * n_sub + se
+                        sbt = t_sc + scb + (2 + sl) * n_sub + se
+                        if _TACC:  # acc = C^T (swap operands/scales/op_sel)
+                            osel = (
+                                f"op_sel:[{ob & 1},{oa & 1},0] op_sel_hi:[{(ob >> 1) & 1},{(oa >> 1) & 1},0]"
+                            )
+                            return (
+                                f"v_mfma_scale_f32_16x16x128_f8f6f4 ${q}, ${bt}, ${at}, ${q}, "
+                                f"${sbt}, ${sat} {osel} cbsz:4 blgp:4"
+                            )
+                        osel = f"op_sel:[{oa & 1},{ob & 1},0] op_sel_hi:[{(oa >> 1) & 1},{(ob >> 1) & 1},0]"
+                        return (
+                            f"v_mfma_scale_f32_16x16x128_f8f6f4 ${q}, ${at}, ${bt}, ${q}, "
+                            f"${sat}, ${sbt} {osel} cbsz:4 blgp:4"
+                        )
+
+                    B = ["s_waitcnt vmcnt(0) lgkmcnt(0)", "s_barrier"]
+                    B += emit_sc_vgpr(sc_t)
+                    for sl in range(nsl):
+                        for ji in range(ntb):
+                            B.append(rd_b1(sl, ji))
+                    for s in range(n_sub + 1):
+                        B.append(rd_a(0, s))
+                    mi = 0
+                    for ii in range(nta):
+                        B.append("s_waitcnt lgkmcnt(0)")
+                        if ii == 0:
+                            B.append("s_waitcnt vmcnt(0)")  # trailing scale; no store in flight
+                        j = 0
+                        for sl in range(nsl):
+                            for ji in range(ntb):
+                                for s in range(n_sub + 1):
+                                    B.append(mfl(ii, sl, ji, s))
+                                    if s == n_sub:
+                                        cq.done(mi, ii, sl, ji)
+                                    B += cq.emit(mi)
+                                    mi += 1
+                                    j += 1
+                                    if j == _ARD and ii + 1 < nta:
+                                        for ss in range(n_sub + 1):
+                                            B.append(rd_a(ii + 1, ss))
+                    B += _CST_HAZ + cq.flush()
+                    return B
+
+                def emit_peel_rt(half, lbl):
+                    """Hw-loop stopped two phases early plus the peeled copy, for a runtime trip
+                    count. The peel consumes k-blocks already in LDS, so it issues no g2s and
+                    an in-flight store cannot serialise a wait through the unified vmcnt."""
+                    B = [f"s_cmp_lt_u32 ${i_nval}, 4", f"s_cbranch_scc1 {lbl}f"]
+                    B += emit_loop("2" if half else "1", half)
+                    B.append(f"{lbl}:")
+                    B.append(f"s_waitcnt vmcnt(0) lgkmcnt({_ELGK})")
+                    B.append("s_barrier")
+                    _scb[0] = 0
+                    B += emit_sc_vgpr(nsct) + emit_inplace(1, [], half)
+                    B.append(f"s_waitcnt vmcnt(0) lgkmcnt({_ELGK})")
+                    _scb[0] = nsct
+                    B += emit_inplace(0, [], half, refill=False, cstq=CstSched())
+                    return B
+
+                def emit_peel_odd(half):
+                    """Odd trip count: peel the last full pair's phase A so the trailing half
+                    k-block merges into the phase behind it, giving the fused store the same
+                    whole-peel window an even KI gets. The peeled phase A is an exact copy."""
+                    return emit_phase_a(half) + emit_peel_fold(half, sw=1)
+
+                # Boundary N-block variant: same drain/barrier sequence, R-half MFMAs dropped.
+                if half_n is not None:
+                    L.append(f"s_cmp_lg_u32 ${i_hn}, 0")
+                    L.append("s_cbranch_scc1 3f")
+                _peel = emit_peel_fold if _CST else emit_peel
+
+                def emit_body(lbl, half):
+                    if _RTPEEL:
+                        return emit_peel_rt(half, lbl)
+                    B = emit_loop("2" if half else "1", half)
+                    if _KPEEL:
+                        B += _peel(half)
+                    elif _OPEEL:
+                        B += emit_peel_odd(half)
+                    return B
+
+                L += emit_body("5", False)
+                if half_n is not None:
+                    L.append("s_branch 4f")
+                    L.append("3:")
+                    L += emit_body("6", True)
+                    L.append("4:")
 
             if _has_tail:
-                # odd-KI trailing phase-A (MFMA-only): the last even-k operands are already
-                # in the ds_read temps (last phase-B refill, or prologue emit_ds when KI==1)
-                # and set0 scales are loaded. No g2s/ds/scale reload -- drain, run the MFMAs.
+                # odd-KI trailing phase-A (MFMA-only): operands + set0 scales already staged, just drain and run.
                 L.append("s_waitcnt vmcnt(0) lgkmcnt(0)")
                 _scb[0] = 0
+                _nst = n_sub - 1 if half_k else n_sub
+                _cq = CstSched() if _CST else None
+                _mi = 0
                 _bm, _bn = 4, 8  # match loop-body block (see emit_inplace)
                 _ncol = 2 * ntb
                 _nib = nta // _bm
@@ -837,7 +1292,7 @@ class MfmaScaleFp4:
                         if 0 <= _cb < _ncb:
                             for _di in range(_bm):
                                 for _dj in range(_bn):
-                                    for _s in range(n_sub):
+                                    for _s in range(_nst):
                                         _ii = _iib * _bm + _di
                                         _col = _cb * _bn + _dj
                                         _sl = _col // ntb
@@ -850,7 +1305,7 @@ class MfmaScaleFp4:
                                         _bt = _tb + _ji * n_sub + _s
                                         _sat = sa_t(_s, _ii // 4)
                                         _sbt = _sbfn(_s)
-                                        if _TACC:  # acc = Cᵀ (swap operands/scales/op_sel)
+                                        if _TACC:  # acc = C^T (swap operands/scales/op_sel)
                                             _osel = (
                                                 f"op_sel:[{_ob & 1},{_oa & 1},0] "
                                                 f"op_sel_hi:[{(_ob >> 1) & 1},{(_oa >> 1) & 1},0]"
@@ -868,6 +1323,13 @@ class MfmaScaleFp4:
                                                 f"v_mfma_scale_f32_16x16x128_f8f6f4 ${_q}, ${_at}, "
                                                 f"${_bt}, ${_q}, ${_sat}, ${_sbt} {_osel} cbsz:4 blgp:4"
                                             )
+                                        if _cq is not None:
+                                            if _s == _nst - 1:
+                                                _cq.done(_mi, _ii, _sl, _ji)
+                                            L += _cq.emit(_mi)
+                                        _mi += 1
+                if _cq is not None:
+                    L += _CST_HAZ + _cq.flush()
             # ── register pinning (PIN + PINSC): scales LOW (PINBASE), frags after ──
             # Bypasses the LLVM RA "Cannot decrease cascade number" crash and aligns
             # the scale literals to the PINBASE base that emit_sc_vgpr writes.
@@ -882,10 +1344,14 @@ class MfmaScaleFp4:
                 for j in order:  # frags: vector<4xi32> = 4 VGPR
                     _vtmp[s * set_sz + j] = f"=&{{v[{bv}:{bv + 3}]}}"
                     bv += 4
+            _vtmp += ["=&v"] * _nvx  # split: rotating ds_read bases + ring offsets
             cons = ",".join(
-                ["=a"] * NT
+                ([f"={{a[{4 * q}:{4 * q + 3}]}}" for q in o_acc] if _CST else ["=a"] * NT)
                 + _vtmp
-                + ["=&s"] * 12  # accs, temps(ops+scale), cnt+3soff+3tmp+4scsoff+1sctmp
+                + ["=&s"] * (12 + (10 if _ROT else 0))  # cnt+3soff+3tmp+4scsoff+1sctmp(+ring)
+                + ((["=&s"] + ["=&v"] * 8) if _CST else [])  # fused store scratch
+                + [f"=&{{v{_CDV + j}}}" for j in range(_NCDV)]  # wide store data pool
+                + (["=&s"] if _RTPEEL else [])  # runtime peel loop bound
                 + ["v"] * ((nbuf + 2 * nbuf_b) * n_sub)  # a(nbuf)/bl/br(nbuf_b) ds_read bases
                 + ["s"] * (nbuf + 2 * nbuf_b)  # g2s dest bases
                 + ["v"] * (nsa + nsb)  # voffsets
@@ -896,6 +1362,11 @@ class MfmaScaleFp4:
                 + ["s", "s"]  # scale rsrc A, B
                 + ["v"]  # scale voffset
                 + ["s", "s", "s", "s"]  # scale soffset inits (A-g0, A-g1, BL, BR)
+                + (["s"] if half_n is not None else [])  # half-N variant selector
+                + ["s"] * (3 * _NOD)  # odd-ring g2s dest bases
+                + (["v"] * 2 if _ROT else [])  # odd-ring per-lane slot strides
+                + (["s", "s", "v", "s"] if _CST else [])  # C SRDs (L,R), voffset, row bytes
+                + (["v"] * (2 * nbuf_b * n_sub) if _BSPL else [])  # even-region B bases
                 + [str(q) for q in o_acc]
             )  # tied accs
             st = (
@@ -903,7 +1374,11 @@ class MfmaScaleFp4:
                 + ", ".join(
                     ["vector<4xf32>"] * NT
                     + (["vector<4xi32>"] * ntmp + ["i32"] * nsct + ["i32"] * _scextra) * NSET
-                    + ["i32"] * 12
+                    + ["i32"] * _nvx
+                    + ["i32"] * (12 + (10 if _ROT else 0))
+                    + ["i32"] * (9 if _CST else 0)
+                    + ["i32"] * _NCDV
+                    + ["i32"] * (1 if _RTPEEL else 0)
                 )
                 + ")>"
             )
@@ -943,6 +1418,23 @@ class MfmaScaleFp4:
         ins.append(_raw(sc_voff))  # scale voffset
         for g in range_constexpr(4):
             ins.append(_raw(sc_soff0[g]))  # scale soffset inits
+        if half_n is not None:
+            ins.append(_raw(half_n))
+        if _SPLIT:
+            for _fr in range_constexpr(3):
+                for _j in range_constexpr(_NOD):
+                    ins.append(_raw(split[_fr][_j]))  # odd-ring g2s dest bases
+            if _ROT:
+                ins.append(_raw(split[3]))
+                ins.append(_raw(split[4]))  # odd-ring slot strides (A, B)
+        if _CST:
+            for _ci in range_constexpr(4):
+                ins.append(_raw(cst[_ci]))  # C SRD L/R, per-lane voffset, row bytes
+        if _BSPL:
+            for _fr in b_base_even:  # even-region B bases (BL, BR)
+                for _b in range_constexpr(nbuf_b):
+                    for _s in range_constexpr(n_sub):
+                        ins.append(_raw(_fr[_b][_s]))
         for q in range_constexpr(nq):
             ins.append(_raw(cL[q]))
         for q in range_constexpr(nq):
@@ -978,19 +1470,15 @@ def _build_mxfp4_gemm_kernel(
     # const_expr() resolves compile-time branches from LOCALS/params, not reliably from
     # module globals -> alias the per-shape epilogue selection to locals before traced use.
     _l_taccw = taccw  # autotune-selected per shape (never-regress epilogue variant axis)
-    _l_tacc = _l_taccw  # TACCW needs the acc=Cᵀ MMA operand swap
+    _l_tacc = _l_taccw  # TACCW needs the acc=C^T MMA operand swap
     swizzle = True
     assert BLOCK_K % 128 == 0 and K % BLOCK_K == 0
     # Split-K: each WG computes a K/ksplit slice into workspace[split], host reduces -- fills
-    # the CUs on few-tile large-K shapes where one-WG-per-tile leaves CUs idle. Only the loop
-    # trip count + per-split K-start bases change; row/scale STRIDES stay full-K. The asm
-    # K-loop is self-contained (ki + initial soffsets + constant steps), so split-K touches
-    # NO asm.
+    # CUs on few-tile large-K shapes. Only trip count + per-split K-start bases change; the asm is untouched.
     assert K % ksplit == 0, f"K={K} not divisible by ksplit={ksplit}"
     K_loop = K // ksplit
     assert K_loop % BLOCK_K == 0, f"K/ksplit={K_loop} not a multiple of {BLOCK_K}"
 
-    const_expr(True)
     NBB = const_expr(2)  # B/SC pool (unroll-2)
     NABUF = const_expr(2)  # A pool (unroll-2)
     OCC = const_expr(1)  # 1 wave/SIMD -> full 256-AGPR file for the accumulator
@@ -1000,10 +1488,6 @@ def _build_mxfp4_gemm_kernel(
     BPR = BLOCK_K // 2  # packed-fp4 bytes per K-iter row in LDS
     KSTEP = BPR
     K2 = K // 2  # packed-fp4 gmem row stride (bytes) -- FULL K (rows span all K)
-    # Per-split K-start byte shifts (split s in 0..ksplit-1):
-    #   A/B operands: s * (K_loop/2) bytes into the packed-fp4 row.
-    #   scale soffset: s * KI * _scvstep bytes (_scvstep = 64*(2*N_SUB)*4 per 256-K block,
-    #   the in-asm o_sca advance; KI blocks per split -> contiguous within the full region).
     _AB_SPLIT_STEP = K_loop // 2
     _SC_SPLIT_STEP = KI * (64 * (2 * N_SUB) * 4)
 
@@ -1061,10 +1545,7 @@ def _build_mxfp4_gemm_kernel(
 
         gl_off_a = fp4_g2s_offsets(lane_id, wave_id, K, N_LDS_STEPS_A, BPR, swizzle=swizzle)
         gl_off_b = fp4_g2s_offsets(lane_id, wave_id, K, N_LDS_STEPS_BH, BPR, swizzle=swizzle)
-        # Operand SRDs/loaders are rebased per-tile (_bind below): the tile's A row base
-        # (bm*BLOCK_M*K2) / B col base (bn*BLOCK_N*K2) exceed 2^31 for large M*K / N*K, which
-        # the whole-loop's int32 voffset/soffset cannot address. One tile per block, so the
-        # per-tile build runs once; _bind stashes the loaders/SRDs for _fill/_compute to read.
+        # Operand SRDs/loaders are rebased per-tile (_bind): the tile's row/col base exceeds int32 for large M*K/N*K.
         _ld: dict = {}
 
         def _bind(bm, bn):
@@ -1154,12 +1635,7 @@ def _build_mxfp4_gemm_kernel(
         _scrsb_v = sb_s2r.rsrc
         sc_voff6 = lane_id * fx.Int32(8 * N_SUB)
 
-        # Cooperative scale staging addresses (COOP autotune axis): the 4 waves load the 4
-        # unique scale groups once into SC_lds (wave w -> slot w, 1KB), then each ds_reads its
-        # A group (slot=wave_m) + B (slot=2+wave_n). Per-wave selection hoisted host-side
-        # (reuse sc_gb6/sc_rb6; g2s rsrc = select(wave_id<2, A, B)) so the asm has no cselect.
-        # _SCSLOT = bytes per LDS scale slot (4 dwords/lane * 64 lanes * 4B).
-        _SCSLOT = const_expr(4 * 64 * 4)  # 1024 B
+        _SCSLOT = const_expr(4 * 64 * 4)  # 1024 B per LDS scale slot
         if const_expr(coop):
             # scalar wave_id so the cond is SCC (not VCC) -> arith.select on the two
             # SGPR rsrc descriptors lowers to s_cselect -> result stays in SGPR (a
@@ -1214,28 +1690,14 @@ def _build_mxfp4_gemm_kernel(
             return (bm, bn, a_off, bl_off, br_off, sa_b, sbl_b, sbr_b)
 
         def _fill(o):
-            # prefill ALL _PRELL operand buffers (k=0..PRELL-1) for A/BL/BR. The
-            # buffer_load_lds of different k buffers are mutually independent.
             _, _, a_off, bl_off, br_off, _, _, _ = o
             for _pp in range_constexpr(0, _PRELL):
                 if const_expr(KI > _pp):
                     _ld["a_g2s"].load(A_buf[_pp], a_off + _pp * KSTEP)
-            for _pp in range_constexpr(0, _PRELL):
+            for _pp in range_constexpr(0, _PRELL - 1):
                 if const_expr(KI > _pp):
                     _ld["bl_g2s"].load(BL_buf[_pp], bl_off + _pp * KSTEP)
                     _ld["br_g2s"].load(BR_buf[_pp], br_off + _pp * KSTEP)
-
-        def _drain():
-            # scale stores skipped (VGPR-direct); drain lgkmcnt + barrier so operand
-            # g2s land + are cross-wave visible before the asm reads them.
-            _llvm.inline_asm(
-                res=None,
-                operands_=[],
-                asm_string="s_waitcnt lgkmcnt(0)",
-                constraints="",
-                has_side_effects=True,
-            )
-            wait_barrier(0)
 
         def _compute(o, _split=None):
             _, _, a_off, bl_off, br_off, sa_b, sbl_b, sbr_b = o
@@ -1335,13 +1797,11 @@ def _build_mxfp4_gemm_kernel(
             _split = _bid // _ntile
             o = _split_shift(_offs(_tile), _split)
             _fill(o)
-            _drain()
             accL, accR = _compute(o, _split)
             _store(o, accL, accR, _split)
         else:
             o = _offs(fx.block_idx.x)
             _fill(o)
-            _drain()
             accL, accR = _compute(o)
             _store(o, accL, accR)
 
@@ -1350,11 +1810,7 @@ def _build_mxfp4_gemm_kernel(
     _pt = {"passthrough": [["amdgpu-agpr-alloc", "256"]]}
     gemm_value_attrs = {"rocdl.flat_work_group_size": "256,256", "rocdl.waves_per_eu": OCC, **_pt}
 
-    # Return the BARE kernel (NOT a launch): the fused factory (``_compile_mxfp4_fused``)
-    # issues the A/B scale preshuffle kernels + this GEMM from a single @flyc.jit host stub
-    # (one Python dispatch, no separate preshuffle launch / CPU sync -- mirrors the mxfp8
-    # backend). BLOCK_M/BLOCK_N/ksplit/value_attrs are returned so the stub can size the
-    # grid + attrs.
+    # Return the BARE kernel (NOT a launch): the fused factory issues preshuffle + this GEMM from one host stub.
     return kernel_gemm_4w, BLOCK_M, BLOCK_N, ksplit, gemm_value_attrs
 
 
@@ -1426,11 +1882,6 @@ def _autotune_mxfp4_config(M, N, K, args, out_fp16=False):
         _MXFP4_CFG_CACHE[key] = cfg
         return cfg
 
-    # Compile every candidate up front, then warm ALL so each is timed against the same warm
-    # L2 (else the first eats the cold-cache cost). In-flight depth axis (vmcnt/lgkmcnt): a
-    # deeper pipeline hides more g2s latency on high-trip-K but adds ramp cost on low/mid-K,
-    # so it is only offered when K is large; the autotune min never regresses. ELGK=15 is the
-    # lgkmcnt 4-bit HW max.
     _try_deepwl = K >= 8192
     _wl_opts = ((10, 9), (16, 15)) if _try_deepwl else ((10, 9),)
     compiled_cands = []
@@ -1451,11 +1902,6 @@ def _autotune_mxfp4_config(M, N, K, args, out_fp16=False):
             compiled(*args)
     torch.cuda.synchronize()
 
-    # Robust timing: min over REPS independent measurements, candidates timed ROUND-ROBIN
-    # (all cfgs once per rep) so GPU-clock drift across the sweep doesn't bias whichever cfg
-    # was timed in a hotter window. Top swizzles sit within a few % of each other, so
-    # interleaving spreads every candidate's reps across the same clock states -> the per-cfg
-    # min is an apples-to-apples floor.
     ITERS, REPS = 20, 8
     cand_t = {cfg: float("inf") for cfg, _ in compiled_cands}
     for _ in range(REPS):
@@ -1469,11 +1915,6 @@ def _autotune_mxfp4_config(M, N, K, args, out_fp16=False):
             e1.record()
             torch.cuda.synchronize()
             cand_t[cfg] = min(cand_t[cfg], e0.elapsed_time(e1))
-    # Noise-robust selection for the wlv/elgk depth axis: its win is near the run-to-run
-    # noise, so a raw global-min can pick a deep-pipeline cfg that only looks faster in a hot
-    # sample then regresses in steady state. Handicap every non-default (wlv,elgk) by
-    # _WL_MARGIN so it is chosen only when it beats 10/9 by > the noise floor -> the axis can
-    # only help, never regress. (The swizzle axis keeps the plain min.)
     _WL_MARGIN = 1.02
     best, best_t = None, float("inf")
     for cfg, t in cand_t.items():
@@ -1482,11 +1923,7 @@ def _autotune_mxfp4_config(M, N, K, args, out_fp16=False):
             best_t, best = _teff, cfg
     if best is None:
         best = (*_mxfp4_nt_config(M, N, K), 10, 9)
-    # Epilogue/scale variant axis (COOP scale-load, TACCW wide store): two correctness-
-    # preserving mechanism swaps timed as a never-regress axis on the swizzle/wl winner.
-    # COOP = 4 waves co-load the scale groups once (less scale HBM; wins low/mid-K fat-N);
-    # TACCW = acc=C^T + permlane16 wide store (wins epilogue-exposed shapes). Compile the
-    # {TACCW,COOP,both} twins, time round-robin vs the plain winner, keep the fastest > noise.
+    # Time the {TACCW,COOP,both} epilogue twins against the plain winner, keep the fastest.
     best = (*best, False, False)  # append (taccw, coop) = (False, False)
     _try_var = best_t < float("inf")
     if _try_var:
@@ -1588,7 +2025,7 @@ def _compile_mxfp4_fused(
         out_fp16=out_fp16,
         beta_is_one=beta_is_one,
     )
-    _PGRID = _MXFP4_PRESHUF_NG * _MXFP4_PRESHUF_BLK  # threads-per-block * fan-out
+    _PGRID = _MXFP4_PRESHUF_FO * _MXFP4_PRESHUF_BLK  # threads-per-block * fan-out
 
     @flyc.jit
     def launch_mxfp4_fused(
@@ -1603,14 +2040,11 @@ def _compile_mxfp4_fused(
         c_n: fx.Int32,
         stream: fx.Stream,
     ):
-        # 1) A + B scale preshuffle in ONE launch (raw E8M0 -> packed int32 in the
-        # A_scale/B_scale ws). Blocks [0, grid_a) do A, [grid_a, grid_a+grid_b) do B; the
-        # kernel segment-selects operand/dim/grp per block. grid = ceildiv(dim*K128, NG*BLK)
-        # per operand (dim*K128 divisible by NG). Merging drops one in-stream kernel launch
-        # + inter-kernel gap per GEMM (6->3 preshuffle launches per training step).
+        # Merge A + B scale preshuffle into ONE launch to drop a kernel launch/gap; grid = ceildiv(dim*K128, FO*BLK), dim*K128 % FO == 0.
         grid_a = ceildiv(c_m * fx.Int32(K128), _PGRID)
         grid_b = ceildiv(c_n * fx.Int32(K128), _PGRID)
-        pre_ab(A_raw, A_scale, B_raw, B_scale, c_m, c_n, fx.Int32(K128), grid_a).launch(
+        # Dense enforces M/N % 256 == 0, so the packed extent equals the real row count.
+        pre_ab(A_raw, A_scale, B_raw, B_scale, c_m, c_n, c_m, c_n, fx.Int32(K128), grid_a).launch(
             grid=(grid_a + grid_b, 1, 1),
             block=(_MXFP4_PRESHUF_BLK, 1, 1),
             stream=stream,
@@ -1660,8 +2094,28 @@ def _get_mxfp4_fused_launch(
 # gives the 4 source rows grp*64 + t*16 + r. Forward map of the deleted C++ preshuffle index.
 
 _MXFP4_PRESHUF_BLK = 256
-_MXFP4_PRESHUF_NG = 4  # g_byte fan-out folded into one preshuffle thread (grid is 1/NG the dwords)
+_MXFP4_PRESHUF_NG = 4  # g bytes packed by one thread
+_MXFP4_PRESHUF_ND = 4  # (r_region, K sub-block) cells packed by one thread
+_MXFP4_PRESHUF_FO = _MXFP4_PRESHUF_NG * _MXFP4_PRESHUF_ND  # output dwords per thread
 _MXFP4_SCALE_WS: dict = {}  # (M, N, K, device) -> (a_sp, b_sp) packed int32 workspace
+
+
+def _mxfp4_pack_cell(dws, n_sub, nd, ng):
+    """Byte-transpose one preshuffle cell so each output dword gathers byte g across
+    source rows. Returns ng lists of nd dwords, each contiguous in the packed layout
+    so it stores as one vector."""
+    I32 = fx.Int32
+    out = []
+    for g in range_constexpr(ng):
+        sh = I32(g * 8)
+        grp = []
+        for last in range_constexpr(nd):
+            p = I32(0)
+            for t in range_constexpr(nd):
+                p = p | (((dws[(last // n_sub) * nd + t][last % n_sub] >> sh) & I32(0xFF)) << I32(t * 8))
+            grp.append(p)
+        out.append(grp)
+    return out
 
 
 def _mxfp4_grp_from(wi, r_region, mode):
@@ -1673,15 +2127,18 @@ def _mxfp4_grp_from(wi, r_region, mode):
     return 4 * (wi // 2) + (wi % 2) + 2 * r_region
 
 
-def _build_mxfp4_preshuffle_kernel_ab():
+def _build_mxfp4_preshuffle_kernel_ab(b_ilv=0):
     # Merged A+B scale preshuffle: ONE grid repacks BOTH operands so the fused stub issues a
     # single preshuffle launch instead of two -> one fewer launch + gap per GEMM (bigger win
     # on small-M/N). Blocks [0, grid_a) do A (mode 0); [grid_a, ...) do B (mode 1); the A/B
     # group map, buffer resources and dim are segment-selected from the WG-uniform block index
     # (readfirstlane -> SGPR arith.select). Per-thread packing math = the single-operand map.
     n_sub = 2
-    nd = 4
+    nd = _MXFP4_PRESHUF_ND
+    n_rr = nd // n_sub
     NG = _MXFP4_PRESHUF_NG
+    FO = _MXFP4_PRESHUF_FO
+    assert not b_ilv or b_ilv == nd
 
     @flyc.kernel(known_block_size=[_MXFP4_PRESHUF_BLK, 1, 1])
     def kern(
@@ -1691,6 +2148,8 @@ def _build_mxfp4_preshuffle_kernel_ab():
         b_out: fx.Tensor,
         dim_a: fx.Int32,
         dim_b: fx.Int32,
+        rd_a: fx.Int32,
+        rd_b: fx.Int32,
         K128: fx.Int32,
         grid_a: fx.Int32,
     ):
@@ -1701,48 +2160,43 @@ def _build_mxfp4_preshuffle_kernel_ab():
         is_b = bid >= grid_a
         local_bid = arith.select(is_b, bid - grid_a, bid)
         dim = arith.select(is_b, dim_b, dim_a)
+        rd = arith.select(is_b, rd_b, rd_a)
         # Per-segment source/dest resources (each carries its own num_records bound).
-        a_rin = buffer_ops.create_buffer_resource(a_raw, max_size=False, num_records_bytes=dim_a * K128 * 4)
+        a_rin = buffer_ops.create_buffer_resource(a_raw, max_size=False, num_records_bytes=rd_a * K128 * 4)
         a_rout = buffer_ops.create_buffer_resource(a_out, max_size=False, num_records_bytes=dim_a * K128 * 4)
-        b_rin = buffer_ops.create_buffer_resource(b_raw, max_size=False, num_records_bytes=dim_b * K128 * 4)
+        b_rin = buffer_ops.create_buffer_resource(b_raw, max_size=False, num_records_bytes=rd_b * K128 * 4)
         b_rout = buffer_ops.create_buffer_resource(b_out, max_size=False, num_records_bytes=dim_b * K128 * 4)
         rin = arith.select(is_b, b_rin, a_rin)
         rout = arith.select(is_b, b_rout, a_rout)
 
-        gid4 = local_bid * _MXFP4_PRESHUF_BLK + fx.thread_idx.x
+        gid = local_bid * _MXFP4_PRESHUF_BLK + fx.thread_idx.x
         total = dim * K128  # output int32 dwords for the active operand
-        total4 = total // NG  # threads (one per g_byte group)
+        ok = gid < total // FO
 
-        last = gid4 % nd
-        e1 = gid4 // nd
-        r = e1 % 16
-        e2 = e1 // 16
+        r = gid % 16
+        e2 = gid // 16
         kk = e2 % KK
         wi = e2 // KK
+        k128 = kk * n_sub  # the thread's two K sub-blocks are adjacent source dwords
+        base = ((wi * KK + kk) * 64 + r) * nd
 
-        r_region = last // n_sub
-        s = last % n_sub
-        k128 = kk * n_sub + s
-        # both group maps computed, segment-selected (mode branch is a trace-time Python if
-        # inside _mxfp4_grp_from, so both variants are emitted then chosen at runtime).
-        grp = arith.select(is_b, _mxfp4_grp_from(wi, r_region, 1), _mxfp4_grp_from(wi, r_region, 0))
-        base = ((wi * KK + kk) * 64 + r) * nd + last
-
-        dws = [fx.Int32(0)] * nd
-        for t in range_constexpr(nd):
-            row = grp * 64 + t * 16 + r
-            dws[t] = fx.Int32(
-                buffer_ops.buffer_load(
-                    rin, row * K128 + k128, vec_width=1, dtype=T.i32, mask=(gid4 < total4) & (row < dim)
-                )
-            )
-        for g in range_constexpr(NG):
-            sh = fx.Int32(g * 8)
-            packed = fx.Int32(0)
+        dws = []
+        for r_region in range_constexpr(n_rr):
+            # both A/B group maps emitted then segment-selected at runtime (trace-time Python if).
+            grp = arith.select(is_b, _mxfp4_grp_from(wi, r_region, 1), _mxfp4_grp_from(wi, r_region, 0))
             for t in range_constexpr(nd):
-                b = (dws[t] >> sh) & fx.Int32(0xFF)
-                packed = packed | (b << fx.Int32(t * 8))
-            buffer_ops.buffer_store(packed, rout, base + g * 64, mask=gid4 < total4)
+                loc = arith.select(is_b, r * b_ilv + t, t * 16 + r) if b_ilv else (t * 16 + r)
+                row = grp * 64 + loc
+                dws.append(
+                    Vec(
+                        buffer_ops.buffer_load(
+                            rin, row * K128 + k128, vec_width=n_sub, dtype=T.i32, mask=ok & (row < rd)
+                        )
+                    )
+                )
+        words = _mxfp4_pack_cell(dws, n_sub, nd, NG)
+        for g in range_constexpr(NG):
+            buffer_ops.buffer_store(Vec.from_elements(words[g]), rout, base + g * 64, mask=ok)
 
     return kern
 

--- a/primus_turbo/flydsl/grouped_gemm/grouped_gemm_mxfp4_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/grouped_gemm_mxfp4_kernel.py
@@ -11,19 +11,10 @@
 # not the MIT license that covers the rest of Primus-Turbo (see LICENSE).
 ###############################################################################
 
-"""FlyDSL MXFP4 (per-32-K E8M0 block-scaled) grouped GEMM for gfx950 (NT fwd/dgrad).
-
-A [total_M, K] fp4 (groups along M), B [G, N, K] fp4, out [total_M, N] bf16;
-``group_offs`` [G+1] int64 splits M. Reuses the dense mxfp4 whole-loop compute
-(``MfmaScaleFp4.call_mxfp4_wholeloop`` + ``S2RLoaderFp4`` + ``StoreCPlain``) with the
-fp8-grouped addressing (O(G) tile scan, per-group A row offset, per-expert B offset,
-C store bounded to the group's tight end). E8M0 scales are repacked into the lane-
-contiguous layout the whole-loop reads: A into per-group 256-aligned slabs (so the
-tile's scale soffset stays 128-region aligned), B per expert.
-"""
+"""FlyDSL MXFP4 (per-32-K E8M0 block-scaled) grouped GEMM for gfx950 (NT fwd/dgrad):
+reuses the dense mxfp4 whole-loop compute with fp8-grouped addressing and lane-packed scales."""
 
 import gc
-import math
 
 import torch
 
@@ -31,33 +22,43 @@ import torch
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 from flydsl._mlir.dialects import llvm as _llvm
+from flydsl.compiler.kernel_function import CompilationContext
 from flydsl.expr import arith, buffer_ops, const_expr, range_constexpr, rocdl
 from flydsl.expr.typing import T
+from flydsl.expr.typing import Vector as Vec
 
 from primus_turbo.flydsl.utils.gemm_helper import (
     G2SLoader,
+    _lane_tbl_count_le,
+    _lane_tbl_get,
+    _lane_tbl_load,
+    _lane_tbl_scan,
+    _lds_barrier,
     _readfirstlane_i32,
-    _robust_time,
+    _readlane_i32,
     ceildiv,
+    ceildiv_pow2,
     make_fp8_rebased_tensor_and_srd,
     resolve_accum_out,
-    wait_barrier,
+    xcd_band_remap_pid,
     xcd_remap_pid,
 )
 from primus_turbo.flydsl.gemm.gemm_mxfp4_kernel import (
     _MXFP4_PRESHUF_BLK,
-    _MXFP4_PRESHUF_NG,
+    _MXFP4_PRESHUF_FO,
     MfmaScaleFp4,
     S2RLoaderFp4,
+    S2RLoaderFp4Split,
     ScaleS2RPacked,
     StoreCPlain,
     _build_mxfp4_preshuffle_kernel_ab,
     _mxfp4_grp_from,
+    _mxfp4_pack_cell,
     fp4_g2s_offsets,
+    fp4_g2s_offsets_split,
 )
 from primus_turbo.flydsl.grouped_gemm.grouped_gemm_fp8_kernel import (
     _grouped_block_mn,
-    _load_go,
     _wgrad_block_mn,
 )
 from primus_turbo.flydsl.grouped_gemm.grouped_gemm_mxfp8_kernel import run_eager_or_capture
@@ -66,47 +67,60 @@ from primus_turbo.flydsl.grouped_gemm.grouped_gemm_mxfp8_kernel import run_eager
 
 _BLOCK = 256  # BLOCK_M = BLOCK_N = BLOCK_K
 _PRESHUF_BLK = 256
-_PRESHUF_NG = 4  # g_byte fan-out per preshuffle thread
+_PRESHUF_NG = 4  # g bytes packed by one preshuffle thread
+_PRESHUF_ND = 4  # (r_region, K sub-block) cells packed by one preshuffle thread
+_PRESHUF_FO = _PRESHUF_NG * _PRESHUF_ND  # output dwords per thread
+_GMXFP4_XCD_BAND_STEP = 2  # M-block granularity a per-group tile count is a multiple of
 
 
-def _pack4(rin, rows, k128, valid, K128):
-    """Pack the 4 source E8M0 rows (byte t <- rows[t]) into NG dwords; returns list[NG]."""
-    I32 = fx.Int32
-    dws = []
-    for t in range_constexpr(4):
-        dws.append(
-            fx.Int32(
-                buffer_ops.buffer_load(
-                    rin, rows[t] * I32(K128) + k128, vec_width=1, dtype=T.i32, mask=valid[t]
-                )
-            )
-        )
-    out = []
-    for g in range_constexpr(_PRESHUF_NG):
-        sh = I32(g * 8)
-        p = I32(0)
-        for t in range_constexpr(4):
-            p = p | (((dws[t] >> sh) & I32(0xFF)) << I32(t * 8))
-        out.append(p)
-    return out
+_GMXFP4_SCHED_HINTS = {
+    "llvm_options": {
+        "amdgpu-sched-strategy": "iterative-ilp",
+        "enable-post-misched": True,
+        "lsr-drop-solution": True,
+    }
+}
 
 
-def _build_grouped_mxfp4_ab_preshuffle(K128: int, G: int, N: int, k128_rd: int = None):
-    """Merged A-slab + B-per-expert scale preshuffle in ONE launch (matches the fp8/dense
-    single-preshuffle structure -> one fewer in-stream kernel launch + gap per grouped GEMM,
-    a bigger relative win on the small/short-K shapes). Blocks [0, a_grid) do the A slab
-    (mode 0, inline a_pre scan over GO); [a_grid, ...) do the B per-expert (mode 1). The
-    two paths are computed then segment-selected (SGPR rsrc via arith.select, values via
-    select) -- no per-thread divergence. ``k128_rd`` real read + 256-block mask = zero pad,
-    no host F.pad."""
+_GMXFP4_SKEW_CUS = 256  # one skew rank per CU
+_GMXFP4_SKEW_STEP = 2  # s_sleep units (~64 clocks) per skew rank
+
+
+def _emit_launch_skew(bid):
+    step = _GMXFP4_SKEW_STEP
+    _llvm.inline_asm(
+        T.i32,
+        [bid.ir_value()],
+        f"s_cmp_lt_u32 $1, {_GMXFP4_SKEW_CUS}\n\ts_cselect_b32 $0, $1, 0\n"
+        f"1:\n\ts_cmp_eq_u32 $0, 0\n\ts_cbranch_scc1 2f\n\ts_sleep {step}\n"
+        "\ts_sub_u32 $0, $0, 1\n\ts_branch 1b\n2:",
+        "=&s,s,~{scc},~{memory}",
+        has_side_effects=True,
+    )
+
+
+def _run_mxfp4_sched(entry, args, compiled_idx):
+    """run_eager_or_capture with the mxfp4 grouped NT schedule hints applied."""
+    if torch.cuda.is_current_stream_capturing():
+        entry[0](*args)
+        return
+    if entry[compiled_idx] is None:
+        with CompilationContext.compile_hints(_GMXFP4_SCHED_HINTS):
+            entry[compiled_idx] = flyc.compile(entry[0], *args)
+    entry[compiled_idx](*args)
+
+
+def _build_grouped_mxfp4_ab_preshuffle(K128: int, G: int, N: int, k128_rd: int = None, b_ilv: int = 0):
+    """Merged A-slab + B-per-expert scale preshuffle in ONE launch (one fewer in-stream launch
+    per grouped GEMM). Blocks [0, a_grid) do the A slab (mode 0), the rest the B per-expert;
+    the two paths are segment-selected with no per-thread divergence. Read is real-K masked."""
     _KRD = K128 if k128_rd is None else k128_rd
-    # ScaleS2RPacked interleaves four 64-row groups at a time, so its physical
-    # row extent must be a 256-multiple even though the FP4 operand keeps the
-    # real N row stride. Without this padding, the last partial quartet leaves
-    # holes in one expert's workspace and spills stores into the next expert.
-    N_SCALE = ceildiv(N, 256) * 256
-    n_sub, nd, KK = 2, 4, K128 // 2
-    b_dwords_pe = N_SCALE * K128 // _PRESHUF_NG
+    N_SCALE = ceildiv(N, 256) * 256  # 256-multiple: ScaleS2RPacked packs four 64-row groups
+    n_sub, nd, KK = 2, _PRESHUF_ND, K128 // 2
+    assert not b_ilv or b_ilv == nd
+    n_rr = nd // n_sub
+    b_dwords_pe = N_SCALE * K128 // _PRESHUF_FO
+    _NWI = 1 + ceildiv(64 // 16 - 1, KK)  # wi values a wave spans (one (wi,kk,r) cell/thread)
 
     @flyc.kernel(known_block_size=[_PRESHUF_BLK, 1, 1])
     def kern(
@@ -135,88 +149,106 @@ def _build_grouped_mxfp4_ab_preshuffle(K128: int, G: int, N: int, k128_rd: int =
         bid = rocdl.readfirstlane(T.i32, fx.block_idx.x)
         is_b = bid >= a_grid
         local = arith.select(is_b, bid - a_grid, bid)
+        lane_id = fx.thread_idx.x % 64
         gid_all = local * I32(_PRESHUF_BLK) + fx.thread_idx.x
         rin = arith.select(is_b, b_rin, a_rin)
         rout = arith.select(is_b, b_rout, a_rout)
 
         b_expert = gid_all // I32(b_dwords_pe)
-        a_total4 = slab_rows * I32(K128) // I32(_PRESHUF_NG)
-        gid4 = arith.select(is_b, gid_all - b_expert * I32(b_dwords_pe), gid_all)
-        total4 = arith.select(is_b, I32(b_dwords_pe), a_total4)
-        last = gid4 % I32(nd)
-        e1 = gid4 // I32(nd)
-        r = e1 % I32(16)
-        e2 = e1 // I32(16)
+        a_total = slab_rows * I32(K128) // I32(_PRESHUF_FO)
+        gid = arith.select(is_b, gid_all - b_expert * I32(b_dwords_pe), gid_all)
+        total = arith.select(is_b, I32(b_dwords_pe), a_total)
+        r = gid % I32(16)
+        e2 = gid // I32(16)
         kk = e2 % I32(KK)
         wi = e2 // I32(KK)
-        r_region = last // I32(n_sub)
-        s = last % I32(n_sub)
-        k128 = kk * I32(n_sub) + s
-        grp_a = _mxfp4_grp_from(wi, r_region, 0)
-        grp_b = _mxfp4_grp_from(wi, r_region, 1)
-        _blk = ((wi * I32(KK) + kk) * I32(64) + r) * I32(nd) + last
+        k128 = kk * I32(n_sub)  # the thread's n_sub K sub-blocks are adjacent source dwords
+        _blk = ((wi * I32(KK) + kk) * I32(64) + r) * I32(nd)
         base = arith.select(is_b, b_expert * I32(N_SCALE * K128) + _blk, _blk)
 
-        # A: inline a_pre scan (owning group -> tight source rows rd0..rd_end)
-        go_t = rocdl.make_buffer_tensor(go_out, max_size=False, num_records_bytes=(G + 1) * 8)
-        go_div = fx.logical_divide(go_t, fx.make_layout(1, 1))
-        rd0 = I32(0)
-        rd_end = I32(0)
-        ok_a = I32(0)
-        apre = I32(0)
-        m_prev = _load_go(go_div, 0)
-        for g in range_constexpr(G):
-            m_nxt = _load_go(go_div, g + 1)
-            p0 = apre
-            p1 = apre + ((m_nxt - m_prev + I32(255)) // I32(256)) * I32(4)
-            inq = (grp_a >= p0) & (grp_a < p1)
-            rd0 = arith.select(inq, m_prev + (grp_a - p0) * I32(64), rd0)
-            rd_end = arith.select(inq, m_nxt, rd_end)
-            ok_a = arith.select(inq, I32(1), ok_a)
-            apre = p1
-            m_prev = m_nxt
-        rd_base = b_expert * I32(N)  # B source row base
+        go_rs = buffer_ops.create_buffer_resource(go_out, max_size=False, num_records_bytes=(G + 1) * 8)
+        _go0 = _lane_tbl_load(go_rs, lane_id, G + 1, stride=2)
+        _go1 = _lane_tbl_load(go_rs, lane_id, G + 1, stride=2, first=1)
+        _own = [lane_id + I32(64 * c) < I32(G) for c in range_constexpr(len(_go0))]
+        _nb = [
+            arith.select(_own[c], ceildiv_pow2(_go1[c] - _go0[c], 256) * I32(4), I32(0))
+            for c in range_constexpr(len(_go0))
+        ]
+        _nbs_end = _lane_tbl_scan(_nb)  # entry g = 64-row groups owned by groups <= g
+        _nbs = [_nbs_end[c] - _nb[c] for c in range_constexpr(len(_nb))]
+        _ngrp = _readlane_i32(_nbs_end[-1], 63)
 
-        okc = arith.select(
-            is_b, (gid4 < I32(b_dwords_pe)) & (b_expert < I32(G)), (gid4 < a_total4) & (ok_a != I32(0))
+        def _a_rows(q):
+            gq = _lane_tbl_count_le(_nbs_end, q)
+            r0 = _lane_tbl_get(_go0, gq) + (q - _lane_tbl_get(_nbs, gq)) * I32(64)
+            return r0, _lane_tbl_get(_go1, gq)
+
+        _wi_u = _readfirstlane_i32(wi)
+        _rows_q = [_a_rows(I32(2) * _wi_u + I32(q)) for q in range_constexpr(2 * _NWI)]
+        _dwi = wi - _wi_u
+        rd_base = b_expert * I32(N)  # B source row base
+        in_grid = arith.select(is_b, (gid < I32(b_dwords_pe)) & (b_expert < I32(G)), gid < a_total) & (
+            gid < total
         )
-        okc = okc & (k128 < I32(_KRD)) & (gid4 < total4)
-        rsrc_rows = [
-            arith.select(is_b, rd_base + grp_b * I32(64) + I32(t * 16) + r, rd0 + I32(t * 16) + r)
-            for t in range_constexpr(4)
-        ]
-        valid = [
-            okc & arith.select(is_b, grp_b * I32(64) + I32(t * 16) + r < I32(N), rsrc_rows[t] < rd_end)
-            for t in range_constexpr(4)
-        ]
-        words = _pack4(rin, rsrc_rows, k128, valid, _KRD)
-        # store ALL in-range blocks: invalid/pad blocks got words=0 from the masked reads,
-        # so slab-pad / 256-pad regions are written 0 (matches the split a_pre_shuf).
-        for g in range_constexpr(_PRESHUF_NG):
-            buffer_ops.buffer_store(words[g], rout, base + I32(g * 64), mask=gid4 < total4)
+
+        dws = []
+        for r_region in range_constexpr(n_rr):
+            rd0, rd_end = _rows_q[r_region]
+            for q in range_constexpr(1, _NWI):
+                _hit = _dwi == I32(q)
+                rd0 = arith.select(_hit, _rows_q[2 * q + r_region][0], rd0)
+                rd_end = arith.select(_hit, _rows_q[2 * q + r_region][1], rd_end)
+            grp_a = _mxfp4_grp_from(wi, r_region, 0)
+            grp_b = _mxfp4_grp_from(wi, r_region, 1)
+            okc = arith.select(is_b, in_grid, in_grid & (grp_a < _ngrp))  # skip slab-pad groups
+            for t in range_constexpr(nd):
+                b_row = grp_b * I32(64) + (r * I32(b_ilv) + I32(t) if b_ilv else I32(t * 16) + r)
+                row = arith.select(is_b, rd_base + b_row, rd0 + I32(t * 16) + r)
+                valid = okc & arith.select(is_b, b_row < I32(N), row < rd_end)
+                v = Vec(
+                    buffer_ops.buffer_load(
+                        rin, row * I32(_KRD) + k128, vec_width=n_sub, dtype=T.i32, mask=valid
+                    )
+                )
+                if const_expr(_KRD % n_sub != 0):  # odd real K128: zero the past-K tail sub-block
+                    v = Vec.from_elements(
+                        [v[0]]
+                        + [
+                            arith.select(k128 + I32(j) < I32(_KRD), v[j], I32(0))
+                            for j in range_constexpr(1, n_sub)
+                        ]
+                    )
+                dws.append(v)
+        words = _mxfp4_pack_cell(dws, n_sub, nd, _PRESHUF_NG)
+        for g in range_constexpr(_PRESHUF_NG):  # pad regions store 0 (masked reads gave words=0)
+            buffer_ops.buffer_store(Vec.from_elements(words[g]), rout, base + I32(g * 64), mask=gid < total)
 
     return kern
 
 
 def _build_grouped_mxfp4_nt_kernel(
-    K, G, N, group_m=4, num_xcds=8, group_n=0, wlv=10, elgk=9, out_fp16=False, k_real=None
+    K,
+    G,
+    N,
+    group_m=4,
+    num_xcds=8,
+    group_n=0,
+    wlv=10,
+    elgk=9,
+    out_fp16=False,
+    k_real=None,
+    xcd_span=16,
+    cst_nt=False,
 ):
     """Grouped MXFP4 NT (out = a @ b^T), per-group A rows + per-expert B, whole-loop compute.
-
-    K = 256-rounded tile/scale extent (the tiny E8M0 scale is zero-padded to it so the
-    preshuffle packs whole 256-blocks). ``k_real`` (<= K, 128-multiple) = the operands' TRUE
-    contraction (row stride, no operand pad). When k_real%256==128 the loop runs
-    k_real//256 full 256-blocks + ONE 128-K tail MFMA (reads the real last 128 K, its scale
-    is the block's s=0 in the padded packing) -- zero operand copy, zero wasted compute."""
+    K is the 256-rounded scale extent; ``k_real`` (<=K, 128-multiple) is the operands' true
+    contraction, its %256==128 tail run as a trailing block with zero-pad scale (no operand copy)."""
     BLOCK_M = BLOCK_N = BLOCK_K = _BLOCK
-    swizzle = True
     _KR = K if k_real is None else k_real  # operand true contraction (128-multiple)
     assert K % 256 == 0 and _KR % 128 == 0
     KI = _KR // BLOCK_K  # FULL 256-blocks over the REAL K
     _K128 = (_KR // 128) % 2  # 1 => trailing 128-K block, handled by scale-pad-zero below
-    # Trailing 128-K: round KI up and let the last 256-block's s=1 multiply the zero-padded
-    # scale (= 0). Fully pipelined into the do-while; one wasted MFMA, no post-loop tail phase.
-    KI_LOOP = KI + 1 if _K128 else KI
+    KI_LOOP = KI + 1 if _K128 else KI  # trailing 128-K: last block's past-K s=1 sub-step drops
     NABUF, NBB, OCC = 2, 2, 2  # fwd waves_per_eu=2: hide the latency-bound short-K/small-tile GEMM
     N_SUB = BLOCK_K // 128
     BPR = BLOCK_K // 2
@@ -226,26 +258,33 @@ def _build_grouped_mxfp4_nt_kernel(
     LDS_BN_HALF = BLOCK_N // 2
     N_TILES_BH = LDS_BN_HALF // 32
     LDS_ROW_STRIDE = BPR
-    a_lds_size = BLOCK_M * LDS_ROW_STRIDE
-    bh_lds_size = LDS_BN_HALF * LDS_ROW_STRIDE
     _ROWS_PER_STEP = 64 // (BPR // 16) * (256 // 64)
     N_LDS_STEPS_A = BLOCK_M // _ROWS_PER_STEP
     N_LDS_STEPS_BH = LDS_BN_HALF // _ROWS_PER_STEP
+    NSA_H = N_LDS_STEPS_A // 2  # g2s steps per parity region
+    NSB_H = N_LDS_STEPS_BH // 2
     _PRELL, _NSCBUF = 2, 2
     K128 = K // 128
     N_SCALE = ceildiv(N, 256) * 256
-    _SCBUF = 4 * 4 * (BLOCK_K // 128) * 64
-    _SCW = 4 * N_SUB * 64
     NBK = ceildiv(N, BLOCK_N)  # n_blocks
+    # Narrowest XCD band (M-blocks) a per-group tile count still divides: the ragged fallback.
+    _SPAN_NARROW = min(xcd_span, _GMXFP4_XCD_BAND_STEP)
+    _WIDE_MB = num_xcds * xcd_span  # M-blocks a group needs to reach every XCD by itself
     _NV = N if (N % BLOCK_N != 0) else None  # non-256 N: mask store cols >= N (no host N-pad)
+    _HALF_N = (N % BLOCK_N != 0) and (N % BLOCK_N <= LDS_BN_HALF)  # last-block R-half all padding
+    _CSTORE = (not out_fp16) and bool(_K128) and (KI_LOOP % 2 == 1 or KI_LOOP >= 4)
+    _BILV = N_TILES_BH if (_CSTORE and LDS_ROW_STRIDE == 128 and N_TILES_BH == 4) else 0
 
-    _anns = {f"A_lds{i}": fx.Array[fx.Float8E4M3FN, a_lds_size, 16] for i in range_constexpr(NABUF)}
-    for _b in range_constexpr(NBB):
-        _anns[f"BL_lds{_b}"] = fx.Array[fx.Float8E4M3FN, bh_lds_size, 16]
-    for _b in range_constexpr(NBB):
-        _anns[f"BR_lds{_b}"] = fx.Array[fx.Float8E4M3FN, bh_lds_size, 16]
-    for _b in range_constexpr(_NSCBUF):
-        _anns[f"SC_lds{_b}"] = fx.Array[fx.Int32, _SCBUF, 16]
+    # parity-split LDS ring: skewed rows (odd 64-multiple stride) straddle two 128B lines
+    _A_SLOT = (BLOCK_M // 2) * LDS_ROW_STRIDE  # skewed rows need 3 slots, aligned rows 2
+    _B_SLOT = (LDS_BN_HALF // 2) * LDS_ROW_STRIDE
+    _SK = 64 * _K128  # skewed region's byte offset from its 128B-aligned line
+    _NOBUF = 3 if _K128 else 2  # a skewed in-place refill needs 2 live + 1 landing slot
+    _anns = {"A_e": fx.Array[fx.Float8E4M3FN, NABUF * _A_SLOT, 16]}
+    _anns["A_o"] = fx.Array[fx.Float8E4M3FN, _NOBUF * _A_SLOT, 16]
+    for _h in ("BL", "BR"):
+        _anns[f"{_h}_e"] = fx.Array[fx.Float8E4M3FN, NBB * _B_SLOT, 16]
+        _anns[f"{_h}_o"] = fx.Array[fx.Float8E4M3FN, _NOBUF * _B_SLOT, 16]
     SS = fx.struct(type("SSFp4Grp", (), {"__annotations__": _anns}))
 
     @flyc.kernel(known_block_size=[256, 1, 1])
@@ -259,68 +298,53 @@ def _build_grouped_mxfp4_nt_kernel(
         c_m: fx.Int32,  # total_M
         c_n: fx.Int32,  # N
         slab_rows: fx.Int32,  # padded A-slab rows
-        grid_upper: fx.Int32,
     ):
         F8 = fx.Float8E4M3FN.ir_type
         lds = fx.SharedAllocator().allocate(SS).peek()
-        A_buf = [getattr(lds, f"A_lds{i}") for i in range_constexpr(NABUF)]
-        BL_buf = [getattr(lds, f"BL_lds{i}") for i in range_constexpr(NBB)]
-        BR_buf = [getattr(lds, f"BR_lds{i}") for i in range_constexpr(NBB)]
-        SC_buf = [getattr(lds, f"SC_lds{b}") for b in range_constexpr(_NSCBUF)]
+        A_lds = [lds.A_e, lds.A_o]
+        BL_lds = [lds.BL_e, lds.BL_o]
+        BR_lds = [lds.BR_e, lds.BR_o]
         lane_id = fx.thread_idx.x % 64
         wave_id = fx.thread_idx.x // 64
         wave_m = wave_id // 2
         wave_n = wave_id % 2
         I32 = fx.Int32
 
-        # ---- tile-independent setup (operand SRDs/loaders built per-tile below, rebased) ----
         mfma = MfmaScaleFp4(N_TILES_A, N_TILES_BH, packed=True, wlv=wlv, elgk=elgk)
-        gl_off_a = fp4_g2s_offsets(lane_id, wave_id, _KR, N_LDS_STEPS_A, BPR, swizzle=swizzle)
-        gl_off_b = fp4_g2s_offsets(lane_id, wave_id, _KR, N_LDS_STEPS_BH, BPR, swizzle=swizzle)
-        a_s2r = S2RLoaderFp4(wave_m, N_TILES_A, LDS_ROW_STRIDE, swizzle=swizzle)
-        b_s2r = S2RLoaderFp4(wave_n, N_TILES_BH, LDS_ROW_STRIDE, swizzle=swizzle)
+        gl_b_e = fp4_g2s_offsets_split(lane_id, wave_id, _KR, NSB_H, 0, 0, ilv=_BILV)
+        gl_b_o = fp4_g2s_offsets_split(lane_id, wave_id, _KR, NSB_H, 1, _SK, ilv=_BILV)
+        gl_b_o0 = fp4_g2s_offsets_split(lane_id, wave_id, _KR, NSB_H, 1, -_SK, ilv=_BILV)
+        b_s2r = S2RLoaderFp4Split(wave_n, N_TILES_BH, LDS_BN_HALF, 0, _K128, ilv=_BILV)
         sa_s2r = ScaleS2RPacked(A_scale, slab_rows, K, 4)
         sb_s2r = ScaleS2RPacked(B_scale, I32(N_SCALE * G), K, 4)
         wave_m_off = wave_m * (N_TILES_A * 16)
         wave_n_off = wave_n * (N_TILES_BH * 16)
 
-        a_base6 = [
-            [a_s2r.base_addr(A_buf[b], s) for s in range_constexpr(N_SUB)] for b in range_constexpr(NABUF)
-        ]
-        bl_base6 = [
-            [b_s2r.base_addr(BL_buf[b], s) for s in range_constexpr(N_SUB)] for b in range_constexpr(NBB)
-        ]
-        br_base6 = [
-            [b_s2r.base_addr(BR_buf[b], s) for s in range_constexpr(N_SUB)] for b in range_constexpr(NBB)
-        ]
+        def _b_bases(lds, b):
+            if const_expr(bool(_BILV)):
+                p = [b_s2r.f_base_ilv(lds[0], lds[1], b, s) for s in range_constexpr(N_SUB)]
+                return [x[1] for x in p], [x[0] for x in p]
+            return [b_s2r.f_base(lds[0], lds[1], b, s) for s in range_constexpr(N_SUB)], None
 
-        def _gbase(buf):
-            v = fx.Int32(fx.ptrtoint(buf.ptr)) + fx.Int32(wave_id) * fx.Int32(1024)
+        _bl = [_b_bases(BL_lds, b) for b in range_constexpr(NBB)]
+        _br = [_b_bases(BR_lds, b) for b in range_constexpr(NBB)]
+        bl_base6 = [x[0] for x in _bl]
+        br_base6 = [x[0] for x in _br]
+        b_even6 = ([x[1] for x in _bl], [x[1] for x in _br]) if const_expr(bool(_BILV)) else None
+        qu_b6 = b_s2r.q_unit() if const_expr(_K128) else None
+
+        def _gbase(buf, slot=0):
+            v = fx.Int32(fx.ptrtoint(buf.ptr)) + fx.Int32(wave_id) * fx.Int32(1024) + fx.Int32(slot)
             return rocdl.readfirstlane(T.i32, v)
 
-        abase6 = [_gbase(A_buf[b]) for b in range_constexpr(NABUF)]
-        blbase6 = [_gbase(BL_buf[b]) for b in range_constexpr(NBB)]
-        brbase6 = [_gbase(BR_buf[b]) for b in range_constexpr(NBB)]
-        gl_a6 = [fx.Int32(gl_off_a[st]) for st in range_constexpr(N_LDS_STEPS_A)]
-        gl_b6 = [fx.Int32(gl_off_b[st]) for st in range_constexpr(N_LDS_STEPS_BH)]
+        blbase6 = [_gbase(BL_lds[0], b * _B_SLOT) for b in range_constexpr(NBB)]
+        brbase6 = [_gbase(BR_lds[0], b * _B_SLOT) for b in range_constexpr(NBB)]
+        bl_od6 = [_gbase(BL_lds[1], j * _B_SLOT) for j in range_constexpr(_NOBUF)]
+        br_od6 = [_gbase(BR_lds[1], j * _B_SLOT) for j in range_constexpr(_NOBUF)]
+        gl_b6 = [fx.Int32(o) for o in gl_b_e] + [fx.Int32(o) for o in gl_b_o]
         scv6 = fx.Int32(0x7F7F7F7F)
-        sc_rb6 = [
-            fx.ptrtoint(
-                fx.add_offset(SC_buf[b].ptr, fx.make_int_tuple(fx.Int32(wave_id) * fx.Int32(_SCW) + lane_id))
-            )
-            for b in range_constexpr(_NSCBUF)
-        ]
-        sc_gb6 = [
-            rocdl.readfirstlane(
-                T.i32,
-                fx.Int32(
-                    fx.ptrtoint(
-                        fx.add_offset(SC_buf[b].ptr, fx.make_int_tuple(fx.Int32(wave_id) * fx.Int32(_SCW)))
-                    )
-                ),
-            )
-            for b in range_constexpr(_NSCBUF)
-        ]
+        sc_rb6 = [fx.Int32(0) for _b in range_constexpr(_NSCBUF)]  # reserved (VGPR-direct scales)
+        sc_gb6 = [fx.Int32(0) for _b in range_constexpr(_NSCBUF)]
         _scrsa_v = sa_s2r.rsrc
         _scrsb_v = sb_s2r.rsrc
         sc_voff6 = lane_id * fx.Int32(8 * N_SUB)
@@ -331,89 +355,107 @@ def _build_grouped_mxfp4_nt_kernel(
                 T.i32, (grp * fx.Int32(K128) + fx.Int32(_PRELL * N_SUB)) * fx.Int32(256)
             )
 
-        # ---- O(G) tile scan: pid -> (group_idx, local tile, m_start, m_end, a_pre) ----
-        go_t = rocdl.make_buffer_tensor(GO, max_size=False, num_records_bytes=(G + 1) * 8)
-        go_div = fx.logical_divide(go_t, fx.make_layout(1, 1))
-        pid = xcd_remap_pid(fx.block_idx.x, grid_upper, num_xcds)
-        total_tiles = I32(0)
-        prev = _load_go(go_div, 0)
-        for g in range_constexpr(G):
-            nxt = _load_go(go_div, g + 1)
-            total_tiles = total_tiles + ceildiv(nxt - prev, BLOCK_M) * I32(NBK)
-            prev = nxt
-        # non-persistent grid: WGs past total_tiles hardware-exit (scf.if cannot
-        # carry the Python-object loader state, so guard via s_endpgm).
-        _tt = _readfirstlane_i32(total_tiles)
+        # lane-resident group scan (lane g owns group g) replaces the serial G-wide compare tree
+        go_rs = buffer_ops.create_buffer_resource(GO, max_size=False, num_records_bytes=(G + 1) * 8)
+        _go0 = _lane_tbl_load(go_rs, lane_id, G + 1, stride=2)
+        _go1 = _lane_tbl_load(go_rs, lane_id, G + 1, stride=2, first=1)
+        _own = [lane_id + I32(64 * c) < I32(G) for c in range_constexpr(len(_go0))]
+        _nb = [
+            arith.select(_own[c], ceildiv_pow2(_go1[c] - _go0[c], BLOCK_M), I32(0))
+            for c in range_constexpr(len(_go0))
+        ]
+        # A band dividing every group's M-block count keeps an XCD's reads in one expert slab.
+        if const_expr(_SPAN_NARROW < xcd_span):
+            _span_res = [
+                arith.select(_own[c], _nb[c] % I32(xcd_span), I32(0)) for c in range_constexpr(len(_nb))
+            ]
+            _span_div = _readlane_i32(_lane_tbl_scan(_span_res)[-1], 63) == I32(0)
+            _nb_wide = I32(64 * len(_nb)) - _lane_tbl_count_le(_nb, I32(_WIDE_MB - 1))
+            _span_ok = _span_div | (_nb_wide == I32(0))
+        _nbs_end = _lane_tbl_scan(_nb)
+        _tcs_end = [v * I32(NBK) for v in _nbs_end]  # entry g = tiles owned by groups <= g
+        _tcs = [_tcs_end[c] - _nb[c] * I32(NBK) for c in range_constexpr(len(_nb))]
+        _sas = [(_nbs_end[c] - _nb[c]) * I32(4) for c in range_constexpr(len(_nb))]
+        total_tiles = _readlane_i32(_tcs_end[-1], 63)
+        bid = fx.block_idx.x
         _llvm.inline_asm(
             None,
-            [pid.ir_value(), arith._to_raw(_tt)],
+            [bid.ir_value(), arith._to_raw(total_tiles)],
             "s_cmp_lt_u32 $0, $1\n\ts_cbranch_scc1 1f\n\ts_endpgm\n\t1:",
             "s,s,~{scc},~{memory}",
             has_side_effects=True,
         )
-        cum = I32(0)
-        group_idx = I32(0)
-        tile_start = I32(0)
-        m_start = I32(0)
-        m_end = I32(0)
-        a_pre_g = I32(0)
-        apre = I32(0)  # inline 64-grp slab-base cumsum (no AP tensor / cumsum launch)
-        p2 = _load_go(go_div, 0)
-        for g in range_constexpr(G):
-            nx = _load_go(go_div, g + 1)
-            tg = ceildiv(nx - p2, BLOCK_M) * I32(NBK)
-            nc = cum + tg
-            inq = (pid >= cum) & (pid < nc)
-            group_idx = arith.select(inq, I32(g), group_idx)
-            tile_start = arith.select(inq, cum, tile_start)
-            m_start = arith.select(inq, p2, m_start)
-            m_end = arith.select(inq, nx, m_end)
-            a_pre_g = arith.select(inq, apre, a_pre_g)
-            apre = apre + ceildiv(nx - p2, BLOCK_M) * I32(4)
-            cum = nc
-            p2 = nx
+        _emit_launch_skew(bid)
+        if const_expr(_SPAN_NARROW < xcd_span):
+            pid = arith.select(  # skew-robust band, group-aligned
+                _span_ok,
+                xcd_band_remap_pid(bid, total_tiles, num_xcds, xcd_span * NBK),
+                xcd_band_remap_pid(bid, total_tiles, num_xcds, _SPAN_NARROW * NBK),
+            )
+        else:
+            pid = xcd_band_remap_pid(bid, total_tiles, num_xcds, xcd_span * NBK)
+        group_idx = _lane_tbl_count_le(_tcs_end, pid)
+        tile_start = _lane_tbl_get(_tcs, group_idx)
+        a_pre_g = _lane_tbl_get(_sas, group_idx)
+        m_start = _lane_tbl_get(_go0, group_idx)
+        m_end = _lane_tbl_get(_go1, group_idx)
         local = pid - tile_start
         bm, bn = _grouped_block_mn(local, m_start, m_end, NBK, BLOCK_M, group_m, group_n)
 
         m_row = m_start + bm * I32(BLOCK_M)  # tight A/C row base
-        # Fold the tile's A row base + per-expert/col B base into the operand SRDs in int64:
-        # large-G MoE (group_idx*c_n*K2) / large total_M (m_row*K2) exceed 2^31, which the
-        # whole-loop's int32 voffset/soffset cannot reach. Residual offsets stay intra-tile.
-        a_base_e = arith.index_cast(T.index, m_row) * arith.index(K2)
+        a_par = m_row % I32(2)
+        a_sh = a_par * I32(64)
+        gl_a_e = fp4_g2s_offsets_split(lane_id, wave_id, _KR, NSA_H, a_par, a_sh)
+        gl_a_o = fp4_g2s_offsets_split(lane_id, wave_id, _KR, NSA_H, I32(1) - a_par, a_sh + I32(_SK))
+        gl_a_o0 = fp4_g2s_offsets_split(lane_id, wave_id, _KR, NSA_H, I32(1) - a_par, a_sh - I32(_SK))
+        a_s2r = S2RLoaderFp4Split(wave_m, N_TILES_A, BLOCK_M, a_par, _K128)
+        a_base6 = [
+            [a_s2r.f_base(A_lds[0], A_lds[1], b, s) for s in range_constexpr(N_SUB)]
+            for b in range_constexpr(NABUF)
+        ]
+        qu_a6 = a_s2r.q_unit() if const_expr(_K128) else None
+        abase6 = [_gbase(A_lds[0], b * _A_SLOT) for b in range_constexpr(NABUF)]
+        a_od6 = [_gbase(A_lds[1], j * _A_SLOT) for j in range_constexpr(_NOBUF)]
+        gl_a6 = [fx.Int32(o) for o in gl_a_e] + [fx.Int32(o) for o in gl_a_o]
+        # Fold A/B bases into int64 SRDs: large-G/large-M exceeds the int32 voffset.
+        a_base_e = arith.index_cast(T.index, m_row) * arith.index(K2) - arith.index_cast(T.index, a_sh)
         b_base_e = (
             arith.index_cast(T.index, group_idx) * arith.index_cast(T.index, c_n)
             + arith.index_cast(T.index, bn) * arith.index(BLOCK_N)
         ) * arith.index(K2)
-        a_nrec = (arith.index_cast(T.index, c_m) - arith.index_cast(T.index, m_row)) * arith.index(K2)
+        a_nrec = (arith.index_cast(T.index, c_m) - arith.index_cast(T.index, m_row)) * arith.index(
+            K2
+        ) + arith.index_cast(T.index, a_sh)
         b_nrec = arith.index(G) * arith.index_cast(T.index, c_n) * arith.index(K2) - b_base_e
         gA, rsrc_a = make_fp8_rebased_tensor_and_srd(A, F8, a_base_e, a_nrec)
         gB, rsrc_b = make_fp8_rebased_tensor_and_srd(B_T, F8, b_base_e, b_nrec)
         a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
         b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
-        a_g2s = G2SLoader(a_div, gl_off_a, N_LDS_STEPS_A, F8, wave_id)
-        bl_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_BH, F8, wave_id)
-        br_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_BH, F8, wave_id)
+        a_g2s = [G2SLoader(a_div, g, NSA_H, F8, wave_id) for g in (gl_a_e, gl_a_o0)]
+        bl_g2s = [G2SLoader(b_div, g, NSB_H, F8, wave_id) for g in (gl_b_e, gl_b_o0)]
+        br_g2s = [G2SLoader(b_div, g, NSB_H, F8, wave_id) for g in (gl_b_e, gl_b_o0)]
         a_off = I32(0)  # A/B tile+expert bases folded into the SRDs above; only the LDS-half
         bl_off = I32(0)  # column shift (br) survives as an int32-safe intra-tile residual.
         br_off = I32(LDS_BN_HALF) * K2
-        # A-scale slab row base (256-aligned): a_pre_g*64 + bm*256 + wave off
-        sa_b = a_pre_g * I32(64) + bm * I32(BLOCK_M) + I32(wave_m_off)
+        sa_b = a_pre_g * I32(64) + bm * I32(BLOCK_M) + I32(wave_m_off)  # 256-aligned slab row base
         sbl_b = bn * I32(BLOCK_N) + I32(wave_n_off)
         sbr_b = bn * I32(BLOCK_N) + I32(LDS_BN_HALF) + I32(wave_n_off)
         b_exp_bytes = group_idx * I32(N_SCALE * K128 * 4)  # padded per-expert B-scale base (bytes)
 
-        # ---- fill operand buffers ----
-        for _pp in range_constexpr(0, _PRELL):
+        for _pp in range_constexpr(0, _PRELL - 1):
             if const_expr(KI_LOOP > _pp):
-                a_g2s.load(A_buf[_pp], a_off + _pp * KSTEP)
-        for _pp in range_constexpr(0, _PRELL):
+                a_g2s[0].load(A_lds[0], a_off + _pp * KSTEP, base_off=I32(_pp * _A_SLOT))
+        for _pp in range_constexpr(0, _NOBUF - 1):
+            if const_expr(KI_LOOP + 1 > _pp):
+                a_g2s[1].load(A_lds[1], a_off + _pp * KSTEP, base_off=I32(_pp * _A_SLOT))
+        for _pp in range_constexpr(0, _PRELL - 1):
             if const_expr(KI_LOOP > _pp):
-                bl_g2s.load(BL_buf[_pp], bl_off + _pp * KSTEP)
-                br_g2s.load(BR_buf[_pp], br_off + _pp * KSTEP)
-        _llvm.inline_asm(
-            res=None, operands_=[], asm_string="s_waitcnt lgkmcnt(0)", constraints="", has_side_effects=True
-        )
-        wait_barrier(0)
+                bl_g2s[0].load(BL_lds[0], bl_off + _pp * KSTEP, base_off=I32(_pp * _B_SLOT))
+                br_g2s[0].load(BR_lds[0], br_off + _pp * KSTEP, base_off=I32(_pp * _B_SLOT))
+        for _pp in range_constexpr(0, _NOBUF - 1):
+            if const_expr(KI_LOOP + 1 > _pp):
+                bl_g2s[1].load(BL_lds[1], bl_off + _pp * KSTEP, base_off=I32(_pp * _B_SLOT))
+                br_g2s[1].load(BR_lds[1], br_off + _pp * KSTEP, base_off=I32(_pp * _B_SLOT))
 
         accL = [mfma.zero_value] * (N_TILES_A * N_TILES_BH)
         accR = [mfma.zero_value] * (N_TILES_A * N_TILES_BH)
@@ -427,6 +469,15 @@ def _build_grouped_mxfp4_nt_kernel(
         _wib = (sbl_b // I32(256)) * I32(2) + (sbl_b % I32(256)) // I32(64)
         _sob = rocdl.readfirstlane(T.i32, b_exp_bytes + _wib * I32(K128) * I32(512))
         sc_soff06 = [_soa, _sc1, _sob, _sc3]
+        _half_n = None
+        if const_expr(_HALF_N):
+            _half_n = _readfirstlane_i32(arith.select(bn == I32(NBK - 1), I32(1), I32(0)))
+        base_row = m_row + I32(wave_m_off)
+        base_col_l = bn * I32(BLOCK_N) + I32(wave_n_off)
+        base_col_r = bn * I32(BLOCK_N) + I32(LDS_BN_HALF) + I32(wave_n_off)
+        _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
+        store_c = StoreCPlain(C, m_end, c_n, mfma.idx, N_TILES_A, N_TILES_BH, _out_ty, ilv=_BILV)
+        _cst = store_c.fused_operands(base_row, base_col_l, base_col_r, n_valid=_NV) if _CSTORE else None
         accL, accR = mfma.call_mxfp4_wholeloop(
             a_base6,
             bl_base6,
@@ -458,35 +509,37 @@ def _build_grouped_mxfp4_nt_kernel(
             sc_voff6,
             sc_soff06,
             ki=KI_LOOP,
-            sc_buf_stride=(_SCBUF * 4),
+            half_n=_half_n,
+            half_k=bool(_K128),
+            split=(a_od6, bl_od6, br_od6, qu_a6, qu_b6),
+            cst=_cst,
+            cst_gap=LDS_BN_HALF * 2,
+            cst_ilv=_BILV,
+            cst_nt=cst_nt,
+            b_base_even=b_even6,
         )
-        base_row = m_row + I32(wave_m_off)
-        base_col_l = bn * I32(BLOCK_N) + I32(wave_n_off)
-        # store bounded to the group's tight end: StoreCPlain's SRD num_records =
-        # m_end*c_n -> partial-tile rows >= m_end (next group) HW-drop.
-        _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
-        store_c = StoreCPlain(C, m_end, c_n, mfma.idx, N_TILES_A, N_TILES_BH, _out_ty)
-        store_c.store(accL, base_row, base_col_l, n_valid=_NV)
-        base_col_r = bn * I32(BLOCK_N) + I32(LDS_BN_HALF) + I32(wave_n_off)
-        store_c.store(accR, base_row, base_col_r, n_valid=_NV)
+        if const_expr(not _CSTORE):
+            store_c.store(accL, base_row, base_col_l, n_valid=_NV)
+            store_c.store(accR, base_row, base_col_r, n_valid=_NV)
 
     _pt = {"passthrough": [["amdgpu-agpr-alloc", "256"]]}
     attrs = {"rocdl.flat_work_group_size": "256,256", "rocdl.waves_per_eu": OCC, **_pt}
-    return kern, attrs, NBK
+    return kern, attrs, NBK, _BILV
 
 
 _GMXFP4_LAUNCH_CACHE: dict = {}
 _GMXFP4_WS_CACHE: dict = {}
 _GMXFP4_AT_CACHE: dict = {}  # (total_M, N, K, G, gm, xcd, gn, out_fp16) -> [raw_launch, compiled]
-# Fixed grouped NT config (gm, xcd, gn): xcd=1 (group-major XCD order) is the dominant L2
-# locality lever; gm=2/gn=4 is within noise of the per-shape optimum. One fixed config keeps
-# one compiled kernel per shape.
-_GMXFP4_DEFAULT_CFG = (2, 1, 4)
-# JIT compile-cache bound: each distinct shape compiles one FlyDSL kernel (GPU code object).
-# Real MoE uses a handful of shapes; a broad test sweep (~480 shapes) accumulates enough
-# code objects to exhaust memory -> drop the caches (and gc the modules) past this cap. A
-# real workload stays well under it, so its kernels are never evicted.
-_GMXFP4_CACHE_CAP = 32
+_GMXFP4_NT_CFG = (4, 8, 0, 16, False)
+# Thin groups: the write-only C stream evicts re-read weights, so non-temporal buys them back.
+_GMXFP4_NT_CFG_THIN = (4, 8, 0, 16, True)
+_GMXFP4_WGRAD_CFG = (2, 1, 4, False, 1, False)
+_GMXFP4_WGRAD_CFG_SHORT = (4, 1, 6, True, 2, True)  # short per-group contraction: see selector
+# When a group's tiles outnumber the CUs the band shape alone decides residency: narrower M.
+_GMXFP4_WGRAD_CFG_SHORT_SPAN = (2, 1, 8, True, 2, True)
+_GMXFP4_WGRAD_SHORT_MG = 8192  # per-group contraction at/below which the short-M blocking applies
+_GMXFP4_CACHE_CAP = 32  # drop caches past this; real MoE uses few shapes, a test sweep many
+_N_CU = 256  # gfx950 compute units, i.e. the width of one dispatch generation
 
 
 def _bound_caches(*caches):
@@ -496,15 +549,37 @@ def _bound_caches(*caches):
         gc.collect()
 
 
-def _compile_grouped_mxfp4_nt_fused(K, G, N, gm, xcd, gn, wlv, elgk, out_fp16, k_real=None):
+def _select_gmxfp4_nt_cfg(total_M, G):
+    """Pick the NT tile blocking from the runtime shape (host-side extents only). A group at
+    least ``num_xcds`` bands wide (in M-blocks) gives every XCD a band inside one expert slab;
+    below that width every XCD sees a different expert, so that regime gets its own blocking."""
+    _gm, xcd, _gn, span, _nt = _GMXFP4_NT_CFG
+    mb = ceildiv(total_M // max(G, 1), _BLOCK)
+    return _GMXFP4_NT_CFG if mb >= xcd * span else _GMXFP4_NT_CFG_THIN
+
+
+def _compile_grouped_mxfp4_nt_fused(
+    K, G, N, gm, xcd, gn, wlv, elgk, out_fp16, k_real=None, span=16, cst_nt=False
+):
     K128 = K // 128
     N_SCALE = ceildiv(N, 256) * 256
     k128_rd = (K if k_real is None else k_real) // 128  # real raw K128 (scale not host-padded)
-    ab_pre_shuf = _build_grouped_mxfp4_ab_preshuffle(K128, G, N, k128_rd)  # merged A+B, 1 launch
-    gemm_k, attrs, NBK = _build_grouped_mxfp4_nt_kernel(
-        K, G, N, group_m=gm, num_xcds=xcd, group_n=gn, wlv=wlv, elgk=elgk, out_fp16=out_fp16, k_real=k_real
+    gemm_k, attrs, NBK, b_ilv = _build_grouped_mxfp4_nt_kernel(
+        K,
+        G,
+        N,
+        group_m=gm,
+        num_xcds=xcd,
+        group_n=gn,
+        wlv=wlv,
+        elgk=elgk,
+        out_fp16=out_fp16,
+        k_real=k_real,
+        xcd_span=span,
+        cst_nt=cst_nt,
     )
-    b_pre_grid = ceildiv(G * N_SCALE * K128, _PRESHUF_NG * _PRESHUF_BLK)
+    ab_pre_shuf = _build_grouped_mxfp4_ab_preshuffle(K128, G, N, k128_rd, b_ilv=b_ilv)  # 1 launch
+    b_pre_grid = ceildiv(G * N_SCALE * K128, _PRESHUF_FO * _PRESHUF_BLK)
 
     @flyc.jit
     def launch(
@@ -526,7 +601,7 @@ def _compile_grouped_mxfp4_nt_fused(K, G, N, gm, xcd, gn, wlv, elgk, out_fp16, k
         ab_pre_shuf(a_raw, a_sp, b_raw, b_sp, GO, c_m, slab_rows, a_pre_grid).launch(
             grid=(a_pre_grid + b_pre_grid, 1, 1), block=(_PRESHUF_BLK, 1, 1), stream=stream
         )
-        gemm_k(a8, b8, C, a_sp, b_sp, GO, c_m, c_n, slab_rows, grid_upper, value_attrs=attrs).launch(
+        gemm_k(a8, b8, C, a_sp, b_sp, GO, c_m, c_n, slab_rows, value_attrs=attrs).launch(
             grid=(grid_upper, 1, 1), block=(256, 1, 1), stream=stream
         )
 
@@ -534,11 +609,7 @@ def _compile_grouped_mxfp4_nt_fused(K, G, N, gm, xcd, gn, wlv, elgk, out_fp16, k
 
 
 def _get_grouped_mxfp4_ws(total_M, N, K128, G, device):
-    # M-generic workspace: key on the static shape (no total_M) and grow the A-slab
-    # buffer only when a larger total_M arrives. The kernel is passed the live slab_rows
-    # (a_pre_grid derives from it), so a larger cached buffer is safe -- only the needed
-    # prefix is written/read. Keeping total_M out of the key stops per-total_M churn from
-    # tripping _bound_caches and evicting the compiled kernels (mirrors #419 for mxfp8).
+    # key on static shape, grow the A-slab only for larger total_M so churn can't evict kernels
     slab_rows = (ceildiv(total_M, 256) + G) * 256  # padded A-slab upper bound for this call
     n_scale = ceildiv(N, 256) * 256
     key = (N, K128, G, device)
@@ -549,82 +620,6 @@ def _get_grouped_mxfp4_ws(total_M, N, K128, G, device):
         e = (a_sp, b_sp, slab_rows)
         _GMXFP4_WS_CACHE[key] = e
     return e[0], e[1], slab_rows
-
-
-_GMXFP4_CFG_CACHE: dict = {}  # (N, K, G, out_fp16) -> raced (gm, xcd, gn); M-generic
-_GMXFP4_PM_CANON = (2048, 4096)  # tokens/group steady points for the race (geomean)
-
-
-def _gmxfp4_nt_candidates():
-    """<=3 L2-swizzle configs raced per NT shape; cand[0]=(2,1,4) is the group-major default
-    that wins most shapes, (2,8,0)/(4,8,0) win wide-N short-K shapes (measured per-shape)."""
-    return [_GMXFP4_DEFAULT_CFG, (2, 8, 0), (4, 8, 0)]
-
-
-def _canon_gmxfp4_targs(args, K, G, N, k_real, pm):
-    """Synthetic balanced NT args at `pm` tokens/group (shapes drive timing; scales=1.0 keep
-    the output finite), reusing the M-independent b-side from `args`. The launch is M-generic,
-    so one compile covers every total_M -- the race just times L2 residency per swizzle."""
-    dev = args[0].device
-    stream = args[13]
-    M_c = G * pm
-    K128 = K // 128
-    a8_c = torch.randint(-127, 127, (M_c, K // 2), device=dev, dtype=torch.int8)
-    out_c = torch.empty((M_c, N), device=dev, dtype=args[2].dtype)
-    a_raw_c = torch.full((M_c * (k_real // 32) // 4,), 0x7F7F7F7F, device=dev, dtype=torch.int32)
-    a_sp_c, b_sp_c, slab_rows_c = _get_grouped_mxfp4_ws(M_c, N, K128, G, dev)
-    n_blocks = (N + 255) // 256
-    grid_upper_c = (ceildiv(M_c, 256) + G) * n_blocks
-    a_pre_grid_c = ceildiv(slab_rows_c * K128, _PRESHUF_NG * _PRESHUF_BLK)
-    go_c = (torch.arange(0, G + 1, dtype=torch.int64, device=dev) * pm).view(torch.int32)
-    return (
-        a8_c,
-        args[1],  # b8 (weights, M-independent)
-        out_c,
-        a_raw_c,
-        args[4],  # b_raw (b scales, M-independent)
-        a_sp_c,
-        b_sp_c,
-        go_c,
-        M_c,
-        N,
-        slab_rows_c,
-        a_pre_grid_c,
-        grid_upper_c,
-        stream,
-    )
-
-
-def _select_gmxfp4_cfg(cfg_key, entry_of, K, G, N, k_real, args):
-    """First-call timed race over <=3 swizzle candidates on synthetic canon args (2 tokens/
-    group steady points, geomean); cached per static shape (no total_M). The swizzle is a pure
-    WG->tile bijection (bit-identical), so this only chases L2 residency, never correctness."""
-    cached = _GMXFP4_CFG_CACHE.get(cfg_key)
-    if cached is not None:
-        return cached
-    points = [_canon_gmxfp4_targs(args, K, G, N, k_real, pm) for pm in _GMXFP4_PM_CANON]
-
-    def _score(cfg):
-        c = flyc.compile(entry_of(cfg)[0], *points[0])  # M-generic -> one compile serves both points
-        for targs in points:
-            for _ in range(5):
-                c(*targs)
-        return math.exp(sum(math.log(_robust_time(c, t)) for t in points) / len(points))
-
-    try:
-        best_cfg, best_score = _GMXFP4_DEFAULT_CFG, _score(_GMXFP4_DEFAULT_CFG)
-    except Exception:  # a bad race falls back to the default, never breaks the GEMM
-        _GMXFP4_CFG_CACHE[cfg_key] = _GMXFP4_DEFAULT_CFG
-        return _GMXFP4_DEFAULT_CFG
-    for cfg in _gmxfp4_nt_candidates()[1:]:
-        try:
-            s = _score(cfg)
-        except Exception:  # a candidate that fails to compile/run is skipped
-            continue
-        if s < best_score * 0.985:  # adopt only if geomean >=1.5% faster than the default
-            best_cfg, best_score = cfg, s
-    _GMXFP4_CFG_CACHE[cfg_key] = best_cfg
-    return best_cfg
 
 
 def grouped_gemm_mxfp4_flydsl_kernel(
@@ -639,11 +634,7 @@ def grouped_gemm_mxfp4_flydsl_kernel(
     dev = a.device
     N_out = N  # true free dim to return
 
-    # ZERO host pad / ZERO torch copies. Free dim N: kernel tiles the real N + masks store
-    # cols >= N. Contraction K: operands stay real (k_real row stride); the whole-loop runs
-    # k_real//256 full 256-blocks + a 128-tail. The tiny E8M0 SCALE is zero-padded to 256
-    # entirely INSIDE the preshuffle (k128_rd real read + 256-block mask) -- no F.pad.
-    k_real = K
+    k_real = K  # kernel tiles real N/K; the E8M0 scale is zero-padded to 256 in the preshuffle
     K256 = (K + 255) // 256 * 256
     au = a.contiguous().view(torch.uint8)  # [total_M, k_real/2] -- real K
     asu = a_scale.contiguous().view(torch.uint8)  # [total_M, k_real/32] -- real K
@@ -654,14 +645,8 @@ def grouped_gemm_mxfp4_flydsl_kernel(
 
     a_raw = asu.contiguous().view(torch.int32).reshape(-1)
     b_raw = bsu.contiguous().view(torch.int32).reshape(-1)
-    # Keep the fp4 operands multi-dim (do NOT flatten to 1D): a large-G MoE B holds
-    # G*N*K/2 > 2^31 int8s, and flydsl packs a 1D tensor's single dim as int32 (host
-    # CABI overflow). Multi-dim keeps every dim/stride int32; the kernel addresses via
-    # the rebased base (make_fp8_rebased_tensor_and_srd), independent of the shape.
-    a8 = au.contiguous().view(torch.int8)
+    a8 = au.contiguous().view(torch.int8)  # keep multi-dim: 1D view of >2^31-elem MoE tensor overflows CABI
     b8 = bu.contiguous().view(torch.int8)
-    # 2D C (NOT flattened): StoreCPlain re-bases per row band from C's base + c_n, so the
-    # shape only needs each dim int32; a 1D total_M*N view overflows the CABI for large M*N.
     out = torch.empty((total_M, N), dtype=out_dtype, device=dev)
 
     go = (group_offs if group_offs.dtype == torch.int64 else group_offs.to(torch.int64)).view(torch.int32)
@@ -669,7 +654,7 @@ def grouped_gemm_mxfp4_flydsl_kernel(
 
     n_blocks = (N + 255) // 256
     grid_upper = (ceildiv(total_M, 256) + G) * n_blocks
-    a_pre_grid = ceildiv(slab_rows * K128, _PRESHUF_NG * _PRESHUF_BLK)
+    a_pre_grid = ceildiv(slab_rows * K128, _PRESHUF_FO * _PRESHUF_BLK)
 
     stream = torch.cuda.current_stream()
     wlv, elgk = 10, 9
@@ -691,38 +676,27 @@ def grouped_gemm_mxfp4_flydsl_kernel(
     )
 
     def _entry(cfg):
-        gm, xcd, gn = cfg
-        lk = (K, G, N, gm, xcd, gn, wlv, elgk, out_fp16, k_real)
+        gm, xcd, gn, span, nt = cfg
+        lk = (K, G, N, gm, xcd, gn, span, nt, wlv, elgk, out_fp16, k_real)
         ent = _GMXFP4_LAUNCH_CACHE.get(lk)
         if ent is None:
-            ent = _compile_grouped_mxfp4_nt_fused(K, G, N, gm, xcd, gn, wlv, elgk, out_fp16, k_real=k_real)
+            ent = _compile_grouped_mxfp4_nt_fused(
+                K, G, N, gm, xcd, gn, wlv, elgk, out_fp16, k_real=k_real, span=span, cst_nt=nt
+            )
             _GMXFP4_LAUNCH_CACHE[lk] = ent
-        # M-generic launch (total_M is a runtime arg, not compiled in) -> key on the static
-        # shape only, reuse the compiled object for every total_M. Dropping total_M here stops
-        # per-total_M entries from evicting the cache (mirrors #419's mxfp8 M-decoupling).
-        atk = (N, K, G, gm, xcd, gn, out_fp16, k_real)  # k_real: same K256 diff real K must not collide
+        atk = (N, K, G, gm, xcd, gn, span, nt, out_fp16, k_real)  # same K256 diff real K must not collide
         e2 = _GMXFP4_AT_CACHE.get(atk)
         if e2 is None:
             e2 = [ent[0], None]
             _GMXFP4_AT_CACHE[atk] = e2
         return e2
 
-    # Per-shape L2-swizzle: race <=3 candidates once per static shape (cached, M-generic);
-    # the (2,1,4) group-major default wins most shapes, a few wide-N short-K shapes take
-    # (2,8,0). Graph capture can't time, so it keeps the default.
-    if torch.cuda.is_current_stream_capturing():
-        cfg = _GMXFP4_DEFAULT_CFG
-    else:
-        cfg = _select_gmxfp4_cfg((N, K, G, out_fp16), _entry, K, G, N, k_real, args)
-    run_eager_or_capture(_entry(cfg), args, 1)
+    _run_mxfp4_sched(_entry(_select_gmxfp4_nt_cfg(total_M, G)), args, 1)
     _bound_caches(_GMXFP4_LAUNCH_CACHE, _GMXFP4_AT_CACHE, _GMXFP4_WS_CACHE)
     return out[:, :N_out] if N_out != N else out
 
 
-# ── WGRAD (variable-K TN via NT compute): C[g] (OUT_M, OUT_N) = lhs[:, g] @ rhs[:, g]^T,
-# contraction = per-group padded M. lhs [OUT_M, M_total/2] / rhs [OUT_N, M_total/2] fp4;
-# scales whole-tensor (rows OUT_M/OUT_N are 256-tiled -> no per-group slab). The whole-loop
-# runs a RUNTIME nval = M_g/256 (even; balanced 256-aligned groups). ──
+# WGRAD (variable-K TN via NT compute): C[g] = lhs[:, g] @ rhs[:, g]^T over per-group padded M
 
 
 def _build_grouped_mxfp4_wgrad_kernel(
@@ -736,6 +710,9 @@ def _build_grouped_mxfp4_wgrad_kernel(
     wlv=10,
     elgk=9,
     out_fp16=False,
+    cst_nt=False,
+    wg_tiles=1,
+    half_m=False,
     beta_is_one=False,  # epilogue accumulates (C += acc) instead of overwriting
 ):
     BLOCK_M = BLOCK_N = BLOCK_K = _BLOCK
@@ -763,7 +740,17 @@ def _build_grouped_mxfp4_wgrad_kernel(
     N_BLOCKS_N = ceildiv(OUT_N, BLOCK_N)
     TILES_PER_GROUP = N_BLOCKS_M * N_BLOCKS_N
     _NV = OUT_N if (OUT_N % BLOCK_N != 0) else None  # non-256 OUT_N: mask store cols >= OUT_N
+    _HALF_N = (OUT_N % BLOCK_N != 0) and (OUT_N % BLOCK_N <= LDS_BN_HALF)  # see the NT kernel
+    # Last M block is half padding, so idling wave_m==1 would not shorten the tile; instead it
+    # re-points its operand and store at the R half and runs the R-dropped body.
+    _HALF_M = half_m and (OUT_M % BLOCK_M != 0) and (OUT_M % BLOCK_M <= BLOCK_M // 2)
+    # The in-loop fused store cannot read C back, so an accumulate takes the standalone one.
+    _CSTORE = (not out_fp16) and not beta_is_one
+    _BILV = N_TILES_BH if (_CSTORE and LDS_ROW_STRIDE == 128 and N_TILES_BH == 4) else 0
     TOTAL = G * TILES_PER_GROUP
+    # One WG walks WGT tiles from opposite ends; backfires once the halved grid under-covers.
+    _WGT = wg_tiles if (wg_tiles > 1 and TOTAL % wg_tiles == 0 and TOTAL // wg_tiles >= _N_CU) else 1
+    GRID = TOTAL // _WGT
 
     _anns = {f"A_lds{i}": fx.Array[fx.Float8E4M3FN, a_lds_size, 16] for i in range_constexpr(NABUF)}
     for _b in range_constexpr(NBB):
@@ -795,14 +782,13 @@ def _build_grouped_mxfp4_wgrad_kernel(
         wave_n = wave_id % 2
         I32 = fx.Int32
 
-        # operand SRDs/loaders built per-tile below (rebased); tile-independent parts here.
         mfma = MfmaScaleFp4(N_TILES_A, N_TILES_BH, packed=True, wlv=wlv, elgk=elgk)
         gl_off_a = fp4_g2s_offsets(lane_id, wave_id, M_total, N_LDS_STEPS_A, BPR, swizzle=swizzle)
-        gl_off_b = fp4_g2s_offsets(lane_id, wave_id, M_total, N_LDS_STEPS_BH, BPR, swizzle=swizzle)
+        gl_off_b = fp4_g2s_offsets(lane_id, wave_id, M_total, N_LDS_STEPS_BH, BPR, swizzle=swizzle, ilv=_BILV)
         a_s2r = S2RLoaderFp4(wave_m, N_TILES_A, LDS_ROW_STRIDE, swizzle=swizzle)
         b_s2r = S2RLoaderFp4(wave_n, N_TILES_BH, LDS_ROW_STRIDE, swizzle=swizzle)
-        _qm = ((OUT_M + 63) // 64) * 64
-        _qn = ((OUT_N + 63) // 64) * 64
+        _qm = ceildiv(OUT_M, 256) * 256
+        _qn = ceildiv(OUT_N, 256) * 256
         sa_s2r = ScaleS2RPacked(A_scale, _qm, M_total, 4)
         sb_s2r = ScaleS2RPacked(B_scale, _qn, M_total, 4)
         wave_m_off = wave_m * (N_TILES_A * 16)
@@ -817,6 +803,12 @@ def _build_grouped_mxfp4_wgrad_kernel(
         br_base6 = [
             [b_s2r.base_addr(BR_buf[b], s) for s in range_constexpr(N_SUB)] for b in range_constexpr(NBB)
         ]
+        if const_expr(_HALF_M):
+            a_s2r_h = S2RLoaderFp4(0, N_TILES_A, LDS_ROW_STRIDE, swizzle=swizzle)
+            a_base6_h = [
+                [a_s2r_h.base_addr(A_buf[b], s) for s in range_constexpr(N_SUB)]
+                for b in range_constexpr(NABUF)
+            ]
 
         def _gbase(buf):
             v = fx.Int32(fx.ptrtoint(buf.ptr)) + fx.Int32(wave_id) * fx.Int32(1024)
@@ -855,116 +847,178 @@ def _build_grouped_mxfp4_wgrad_kernel(
                 T.i32, (grp * fx.Int32(K128m) + fx.Int32(_PRELL * N_SUB)) * fx.Int32(256) + ksb
             )
 
-        go_t = rocdl.make_buffer_tensor(GO, max_size=False, num_records_bytes=(G + 1) * 8)
-        go_div = fx.logical_divide(go_t, fx.make_layout(1, 1))
-        pid = xcd_remap_pid(fx.block_idx.x, I32(TOTAL), num_xcds)
-        group_idx, block_m, block_n = _wgrad_block_mn(
-            pid, G, TILES_PER_GROUP, N_BLOCKS_M, N_BLOCKS_N, group_m, group_n, False
-        )
-        m_start = _load_go(go_div, group_idx)
-        m_end = _load_go(go_div, group_idx + 1)
-        nval = ((m_end - m_start) // I32(512)) * I32(2)  # even 256-block count
+        # Lane-resident group table: bounds cost a v_readlane, not a load occ=1 cannot hide.
+        go_rs = buffer_ops.create_buffer_resource(GO, max_size=False, num_records_bytes=(G + 1) * 8)
+        go_tbl = _lane_tbl_load(go_rs, lane_id, G + 1, stride=2)
+        # LPT order: tile cost tracks token count, so two half-sums pick the walk direction.
+        _go_half = _lane_tbl_get(go_tbl, I32(G // 2))
+        _head_tokens = _go_half - _lane_tbl_get(go_tbl, I32(0))
+        _tail_tokens = _lane_tbl_get(go_tbl, I32(G)) - _go_half
+        _tail_heavy = _tail_tokens > _head_tokens
+        for _tt in range_constexpr(_WGT):
+            if const_expr(_tt):
+                _lds_barrier()  # the previous tile's ds_reads must retire before its buffers refill
+            # Sub-tiles alternate ends sequentially: co-residency would cost more turnaround.
+            if const_expr(_tt % 2 == 0):
+                _pl = fx.block_idx.x + I32((_tt // 2) * GRID)
+            else:
+                _pl = I32(TOTAL - 1 - (_tt // 2) * GRID) - fx.block_idx.x
+            pid_lin = _readfirstlane_i32(arith.select(_tail_heavy, I32(TOTAL - 1) - _pl, _pl))
+            pid = xcd_remap_pid(pid_lin, I32(TOTAL), num_xcds)
+            group_idx, block_m, block_n = _wgrad_block_mn(
+                pid, G, TILES_PER_GROUP, N_BLOCKS_M, N_BLOCKS_N, group_m, group_n, False
+            )
+            _gi = _readfirstlane_i32(group_idx)
+            m_start = _lane_tbl_get(go_tbl, _gi)
+            m_end = _lane_tbl_get(go_tbl, _gi + I32(1))
+            nval = ((m_end - m_start) // I32(512)) * I32(2)  # even 256-block count
 
-        a_row = block_m * I32(BLOCK_M)
-        b_row = block_n * I32(BLOCK_N)
-        # Fold the tile's row base + per-group contraction start into the operand SRDs in
-        # int64: a_row*M2 (large OUT_M) and the m_start byte offset (large M_total) push the
-        # start past 2^31, unreachable by the whole-loop's int32 voffset/soffset.
-        _ms2 = arith.index_cast(T.index, m_start >> 1)
-        a_base_e = arith.index_cast(T.index, a_row) * arith.index(M2) + _ms2
-        b_base_e = arith.index_cast(T.index, b_row) * arith.index(M2) + _ms2
-        a_nrec = arith.index(OUT_M) * arith.index(M2) - a_base_e
-        b_nrec = arith.index(OUT_N) * arith.index(M2) - b_base_e
-        gA, rsrc_a = make_fp8_rebased_tensor_and_srd(A, F8, a_base_e, a_nrec)
-        gB, rsrc_b = make_fp8_rebased_tensor_and_srd(B_T, F8, b_base_e, b_nrec)
-        a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
-        b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
-        a_g2s = G2SLoader(a_div, gl_off_a, N_LDS_STEPS_A, F8, wave_id)
-        bl_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_BH, F8, wave_id)
-        br_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_BH, F8, wave_id)
-        a_off = I32(0)  # tile row base + contraction start folded into the SRDs above; only
-        bl_off = I32(0)  # br's LDS-half row shift survives as an int32-safe residual.
-        br_off = I32(LDS_BN_HALF) * I32(M2)
-        sa_b = a_row + I32(wave_m_off)
-        sbl_b = b_row + I32(wave_n_off)
-        sbr_b = b_row + I32(LDS_BN_HALF) + I32(wave_n_off)
-        ksb = (m_start // I32(256)) * I32(_SCVSTEP)  # contraction-start scale byte offset
+            a_row = block_m * I32(BLOCK_M)
+            b_row = block_n * I32(BLOCK_N)
+            # M-side half tile: wave_m == 1 re-points at the R half and runs the R-dropped body.
+            if const_expr(_HALF_M):
+                _lm = block_m == I32(N_BLOCKS_M - 1)
+                if const_expr(_HALF_N):
+                    _ln = block_n == I32(N_BLOCKS_N - 1)
+                    _hmf = I32(arith.select(_ln, I32(0), arith.select(_lm, I32(1), I32(0))))
+                else:
+                    _hmf = I32(arith.select(_lm, I32(1), I32(0)))
+                _hm = _hmf == I32(1)
+                _hmw = (_hmf + wave_m) == I32(2)  # this wave swaps onto the R column half
+            # fold row base + contraction start into the int64 SRDs: large OUT_M/M_total pass 2^31
+            _ms2 = arith.index_cast(T.index, m_start >> 1)
+            a_base_e = arith.index_cast(T.index, a_row) * arith.index(M2) + _ms2
+            b_base_e = arith.index_cast(T.index, b_row) * arith.index(M2) + _ms2
+            a_nrec = arith.index(OUT_M) * arith.index(M2) - a_base_e
+            b_nrec = arith.index(OUT_N) * arith.index(M2) - b_base_e
+            gA, rsrc_a = make_fp8_rebased_tensor_and_srd(A, F8, a_base_e, a_nrec)
+            gB, rsrc_b = make_fp8_rebased_tensor_and_srd(B_T, F8, b_base_e, b_nrec)
+            a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
+            b_div = fx.logical_divide(gB, fx.make_layout(1, 1))
+            a_g2s = G2SLoader(a_div, gl_off_a, N_LDS_STEPS_A, F8, wave_id)
+            bl_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_BH, F8, wave_id)
+            br_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_BH, F8, wave_id)
+            a_off = I32(0)  # tile row base + contraction start folded into the SRDs above; only
+            bl_off = I32(0)  # br's LDS-half row shift survives as an int32-safe residual.
+            br_off = I32(LDS_BN_HALF) * I32(M2)
+            sa_b = a_row + I32(wave_m_off)
+            sbl_b = b_row + I32(wave_n_off)
+            sbr_b = b_row + I32(LDS_BN_HALF) + I32(wave_n_off)
+            if const_expr(_HALF_M):
+                sa_b = I32(arith.select(_hm, a_row, sa_b))
+            ksb = (m_start // I32(256)) * I32(_SCVSTEP)  # contraction-start scale byte offset
 
-        for _pp in range_constexpr(0, _PRELL):
-            a_g2s.load(A_buf[_pp], a_off + _pp * KSTEP)
-        for _pp in range_constexpr(0, _PRELL):
-            bl_g2s.load(BL_buf[_pp], bl_off + _pp * KSTEP)
-            br_g2s.load(BR_buf[_pp], br_off + _pp * KSTEP)
-        _llvm.inline_asm(
-            res=None, operands_=[], asm_string="s_waitcnt lgkmcnt(0)", constraints="", has_side_effects=True
-        )
-        wait_barrier(0)
+            for _pp in range_constexpr(0, _PRELL):
+                a_g2s.load(A_buf[_pp], a_off + _pp * KSTEP)
+            # B stops one ring slot short: the whole-loop asm issues and drains it behind its k=0 loads
+            for _pp in range_constexpr(0, _PRELL - 1):
+                bl_g2s.load(BL_buf[_pp], bl_off + _pp * KSTEP)
+                br_g2s.load(BR_buf[_pp], br_off + _pp * KSTEP)
 
-        accL = [mfma.zero_value] * (N_TILES_A * N_TILES_BH)
-        accR = [mfma.zero_value] * (N_TILES_A * N_TILES_BH)
-        soff6_a = rocdl.readfirstlane(T.i32, a_off + fx.Int32(_PRELL * KSTEP))
-        soff6_bl = rocdl.readfirstlane(T.i32, bl_off + fx.Int32(_PRELL * KSTEP))
-        soff6_br = rocdl.readfirstlane(T.i32, br_off + fx.Int32(_PRELL * KSTEP))
-        _sc1 = _scsoff(sa_b, 64, ksb)
-        _sc3 = _scsoff(sbr_b, 0, ksb)
-        _wia = sa_b // I32(128)
-        _wib = (sbl_b // I32(256)) * I32(2) + (sbl_b % I32(256)) // I32(64)
-        _soa = rocdl.readfirstlane(T.i32, _wia * I32(K128m) * I32(512) + ksb)
-        _sob = rocdl.readfirstlane(T.i32, _wib * I32(K128m) * I32(512) + ksb)
-        sc_soff06 = [_soa, _sc1, _sob, _sc3]
-        accL, accR = mfma.call_mxfp4_wholeloop(
-            a_base6,
-            bl_base6,
-            br_base6,
-            a_s2r.tile_stride,
-            b_s2r.tile_stride,
-            abase6,
-            blbase6,
-            brbase6,
-            gl_a6,
-            gl_b6,
-            rsrc_a,
-            rsrc_b,
-            fx.Int32(KSTEP),
-            scv6,
-            accL,
-            accR,
-            N_SUB,
-            N_LDS_STEPS_A,
-            N_LDS_STEPS_BH,
-            nval,
-            soff6_a,
-            soff6_bl,
-            soff6_br,
-            sc_rb6,
-            sc_gb6,
-            _scrsa_v,
-            _scrsb_v,
-            sc_voff6,
-            sc_soff06,
-            ki=None,
-            sc_buf_stride=(_SCBUF * 4),
-        )
-        base_row = group_idx * I32(OUT_M) + a_row + I32(wave_m_off)
-        base_col_l = b_row + I32(wave_n_off)
-        base_col_r = b_row + I32(LDS_BN_HALF) + I32(wave_n_off)
-        _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
-        store_c = StoreCPlain(
-            C,
-            (group_idx + I32(1)) * I32(OUT_M),
-            OUT_N,
-            mfma.idx,
-            N_TILES_A,
-            N_TILES_BH,
-            _out_ty,
-            beta_is_one=beta_is_one,
-        )
-        store_c.store(accL, base_row, base_col_l, n_valid=_NV)
-        store_c.store(accR, base_row, base_col_r, n_valid=_NV)
+            accL = [mfma.zero_value] * (N_TILES_A * N_TILES_BH)
+            accR = [mfma.zero_value] * (N_TILES_A * N_TILES_BH)
+            soff6_a = rocdl.readfirstlane(T.i32, a_off + fx.Int32(_PRELL * KSTEP))
+            _blo = bl_off + fx.Int32(_PRELL * KSTEP)
+            _bro = br_off + fx.Int32(_PRELL * KSTEP)
+            if const_expr(_HALF_M and _HALF_N):
+                # half_g2s off here, so a boundary N block's padding R half folds onto L rows.
+                _bro = I32(arith.select(_ln, _blo, _bro))
+            soff6_bl = rocdl.readfirstlane(T.i32, _blo)
+            soff6_br = rocdl.readfirstlane(T.i32, _bro)
+            _sc1 = _scsoff(sa_b, 64, ksb)
+            _sc3 = _scsoff(sbr_b, 0, ksb)
+            _wia = sa_b // I32(128)
+            _wib = (sbl_b // I32(256)) * I32(2) + (sbl_b % I32(256)) // I32(64)
+            _sob_v = _wib * I32(K128m) * I32(512) + ksb
+            if const_expr(_HALF_M):
+                _sob_v = I32(arith.select(_hmw, _sob_v + I32(8), _sob_v))
+            _soa = rocdl.readfirstlane(T.i32, _wia * I32(K128m) * I32(512) + ksb)
+            _sob = rocdl.readfirstlane(T.i32, _sob_v)
+            sc_soff06 = [_soa, _sc1, _sob, _sc3]
+            _half_n = None
+            if const_expr(_HALF_N or _HALF_M):
+                _hnv = I32(0)
+                if const_expr(_HALF_N):
+                    _hnv = I32(arith.select(block_n == I32(N_BLOCKS_N - 1), I32(1), _hnv))
+                if const_expr(_HALF_M):
+                    _hnv = I32(arith.select(_lm, I32(1), _hnv))
+                _half_n = _readfirstlane_i32(_hnv)
+            base_row = group_idx * I32(OUT_M) + a_row + I32(wave_m_off)
+            base_col_l = b_row + I32(wave_n_off)
+            base_col_r = b_row + I32(LDS_BN_HALF) + I32(wave_n_off)
+            if const_expr(_HALF_M):
+                base_row = I32(arith.select(_hm, group_idx * I32(OUT_M) + a_row, base_row))
+                base_col_l = I32(arith.select(_hmw, base_col_r, base_col_l))
+            _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
+            store_c = StoreCPlain(
+                C,
+                (group_idx + I32(1)) * I32(OUT_M),
+                OUT_N,
+                mfma.idx,
+                N_TILES_A,
+                N_TILES_BH,
+                _out_ty,
+                ilv=_BILV,
+                beta_is_one=beta_is_one,
+            )
+            _cst = store_c.fused_operands(base_row, base_col_l, base_col_r, n_valid=_NV) if _CSTORE else None
+            if const_expr(_HALF_M):
+                a_base_t = [
+                    [arith.select(_hmw, a_base6_h[b][s], a_base6[b][s]) for s in range_constexpr(N_SUB)]
+                    for b in range_constexpr(NABUF)
+                ]
+                bl_base_t = [
+                    [arith.select(_hmw, br_base6[b][s], bl_base6[b][s]) for s in range_constexpr(N_SUB)]
+                    for b in range_constexpr(NBB)
+                ]
+            else:
+                a_base_t, bl_base_t = a_base6, bl_base6
+            accL, accR = mfma.call_mxfp4_wholeloop(
+                a_base_t,
+                bl_base_t,
+                br_base6,
+                a_s2r.tile_stride,
+                b_s2r.tile_stride,
+                abase6,
+                blbase6,
+                brbase6,
+                gl_a6,
+                gl_b6,
+                rsrc_a,
+                rsrc_b,
+                fx.Int32(KSTEP),
+                scv6,
+                accL,
+                accR,
+                N_SUB,
+                N_LDS_STEPS_A,
+                N_LDS_STEPS_BH,
+                nval,
+                soff6_a,
+                soff6_bl,
+                soff6_br,
+                sc_rb6,
+                sc_gb6,
+                _scrsa_v,
+                _scrsb_v,
+                sc_voff6,
+                sc_soff06,
+                ki=None,
+                sc_buf_stride=(_SCBUF * 4),
+                half_n=_half_n,
+                half_g2s=not _HALF_M,
+                cst=_cst,
+                cst_gap=LDS_BN_HALF * 2,
+                cst_ilv=_BILV,
+                cst_nt=cst_nt,
+            )
+            if const_expr(not _CSTORE):
+                store_c.store(accL, base_row, base_col_l, n_valid=_NV)
+                store_c.store(accR, base_row, base_col_r, n_valid=_NV)
 
     _pt = {"passthrough": [["amdgpu-agpr-alloc", "256"]]}
     attrs = {"rocdl.flat_work_group_size": "256,256", "rocdl.waves_per_eu": OCC, **_pt}
-    return kern, attrs, TOTAL
+    return kern, attrs, GRID, _BILV
 
 
 _GMXFP4_WGRAD_LAUNCH_CACHE: dict = {}
@@ -976,8 +1030,8 @@ def _get_grouped_mxfp4_wgrad_ws(OUT_M, OUT_N, K128m, device):
     key = (OUT_M, OUT_N, K128m, device)
     e = _GMXFP4_WGRAD_WS_CACHE.get(key)
     if e is None:
-        qm = ((OUT_M + 63) // 64) * 64
-        qn = ((OUT_N + 63) // 64) * 64
+        qm = ceildiv(OUT_M, 256) * 256
+        qn = ceildiv(OUT_N, 256) * 256
         a_sp = torch.empty(qm * K128m, dtype=torch.int32, device=device)
         b_sp = torch.empty(qn * K128m, dtype=torch.int32, device=device)
         e = (a_sp, b_sp)
@@ -985,12 +1039,22 @@ def _get_grouped_mxfp4_wgrad_ws(OUT_M, OUT_N, K128m, device):
     return e
 
 
+def _select_gmxfp4_wgrad_cfg(M_total, G, OUT_M=0, OUT_N=0):
+    """Pick the wgrad tile blocking from the mean per-group contraction: a short one writes
+    G x more C per FLOP and needs the non-temporal store, and splits again on the per-group
+    tile count, where a group wider than one CU keeps its own rows resident."""
+    if M_total // max(G, 1) > _GMXFP4_WGRAD_SHORT_MG:
+        return _GMXFP4_WGRAD_CFG
+    if ceildiv(OUT_M, _BLOCK) * ceildiv(OUT_N, _BLOCK) > _N_CU:
+        return _GMXFP4_WGRAD_CFG_SHORT_SPAN
+    return _GMXFP4_WGRAD_CFG_SHORT
+
+
 def _compile_grouped_mxfp4_wgrad_fused(
-    OUT_M, OUT_N, G, M_total, gm, xcd, gn, wlv, elgk, out_fp16, beta_is_one=False
+    OUT_M, OUT_N, G, M_total, gm, xcd, gn, nt, wgt, hm, wlv, elgk, out_fp16, beta_is_one=False
 ):
     K128m = M_total // 128
-    pre_ab = _build_mxfp4_preshuffle_kernel_ab()
-    gemm_k, attrs, TOTAL = _build_grouped_mxfp4_wgrad_kernel(
+    gemm_k, attrs, GRID, b_ilv = _build_grouped_mxfp4_wgrad_kernel(
         OUT_M,
         OUT_N,
         G,
@@ -1001,9 +1065,15 @@ def _compile_grouped_mxfp4_wgrad_fused(
         wlv=wlv,
         elgk=elgk,
         out_fp16=out_fp16,
+        cst_nt=nt,
+        wg_tiles=wgt,
+        half_m=hm,
         beta_is_one=beta_is_one,
     )
-    _PGRID = _MXFP4_PRESHUF_NG * _MXFP4_PRESHUF_BLK
+    pre_ab = _build_mxfp4_preshuffle_kernel_ab(b_ilv=b_ilv)  # b_ilv: rhs scale follows rhs row map
+    _PGRID = _MXFP4_PRESHUF_FO * _MXFP4_PRESHUF_BLK
+    QM = ceildiv(OUT_M, 256) * 256  # 256-rounded packed extent; surplus rows masked off the read
+    QN = ceildiv(OUT_N, 256) * 256
 
     @flyc.jit
     def launch(
@@ -1017,16 +1087,25 @@ def _compile_grouped_mxfp4_wgrad_fused(
         GO: fx.Tensor,
         stream: fx.Stream,
     ):
-        grid_a = ceildiv(fx.Int32(OUT_M) * fx.Int32(K128m), _PGRID)
-        grid_b = ceildiv(fx.Int32(OUT_N) * fx.Int32(K128m), _PGRID)
-        pre_ab(a_raw, a_sp, b_raw, b_sp, fx.Int32(OUT_M), fx.Int32(OUT_N), fx.Int32(K128m), grid_a).launch(
-            grid=(grid_a + grid_b, 1, 1), block=(_MXFP4_PRESHUF_BLK, 1, 1), stream=stream
-        )
+        grid_a = ceildiv(fx.Int32(QM) * fx.Int32(K128m), _PGRID)
+        grid_b = ceildiv(fx.Int32(QN) * fx.Int32(K128m), _PGRID)
+        pre_ab(
+            a_raw,
+            a_sp,
+            b_raw,
+            b_sp,
+            fx.Int32(QM),
+            fx.Int32(QN),
+            fx.Int32(OUT_M),
+            fx.Int32(OUT_N),
+            fx.Int32(K128m),
+            grid_a,
+        ).launch(grid=(grid_a + grid_b, 1, 1), block=(_MXFP4_PRESHUF_BLK, 1, 1), stream=stream)
         gemm_k(a8, b8, C, a_sp, b_sp, GO, value_attrs=attrs).launch(
-            grid=(TOTAL, 1, 1), block=(256, 1, 1), stream=stream
+            grid=(GRID, 1, 1), block=(256, 1, 1), stream=stream
         )
 
-    return launch, TOTAL
+    return launch, GRID
 
 
 def grouped_gemm_mxfp4_variable_k_flydsl_kernel(
@@ -1043,15 +1122,9 @@ def grouped_gemm_mxfp4_variable_k_flydsl_kernel(
     beta=0.0,
     out=None,
 ):
-    """FlyDSL MXFP4 grouped variable-K wgrad (bare-asm whole-loop). lhs [OUT_M, M/2] /
-    rhs [OUT_N, M/2] fp4 in the FlyDSL-quant colwise layout (each group's M already
-    512-aligned), group_offs [G+1] the matching 512-padded per-group M offsets. Runs the
-    NT whole-loop with a runtime nval directly -- no on-GPU repack, no free-dim pad (the
-    non-256 OUT_M rows are SRD-dropped, OUT_N cols masked in the store). Returns
-    C [G, OUT_M, OUT_N].
-
-    ``beta=1.0`` accumulates into ``out`` (``out[g] += lhs[:,g] @ rhs[:,g]^T``) in the
-    epilogue instead of overwriting it, and therefore requires ``out``."""
+    """MXFP4 grouped variable-K wgrad (bare-asm whole-loop) -> C [G, OUT_M, OUT_N]. lhs/rhs are
+    fp4 in the colwise 512-aligned quant layout with group_offs [G+1] the matching padded offsets,
+    so the NT whole-loop runs at a runtime nval. ``beta=1.0`` accumulates into ``out``."""
     assert lhs.ndim == 2 and rhs.ndim == 2
     assert lhs.shape[0] == OUT_M and rhs.shape[0] == OUT_N
     M_total = lhs.shape[1] * 2  # colwise contraction width (512-padded per group by the quant)
@@ -1059,9 +1132,7 @@ def grouped_gemm_mxfp4_variable_k_flydsl_kernel(
     dev = lhs.device
     out_fp16 = out_dtype == torch.float16
 
-    # Keep the fp4 operands 2D (do NOT flatten): a large total_M makes OUT_*/2 * M/2
-    # exceed 2^31 int8s, which flydsl packs as an int32 dim (host CABI overflow). The
-    # kernel addresses via the rebased base, independent of the operand shape.
+    # keep fp4 operands 2D: a flat view of >2^31-int8 total_M overflows the CABI int32 dim
     a8 = lhs.contiguous().view(torch.int8)
     b8 = rhs.contiguous().view(torch.int8)
     a_raw = lhs_scale.contiguous().view(torch.int32).reshape(-1)
@@ -1070,8 +1141,7 @@ def grouped_gemm_mxfp4_variable_k_flydsl_kernel(
 
     K128m = M_total // 128
     a_sp, b_sp = _get_grouped_mxfp4_wgrad_ws(OUT_M, OUT_N, K128m, dev)
-    # 3D C (NOT flattened): StoreCPlain re-bases per row band from C's base + OUT_N; a 1D
-    # G*OUT_M*OUT_N view overflows the CABI for large-G MoE grad_b (> 2^31 elems).
+    # 3D: a 1D G*OUT_M*OUT_N view overflows the CABI int32 dim on large-G grad_b.
     out = resolve_accum_out(out, beta, (G, OUT_M, OUT_N), dev, out_dtype)
     beta_is_one = beta == 1.0
 
@@ -1080,21 +1150,21 @@ def grouped_gemm_mxfp4_variable_k_flydsl_kernel(
     args = (a8, b8, out, a_raw, b_raw, a_sp, b_sp, go_pad, stream)
 
     def _entry(cfg):
-        gm, xcd, gn = cfg
-        lk = (OUT_M, OUT_N, G, M_total, gm, xcd, gn, wlv, elgk, out_fp16, beta_is_one)
+        gm, xcd, gn, nt, wgt, hm = cfg
+        lk = (OUT_M, OUT_N, G, M_total, gm, xcd, gn, nt, wgt, hm, wlv, elgk, out_fp16, beta_is_one)
         ent = _GMXFP4_WGRAD_LAUNCH_CACHE.get(lk)
         if ent is None:
             ent = _compile_grouped_mxfp4_wgrad_fused(
-                OUT_M, OUT_N, G, M_total, gm, xcd, gn, wlv, elgk, out_fp16, beta_is_one
+                OUT_M, OUT_N, G, M_total, gm, xcd, gn, nt, wgt, hm, wlv, elgk, out_fp16, beta_is_one
             )
             _GMXFP4_WGRAD_LAUNCH_CACHE[lk] = ent
-        atk = (OUT_M, OUT_N, M_total, G, gm, xcd, gn, out_fp16, beta_is_one)
+        atk = (OUT_M, OUT_N, M_total, G, gm, xcd, gn, nt, wgt, hm, out_fp16, beta_is_one)
         e2 = _GMXFP4_WGRAD_AT_CACHE.get(atk)
         if e2 is None:
             e2 = [ent[0], None]
             _GMXFP4_WGRAD_AT_CACHE[atk] = e2
         return e2
 
-    run_eager_or_capture(_entry(_GMXFP4_DEFAULT_CFG), args, 1)
+    run_eager_or_capture(_entry(_select_gmxfp4_wgrad_cfg(M_total, G, OUT_M, OUT_N)), args, 1)
     _bound_caches(_GMXFP4_WGRAD_LAUNCH_CACHE, _GMXFP4_WGRAD_AT_CACHE, _GMXFP4_WGRAD_WS_CACHE)
     return out

--- a/primus_turbo/flydsl/utils/gemm_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_helper.py
@@ -2161,3 +2161,113 @@ class StoreCBf16:
             for r in range_constexpr(4):
                 m = base_m + ti * 16 + m_hi + r
                 self._store_masked(acc[r], row_base + m, n_valid)
+
+
+# MXFP4 kernel helpers: lane-table group search (with its DPP scan primitives),
+# power-of-two ceildiv/floordiv, and the XCD band remap.
+
+
+def xcd_band_remap_pid(pid, total_pids, num_xcd, band):
+    """Band-cyclic variant of ``xcd_remap_pid``: an XCD owns every ``num_xcd``-th run of
+    ``band`` tiles, keeping intra-run L2 reuse while every XCD samples the full tile range.
+    That balances a non-uniform per-tile cost the contiguous remap would strand on one XCD."""
+    if num_xcd <= 1 or band <= 0:
+        return pid
+    assert num_xcd & (num_xcd - 1) == 0
+    span = num_xcd * band
+    local = floordiv_pow2(pid, num_xcd)
+    xcd = pid - local * num_xcd
+    rnd = local // band
+    mapped = (rnd * num_xcd + xcd) * band + (local - rnd * band)
+    return arith.select(pid < (total_pids // span) * span, mapped, pid)
+
+
+def _lane_tbl_get(tbl, idx):
+    """Entry ``idx`` (wave-uniform, or a Python int) of a lane-resident table."""
+    if isinstance(idx, int):
+        return _readlane_i32(tbl[idx // 64], idx % 64)
+    v = _readlane_i32(tbl[0], idx)
+    for c in range(1, len(tbl)):
+        hit = idx >= fx.Int32(64 * c)
+        v = arith.select(hit, _readlane_i32(tbl[c], idx - fx.Int32(64 * c)), v)
+    return v
+
+
+def _lane_tbl_load(rsrc, lane, n_entries, stride=1, first=0):
+    """Gather entries [0, n_entries) of an i32 buffer view into lane-resident chunks.
+    Entry i reads i32 element ``(i + first) * stride``; lanes past the buffer bound read 0."""
+    n_chunk = ceildiv(n_entries, 64)
+    return [_lane_load_i32(rsrc, (lane + 64 * c + first) * stride) for c in range_constexpr(n_chunk)]
+
+
+def _lane_tbl_scan(tbl):
+    """Inclusive add-scan across a lane-resident table (chunk totals carried forward)."""
+    out = []
+    base = fx.Int32(0)
+    for v in tbl:
+        s = _wave_prefix_add_i32(v) + base
+        out.append(s)
+        base = _readlane_i32(s, 63)
+    return out
+
+
+def _lane_tbl_count_le(tbl, bound):
+    """Number of table entries <= ``bound``."""
+    n = _wave_count_le_i32(tbl[0], bound)
+    for c in range(1, len(tbl)):
+        n = n + _wave_count_le_i32(tbl[c], bound)
+    return n
+
+
+def _readlane_i32(v, lane):
+    """Broadcast one lane of a per-lane i32 into an SGPR; lane must be wave-uniform."""
+    raw = _raw(v)
+    return ArithValue(_res_of(rocdl.readlane(res=raw.type, src=raw, lane=lane)))
+
+
+def _wave_count_le_i32(v, bound):
+    """Number of lanes whose per-lane i32 is <= the wave-uniform bound. One ballot plus one
+    s_bcnt1; on a monotone table this is the first lane above bound, an O(1) stand-in for a
+    G-wide boundary compare chain."""
+    m = _res_of(rocdl.ballot(res=ir.IntegerType.get_signless(64), pred=_raw(v <= bound)))
+    n = _res_of(_llvm.intr_ctpop(m))
+    return ArithValue(arith.trunci(T.i32, n))
+
+
+def _res_of(op):
+    """Unwrap an op builder's single result (some rocdl builders already return one)."""
+    return op.result if hasattr(op, "result") else op
+
+
+def _lane_load_i32(rsrc, idx):
+    """One per-lane i32 gather from a buffer resource; out-of-range lanes read 0."""
+    return ArithValue(_buffer_ops.buffer_load(rsrc, idx, vec_width=1, dtype=T.i32))
+
+
+# A lane-resident int32 table (entry i in lane i%64 of chunk i//64) makes a lookup one v_readlane and a prefix sum one wave scan, avoiding SGPR overflow / an LDS barrier.
+
+
+def _wave_prefix_add_i32(v):
+    """Wave64 inclusive add-scan of a per-lane i32 (lane l ends with the sum of 0..l).
+    DPP steps replace the serial carry; bound_ctrl zeroes the shifted-in lanes. Requires a
+    full EXEC mask (kernel entry)."""
+    for _sh in (1, 2, 4, 8):
+        v = _dpp_add_i32(v, _DPP_ROW_SHR + _sh)
+    v = _dpp_add_i32(v, _DPP_ROW_BCAST15, row_mask=0xA)
+    return _dpp_add_i32(v, _DPP_ROW_BCAST31, row_mask=0xC)
+
+
+_DPP_ROW_SHR = 0x110
+
+
+_DPP_ROW_BCAST31 = 0x143
+
+
+_DPP_ROW_BCAST15 = 0x142
+
+
+def _dpp_add_i32(acc, ctrl, row_mask=0xF):
+    """acc + DPP(acc, ctrl); masked-off and shifted-in lanes contribute 0."""
+    raw = _raw(acc)
+    r = rocdl.update_dpp(raw.type, _raw(fx.Int32(0)), raw, ctrl, row_mask, 0xF, True)
+    return acc + ArithValue(_res_of(r))


### PR DESCRIPTION
# Description

The FlyDSL MXFP4 dense and grouped GEMM kernels are retuned for the gpt-oss-20b MoE shapes on gfx950. The work was driven by a benchmark board that scores the MoE projections under **unbalanced expert routing**, which is where the previous kernels lost the most: a hot expert forced every group onto its tiling, so the wgrad collapsed as soon as the token distribution stopped being uniform.

Two changes carry almost all of the gain:

- **wgrad tile blocking is chosen from the per-group contraction, not one global config.** A short contraction writes G× more C for the same FLOP, so the store saturates and evicts the operand slabs it shares L2 with — a non-temporal store buys those hits back. Past one CU's worth of tiles the machine sits inside a single group, so its own operand rows must stay resident and the wide band wins instead.
- **A thinner NT candidate for the tall-narrow shapes** the MoE projections produce.

This branch is rebased onto `main` as a single commit. `main`'s own work on these files is preserved rather than overwritten — `StoreCPlain` now carries both the `beta_is_one` accumulate epilogue (grad accumulation fuse, #443) and the interleaved-column/span-drop store this work needs, and the `_out_ty` hoist from #440 is re-applied at both store sites of the restructured file. Only the MXFP4 kernels are taken from the tuning branch; the MXFP8/FP8 kernels it also touched are left to their own branches.

Fixes # (N/A)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring *(performance tuning; no API change)*

## Changes

- **`flydsl/grouped_gemm/grouped_gemm_mxfp4_kernel.py`** — wgrad tile blocking selected from the mean per-group contraction, with a second split on the per-group tile count; non-temporal C store for the thin-group arm; lane-resident group table (a tile's contraction bounds cost one `v_readlane` instead of a global load an occ=1 prologue cannot hide) replacing the serial G-wide compare tree; LPT walk order so the longest group is not exposed as a tail; band-cyclic XCD remap.
- **`flydsl/gemm/gemm_mxfp4_kernel.py`** — `half_g2s` / `cst_nt` whole-loop variants (live-R-half operand streaming, non-temporal fused store); peeled-epilogue variants that fold the C store into the MFMA stream. Per-accumulator MFMA order is unchanged, so C is bit-identical to the unfolded peel.
- **`flydsl/utils/gemm_helper.py`** — adds only what these kernels need: the lane-table group search with its DPP scan primitives, power-of-two `ceildiv`/`floordiv` for device values (signed `//` lowers to a costly `floordivsi`; gfx9 has no scalar integer divide), and the XCD band remap.

## Benchmark

gfx950 (MI355X), single GPU, kernel-only. gpt-oss-20b deployment regime read from an e2e trace: **EP1 → G=32 local experts, per-expert M=4096 (Mtot=131072), hidden 2880 128-padded to 2944, gate_up N=5760 / down N=2944**. FLOP = `2·Mtot·K·N`; TFLOP/s from min-of-30. Both sides measured back-to-back on the same GPU with the same script.

Token distributions: `balanced` = 32×4096; `moderate` / `heavy` = `1/(i+1)^1.1` / `1/(i+1)^2.2`; `extreme` = 4 experts hold everything, 28 empty groups.

| dist | op | proj | main (TF) | this PR (TF) | speedup |
|---|---|---|---:|---:|---:|
| balanced | fwd | gate_up | 3113 | **4245** | 1.36× |
| balanced | fwd | down | 2750 | **4027** | 1.46× |
| balanced | dgrad | gate_up | 3518 | **4575** | 1.30× |
| balanced | dgrad | down | 2747 | **4004** | 1.46× |
| balanced | wgrad | gate_up | 3895 | **4336** | 1.11× |
| balanced | wgrad | down | 3584 | **4187** | 1.17× |
| moderate | fwd | gate_up | 2929 | **4193** | 1.43× |
| moderate | fwd | down | 2779 | **4115** | 1.48× |
| moderate | dgrad | gate_up | 3478 | **4577** | 1.32× |
| moderate | dgrad | down | 2747 | **4054** | 1.48× |
| moderate | wgrad | gate_up | 3807 | **4325** | 1.14× |
| moderate | wgrad | down | 3626 | **4190** | 1.16× |
| heavy | fwd | gate_up | 2832 | **4321** | 1.53× |
| heavy | fwd | down | 2698 | **4144** | 1.54× |
| heavy | dgrad | gate_up | 3309 | **4659** | 1.41× |
| heavy | dgrad | down | 2707 | **4154** | 1.53× |
| heavy | wgrad | gate_up | 3552 | **3902** | 1.10× |
| heavy | wgrad | down | 3517 | **4033** | 1.15× |
| extreme | fwd | gate_up | 2927 | **4407** | 1.51× |
| extreme | fwd | down | 2612 | **4356** | 1.67× |
| extreme | dgrad | gate_up | 3250 | **4744** | 1.46× |
| extreme | dgrad | down | 2613 | **4321** | 1.65× |
| extreme | wgrad | gate_up | 3567 | **4017** | 1.13× |
| extreme | wgrad | down | 3382 | **3609** | 1.07× |

Per-distribution geomean speedup: **balanced 1.30× · moderate 1.33× · heavy 1.36× · extreme 1.39×**.

**All 24 cells: geomean 1.345×, min 1.07×, max 1.67×. No cell regresses.** The gain grows with skew, which is what the change targets.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation *(no user-facing API change)*
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Both suites pass on top of `main`, in the default run and in the deterministic run that pins the FlyDSL backend:

| suite | default | `--deterministic-only` |
|---|---|---|
| `tests/pytorch/ops/test_grouped_gemm_fp4.py` | 2108 passed, 128 skipped | **128 passed** (64 of them `backend=FLYDSL`), 2108 skipped |
| `tests/pytorch/ops/test_gemm_fp4.py` | 177 passed, 715 skipped | 15 passed, 877 skipped |

The deterministic suite is the one that covers this change: it pins `BackendType.FLYDSL`, runs fwd + dgrad + wgrad bit-exact across 10 repeats with the B-scale workspace poisoned by a distinct sentinel per repeat, and includes the unbalanced (`balance=False`) routing this PR targets.
