### PR TITLE
fix(grouped-gemm): BLOCK_K=32 for variable-K on gfx942 to avoid Triton 3.8.0 VGPR spill (AIMA-250)

### DIFF
--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
@@ -162,7 +162,12 @@ def _get_gg_bf16_vk_config(OUT_M, OUT_N, avg_k, dtype_lhs, dtype_rhs, G, num_sms
                 BLOCK_M, BLOCK_N, group_m = om, on, ogm
                 cache_a, cache_b = oc_a, oc_b
     else:
-        BLOCK_M, BLOCK_N, BLOCK_K = 256, 256, 64
+        # BLOCK_K=32 (not 64): on Triton 3.8.0 the 256x256x64 variable-K tile
+        # overflows the VGPR file and spills (n_regs=256, n_spills=65), making
+        # this kernel up to 5.4x slower than on Triton 3.7.1 (AIMA-250). BK=32
+        # keeps the 256x256 output tile, drops spills to 0, and is 1.6-3.5x
+        # faster in microbench / 1.44x faster end-to-end. Matches gfx950 above.
+        BLOCK_M, BLOCK_N, BLOCK_K = 256, 256, 32
         group_m = 4
         num_stages_val = 2
         cache_a, cache_b = ".ca", ".ca"


### PR DESCRIPTION
## Summary

Fixes a severe MoE backward-pass performance regression on Triton 3.8.0 by changing `BLOCK_K` from 64 to 32 in the gfx942 branch of `_get_gg_bf16_vk_config` — the config used by the variable-K grouped GEMM (`_grouped_variable_k_gemm_kernel`), which computes the MoE expert-weight gradient (dW2).

Tracked in **AIMA-250**: DeepSeek-V2-Lite BF16 pretraining regressed ~48.7% (17.05 → 25.35 s/iter) between Primus v26.5 (Triton 3.7.1) and v26.5.1rc (Triton 3.8.0), with the entire delta localized to this one kernel (1.68 → 9.12 ms/launch, ~5.4×).

## Root cause

The kernel source is byte-identical across the two releases; only the Triton compiler changed (3.7.1 → 3.8.0). On 3.8.0 the `256×256×64` variable-K tile on gfx942 overflows the VGPR file and spills:

| Config | n_regs | n_spills |
|---|---|---|
| BLOCK_K=64 (old default) | 256 (maxed) | **65** |
| BLOCK_K=32 (this PR) | 248 | **0** |

The gfx950 branch already uses `BLOCK_K=32`; this brings gfx942 in line.

## Fix

One line in `_get_gg_bf16_vk_config` (gfx942 `else` branch): `BLOCK_K` 64 → 32. The 256×256 output tile is unchanged, so grid/occupancy logic is unaffected.

## Microbenchmark (MI300X, Triton 3.8.0, DSv2-Lite dW2 shapes: G=64, OUT_M=1408, OUT_N=2048)

| avg tokens/expert | BK=64 (old) | BK=32 (fix) | speedup | spills 64→32 |
|---|---|---|---|---|
| 128  | 429 µs  | 267 µs  | 1.60× | 65 → 0 |
| 256  | 712 µs  | 364 µs  | 1.95× | 65 → 0 |
| 512  | 1528 µs | 594 µs  | 2.57× | 65 → 0 |
| 1024 | 2945 µs | 946 µs  | 3.11× | 65 → 0 |
| 2048 | 6603 µs | 1878 µs | 3.51× | 65 → 0 |

Correctness vs an fp32 reference grouped matmul: rel-err 1.66e-03 for both configs (pure BF16 rounding).

## End-to-end training (DeepSeek-V2-Lite BF16, 8× MI300X, EP=8, mock data, 50 iters, image `primus_the_rock_ci_4c14768_20260820`, Triton 3.8.0)

| | s/iter (steady, iters 5–50) | TFLOP/s/GPU |
|---|---|---|
| Before (BK=64) | 25.98 | 213 |
| After (BK=32)  | **18.00** | **308** |

**1.44× faster (−30.7% s/iter).** Recovers ~89% of the AIMA-250 regression vs the v26.5 baseline (17.05 s/iter). Loss curve unchanged and healthy (11.85 → 7.27 over 50 iters); run exits cleanly.

## Test plan

- [x] Numerical correctness vs reference (rel-err 1.66e-03, unchanged)
- [x] VGPR spills eliminated (65 → 0) via compiled-kernel `n_spills`
- [x] Microbenchmark sweep across token loads
- [x] Full DSv2-Lite training run before vs after (25.98 → 18.00 s/iter)

Fixes AIMA-250.
