### PR TITLE
fix: loosen flydsl install requires on gfx1250

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -524,13 +524,13 @@ if __name__ == "__main__":
     entry_points = {}
     install_requires = [
         "scipy",
+        "flydsl==0.2.4",
     ]
 
-    # TODO(ruibin): Triton 3.7.0 and flydsl 0.2.4 does not support gfx1250, so we skip their installation when building for gfx1250.
+    # TODO(ruibin): Triton 3.7.0 does not support gfx1250, so we skip their installation when building for gfx1250.
     offload_arch_list, _ = get_offload_archs()
     if "--offload-arch=gfx1250" not in offload_arch_list:
         install_requires.append("triton>=3.7.0")
-        install_requires.append("flydsl==0.2.4")
     else:
         print("[Primus-Turbo Setup] Building for gfx1250; skipping triton dependency.")
 


### PR DESCRIPTION
# Description

Previously, `flydsl==0.2.4` was only added to `install_requires` when the build was **not** targeting gfx1250, because Triton 3.7.0 and flydsl 0.2.4 were assumed to lack gfx1250 support.

flydsl 0.2.4 can now be installed on gfx1250, so pinning it only for non-gfx1250 builds was too strict and left gfx1250 environments without the required dependency.

This change always installs `flydsl==0.2.4` and still skips `triton>=3.7.0` on gfx1250, since Triton 3.7.0 still does not support that architecture.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Always include `flydsl==0.2.4` in `install_requires`, including gfx1250 builds.
- Keep skipping `triton>=3.7.0` when `--offload-arch=gfx1250` is in the offload arch list.
- Update the gfx1250 setup comment so it only mentions the Triton limitation.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
