### PR TITLE
feat: add grouped_mlp_fp8 and fuse silu fwd and bwd into grouped gemm kernel

### DIFF
--- a/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_glu_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_glu_kernel.py
@@ -1,0 +1,471 @@
+###############################################################################
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2025 FlyDSL Project Contributors
+#
+# Adapted from FlyDSL (https://github.com/ROCm/FlyDSL)
+# Modified by the Primus-Turbo team.
+#
+# This file is distributed under the Apache License 2.0 (see LICENSE-APACHE),
+# not the MIT license that covers the rest of Primus-Turbo (see LICENSE).
+###############################################################################
+
+"""FlyDSL fp8 per-tensor grouped GEMM with the SwiGLU activation fused in.
+
+Two entries: the fc1 forward, which emits the pre-activation ``l1`` and the
+activation together, and the fc2 dgrad, which consumes ``dact`` in registers so
+it never reaches HBM. Both go through the shared NT/NN kernel factories in
+``grouped_gemm_fp8_kernel``, which carry the fused epilogue behind their ``glu``
+and ``dglu`` flags -- the fusion reuses those mainloops rather than forking them,
+so what lives here is the entry layer and the swizzle race it needs.
+"""
+
+from typing import NamedTuple
+
+import torch
+from flydsl.compiler.kernel_function import CompilationContext
+
+from primus_turbo.flydsl.grouped_gemm.grouped_gemm_fp8_kernel import (
+    _GG_SCHED_HINTS,
+    _GROUPED_AGPR,
+    _balanced_group_offs,
+    _compile_grouped_nn,
+    _compile_grouped_nt,
+)
+
+_GROUPED_GLU_CACHE: dict = {}
+
+# Swizzle arms for the fused entries, per direction. Each of these wins at some
+# measured shape; the ones left out are dominated everywhere (group-major (1, 4)
+# is 3-20% down at every shape).
+_GLU_NT_CANDS = ((4, 4), (4, 8), (8, 8), (4, 0))
+_GLU_NN_CANDS = ((4, 4), (8, 4), (8, 8), (4, 8))
+
+
+def _glu_probe_m(G: int) -> int:
+    """Rows for the race's synthetic probe: production scale, and enough to fill.
+
+    One canonical M, unlike the plain path's two: what moves with M is under
+    1.5%, not worth a second point in a race this slow per launch.
+    """
+    pm = max(1024, -(-32768 // max(G, 1)))  # >= 32768 rows, so the grid fills
+    return G * pm
+
+
+def _glu_race_time(launch, args, warmup=40, reps=3, iters=20):
+    """Median-of-`reps`. Shorter warmup than ``_robust_time``: its 250 iters are
+    for short-K kernels that mis-pick before boost clock, and these are two
+    orders of magnitude longer per launch, so they get there in a few."""
+    for _ in range(warmup):
+        launch(*args)
+    torch.cuda.synchronize()
+    ts = []
+    for _ in range(reps):
+        e0 = torch.cuda.Event(enable_timing=True)
+        e1 = torch.cuda.Event(enable_timing=True)
+        e0.record()
+        for _ in range(iters):
+            launch(*args)
+        e1.record()
+        torch.cuda.synchronize()
+        ts.append(e0.elapsed_time(e1) / iters)
+    ts.sort()
+    return ts[len(ts) // 2]
+
+
+def _autotune_glu(build, cands, mk_probe):
+    """Race the tile swizzle for a fused GLU kernel and return the winner.
+
+    Same shape as the plain path's race, for the same reasons: time on a
+    *balanced* synthetic distribution so the pick depends only on the static
+    shape and not on whichever token skew the first real call happens to carry,
+    and guard each arm numerically so a bad compile cannot win on speed alone.
+    Only the swizzle is raced; an arm compiled unlike production would not
+    transfer.
+
+    Worth racing at all because the spread runs both ways: the hardcoded (4, 4)
+    is within 0.4% at the two production MLP widths but up to 9% off elsewhere.
+    """
+    probe = mk_probe()
+    if probe is None:  # probe would not fit; keep the static arm
+        return build(*cands[0])
+    args, out_view = probe
+
+    base = build(*cands[0])
+    base(*args)
+    torch.cuda.synchronize()
+    # Cloned: the other arms overwrite out_view, and .float() is a no-op view
+    # when the output is already fp32.
+    ref = out_view.detach().float().clone()
+    refnorm = float((ref * ref).sum().item()) or 1.0
+
+    def score(launch):
+        launch(*args)
+        torch.cuda.synchronize()
+        o = out_view.detach().float()
+        e = float(((o - ref) * (o - ref)).sum().item())
+        if (e / refnorm) >= (2e-2**2) or not torch.isfinite(o.view(-1)[:1024]).all().item():
+            return None
+        return _glu_race_time(launch, args)
+
+    best, bs = base, score(base)
+    for cand in cands[1:]:
+        # An arm that will not build is one arm lost, not a failed call: the base
+        # is the config that shipped, so it is always there to fall back on.
+        try:
+            cl = build(*cand)
+        except Exception:
+            continue
+        s = score(cl)
+        if s is not None and bs is not None and s < bs * 0.985:  # past the noise margin
+            best, bs = cl, s
+
+    # Hand the allocator back the probe outright. The probes run to a gigabyte a
+    # side, and leaving them in the caching allocator was measured to make the
+    # *plain* GEMM's own race, running later in the same process, mis-pick an arm
+    # and stay 2x slow for the rest of it.
+    probe = args = out_view = ref = None
+    torch.cuda.empty_cache()
+    return best
+
+
+def grouped_gemm_fp8_glu_tensorwise_flydsl_kernel(
+    a: "torch.Tensor",
+    b: "torch.Tensor",
+    a_scale: "torch.Tensor",
+    b_scale: "torch.Tensor",
+    probs: "torch.Tensor",
+    group_offs: "torch.Tensor",
+    act_out: "torch.Tensor",
+    intermediate_out: "torch.Tensor",
+    trans_b: bool = False,
+    *,
+    activation: str = "silu",
+    out_dtype=torch.bfloat16,
+    num_cu: "int | None" = None,
+) -> "tuple[torch.Tensor, torch.Tensor]":
+    """FlyDSL fc1 grouped fp8 GEMM with a fused SwiGLU epilogue, matching the Triton entry.
+
+    Computes ``l1 = [gate|up] = (a[g] @ b[g]^T) * a_scale * b_scale`` [M, 2I] and
+    ``act = silu(gate) * up * probs`` [M, I] in one launch, both in ``out_dtype``.
+    ``l1`` is written because backward's dswiglu needs both halves; ``act`` is the
+    only one that carries ``probs``.
+
+    Where the Triton twin computes a 2I-wide tile and permutes it to bring gate
+    beside up (its epilogue's largest single cost), this points the tile's second
+    B pool at the up half of the weight, so the pair already shares a lane. See
+    ``StoreCSwiGLU``.
+
+    NT only (``trans_b=True``, b [G, 2I, K]): the pairing lives in the NT body's
+    quadrant registers, and the NN twin has no equivalent hook yet.
+
+    Args:
+        act_out: [M_total, I] buffer receiving the activation.
+        intermediate_out: [M_total, 2I] buffer receiving ``l1``. Both are the
+            caller's to allocate: every slot is written, so neither needs
+            initialising.
+
+    Returns:
+        ``(act_out, intermediate_out)``.
+    """
+    assert activation == "silu", f"FlyDSL fused GLU implements silu only, got {activation}"
+    assert trans_b, "FlyDSL fused GLU is NT only: pass b as [G, 2I, K]"
+    assert a.ndim == 2 and b.ndim == 3
+    M_total, K = a.shape
+    G = b.shape[0]
+    N2, K_b = b.shape[1], b.shape[2]
+    assert K == K_b, f"K mismatch a={K} b={K_b}"
+    assert N2 % 2 == 0, f"fc1 width must be even (gate||up), got {N2}"
+    I = N2 // 2
+    assert probs.ndim == 1 and probs.shape[0] == M_total and probs.dtype == torch.float32
+
+    act, l1 = act_out, intermediate_out
+    assert act.shape == (M_total, I) and act.dtype == out_dtype and act.device == a.device
+    assert l1.shape == (M_total, N2) and l1.dtype == out_dtype and l1.device == a.device
+
+    _go64 = group_offs if group_offs.dtype == torch.int64 else group_offs.to(torch.int64)
+    go32 = _go64.view(torch.int32)
+    out_fp16 = out_dtype == torch.float16
+    cbsz = 1 if a.dtype == torch.float8_e5m2 else 0
+    blgp = 1 if b.dtype == torch.float8_e5m2 else 0
+    _capped = num_cu is not None and num_cu > 0
+    ckey = (I, K, G, out_fp16, cbsz, blgp, num_cu if _capped else 0)
+
+    launch = _GROUPED_GLU_CACHE.get(ckey)
+    if launch is None:
+
+        def _build(_xcd, _gm):
+            return _compile_grouped_nt(
+                K=K,
+                G=G,
+                BLOCK_M=256,
+                BLOCK_N=256,
+                nt_vmcnt=3,
+                # Raced per shape over _GLU_NT_CANDS, not defaulted: taking the
+                # plain entry's row-major default literally cost 0.66 ms of L2
+                # reuse at I=5760 (8.2 GB of extra HBM reads).
+                num_xcd=_xcd,
+                agpr_inplace=_GROUPED_AGPR,
+                out_fp16=out_fp16,
+                cbsz=cbsz,
+                blgp=blgp,
+                group_m=_gm,
+                # The pair store is the scalar path's; CShuffle stages one fragment
+                # through LDS and has nowhere to put the second.
+                store_cshuffle=False,
+                sched_schedbar=True,
+                # One tile per WG unless the caller reserves CUs, matching the
+                # plain GEMM's fast path: the scf.for tile loop costs ~0.6 ms at
+                # this shape against a straight-line one-tile body.
+                persistent=_capped,
+                cap_cu=(num_cu if _capped else -1),
+                N=I,
+                glu=True,
+                glu_i=I,
+                # Non-temporal on both output streams, worth 1.11x: 4.4 GB that
+                # nothing here reads again would otherwise evict the A/B tiles the
+                # next mainloop wants. Bit 1 is the one that pays -- bit 4
+                # (aux=16) costs 1.5x, so this is not a monotone knob.
+                cstore_aux=2,
+                glu_act_aux=2,
+            )
+
+        def _probe():
+            M_c = _glu_probe_m(G)
+            try:
+                a_c = torch.empty((M_c, K), device=a.device, dtype=torch.uint8)
+                a_c.random_(0, 64, generator=torch.Generator(device=a.device).manual_seed(0))
+                l1_c = torch.empty((M_c, N2), device=a.device, dtype=out_dtype)
+                act_c = torch.empty((M_c, I), device=a.device, dtype=out_dtype)
+                probs_c = torch.ones(M_c, device=a.device, dtype=torch.float32)
+            except torch.cuda.OutOfMemoryError:
+                return None
+            return (
+                a_c.view(torch.int8),
+                b.view(torch.int8),
+                l1_c,
+                act_c,
+                probs_c,
+                a_scale.float().reshape(1),
+                b_scale.float().reshape(1),
+                _balanced_group_offs(M_c, G, a.device),
+                M_c,
+                I,
+                torch.cuda.current_stream(),
+            ), act_c
+
+        with CompilationContext.compile_hints(_GG_SCHED_HINTS):
+            launch = _autotune_glu(_build, _GLU_NT_CANDS, _probe)
+        _GROUPED_GLU_CACHE[ckey] = launch
+
+    with CompilationContext.compile_hints(_GG_SCHED_HINTS):
+        launch(
+            a.view(torch.int8),
+            b.view(torch.int8),
+            l1,
+            act,
+            probs,
+            a_scale.float().reshape(1),
+            b_scale.float().reshape(1),
+            go32,
+            M_total,
+            I,  # c_n is the gate width; the kernel derives 2I where it needs it
+            torch.cuda.current_stream(),
+        )
+    return act, l1
+
+
+_GROUPED_DGLU_CACHE: dict = {}
+
+_DGLU_BLOCK_N = 256
+
+
+class GradProbsPartialSpec(NamedTuple):
+    """The grad_probs partial buffer a fused dgrad expects from its caller."""
+
+    shape: "tuple[int, int]"
+    needs_zero: bool
+
+
+def grouped_gemm_fp8_dglu_grad_probs_partial_spec(
+    a: "torch.Tensor", b: "torch.Tensor"
+) -> GradProbsPartialSpec:
+    """The buffer :func:`grouped_gemm_fp8_dglu_tensorwise_flydsl_kernel` expects.
+
+    ``grad_probs_partial.sum(0)`` is the gradient wrt ``probs``. Allocating and
+    folding stay with the caller, so this module owns neither.
+
+    One slice per ``(block_n, 16-lane half)``, rather than the Triton twin's one
+    per tile: every wave's rows are disjoint in the banded epilogue, so waves
+    share a slice and only the column block and the half of the 32 lanes
+    covering a row have to be distinct.
+
+    ``needs_zero`` is True, unlike the Triton twin: a group's last M-tile is
+    clamped off at ``m_end``, so the rows past it are never written and would
+    otherwise poison the fold.
+
+    Returns:
+        ``shape`` is ``(n_blocks * 2, M_total)``, float32.
+    """
+    M_total = a.shape[0]
+    I = b.shape[2]
+    n_blocks = -(-I // _DGLU_BLOCK_N)
+    return GradProbsPartialSpec(shape=(n_blocks * 2, M_total), needs_zero=True)
+
+
+def grouped_gemm_fp8_dglu_tensorwise_flydsl_kernel(
+    a: "torch.Tensor",
+    b: "torch.Tensor",
+    a_scale: "torch.Tensor",
+    b_scale: "torch.Tensor",
+    intermediate: "torch.Tensor",
+    group_offs: "torch.Tensor",
+    probs: "torch.Tensor",
+    out: "torch.Tensor",
+    grad_probs_partial: "torch.Tensor",
+    trans_b: bool = False,
+    *,
+    activation: str = "silu",
+    num_cu: "int | None" = None,
+) -> "torch.Tensor":
+    """FlyDSL fc2 dgrad with the SwiGLU gradient fused into its epilogue.
+
+    Computes ``dact = (a[g] @ b[g]) * a_scale * b_scale`` and consumes it in
+    registers, so ``dact`` never reaches HBM:
+
+        dl1 = [f'(gate) * up * (dact * probs) | f(gate) * (dact * probs)]
+
+    Unlike the forward twin this needs no tile geometry changes -- the GEMM's N
+    axis is already I, so gate and up are a plain pair of global reads I columns
+    apart. What it adds is the ``grad_probs`` reduction, whose sum spans all of
+    I while a tile spans 256 columns: each wave folds the columns it owns and
+    writes one partial for the caller to sum. No atomics, so the result is
+    bitwise reproducible, matching the Triton entry.
+
+    NN only (``trans_b=False``, b [G, K, I]).
+
+    Args:
+        out: [M_total, 2I] buffer receiving ``dl1``, in ``intermediate``'s dtype,
+            gate gradient in [:, :I] and up in [:, I:].
+        grad_probs_partial: float32 buffer receiving the grad_probs partials, as
+            :func:`grouped_gemm_fp8_dglu_grad_probs_partial_spec` describes it --
+            including that it has to arrive zeroed.
+
+    Returns:
+        ``out``, for call-site convenience.
+    """
+    assert activation == "silu", f"FlyDSL fused dGLU implements silu only, got {activation}"
+    assert not trans_b, "FlyDSL fused dGLU is NN only: pass b as [G, K, I]"
+    assert a.ndim == 2 and b.ndim == 3 and intermediate.ndim == 2
+    M_total, K = a.shape
+    G, K_b, I = b.shape
+    assert K == K_b, f"K mismatch a={K} b={K_b}"
+    assert intermediate.shape == (M_total, 2 * I), (
+        f"intermediate must be [{M_total}, {2 * I}], got {tuple(intermediate.shape)}"
+    )
+    assert probs.ndim == 1 and probs.shape[0] == M_total and probs.dtype == torch.float32
+
+    out_dtype = intermediate.dtype
+    assert out.shape == (M_total, 2 * I) and out.dtype == out_dtype
+    partial_shape = grouped_gemm_fp8_dglu_grad_probs_partial_spec(a, b).shape
+    assert grad_probs_partial.shape == partial_shape and grad_probs_partial.dtype == torch.float32, (
+        f"grad_probs_partial must be {list(partial_shape)} float32, got "
+        f"{list(grad_probs_partial.shape)} {grad_probs_partial.dtype}; "
+        "size it with grouped_gemm_fp8_dglu_grad_probs_partial_spec"
+    )
+    dl1 = out
+
+    _go64 = group_offs if group_offs.dtype == torch.int64 else group_offs.to(torch.int64)
+    go32 = _go64.view(torch.int32)
+    out_fp16 = out_dtype == torch.float16
+    cbsz = 1 if a.dtype == torch.float8_e5m2 else 0
+    blgp = 1 if b.dtype == torch.float8_e5m2 else 0
+    _capped = num_cu is not None and num_cu > 0
+    ckey = (I, K, G, out_fp16, cbsz, blgp, num_cu if _capped else 0)
+
+    launch = _GROUPED_DGLU_CACHE.get(ckey)
+    if launch is None:
+
+        def _build(_xcd, _gm):
+            return _compile_grouped_nn(
+                K=K,
+                G=G,
+                BLOCK_M=256,
+                BLOCK_N=_DGLU_BLOCK_N,
+                nt_vmcnt=3,
+                # Raced per shape over _GLU_NN_CANDS. The arms differ from the
+                # forward's -- (8, 4) pays here and row-major does not -- and the
+                # spread reaches 1.090x at I=1024.
+                num_xcd=_xcd,
+                group_m=_gm,
+                agpr_inplace=_GROUPED_AGPR,
+                out_fp16=out_fp16,
+                cbsz=cbsz,
+                blgp=blgp,
+                store_cshuffle=False,
+                sched_schedbar=False,
+                persistent=_capped,
+                cap_cu=(num_cu if _capped else -1),
+                N=I,
+                dglu=True,
+                glu_i=I,
+                # Non-temporal, as in the forward, but this only pays because the
+                # banded epilogue's accesses are whole lines: at 64 bytes a store
+                # is half a line whose other half belongs to the neighbouring
+                # wave, and the two have to meet in L2 to form one, which
+                # non-temporal prevents. Per-wave staging preferred aux=0.
+                cstore_aux=2,
+            )
+
+        def _probe():
+            M_c = _glu_probe_m(G)
+            try:
+                a_c = torch.empty((M_c, K), device=a.device, dtype=torch.uint8)
+                a_c.random_(0, 64, generator=torch.Generator(device=a.device).manual_seed(0))
+                # Not zeros: at gate = up = 0 every gradient is 0 for every arm,
+                # which would leave the numeric guard comparing zero to zero.
+                l1_c = torch.empty((M_c, 2 * I), device=a.device, dtype=out_dtype)
+                l1_c.uniform_(-2.0, 2.0)
+                dl1_c = torch.empty((M_c, 2 * I), device=a.device, dtype=out_dtype)
+                probs_c = torch.ones(M_c, device=a.device, dtype=torch.float32)
+                grad_probs_c = torch.zeros((partial_shape[0], M_c), device=a.device, dtype=torch.float32)
+            except torch.cuda.OutOfMemoryError:
+                return None
+            return (
+                a_c.view(torch.int8),
+                b.view(torch.int8),
+                dl1_c,
+                a_scale.float().reshape(1),
+                b_scale.float().reshape(1),
+                _balanced_group_offs(M_c, G, a.device),
+                l1_c,
+                probs_c,
+                grad_probs_c,
+                M_c,
+                I,
+                M_c,
+                torch.cuda.current_stream(),
+            ), dl1_c
+
+        with CompilationContext.compile_hints(_GG_SCHED_HINTS):
+            launch = _autotune_glu(_build, _GLU_NN_CANDS, _probe)
+        _GROUPED_DGLU_CACHE[ckey] = launch
+
+    with CompilationContext.compile_hints(_GG_SCHED_HINTS):
+        launch(
+            a.view(torch.int8),
+            b.view(torch.int8),
+            dl1,
+            a_scale.float().reshape(1),
+            b_scale.float().reshape(1),
+            go32,
+            intermediate,
+            probs,
+            grad_probs_partial,
+            M_total,
+            I,
+            M_total,
+            torch.cuda.current_stream(),
+        )
+    return dl1

--- a/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -44,8 +44,10 @@ from primus_turbo.flydsl.utils.gemm_helper import (
     S2RLoader,
     S2RLoaderShear,
     S2RLoaderTr,
+    StoreCdSwiGLUCShuffle,
     StoreCPerTensor,
     StoreCPerTensorCShuffle,
+    StoreCSwiGLU,
     _lane_tbl_count_le,
     _lane_tbl_get,
     _lane_tbl_load,
@@ -206,6 +208,8 @@ def _compile_grouped_nn(
     nn_elgk: bool = True,  # graded drain of the B transpose reads: the b0 stage rides the a0 fragment's compiler-scored wait, the b1 stage drains one tile at a time inside its mfma column. Off = one lgkmcnt(0) per stage with no mfma to cover it
     nn_esplit: int = 4,  # epilogue store schedule, see _NN_E_SCHED: how the tile's four accumulator quadrants are split into barrier-separated store batches. 0 = one 128-store burst after the trailing barrier
     beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
+    dglu: bool = False,  # fuse the SwiGLU gradient into the epilogue: read l1, write dl1 [M,2I] and grad_probs partials, so dact never reaches HBM
+    glu_i: int = 0,  # activation width I; the GEMM's N already equals it, so no geometry changes (unlike the fwd)
 ):
     """Persistent (CPU-sync-free) grouped NN dgrad: a fixed grid of WGs strides the tile
     space via scf.for, amortising per-WG fixed cost. ``group_m``/``group_n`` port the NT
@@ -248,9 +252,27 @@ def _compile_grouped_nn(
     # The split reorders the quadrants of the scalar epilogue; the LDS-staged CShuffle one
     # shares a single staging buffer across them and has to keep the emitted order.
     _esplit = 0 if store_cshuffle else nn_esplit
+    if dglu:
+        assert glu_i > 0 and not store_cshuffle and not beta_is_one
+        assert N == glu_i, f"dglu needs the GEMM's N to be I, got N={N} I={glu_i}"
+        # The half-N skip is fine for the pair store: the quadrant it drops is
+        # entirely past I on the boundary block, so it contributes nothing to
+        # grad_probs either, and the epilogue takes c_hi=None for it.
+        _col_safe = N > 0 and (N % BLOCK_N == 0 or (nn_halfn and N % LDS_BLOCK_N == 0))
 
     _cshuf_ty = fx.Float16 if out_fp16 else fx.BFloat16
     _cshuf_n = 8 * 16 * (N_TILES_B * 16)
+    if dglu:
+        # The staging pool and the shear's two extra A slots cannot both fit in
+        # the 160 KB that keeps this at one workgroup per CU, so the shear goes;
+        # dropping it is also what turns _cshuf_lds on. f32 because it stages
+        # dact, an input to the gradient: rounding to out_ty first would add a
+        # second rounding ahead of the math. One staging region per wave_m group
+        # (16 rows x the full 256 columns) = 32 KB, what the shear returned.
+        _kshear = False
+        _cshuf_lds = True
+        _cshuf_ty = fx.Float32
+        _cshuf_n *= 2
 
     @fx.struct
     class SharedStorage:
@@ -280,7 +302,11 @@ def _compile_grouped_nn(
         A_scale: fx.Tensor,
         B_scale: fx.Tensor,
         group_offs: fx.Tensor,  # int32 view of int64 [G+1]; _load_go reads low word at i32[2*idx]
+        L1: fx.Tensor,  # dglu only: saved fc1 pre-activation [M,2I]; C is passed twice otherwise
+        PROBS: fx.Tensor,  # dglu only: routing probs [M] fp32
+        GRAD_PROBS_PARTIAL: fx.Tensor,  # dglu only: [n_blocks*2, M] fp32 grad_probs partials
         c_n: fx.Int32,
+        grad_probs_stride: fx.Int32,
     ):
         _ = str(fx.thread_idx.x)  # materialize before S2RLoaderTr (dense NN note)
         F8_IR_t = fx.Float8E4M3FN.ir_type
@@ -452,7 +478,30 @@ def _compile_grouped_nn(
             b_s2r = S2RLoaderTr(
                 wave_n, N_TILES_B, 32, inline_asm=(agpr_inplace and acc_mode == "agpr"), wswz=_nnwz
             )
-            if const_expr(store_cshuffle):
+            if const_expr(dglu):
+                store_c = StoreCdSwiGLUCShuffle(
+                    A_scale,
+                    B_scale,
+                    C,
+                    L1,
+                    PROBS,
+                    GRAD_PROBS_PARTIAL,
+                    # Every wave's rows are disjoint, so a partial slice only has
+                    # to be distinct per (column block, 16-lane half).
+                    block_n * fx.Int32(2),
+                    grad_probs_stride,
+                    m_end,
+                    glu_i,
+                    mfma.idx,
+                    N_TILES_A,
+                    N_TILES_B,
+                    _out_ty,
+                    lds.C_lds_shuffle,
+                    wave_id,
+                    col_safe=_col_safe,
+                    store_aux=cstore_aux,
+                )
+            elif const_expr(store_cshuffle):
                 store_c = StoreCPerTensorCShuffle(
                     A_scale,
                     B_scale,
@@ -693,19 +742,28 @@ def _compile_grouped_nn(
                 # Epilogue store schedule: batching each quadrant behind a barrier keeps all
                 # waves inside one row/column band (contiguous columns) instead of one spread
                 # burst. Separator must be the barrier; a vmcnt throttle drains but never aligns.
-                _store_split(
-                    store_c,
-                    (
-                        (c00, 0, 0),
-                        (c01, 0, LDS_BLOCK_N),
-                        (c10, LDS_BLOCK_M, 0),
-                        (c11, LDS_BLOCK_M, LDS_BLOCK_N),
-                    ),
-                    base_row,
-                    base_col,
-                    _esplit,
-                    _full,
-                )
+                if const_expr(dglu):
+                    # Column pairs, not quadrants: grad_probs folds c00 with c01.
+                    # The half body has no c01/c11 to fold; that quadrant is all
+                    # past I, so it contributes nothing and the epilogue skips it.
+                    _hi0 = c01 if const_expr(_full) else None
+                    _hi1 = c11 if const_expr(_full) else None
+                    store_c.store_pair(c00, _hi0, base_row, base_col, LDS_BLOCK_N)
+                    store_c.store_pair(c10, _hi1, base_row + LDS_BLOCK_M, base_col, LDS_BLOCK_N)
+                else:
+                    _store_split(
+                        store_c,
+                        (
+                            (c00, 0, 0),
+                            (c01, 0, LDS_BLOCK_N),
+                            (c10, LDS_BLOCK_M, 0),
+                            (c11, LDS_BLOCK_M, LDS_BLOCK_N),
+                        ),
+                        base_row,
+                        base_col,
+                        _esplit,
+                        _full,
+                    )
 
             # Wave-uniform runtime half-N predicate (block_n is uniform per tile).
             _nb_last = n_blocks - fx.Int32(1)
@@ -758,9 +816,58 @@ def _compile_grouped_nn(
             A_scale,
             B_scale,
             group_offs,
+            # C into the unused dglu slots so one kernel body serves both; the
+            # const_expr branches keep the emitted code identical here.
+            C,
+            C,
+            C,
             c_n,
+            fx.Int32(0),
             value_attrs=attrs,
         ).launch(grid=(grid_x, 1, 1), block=(512, 1, 1), stream=stream)
+
+    if const_expr(dglu):
+
+        @flyc.jit
+        def launch_grouped_nn_dglu_persistent(
+            A: fx.Tensor,
+            B: fx.Tensor,
+            DL1: fx.Tensor,
+            A_scale: fx.Tensor,
+            B_scale: fx.Tensor,
+            group_offs: fx.Tensor,
+            L1: fx.Tensor,
+            PROBS: fx.Tensor,
+            GRAD_PROBS_PARTIAL: fx.Tensor,
+            m_total: int,
+            c_n: fx.Int32,
+            grad_probs_stride: fx.Int32,
+            stream: fx.Stream,
+        ):
+            n_blocks = ceildiv(c_n, BLOCK_N)
+            upper = (ceildiv(m_total, BLOCK_M) + G) * n_blocks
+            ncus = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+            _cap = ncus if cap_cu <= 0 else min(int(cap_cu), ncus)
+            grid_x = arith.select(upper < _cap, upper, fx.Int32(_cap)) if persistent else upper
+            attrs = make_value_attrs(
+                waves_per_eu, 128 if (agpr_inplace and acc_mode == "agpr") else 0, "512,512"
+            )
+            kernel_grouped_nn_persistent(
+                A,
+                B,
+                DL1,
+                A_scale,
+                B_scale,
+                group_offs,
+                L1,
+                PROBS,
+                GRAD_PROBS_PARTIAL,
+                c_n,
+                grad_probs_stride,
+                value_attrs=attrs,
+            ).launch(grid=(grid_x, 1, 1), block=(512, 1, 1), stream=stream)
+
+        return launch_grouped_nn_dglu_persistent
 
     return launch_grouped_nn_persistent
 
@@ -792,6 +899,9 @@ def _compile_grouped_nt(
     N: int = 0,  # compile-time output width (0 = unknown): lets _col_safe prove the epilogue's column OOB select dead. Part of the autotune cache key
     nt_esplit: int = 4,  # epilogue store schedule (see _NN_E_SCHED), the twin of the NN dgrad's nn_esplit. 0 = one 128-store burst
     beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
+    glu: bool = False,  # fuse a SwiGLU epilogue: B_T is [2I, K] gate||up, the tile pairs the two bands in registers and writes l1 [M,2I] + act [M,I]
+    glu_i: int = 0,  # gate half width I (required when glu); N is this same I, i.e. the activation's width
+    glu_act_aux: int = 0,  # aux immediate for the act store alone (it is pure streaming output, so evict-first may pay where it would not for l1)
 ):
     """Grouped NT forward (out = a @ b^T). persistent=True: a fixed grid of WGs strides the
     tile space via scf.for (cap_cu reserves CUs for comm overlap); persistent=False: one tile
@@ -817,20 +927,45 @@ def _compile_grouped_nt(
     b_lds_size = LDS_BLOCK_N * BLOCK_K
     KS = k_stride if k_stride else K  # addressing row stride (>= K); compute dim stays K
     assert KS >= K
+    # GLU mode retiles the N axis. A tile owns _NBLK = LDS_BLOCK_N columns of the
+    # *gate* half and pairs them with the same columns of the up half, so its two B
+    # LDS pools hold two 128-column *bands* of B_T (offset I apart) rather than the
+    # two halves of one 256-wide block. Total tiles are unchanged -- ceildiv(I, 128)
+    # equals ceildiv(2I, 256) -- so the mainloop does the same work; only where the
+    # second pool reads and where the results land differ.
+    if glu:
+        assert glu_i > 0 and N == glu_i, f"glu needs N == glu_i (the gate width); got N={N} glu_i={glu_i}"
+        # The pairing lives in the dist2 body's quadrant registers, and the pair
+        # store is the scalar path's (CShuffle stages one fragment through LDS).
+        assert nt_dist2 and not store_cshuffle, "fused GLU epilogue rides the scalar dist2 store path"
+        assert not beta_is_one, "fused GLU epilogue overwrites; there is nothing to accumulate into"
+    _NBLK = LDS_BLOCK_N if glu else BLOCK_N
     # Known N makes the scalar epilogue per-element OOB select dead (nt_dist2 supplies the in-bounds half-N boundary body).
-    _col_safe = N > 0 and (N % BLOCK_N == 0 or (nt_dist2 and N % LDS_BLOCK_N == 0))
-    _nb_c = ceildiv(N, BLOCK_N) if N > 0 else 0  # compile-time N-block count (0 = take it from c_n)
+    _col_safe = (
+        (N > 0 and N % _NBLK == 0)
+        if glu
+        else (N > 0 and (N % BLOCK_N == 0 or (nt_dist2 and N % LDS_BLOCK_N == 0)))
+    )
+    _nb_c = ceildiv(N, _NBLK) if N > 0 else 0  # compile-time N-block count (0 = take it from c_n)
     # Group-offs table form (see _SGPR_GO_MAX_G): SGPR/s_buffer_load vs lane-resident gather.
     _sgo = G <= _SGPR_GO_MAX_G
     # Boundary-N body width, in B column-tiles per wave (N_TILES_B=2 is the full tile). When
     # the last N-block's valid width fits the lower half of the b0 LDS pool its upper columns
     # are pure padding, so one column-tile per wave covers it. Needs the runtime half-N branch.
-    _bnd_ntb = 1 if (nt_dist2 and N > 0 and 0 < N % BLOCK_N <= LDS_BLOCK_N // 2) else N_TILES_B
+    # GLU never narrows: the second pool is the up band, not padding columns, so both
+    # column-tiles are always live and the N tail is handled by masking instead.
+    _bnd_ntb = (
+        N_TILES_B
+        if glu
+        else (1 if (nt_dist2 and N > 0 and 0 < N % BLOCK_N <= LDS_BLOCK_N // 2) else N_TILES_B)
+    )
     # B_T[G,N,KS] spans < 2^31 elements: its SRD base/extent then stay int32, and each group's
     # base is a compile-time constant that drops straight out of the tile decode. _B_GRP=1 keeps
     # the runtime form (the decode yields the plain group index and the caller scales it).
-    _b32 = N > 0 and G * N * KS < 2**31
-    _B_GRP = N * KS if _b32 else 1
+    # Under glu the weight is [G, 2I, KS], so the group stride is twice the gate width.
+    _bn_rows = 2 * glu_i if glu else N
+    _b32 = N > 0 and G * _bn_rows * KS < 2**31
+    _B_GRP = _bn_rows * KS if _b32 else 1
 
     _cshuf_ty = fx.Float16 if out_fp16 else fx.BFloat16
     _cshuf_n = 8 * 16 * (N_TILES_B * 16)
@@ -858,12 +993,19 @@ def _compile_grouped_nt(
     def kernel_grouped_nt_persistent(
         A: fx.Tensor,
         B_T: fx.Tensor,
-        C: fx.Tensor,
+        C: fx.Tensor,  # glu: l1 [M, 2I]
+        ACT: fx.Tensor,  # glu: act [M, I]. Otherwise unused -- the launch aliases it to C.
+        PROBS: fx.Tensor,  # glu: routing probs [M] fp32. Otherwise unused, aliased to C.
         A_scale: fx.Tensor,
         B_scale: fx.Tensor,
         group_offs: fx.Tensor,  # int32 view of int64 [G+1]; _load_go reads low word at i32[2*idx]
-        c_n: fx.Int32,
+        c_n: fx.Int32,  # glu: the gate width I, not the 2I the GEMM writes
     ):
+        # ACT/PROBS ride along in both modes because the body has to stay inside this
+        # decorator: @flyc.kernel rewrites the AST (dynamic `if` -> dispatch), and a
+        # body hoisted into a plain shared function would lose that. Under const_expr
+        # the plain GEMM never reads them, so they cost two dropped kernel args and
+        # nothing in the mainloop.
         F8_IR_t = fx.Float8E4M3FN.ir_type
         _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
         # Compile-time N (same autotune key supplies c_n): see the NN twin -- constant divisors
@@ -954,19 +1096,26 @@ def _compile_grouped_nt(
             a_nrec = (uindex(m_total) - uindex(m_row)) * arith.index(KS)
             if const_expr(_b32):
                 # Whole B_T fits in int32 -> base/extent are one int32 add and one int32 subtract.
-                _b_off = group_b + block_n * fx.Int32(BLOCK_N * KS)
+                _b_off = group_b + block_n * fx.Int32(_NBLK * KS)
                 b_base = uindex(_b_off)
-                b_nrec = arith.index(G * N * KS) - b_base
+                b_nrec = arith.index(G * _bn_rows * KS) - b_base
             else:
-                cn_i = arith.index_cast(T.index, c_n)
+                # glu: c_n is the gate width, so B_T's row count per group is 2*c_n.
+                bn_i = arith.index_cast(T.index, c_n * fx.Int32(2) if const_expr(glu) else c_n)
                 b_base = (
-                    arith.index_cast(T.index, group_b) * cn_i + arith.index_cast(T.index, block_n * BLOCK_N)
+                    arith.index_cast(T.index, group_b) * bn_i + arith.index_cast(T.index, block_n * _NBLK)
                 ) * arith.index(KS)
-                b_nrec = arith.index(G) * cn_i * arith.index(KS) - b_base
+                b_nrec = arith.index(G) * bn_i * arith.index(KS) - b_base
             A0_gl_offset = 0
             A1_gl_offset = LDS_BLOCK_M * KS
             B0_gl_offset = 0
-            B1_gl_offset = LDS_BLOCK_N * KS
+            # The one offset the whole fusion turns on: under glu the second B pool is
+            # the *up* band, I weight rows further in, not the next 128 columns. That is
+            # what puts gate[m, j] and up[m, j] in the same lane at the same fragment
+            # index, so the epilogue pairs them without a shuffle. Past the last full
+            # band both bands run off the end of B_T; the SRD clamps those reads and the
+            # epilogue's column mask drops the results.
+            B1_gl_offset = (glu_i * KS) if glu else (LDS_BLOCK_N * KS)
 
             gA = make_fp8_buffer_tensor_rebased(A, F8_IR_t, a_base, a_nrec)
             gB = make_fp8_buffer_tensor_rebased(B_T, F8_IR_t, b_base, b_nrec)
@@ -989,7 +1138,24 @@ def _compile_grouped_nt(
             b_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_B, F8_IR_t, wave_id)
             a_s2r = S2RLoader(wave_m, N_TILES_A)
             b_s2r = S2RLoader(wave_n, N_TILES_B)
-            if const_expr(store_cshuffle):
+            if const_expr(glu):
+                store_c = StoreCSwiGLU(
+                    A_scale,
+                    B_scale,
+                    C,  # l1 [M, 2I]
+                    ACT,  # act [M, I]
+                    PROBS,
+                    m_end,
+                    glu_i,
+                    mfma.idx,
+                    N_TILES_A,
+                    N_TILES_B,
+                    _out_ty,
+                    col_safe=_col_safe,
+                    store_aux=_cstore_aux,
+                    act_aux=glu_act_aux,
+                )
+            elif const_expr(store_cshuffle):
                 store_c = StoreCPerTensorCShuffle(
                     A_scale,
                     B_scale,
@@ -1043,7 +1209,8 @@ def _compile_grouped_nt(
                 wave_n_offset = wave_n * (N_TILES_B * 16)
                 wave_m_offset = wave_m * (N_TILES_A * 16)
                 _base_row = m_row + wave_m_offset
-                _base_col = block_n * BLOCK_N + wave_n_offset
+                # _NBLK == BLOCK_N unless glu, where a tile spans 128 gate columns.
+                _base_col = block_n * _NBLK + wave_n_offset
                 if const_expr(_bnd_ntb < N_TILES_B):
                     # Narrow twin of (mfma, b_s2r, b_g2s, store_c) for the boundary body: one B
                     # column-tile per wave and one g2s load step cover the same pool rows, so the
@@ -1208,21 +1375,34 @@ def _compile_grouped_nt(
                     if const_expr(_full):
                         c11 = _mm.call(a1_frag, b1_frag, c11)
                     rocdl.s_setprio(0)
-                    # Batched epilogue store, same lever as the NN dgrad body's; this one owns
-                    # the forward cells of the tw suite.
-                    _store_split(
-                        _st,
-                        (
-                            (c00, 0, 0),
-                            (c01 if _full else None, 0, LDS_BLOCK_N),
-                            (c10, LDS_BLOCK_M, 0),
-                            (c11 if _full else None, LDS_BLOCK_M, LDS_BLOCK_N),
-                        ),
-                        _base_row,
-                        _bcol,
-                        _esplit,
-                        _full,
-                    )
+                    if const_expr(glu):
+                        # The quadrants are (gate, up) pairs sharing rows rather than
+                        # four corners of one tile, so they leave in two pair stores.
+                        _st.store_pair(c00, c01, _base_row, _bcol)
+                        _st.store_pair(c10, c11, _base_row + LDS_BLOCK_M, _bcol)
+                    else:
+                        # Batched epilogue store, same lever as the NN dgrad body's; this one owns
+                        # the forward cells of the tw suite.
+                        _store_split(
+                            _st,
+                            (
+                                (c00, 0, 0),
+                                (c01 if _full else None, 0, LDS_BLOCK_N),
+                                (c10, LDS_BLOCK_M, 0),
+                                (c11 if _full else None, LDS_BLOCK_M, LDS_BLOCK_N),
+                            ),
+                            _base_row,
+                            _bcol,
+                            _esplit,
+                            _full,
+                        )
+
+                if const_expr(glu):
+                    # No half-N body under glu: the second pool holds the up band, not
+                    # padding columns, so both are always live and the N tail is masked
+                    # in the epilogue instead of being skipped here.
+                    _body_d2(2)
+                    return
 
                 # Wave-uniform runtime half-N predicate: last N-block whose valid width fits the b0 LDS half (b1 all padding).
                 _nb_last = n_blocks - fx.Int32(1)
@@ -1372,6 +1552,53 @@ def _compile_grouped_nt(
             gb, ts, ms, me = _find_group(tt)
             _do_tile(tt, gb, ts, ms, me)
 
+    def _grid_and_attrs(m_total, c_n):
+        """Tile count -> grid width, plus the launch value attrs. In GLU mode a tile
+        owns ``_NBLK`` columns of the *gate* half instead of BLOCK_N of the raw
+        output, and ``c_n`` is that gate width -- the tile count works out the same,
+        since two 128-wide bands replace one 256-wide block."""
+        n_blocks = ceildiv(c_n, _NBLK)
+        upper = (ceildiv(m_total, BLOCK_M) + G) * n_blocks
+        ncus = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
+        # cap_cu>0 reserves CUs for comm-compute overlap; cap_cu<=0 = full device.
+        _cap = ncus if cap_cu <= 0 else min(int(cap_cu), ncus)
+        # persistent: cap to _cap WGs. non-persistent: full grid, over-launched WGs s_endpgm.
+        grid_x = arith.select(upper < _cap, upper, fx.Int32(_cap)) if persistent else upper
+        attrs = make_value_attrs(waves_per_eu, 128 if (agpr_inplace and acc_mode == "agpr") else 0, "512,512")
+        return grid_x, attrs
+
+    if const_expr(glu):
+
+        @flyc.jit
+        def launch_grouped_nt_glu_persistent(
+            A: fx.Tensor,
+            B_T: fx.Tensor,
+            L1: fx.Tensor,
+            ACT: fx.Tensor,
+            PROBS: fx.Tensor,
+            A_scale: fx.Tensor,
+            B_scale: fx.Tensor,
+            group_offs: fx.Tensor,
+            m_total: int,
+            c_n: fx.Int32,
+            stream: fx.Stream,
+        ):
+            grid_x, attrs = _grid_and_attrs(m_total, c_n)
+            kernel_grouped_nt_persistent(
+                A,
+                B_T,
+                L1,
+                ACT,
+                PROBS,
+                A_scale,
+                B_scale,
+                group_offs,
+                c_n,
+                value_attrs=attrs,
+            ).launch(grid=(grid_x, 1, 1), block=(512, 1, 1), stream=stream)
+
+        return launch_grouped_nt_glu_persistent
+
     @flyc.jit
     def launch_grouped_nt_persistent(
         A: fx.Tensor,
@@ -1384,18 +1611,13 @@ def _compile_grouped_nt(
         c_n: fx.Int32,
         stream: fx.Stream,
     ):
-        n_blocks = ceildiv(c_n, BLOCK_N)
-        upper = (ceildiv(m_total, BLOCK_M) + G) * n_blocks
-        ncus = torch.cuda.get_device_properties(torch.cuda.current_device()).multi_processor_count
-        # cap_cu>0 reserves CUs for comm-compute overlap; cap_cu<=0 = full device.
-        _cap = ncus if cap_cu <= 0 else min(int(cap_cu), ncus)
-        # persistent: cap to _cap WGs. non-persistent: full grid, over-launched WGs s_endpgm.
-        grid_x = arith.select(upper < _cap, upper, fx.Int32(_cap)) if persistent else upper
-        attrs = make_value_attrs(waves_per_eu, 128 if (agpr_inplace and acc_mode == "agpr") else 0, "512,512")
+        grid_x, attrs = _grid_and_attrs(m_total, c_n)
         kernel_grouped_nt_persistent(
             A,
             B_T,
             C,
+            C,  # ACT unused without glu
+            C,  # PROBS unused without glu
             A_scale,
             B_scale,
             group_offs,

--- a/primus_turbo/flydsl/utils/gemm_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_helper.py
@@ -629,6 +629,26 @@ def _dpp_add_i32(acc, ctrl, row_mask=0xF):
     return acc + ArithValue(_res_of(r))
 
 
+def _dpp_add_f32(acc, ctrl, row_mask=0xF):
+    """acc + DPP(acc, ctrl) for f32; masked-off and shifted-in lanes contribute 0."""
+    raw = _raw(acc)
+    r = rocdl.update_dpp(raw.type, _raw(fx.Float32(0.0)), raw, ctrl, row_mask, 0xF, True)
+    return acc + fx.Float32(_res_of(r))
+
+
+def _row16_sum_f32(v):
+    """Sum an f32 across each 16-lane DPP row; lane 15 of the row ends with the total.
+
+    Four ROW_SHR adds, i.e. an inclusive scan whose last lane holds the row sum.
+    All full-rate VALU. The obvious alternative -- a ``gpu.shuffle`` XOR butterfly
+    -- lowers to ``ds_bpermute_b32``, one LDS crossbar op per step, and at the
+    rate a GEMM epilogue calls this that measured +0.59 ms.
+    """
+    for _sh in (1, 2, 4, 8):
+        v = _dpp_add_f32(v, _DPP_ROW_SHR + _sh)
+    return v
+
+
 def _wave_prefix_add_i32(v):
     """Wave64 inclusive add-scan of a per-lane i32 (lane l ends with the sum of 0..l). Six DPP
     steps replace the serial carry (bound_ctrl zeroes shifted-in lanes). Requires a full EXEC
@@ -917,7 +937,151 @@ class StoreCPerTensor:
                     )
 
 
+_LOG2E = 1.4426950408889634  # folds exp's log2e into exp2
+
+
+def _sigmoid_rcp(x):
+    """``sigmoid(x)`` via exp2 and the raw hardware reciprocal.
+
+    Spelled to match ``primus_turbo.triton.utils.silu._sigmoid_rcp`` operation
+    for operation, so a fused FlyDSL epilogue and the Triton one it replaces
+    agree to the last bit. Every IEEE-exact form of ``1/(1+exp(-x))`` costs
+    several times the VALU ops, and skipping the Newton fixup leaves
+    ``v_rcp_f32`` at ~1 ulp -- orders below bf16's 8-bit mantissa.
+    """
+    d = fx.Float32(1.0) + fx.Float32(rocdl.exp2(T.f32, _raw(x * fx.Float32(-_LOG2E))))
+    return fx.Float32(rocdl.rcp(T.f32, _raw(d)))
+
+
+class StoreCSwiGLU(StoreCPerTensor):
+    """Fused SwiGLU epilogue: consumes a *pair* of accumulator fragments.
+
+    The GEMM writes [M, 2I] as gate||up, and the activation needs column ``j``
+    beside column ``j + I`` of the same row -- thousands of columns apart, so a
+    tile walking the output linearly can never hold both. The Triton epilogue
+    pays a permute to peel a wide tile into halves; this avoids creating the
+    problem at all. The NT kernel already splits its N-tile across two B LDS
+    pools, so pointing the second pool at the weight rows for ``up`` (row offset
+    ``I``) instead of the next 128 columns makes gate and up for one
+    ``(row, j)`` land in the same lane at the same fragment index.
+
+    Writes ``l1`` gate at [row, j], ``l1`` up at [row, j + I] -- scaled but
+    un-activated, which backward needs -- and ``act`` at [row, j]. Only ``act``
+    takes the ``probs`` scaling. Both outputs stay ``out_ty``: quantising here
+    would need an amax no single tile can know.
+    """
+
+    def __init__(
+        self,
+        A_scale,
+        B_scale,
+        L1,
+        ACT,
+        PROBS,
+        c_rows,
+        glu_i,
+        c_idx_fn,
+        n_tiles_a,
+        n_tiles_b,
+        out_ty,
+        col_safe=False,
+        store_aux=0,
+        act_aux=0,
+    ):
+        # c_cols is l1's width, twice the activation's. The inherited store() is
+        # unused here, but the scale loading and lane geometry are not.
+        super().__init__(
+            A_scale,
+            B_scale,
+            L1,
+            c_rows,
+            2 * glu_i,
+            c_idx_fn,
+            n_tiles_a,
+            n_tiles_b,
+            out_ty,
+            col_safe=col_safe,
+            store_aux=store_aux,
+        )
+        self.glu_i = glu_i
+        self.act_base = _buffer_ops.extract_base_index(ACT)
+        self.act_aux = act_aux
+        _prow = _as_index(c_rows)
+        _pnrec = arith.minui(_prow * arith.index(4), arith.index(0x7FFFFFFF))
+        self.probs_rs = _buffer_ops.create_buffer_resource(
+            PROBS,
+            max_size=False,
+            num_records_bytes=arith.index_cast(T.index, _readfirstlane_i32(arith.index_cast(T.i64, _pnrec))),
+        )
+
+    def _probs(self, row):
+        return fx.Float32(_buffer_ops.buffer_load(self.probs_rs, row, vec_width=1, dtype=T.f32))
+
+    def store_pair(self, gate_frag, up_frag, base_row, base_col):
+        """One quadrant pair. ``base_col`` is in gate space, i.e. within [0, I).
+
+        A row's two column chunks must go out back to back, one stream at a
+        time. This drives three streams (l1's gate band, l1's up band ``I``
+        columns away, act in another tensor) and a lane holds 32 bytes, so it
+        takes both ``tj`` chunks to fill a 64-byte line. Interleaving the streams
+        instead leaves the halves of a line eleven stores apart, so it is evicted
+        half written and L2 reads it back: 8.2 GB of extra HBM traffic, 1.55 ms.
+        Ordering it this way costs 16 live values per ``ti``, which fits.
+        """
+        scale = self._scale()
+        # l1's band spans both halves (2I wide), act's is I wide, and both are
+        # pinned to the same rows -- so one row_local drives all three addresses.
+        l1_rs = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
+        act_rs = make_row_band_resource(self.act_base, base_row, self.c_rows, self.glu_i, 2)
+        col0 = base_col + self.lane_id % 16
+        NTB = self.n_tiles_b
+        for ti in range_constexpr(self.n_tiles_a):
+            row_local = ti * 16 + (self.lane_id // 16) * 4
+            # probs varies with the row alone, so it is hoisted off the column loop.
+            pr = [self._probs(base_row + row_local + i) for i in range_constexpr(4)]
+            l1_off = [((row_local + i) * self.c_cols + col0) * 2 for i in range_constexpr(4)]
+            act_off = [((row_local + i) * self.glu_i + col0) * 2 for i in range_constexpr(4)]
+            valid = [None if self.col_safe else (col0 + tj * 16) < self.glu_i for tj in range_constexpr(NTB)]
+            gv, uv = [], []
+            for tj in range_constexpr(NTB):
+                g_vec = Vec(gate_frag[self.c_idx_fn(ti, tj)])
+                u_vec = Vec(up_frag[self.c_idx_fn(ti, tj)])
+                if self.scaled:
+                    g_vec = g_vec * scale  # wave-uniform scale packs to v_pk_mul_f32
+                    u_vec = u_vec * scale
+                gv.append(g_vec)
+                uv.append(u_vec)
+
+            def _emit(rsrc, offs, val_fn, aux, valid=valid):
+                """One stream, one row at a time, both column chunks adjacent."""
+                for i in range_constexpr(4):
+                    for tj in range_constexpr(NTB):
+                        _buffer_ops.buffer_store(
+                            val_fn(tj, i).to(self.out_ty),
+                            rsrc,
+                            offs[i] + tj * 16 * 2,
+                            mask=valid[tj],
+                            cache_modifier=aux,
+                            offset_is_bytes=True,
+                        )
+
+            _emit(l1_rs, l1_off, lambda tj, i, gv=gv: gv[tj][i], self.store_aux)
+            _emit(
+                l1_rs,
+                [o + self.glu_i * 2 for o in l1_off],
+                lambda tj, i, uv=uv: uv[tj][i],
+                self.store_aux,
+            )
+            _emit(
+                act_rs,
+                act_off,
+                lambda tj, i, gv=gv, uv=uv, pr=pr: gv[tj][i] * _sigmoid_rcp(gv[tj][i]) * uv[tj][i] * pr[i],
+                self.act_aux,
+            )
+
+
 _DPP_QUAD_SWAP1 = 0xB1  # quad_perm:[1,0,3,2] -- exchange with the neighbouring lane
+_DPP_QUAD_SWAP2 = 0x4E  # quad_perm:[2,3,0,1] -- exchange with the lane two over
 _PERM_LO_PAIR = 0x05040100  # {own low half, right neighbour's low half}
 _PERM_HI_PAIR = 0x03020706  # {left neighbour's high half, own high half}
 
@@ -1311,6 +1475,248 @@ class StoreCPerTensorCShuffle:
                 S2RLoaderTr._wait_lgkmcnt(0)
                 _read_store_ti(ti, wave_base)
                 S2RLoaderTr._wait_lgkmcnt(0)  # drain re-read before next ti overwrites LDS
+
+
+class StoreCdSwiGLUCShuffle:
+    """Fused SwiGLU-gradient epilogue for the fc2 dgrad, staged through LDS.
+
+    The accumulator *is* ``dact`` -- the GEMM's N axis is already I -- so per
+    element, with ``d_raw`` the unscaled accumulator:
+
+        s = sigmoid(gate);  silu = s * gate;  d = d_raw * probs[m]
+        dl1[m, j]     = d * up * s * (1 + gate - silu)      (dgate)
+        dl1[m, j + I] = d * silu                            (dup)
+        grad_probs[m] += d_raw * silu * up                  (probs unscaled)
+
+    ``grad_probs`` sums over all of I, which one tile does not span, so this
+    writes partials for the caller to fold -- no atomics, bitwise reproducible,
+    matching the Triton twin.
+
+    The LDS round trip is what makes the memory ops vectorise. The MFMA fragment
+    gives a lane one column per (ti, tj, i), so working in registers means
+    2-byte scalar ops and more live registers than the 128-VGPR budget has
+    spare: 512 memory instructions per lane per tile and 268 B of spill,
+    measured at +0.708 ms against a +0.143 ms bandwidth floor. After the round
+    trip a lane owns 8 contiguous columns of one row, so each half of l1 is one
+    128-bit load and each half of dl1 one 128-bit store.
+
+    Staged as f32, not ``out_ty``: this is an input to the gradient, and
+    rounding to bf16 first would put a second rounding ahead of the math.
+
+    Costs the K-shear A fetch, which shares this pool's LDS -- 0.003 ms of
+    mainloop against the 0.018 ms the staging adds.
+    """
+
+    stages_lds = True
+
+    def __init__(
+        self,
+        A_scale,
+        B_scale,
+        DL1,
+        L1,
+        PROBS,
+        GRAD_PROBS_PARTIAL,
+        grad_probs_row,
+        grad_probs_stride,
+        c_rows,
+        glu_i,
+        c_idx_fn,
+        n_tiles_a,
+        n_tiles_b,
+        out_ty,
+        c_lds,
+        wave_id,
+        row_pad=0,
+        col_safe=False,
+        store_aux=0,
+    ):
+        self.BAND_COLS = 256
+        self.row_pad = row_pad
+        self.col_safe = col_safe
+        self.c_rows = c_rows
+        self.c_cols = 2 * glu_i
+        self.glu_i = glu_i
+        self.lane_id = fx.thread_idx.x % 64
+        self.wave_id = wave_id
+        self.c_idx_fn = c_idx_fn
+        self.n_tiles_a = n_tiles_a
+        self.n_tiles_b = n_tiles_b
+        self.out_ty = out_ty
+        self.store_aux = store_aux
+        self.Cc = n_tiles_b * 16  # columns one wave owns in a 16-row sub-tile
+        self.EPL = (16 * self.Cc) // 64  # f32 elements each lane re-reads
+        self.VEC = 8  # 16b elements in a 128b global access
+        assert self.EPL == self.VEC, f"dglu CShuffle wants EPL == {self.VEC} (BLOCK_N=256), got {self.EPL}"
+        # Runs are VEC-aligned in the global column space, so a run is either
+        # wholly inside I or wholly past it and one mask per run suffices.
+        assert glu_i % self.VEC == 0, f"I must be a multiple of {self.VEC}, got {glu_i}"
+        self.c_lds = c_lds
+        self.c_base = _buffer_ops.extract_base_index(DL1)
+        self.l1_base = _buffer_ops.extract_base_index(L1)
+        self.probs_base = _buffer_ops.extract_base_index(PROBS)
+        self.grad_probs_base = _buffer_ops.extract_base_index(GRAD_PROBS_PARTIAL)
+        self.grad_probs_row = grad_probs_row
+        self.grad_probs_stride = grad_probs_stride
+        self.scaled = A_scale is not None
+        if self.scaled:
+            gSA = fx.rocdl.make_buffer_tensor(A_scale, max_size=False, num_records_bytes=4)
+            gSB = fx.rocdl.make_buffer_tensor(B_scale, max_size=False, num_records_bytes=4)
+            self.sa_div = fx.logical_divide(gSA, fx.make_layout(1, 1))
+            self.sb_div = fx.logical_divide(gSB, fx.make_layout(1, 1))
+            self.scale_atom_1 = fx.make_copy_atom(fx.rocdl.BufferCopy32b(), fx.Float32)
+            self.reg_f32_1 = fx.make_rmem_tensor(fx.make_layout(1, 1), fx.Float32)
+        self._store_ptr_t = fx.PointerType.get(T.f32, 2, 4)
+        self._read_ptr_t = fx.PointerType.get(T.f32, 2, 16)
+
+    def _load_scalar(self, div):
+        fx.copy(self.scale_atom_1, fx.slice(div, (None, fx.Int32(0))), self.reg_f32_1)
+        return Vec(fx.memref_load_vec(self.reg_f32_1))[0]
+
+    def flush(self):
+        """Nothing is queued past the call that emitted it."""
+
+    def store_pair(self, c_lo, c_hi, base_row, base_col, hi_col_off):
+        """Both column quadrants of one row block, four waves staging one band.
+
+        Staging per wave would leave a wave owning a 16x32 patch, so four lanes
+        cover a row and an access is 64 bytes -- half a line, sixteen scattered
+        ones per instruction, measured at 2.80 TB/s against the 5.28 both
+        standalone kernels reach. Instead the four waves sharing a ``wave_m``
+        cover the same rows and their two quadrants together span all 256
+        columns, so they stage one 16-row band of the full width and take four
+        rows each, 32 lanes to a row: 512 contiguous bytes per instruction, with
+        the same 8 elements per lane and so the same register pressure.
+
+        Costs two workgroup barriers per band, to publish the staging and to
+        stop it being overwritten. Both wave_m groups run the same sequence, so
+        neither barrier diverges.
+        """
+        scale = self._load_scalar(self.sa_div) * self._load_scalar(self.sb_div) if self.scaled else None
+        lds_base = fx.Int32(fx.ptrtoint(self.c_lds.ptr))
+        one = fx.Float32(1.0)
+        zero = fx.Float32(0.0)
+        wave_n = self.wave_id % 4
+        wave_m = self.wave_id // 4
+        row_stride = self.BAND_COLS + self.row_pad
+        group_base = wave_m * (16 * row_stride)
+        band_col0 = base_col - wave_n * self.Cc  # block_n * BLOCK_N
+        # A lane sums its own 8 columns, then the 16 lanes of its DPP row fold
+        # into lane 15. The 32 lanes covering a row straddle two such rows;
+        # rather than pay a permlane to join them, each half publishes to its own
+        # grad_probs_partial slice and the caller's fold adds them.
+        lane16 = self.lane_id % 16
+        half = (self.lane_id % 32) // 16
+
+        col_in = (self.lane_id % 32) * self.VEC
+        gcol = band_col0 + col_in
+        valid = None if self.col_safe else (gcol + fx.Int32(self.VEC)) <= self.glu_i
+        # c_hi=None is the boundary block's half body: its columns are all past I,
+        # so it is neither staged nor stored. One lane sweep covers both quadrants
+        # here, so the lanes that would have read it have to be masked off
+        # explicitly -- the column mask does not necessarily do it, since
+        # ``col_safe`` is allowed to lean on this skip and drop the mask entirely.
+        if const_expr(c_hi is None):
+            half0 = half == 0
+            valid = half0 if valid is None else (valid & half0)
+        quads = ((c_lo, 0),) if const_expr(c_hi is None) else ((c_lo, 0), (c_hi, hi_col_off))
+
+        for ti in range_constexpr(self.n_tiles_a):
+            row0 = base_row + ti * 16
+            dl1_rs = make_row_band_resource(self.c_base, row0, self.c_rows, self.c_cols, 2)
+            l1_rs = make_row_band_resource(self.l1_base, row0, self.c_rows, self.c_cols, 2)
+            pr_rs = make_row_band_resource(self.probs_base, row0, self.c_rows, 1, 4)
+
+            # Issue both chunks' saved-activation reads before staging, not after
+            # the barrier. They depend on nothing in LDS, and at one workgroup per
+            # CU there are only eight waves to keep requests in flight -- right at
+            # the concurrency this needs to saturate HBM -- so their latency wants
+            # the staging writes and the barrier to hide under.
+            rows_in = [wave_n * 4 + c * 2 + self.lane_id // 32 for c in range_constexpr(2)]
+            eoffs = [r * self.c_cols + gcol for r in rows_in]
+            loaded = [(self._l1v(l1_rs, e, valid), self._l1v(l1_rs, e + self.glu_i, valid)) for e in eoffs]
+            prs = [fx.Float32(_buffer_ops.buffer_load(pr_rs, r, vec_width=1, dtype=T.f32)) for r in rows_in]
+
+            for frag, qoff in quads:
+                for tj in range_constexpr(self.n_tiles_b):
+                    vec = Vec(frag[self.c_idx_fn(ti, tj)])
+                    if self.scaled:
+                        vec = vec * scale
+                    lds_col = qoff + wave_n * self.Cc + tj * 16 + lane16
+                    for i in range_constexpr(4):
+                        e = group_base + ((self.lane_id // 16) * 4 + i) * row_stride + lds_col
+                        fx.inttoptr(self._store_ptr_t, lds_base + e * 4).store(vec[i])
+            S2RLoaderTr._wait_lgkmcnt(0)
+            rocdl.s_barrier()  # band staged by all four waves
+
+            for c in range_constexpr(2):
+                row_in = rows_in[c]
+                dact = Vec(
+                    fx.make_view(
+                        fx.inttoptr(
+                            self._read_ptr_t,
+                            lds_base + (group_base + row_in * row_stride + col_in) * 4,
+                        ),
+                        fx.make_layout(self.VEC, 1),
+                    ).load()
+                )
+                eoff = eoffs[c]
+                g_raw, u_raw = loaded[c]
+                g = Vec(g_raw).to(fx.Float32)
+                u = Vec(u_raw).to(fx.Float32)
+                pr = prs[c]
+                dg, du, grad_probs = [], [], zero
+                for k in range_constexpr(self.VEC):
+                    s = _sigmoid_rcp(g[k])
+                    silu = s * g[k]
+                    d_raw = dact[k]
+                    grad_probs = grad_probs + d_raw * silu * u[k]
+                    d = d_raw * pr
+                    du.append((d * silu).to(self.out_ty))
+                    dg.append((d * u[k] * s * (one + g[k] - silu)).to(self.out_ty))
+                off = eoff * 2
+                for vals, dcol in ((dg, 0), (du, self.glu_i * 2)):
+                    _buffer_ops.buffer_store(
+                        Vec.from_elements(vals, self.out_ty),
+                        dl1_rs,
+                        off + dcol,
+                        mask=valid,
+                        cache_modifier=self.store_aux,
+                        offset_is_bytes=True,
+                    )
+                if valid is not None:
+                    grad_probs = fx.Float32(arith.select(valid, grad_probs, zero))
+                grad_probs = _row16_sum_f32(grad_probs)
+                # Every wave's rows are disjoint, so a slice is shared by all of
+                # them and only (column block, half) has to be distinct.
+                for h in range_constexpr(2):
+                    grad_probs_rs = make_row_band_resource(
+                        self.grad_probs_base
+                        + _as_index((self.grad_probs_row + h) * self.grad_probs_stride * 4),
+                        row0,
+                        self.c_rows,
+                        1,
+                        4,
+                    )
+                    _buffer_ops.buffer_store(
+                        grad_probs,
+                        grad_probs_rs,
+                        row_in * 4,
+                        mask=(lane16 == 15) & (half == h),
+                        offset_is_bytes=True,
+                    )
+            S2RLoaderTr._wait_lgkmcnt(0)
+            rocdl.s_barrier()  # band consumed, safe to restage
+
+    def _l1v(self, rsrc, elem_off, valid):
+        """One VEC-wide saved-activation run; buffer_load offsets are in elements."""
+        return _buffer_ops.buffer_load(
+            rsrc,
+            elem_off,
+            vec_width=self.VEC,
+            dtype=self.out_ty.ir_type,
+            mask=valid,
+        )
 
 
 def _store_quadrants(store_c, c00, c01, c10, c11, base_row, base_col, LDS_BLOCK_M, LDS_BLOCK_N):

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
@@ -38,7 +38,7 @@ from primus_turbo.triton.grouped_gemm.grouped_gemm_fp4_kernel import (
     grouped_gemm_mxfp4_triton_kernel,
     grouped_gemm_mxfp4_variable_k_triton_kernel,
 )
-from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
+from primus_turbo.triton.grouped_gemm.grouped_gemm_helper import (
     grouped_gemm_output_tail_kernel,
 )
 

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -40,7 +40,7 @@ from primus_turbo.triton.grouped_gemm.grouped_gemm_fp8_kernel import (
     grouped_gemm_mxfp8_triton_kernel,
     grouped_gemm_mxfp8_variable_k_triton_kernel,
 )
-from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
+from primus_turbo.triton.grouped_gemm.grouped_gemm_helper import (
     grouped_gemm_output_tail_kernel,
 )
 
@@ -1127,3 +1127,214 @@ def grouped_gemm_fp8_variable_k_impl_meta(
     if trans_c:
         m, n = n, m
     return torch.empty((bs, m, n), device=a.device, dtype=out_dtype)
+
+
+def _check_glu_dispatch(granularity: int, trans_a: bool) -> None:
+    """The fused GLU epilogue has one scaling mode and one A layout."""
+    assert ScalingGranularity(granularity) == ScalingGranularity.TENSORWISE, (
+        f"Fused GLU grouped GEMM is tensorwise-only, got {ScalingGranularity(granularity)}"
+    )
+    assert not trans_a, "Fused GLU grouped GEMM does not support trans_a"
+
+
+def _alloc_grad_probs_partial(spec, device: torch.device) -> torch.Tensor:
+    """The grad_probs partial buffer a fused dgrad asked for.
+
+    The kernels allocate nothing, and both the shape and ``needs_zero`` follow
+    from a tiling only they know, so the spec is asked for rather than
+    reconstructed here.
+    """
+    fill = torch.zeros if spec.needs_zero else torch.empty
+    return fill(spec.shape, device=device, dtype=torch.float32)
+
+
+@_torch_custom_op_wrapper("primus_turbo::grouped_gemm_fp8_glu_impl", mutates_args=(), device_types="cuda")
+def grouped_gemm_fp8_glu_impl(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_lens: torch.Tensor,  # not used
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: int | None,
+    probs: torch.Tensor,
+    activation: str = "silu",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """fc1 grouped GEMM with the GLU activation fused into its epilogue.
+
+    Returns ``(act, intermediate)``: the activation [M, N // 2] that feeds fc2,
+    and the pre-activation [M, N] that the backward needs. ``probs`` is folded
+    into ``act`` only -- ``intermediate`` is always the unscaled GEMM output.
+    """
+    _check_glu_dispatch(granularity, trans_a)
+
+    assert is_gfx950(), "grouped_gemm_fp8_glu_impl is only supported on gfx950"
+    assert trans_b == True, "trans_b must be True for grouped_gemm_fp8_glu_impl"
+    assert a.shape[1] >= 129, "a.shape[1] must be >= 129 for grouped_gemm_fp8_glu_impl"
+
+    M = a.shape[0]
+    N = b.shape[1] if trans_b else b.shape[2]
+
+    act = torch.empty((M, N // 2), device=a.device, dtype=out_dtype)
+    intermediate = torch.empty((M, N), device=a.device, dtype=out_dtype)
+
+    from primus_turbo.flydsl.grouped_gemm.grouped_gemm_fp8_glu_kernel import (
+        grouped_gemm_fp8_glu_tensorwise_flydsl_kernel,
+    )
+
+    return grouped_gemm_fp8_glu_tensorwise_flydsl_kernel(
+        a,
+        b,
+        a_scales,
+        b_scales,
+        probs,
+        group_offs,
+        act,
+        intermediate,
+        trans_b=trans_b,
+        activation=activation,
+        out_dtype=out_dtype,
+        num_cu=num_cu,
+    )
+
+
+@_torch_custom_op_wrapper("primus_turbo::grouped_gemm_fp8_dglu_impl", mutates_args=(), device_types="cuda")
+def grouped_gemm_fp8_dglu_impl(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_lens: torch.Tensor,  # not used
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: int | None,
+    probs: torch.Tensor,
+    intermediate: torch.Tensor,
+    activation: str = "silu",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """fc2 dgrad with the GLU activation gradient fused into its epilogue.
+
+    ``a`` is the fc2 output gradient and ``b`` the fc2 weight oriented for the
+    dgrad, so ``a @ b`` is the gradient wrt the activation; the epilogue consumes
+    it in registers against ``intermediate`` (the pre-activation the forward
+    wrote).
+
+    Returns ``(grad_intermediate, grad_probs)``: the pre-activation gradient
+    [M, 2 * N], and [M] fp32 the gradient wrt the routing probabilities -- the
+    gradient wrt the activation, taken before the probs scaling, times the
+    activation, summed over the hidden dimension. The kernels leave that sum as
+    per-tile partials and this function folds them.
+    """
+    _check_glu_dispatch(granularity, trans_a)
+
+    assert is_gfx950(), "grouped_gemm_fp8_dglu_impl is only supported on gfx950"
+    assert trans_b == False, "trans_b must be False for grouped_gemm_fp8_dglu_impl"
+    assert a.shape[1] >= 129, "a.shape[1] must be >= 129 for grouped_gemm_fp8_dglu_impl"
+
+    M = a.shape[0]
+    N = b.shape[1] if trans_b else b.shape[2]
+
+    from primus_turbo.flydsl.grouped_gemm.grouped_gemm_fp8_glu_kernel import (
+        grouped_gemm_fp8_dglu_grad_probs_partial_spec,
+        grouped_gemm_fp8_dglu_tensorwise_flydsl_kernel,
+    )
+
+    out = torch.empty((M, N * 2), device=a.device, dtype=out_dtype)
+    grad_probs_partial = _alloc_grad_probs_partial(
+        grouped_gemm_fp8_dglu_grad_probs_partial_spec(a, b), a.device
+    )
+    grouped_gemm_fp8_dglu_tensorwise_flydsl_kernel(
+        a,
+        b,
+        a_scales,
+        b_scales,
+        intermediate,
+        group_offs,
+        probs,
+        out,
+        grad_probs_partial,
+        trans_b=trans_b,
+        activation=activation,
+        num_cu=num_cu,
+    )
+
+    return out, torch.sum(grad_probs_partial, dim=0)
+
+
+@grouped_gemm_fp8_glu_impl.register_fake
+def grouped_gemm_fp8_glu_impl_meta(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: int | None,
+    probs: torch.Tensor,
+    activation: str = "silu",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    _check_glu_dispatch(granularity, trans_a)
+
+    assert a.dim() == 2, f"a must be 2D, got {a.shape}"
+    assert b.dim() == 3, f"b must be 3D, got {b.shape}"
+    assert a.dtype in [float8_e4m3, float8_e5m2], f"a must be fp8, got {a.dtype}"
+    assert b.dtype in [float8_e4m3, float8_e5m2], f"b must be fp8, got {b.dtype}"
+    assert out_dtype in [
+        torch.float16,
+        torch.bfloat16,
+    ], f"out_dtype must be float16 or bfloat16, got {out_dtype}"
+
+    # b holds gate||up, so its N is twice the activation's width.
+    m = a.shape[0]
+    n = b.shape[1] if trans_b else b.shape[2]
+    act = torch.empty((m, n // 2), device=a.device, dtype=out_dtype)
+    intermediate = torch.empty((m, n), device=a.device, dtype=out_dtype)
+    return act, intermediate
+
+
+@grouped_gemm_fp8_dglu_impl.register_fake
+def grouped_gemm_fp8_dglu_impl_meta(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: int | None,
+    probs: torch.Tensor,
+    intermediate: torch.Tensor,
+    activation: str = "silu",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    _check_glu_dispatch(granularity, trans_a)
+
+    assert a.dim() == 2, f"a must be 2D, got {a.shape}"
+    assert b.dim() == 3, f"b must be 3D, got {b.shape}"
+    assert a.dtype in [float8_e4m3, float8_e5m2], f"a must be fp8, got {a.dtype}"
+    assert b.dtype in [float8_e4m3, float8_e5m2], f"b must be fp8, got {b.dtype}"
+    assert out_dtype in [
+        torch.float16,
+        torch.bfloat16,
+    ], f"out_dtype must be float16 or bfloat16, got {out_dtype}"
+
+    # This is the dgrad wrt the activation, so the gate||up gradient it writes
+    # is twice as wide. grad_probs is per-row and always fp32, whatever out_dtype is.
+    m = a.shape[0]
+    n = b.shape[1] if trans_b else b.shape[2]
+    grad_intermediate = torch.empty((m, n * 2), device=a.device, dtype=out_dtype)
+    grad_probs = torch.empty((m,), device=a.device, dtype=torch.float32)
+    return grad_intermediate, grad_probs

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_impl.py
@@ -25,8 +25,10 @@ from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
     BaseGroupedGEMMKernelDispatcher,
     BaseGroupedGEMMVariableKKernelDispatcher,
 )
-from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
+from primus_turbo.triton.grouped_gemm.grouped_gemm_helper import (
     grouped_gemm_output_tail_kernel,
+)
+from primus_turbo.triton.grouped_gemm.grouped_gemm_kernel import (
     grouped_gemm_triton_kernel,
     grouped_gemm_variable_k_triton_kernel,
 )

--- a/primus_turbo/pytorch/ops/grouped_mlp_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_mlp_fp8.py
@@ -1,0 +1,451 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+from typing import Optional, Union
+
+import torch
+
+from primus_turbo.pytorch.core.backend import BackendType
+from primus_turbo.pytorch.core.low_precision import (
+    Float8QuantConfig,
+    ScalingGranularity,
+)
+from primus_turbo.pytorch.core.quantized_tensor import (
+    QuantizedTensor,
+    QuantizedTensorPair,
+    check_quantized_tensor,
+)
+from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_fp8_impl import (
+    grouped_gemm_fp8_dglu_impl,
+    grouped_gemm_fp8_glu_impl,
+    grouped_gemm_fp8_impl,
+    grouped_gemm_fp8_variable_k_accum_impl,
+    grouped_gemm_fp8_variable_k_impl,
+)
+from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_utils import (
+    group_offs_from_lens,
+)
+from primus_turbo.pytorch.ops.utils import (
+    _ensure_contiguous_grad_out,
+    _get_dummy_wgrad,
+    _get_fp8_dtype,
+    _setup_fused_grad_accum,
+)
+
+__all__ = [
+    "grouped_mlp_fp8",
+]
+
+
+_SUPPORTED_ACTIVATIONS = ("silu",)
+
+
+def _grouped_gemm_fp8_variable_k_impl_wrapper(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scales: torch.Tensor,
+    b_scales: torch.Tensor,
+    group_lens: torch.Tensor,
+    group_offs: torch.Tensor,
+    trans_a: bool,
+    trans_b: bool,
+    trans_c: bool,
+    out_dtype: torch.dtype,
+    granularity: int,
+    num_cu: Optional[int],
+    default_backend: int,
+    inplace_add_to_out: bool = False,
+    out: Optional[torch.Tensor] = None,
+) -> Optional[torch.Tensor]:
+    """Run the variable-K wgrad GEMM, accumulating into ``out`` when asked to.
+
+    Returns the weight gradient for autograd, or a dummy buffer when the wgrad went
+    straight into ``out``: forward already flagged the weight, so the training
+    framework's own accumulation step stands down. Megatron still expects a tensor
+    rather than None there, so its backward hooks stay on the main thread; the
+    contents are never read. It is handed back in the weight's own dtype, since a
+    mismatch would make autograd allocate and cast a full-size copy.
+    """
+    inputs = (a, b, a_scales, b_scales, group_lens, group_offs)
+    options = dict(
+        trans_a=trans_a,
+        trans_b=trans_b,
+        trans_c=trans_c,
+        out_dtype=out_dtype,
+        granularity=granularity,
+        num_cu=num_cu,
+        default_backend=default_backend,
+    )
+
+    if not inplace_add_to_out:
+        return grouped_gemm_fp8_variable_k_impl(*inputs, **options)
+
+    assert out is not None, "out should not be None when inplace_add_to_out is True"
+    grouped_gemm_fp8_variable_k_accum_impl(*inputs, out=out, **options)
+
+    return _get_dummy_wgrad(out.shape, out_dtype)
+
+
+class FP8GroupedMLPTensorFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        x: Union[torch.Tensor, QuantizedTensor],
+        probs: torch.Tensor,
+        w1: Union[torch.Tensor, QuantizedTensor],
+        w2: Union[torch.Tensor, QuantizedTensor],
+        x_t: Optional[QuantizedTensor],  # not used
+        w1_t: Optional[QuantizedTensor],  # not used
+        w2_t: Optional[QuantizedTensor],  # not used
+        group_lens: torch.Tensor,  # [B,] int64
+        group_offs: torch.Tensor,  # [B + 1,] int64
+        trans_w1: bool,
+        trans_w2: bool,
+        activation: str,
+        out_dtype: torch.dtype,
+        config: Float8QuantConfig,
+        num_cu: int | None,
+        fuse_wgrad_accum_pattern: Union[None, str] = None,
+    ):
+        assert activation in _SUPPORTED_ACTIVATIONS, (
+            f"Unsupported activation: {activation!r}, expected one of {_SUPPORTED_ACTIVATIONS}"
+        )
+
+        # Each weight carries its own accumulation buffer, so the two wgrads
+        # cannot share one: resolve them separately while the parameter objects
+        # are still in hand.
+        fuse_w1_accum, w1_main_grad = _setup_fused_grad_accum(w1, fuse_wgrad_accum_pattern)
+        fuse_w2_accum, w2_main_grad = _setup_fused_grad_accum(w2, fuse_wgrad_accum_pattern)
+
+        assert config.granularity == ScalingGranularity.TENSORWISE
+
+        # Also the dtype the fc1 activation is quantised to before fc2.
+        x_dtype = _get_fp8_dtype(config.format, True)
+
+        if isinstance(x, QuantizedTensor):
+            assert x._is_grouped_tensor, "A QuantizedTensor input must be a grouped tensor"
+            check_quantized_tensor(x, config)
+            quantized_x = x
+            group_offs = x.group_offs
+        else:
+            quantized_x = QuantizedTensor.quantize(
+                x,
+                x_dtype,
+                config.granularity,
+                axis=-1,
+                block_size=config.block_size,
+                group_lens=group_lens,
+            )
+
+        if isinstance(w1, QuantizedTensor):
+            assert not w1._is_grouped_tensor, "w1 QuantizedTensor input must not be a grouped tensor"
+            check_quantized_tensor(w1, config)
+            quantized_w1 = w1
+        else:
+            w1_dtype = _get_fp8_dtype(config.format, True)
+            quantized_w1 = QuantizedTensor.quantize(
+                w1,
+                w1_dtype,
+                config.granularity,
+                axis=-1,
+                block_size=config.block_size,
+            )
+
+        if isinstance(w2, QuantizedTensor):
+            assert not w2._is_grouped_tensor, "w2 QuantizedTensor input must not be a grouped tensor"
+            check_quantized_tensor(w2, config)
+            quantized_w2 = w2
+        else:
+            w2_dtype = _get_fp8_dtype(config.format, True)
+            quantized_w2 = QuantizedTensor.quantize(
+                w2,
+                w2_dtype,
+                config.granularity,
+                axis=-1,
+                block_size=config.block_size,
+            )
+
+        fc1_act, fc1_out = grouped_gemm_fp8_glu_impl(
+            quantized_x.qdata,
+            quantized_w1.qdata,
+            quantized_x.scale_inv,
+            quantized_w1.scale_inv,
+            group_lens,
+            group_offs,
+            trans_a=False,
+            trans_b=trans_w1,
+            out_dtype=out_dtype,
+            granularity=config.granularity.value,
+            num_cu=num_cu,
+            activation=activation,
+            probs=probs,
+        )
+
+        quantized_act = QuantizedTensor.quantize(
+            fc1_act,
+            x_dtype,
+            config.granularity,
+            axis=-1,
+            block_size=config.block_size,
+            group_lens=group_lens,
+        )
+
+        fc2_out = grouped_gemm_fp8_impl(
+            quantized_act.qdata,
+            quantized_w2.qdata,
+            quantized_act.scale_inv,
+            quantized_w2.scale_inv,
+            group_lens,
+            group_offs,
+            trans_a=False,
+            trans_b=trans_w2,
+            out_dtype=out_dtype,
+            granularity=config.granularity.value,
+            num_cu=num_cu,
+            default_backend=BackendType.TRITON.value,
+            maybe_pre_sync=True,
+        )
+
+        ctx.save_for_backward(
+            quantized_x.qdata,
+            quantized_act.qdata,
+            quantized_w1.qdata,
+            quantized_w2.qdata,
+            quantized_x.scale_inv,
+            quantized_act.scale_inv,
+            quantized_w1.scale_inv,
+            quantized_w2.scale_inv,
+            fc1_out,
+            probs,
+            group_lens,
+            group_offs,
+        )
+        ctx.trans_w1 = trans_w1
+        ctx.trans_w2 = trans_w2
+        ctx.activation = activation
+        ctx.config = config
+        ctx.out_dtype = out_dtype
+        ctx.num_cu = num_cu
+        ctx.fuse_w1_accum = fuse_w1_accum
+        ctx.fuse_w2_accum = fuse_w2_accum
+        # Kept off save_for_backward on purpose: the wgrad GEMM writes into these
+        # buffers in place, which would bump the version counter that saved tensors
+        # are checked against.
+        ctx.w1_main_grad = w1_main_grad
+        ctx.w2_main_grad = w2_main_grad
+
+        return fc2_out
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        grad_out = _ensure_contiguous_grad_out(grad_out)
+        (
+            x_fp8,
+            act_fp8,
+            w1_fp8,
+            w2_fp8,
+            x_scale_inv,
+            act_scale_inv,
+            w1_scale_inv,
+            w2_scale_inv,
+            fc1_out,
+            probs,
+            group_lens,
+            group_offs,
+        ) = ctx.saved_tensors
+
+        grad_out_dtype = _get_fp8_dtype(ctx.config.format, False)
+        quantized_grad_out = QuantizedTensor.quantize(
+            grad_out,
+            grad_out_dtype,
+            ctx.config.granularity,
+            axis=-1,
+            block_size=ctx.config.block_size,
+            group_lens=group_lens,
+        )
+
+        # grad_w2 = act^T @ grad_out, both operands already in hand.
+        grad_w2 = _grouped_gemm_fp8_variable_k_impl_wrapper(
+            act_fp8,
+            quantized_grad_out.qdata,
+            act_scale_inv,
+            quantized_grad_out.scale_inv,
+            group_lens,
+            group_offs,
+            trans_a=True,
+            trans_b=False,
+            trans_c=ctx.trans_w2,
+            out_dtype=ctx.out_dtype,
+            granularity=ctx.config.granularity.value,
+            num_cu=ctx.num_cu,
+            default_backend=BackendType.TRITON.value,
+            inplace_add_to_out=ctx.fuse_w2_accum,
+            out=ctx.w2_main_grad,
+        )
+
+        # fc2 dgrad (grad_out @ w2^T) with the activation gradient fused into its
+        # epilogue, giving the pre-activation gradient directly. The probs
+        # scaling and grad_probs both ride along inside that epilogue.
+        grad_fc1_out, grad_probs = grouped_gemm_fp8_dglu_impl(
+            quantized_grad_out.qdata,
+            w2_fp8,
+            quantized_grad_out.scale_inv,
+            w2_scale_inv,
+            group_lens,
+            group_offs,
+            trans_a=False,
+            trans_b=not ctx.trans_w2,
+            out_dtype=ctx.out_dtype,
+            granularity=ctx.config.granularity.value,
+            num_cu=ctx.num_cu,
+            activation=ctx.activation,
+            probs=probs,
+            intermediate=fc1_out,
+        )
+
+        quantized_grad_fc1_out = QuantizedTensor.quantize(
+            grad_fc1_out,
+            grad_out_dtype,
+            ctx.config.granularity,
+            axis=-1,
+            block_size=ctx.config.block_size,
+            group_lens=group_lens,
+        )
+
+        # grad_x = grad_fc1_out @ w1^T
+        grad_x = grouped_gemm_fp8_impl(
+            quantized_grad_fc1_out.qdata,
+            w1_fp8,
+            quantized_grad_fc1_out.scale_inv,
+            w1_scale_inv,
+            group_lens,
+            group_offs,
+            trans_a=False,
+            trans_b=not ctx.trans_w1,
+            out_dtype=ctx.out_dtype,
+            granularity=ctx.config.granularity.value,
+            num_cu=ctx.num_cu,
+            default_backend=BackendType.TRITON.value,
+        )
+
+        # grad_w1 = x^T @ grad_fc1_out
+        grad_w1 = _grouped_gemm_fp8_variable_k_impl_wrapper(
+            x_fp8,
+            quantized_grad_fc1_out.qdata,
+            x_scale_inv,
+            quantized_grad_fc1_out.scale_inv,
+            group_lens,
+            group_offs,
+            trans_a=True,
+            trans_b=False,
+            trans_c=ctx.trans_w1,
+            out_dtype=ctx.out_dtype,
+            granularity=ctx.config.granularity.value,
+            num_cu=ctx.num_cu,
+            default_backend=BackendType.TRITON.value,
+            inplace_add_to_out=ctx.fuse_w1_accum,
+            out=ctx.w1_main_grad,
+        )
+
+        return (
+            grad_x,  # x
+            grad_probs,  # probs
+            grad_w1,  # w1
+            grad_w2,  # w2
+            None,  # x_t
+            None,  # w1_t
+            None,  # w2_t
+            None,  # group_lens
+            None,  # group_offs
+            None,  # trans_w1
+            None,  # trans_w2
+            None,  # activation
+            None,  # out_dtype
+            None,  # config
+            None,  # num_cu
+            None,  # fuse_wgrad_accum_pattern
+        )
+
+
+@torch._dynamo.disable(
+    recursive=True,
+    reason=(
+        "Grouped FP8 MLP constructs (Grouped)QuantizedTensor wrapper subclasses "
+        "inside its autograd.Function.forward and reads their inner tensors "
+        "(x / w1 / w2 / scale_inv / group_lens / group_offs). Dynamo cannot recover Python "
+        "sources for those graph-internal inner tensors, tripping gb0116 "
+        "('SourcelessBuilder.create cannot wrap FakeTensor'). "
+    ),
+)
+def grouped_mlp_fp8(
+    x: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    group_lens: torch.Tensor,
+    probs: torch.Tensor,
+    group_offs: torch.Tensor | None = None,
+    trans_w1: bool = False,
+    trans_w2: bool = False,
+    out_dtype: Union[None, torch.dtype] = None,
+    config: Union[Float8QuantConfig, None] = None,
+    num_cu: int | None = None,
+    fuse_wgrad_accum_pattern: Union[None, str] = None,
+    activation: Union[None, str] = None,
+) -> torch.Tensor:
+    if config is None:
+        config = Float8QuantConfig()
+
+    assert activation in _SUPPORTED_ACTIVATIONS, (
+        f"Unsupported activation: {activation!r}, expected one of {_SUPPORTED_ACTIVATIONS}"
+    )
+
+    assert probs is not None, "probs is required: the fused GLU epilogues always scale by it"
+
+    if group_offs is None:
+        group_offs = group_offs_from_lens(group_lens)
+
+    if isinstance(x, QuantizedTensorPair):
+        x_data, x_data_t = x.data, x.data_t
+    else:
+        x_data, x_data_t = x, None
+
+    if isinstance(w1, QuantizedTensorPair):
+        w1_data, w1_data_t = w1.data, w1.data_t
+    else:
+        w1_data, w1_data_t = w1, None
+
+    if isinstance(w2, QuantizedTensorPair):
+        w2_data, w2_data_t = w2.data, w2.data_t
+    else:
+        w2_data, w2_data_t = w2, None
+
+    if out_dtype is None:
+        assert w1_data.dtype == w2_data.dtype, "w1 and w2 must have the same dtype"
+        out_dtype = torch.promote_types(x_data.dtype, w1_data.dtype)
+
+    if config.granularity == ScalingGranularity.TENSORWISE:
+        # TENSORWISE has a single scalar scale (no col-wise trans cache needed);
+        # the inner ``data_t`` is ignored if provided.
+        return FP8GroupedMLPTensorFunc.apply(
+            x_data,
+            probs,
+            w1_data,
+            w2_data,
+            x_data_t,
+            w1_data_t,
+            w2_data_t,
+            group_lens,
+            group_offs,
+            trans_w1,
+            trans_w2,
+            activation,
+            out_dtype,
+            config,
+            num_cu,
+            fuse_wgrad_accum_pattern,
+        )
+    else:
+        raise ValueError(f"Unsupported FP8 ScalingGranularity: {config.granularity}")

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_glu_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_glu_kernel.py
@@ -1,0 +1,1429 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""
+Grouped GEMM Triton persistent kernels with a fused GLU-activation epilogue -- FP8 tensorwise.
+
+The operands are FP8 and the fp32 accumulator is dequantised by the per-tensor
+scale product before the epilogue sees it::
+
+    l1[g] = (a[g] @ B_view[g]) * a_scale * b_scale        # [M_g, 2I], gate||up
+    act[g] = f(l1[g][:, :I]) * l1[g][:, I:] * probs[g]    # [M_g, I]
+
+Only SwiGLU (``f = silu``) is implemented; see ``_glu_activation`` below.
+
+Two kernels: the fc1 forward above, and the backward that hangs the activation
+gradient off fc2's dgrad. The forward always writes ``l1``, so there is no
+variant that recomputes fc1 inside the gradient epilogue.
+
+The generic grouped-GEMM scaffolding -- the pid/XCD remapping, the tile to group
+lookup, the plain per-tile K-loop -- comes from ``grouped_gemm_helper``, and the
+activation math from ``primus_turbo.triton.utils.silu``. The pair-tile
+addressing and register-tile surgery this epilogue needs are local to this
+module.
+
+``act`` and ``l1`` are written as BF16/FP16, not FP8: re-quantising here would
+need a per-tensor amax that only exists after every tile has run, so the FP8
+cast for the fc2 GEMM stays a separate pass.
+
+The scale is applied to the whole accumulator right after the K-loop -- a
+per-tensor scale cannot fold into it -- so everything downstream is defined on
+real values rather than the quantised sum.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import NamedTuple
+
+import torch
+import triton
+import triton.language as tl
+
+from primus_turbo.pytorch.core.utils import get_num_cus
+from primus_turbo.triton.grouped_gemm.grouped_gemm_fp8_kernel import (
+    _get_gg_fp8_tw_fwd_config,
+)
+from primus_turbo.triton.grouped_gemm.grouped_gemm_helper import (
+    NUM_XCDS,
+    _chiplet_transform_chunked,
+    _count_group_tiles,
+    _gemm_tile_dot,
+    _locate_group,
+    _swizzle_tile,
+)
+from primus_turbo.triton.utils.silu import silu_mul_bwd_act, silu_mul_probs
+
+# Operand dtypes these kernels accept. Both the OCP (gfx950) and FNUZ (gfx942)
+# spellings are listed because the encoding is picked per architecture by
+# ``primus_turbo.pytorch.core.low_precision``; the kernels themselves only ever
+# see the raw bits and the dequantisation scale.
+_SUPPORTED_FP8_DTYPES = (
+    torch.float8_e4m3fn,
+    torch.float8_e5m2,
+    torch.float8_e4m3fnuz,
+    torch.float8_e5m2fnuz,
+)
+
+# The activation and pre-activation this module writes. FP8 is deliberately
+# absent: see the module docstring.
+_SUPPORTED_OUT_DTYPES = (torch.bfloat16, torch.float16)
+
+
+def _check_fp8_operands(a: torch.Tensor, b: torch.Tensor) -> None:
+    assert a.dtype in _SUPPORTED_FP8_DTYPES, f"a must be FP8, got {a.dtype}"
+    assert b.dtype in _SUPPORTED_FP8_DTYPES, f"b must be FP8, got {b.dtype}"
+
+
+def _check_scales(a_scale: torch.Tensor, b_scale: torch.Tensor) -> None:
+    """Per-tensor scales: one fp32 element each, on device."""
+    for name, s in (("a_scale", a_scale), ("b_scale", b_scale)):
+        assert s.numel() == 1, f"{name} must be a scalar tensor (tensorwise scaling), got {tuple(s.shape)}"
+        assert s.dtype == torch.float32, f"{name} must be float32, got {s.dtype}"
+
+
+def _check_out_dtype(out_dtype: torch.dtype) -> None:
+    assert out_dtype in _SUPPORTED_OUT_DTYPES, (
+        f"FP8 GLU writes a high-precision activation; out_dtype must be one of "
+        f"{_SUPPORTED_OUT_DTYPES}, got {out_dtype}"
+    )
+
+
+# ===============================================================================
+# Activation dispatch
+#
+# The activation math itself lives in ``primus_turbo.triton.utils.silu``; these
+# two wrappers are the only places the epilogues name a concrete activation.
+# ===============================================================================
+
+# GLU-family activations the fused kernels can apply. The launchers validate
+# against this tuple so ``_glu_activation`` never sees an unknown name.
+SUPPORTED_ACTIVATIONS = ("silu",)
+
+
+@triton.jit
+def _glu_activation(gate, up, probs_row, ACTIVATION: tl.constexpr):
+    """Gate activation on a pair of fp32 register tiles, scaled by ``probs_row``.
+
+    ``ACTIVATION`` is a constexpr string, so the branch folds at compile time
+    and each variant gets its own specialisation. Only SwiGLU is implemented;
+    anything else fails to compile rather than silently falling back.
+
+    Adding a variant means a branch here, one in :func:`_glu_activation_grad`,
+    and a name in ``SUPPORTED_ACTIVATIONS``. Note that the activation shares
+    registers with a live BLOCK_M x BLOCK_N fp32 accumulator already at the VGPR
+    ceiling: a GeGLU spelled with ``tl.erf`` crashes the AMDGPU backend from here
+    ("Virtual register defs don't dominate all uses") while compiling fine in the
+    standalone geglu kernel. A new activation needs its own compile check, not
+    just a numerical one.
+    """
+    if ACTIVATION == "silu":
+        out = silu_mul_probs(gate, up, probs_row)
+    else:
+        tl.static_assert(False, "ACTIVATION must be one of SUPPORTED_ACTIVATIONS")
+        out = gate
+    return out
+
+
+@triton.jit
+def _glu_activation_grad(gate, up, dout, ACTIVATION: tl.constexpr):
+    """Backward counterpart of :func:`_glu_activation`.
+
+    Returns ``(dgate, dup, dout_act)``, the last being the per-element grad_probs
+    term. ``probs`` does not appear: ``dout`` has to arrive *unscaled* for that
+    term to be the routing gradient, so the caller scales the halves afterwards.
+    """
+    if ACTIVATION == "silu":
+        dgate, dup, dout_act = silu_mul_bwd_act(gate, up, dout)
+    else:
+        tl.static_assert(False, "ACTIVATION must be one of SUPPORTED_ACTIVATIONS")
+        dgate, dup, dout_act = gate, up, dout
+    return dgate, dup, dout_act
+
+
+# ===============================================================================
+# Pair-tile addressing and register-tile surgery
+#
+# A gated activation needs columns ``j`` and ``j + I`` of the same row, which a
+# plain contiguous BLOCK_N slice of the 2I-wide fc1 output splits across two
+# programs. The forward instead hands each program ``HALF = BLOCK_N // 2``
+# gate/up *pairs*; what follows implements that remapping and the register
+# reshuffles the epilogues need to take the tile apart again.
+# ===============================================================================
+
+
+@triton.jit
+def _pair_tile_locate(
+    global_tile_id,
+    group_offs_ptr,
+    G,
+    num_pid_n,
+    BLOCK_SIZE_M: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    """Resolve a pair-tile id to ``(in_range, m_start_g, M_g, pid_m, pid_n, group_idx)``.
+
+    Split out from the tile body so the out-of-range early return stays in the
+    caller: wrapping the dot in a conditional instead would put the whole
+    K-loop under a branch.
+    """
+    group_idx, tile_start, total_tiles = _locate_group(
+        global_tile_id, group_offs_ptr, G, num_pid_n, BLOCK_SIZE_M
+    )
+    if global_tile_id >= total_tiles:
+        return False, tl.cast(0, tl.int64), 0, 0, 0, 0
+
+    local_tile = global_tile_id - tile_start
+    m_start_g = tl.load(group_offs_ptr + group_idx)  # keep int64 to avoid address overflow
+    M_g = (tl.load(group_offs_ptr + group_idx + 1) - tl.load(group_offs_ptr + group_idx)).to(tl.int32)
+    pid_m, pid_n = _swizzle_tile(local_tile, tl.cdiv(M_g, BLOCK_SIZE_M), num_pid_n, GROUP_SIZE_M)
+    return True, m_start_g, M_g, pid_m, pid_n, group_idx
+
+
+@triton.jit
+def _pair_tile_cols(
+    pid_n,
+    INTER_N,
+    BLOCK_SIZE_N: tl.constexpr,
+    N_ALIGNED: tl.constexpr,
+    PAIR_CONTIG: tl.constexpr,
+):
+    """Column indices for one pair-tile: ``(rn_g, pair)`` over an ``I``-wide tensor.
+
+    ``PAIR_CONTIG`` is ``gcd(HALF, I)``: the longest run the wrapped index is
+    still guaranteed contiguous over, which is what the store vectoriser needs.
+    When ``HALF`` divides ``I`` nothing wraps and it degenerates to ``HALF``.
+    """
+    HALF: tl.constexpr = BLOCK_SIZE_N // 2
+    pair = pid_n * HALF + tl.arange(0, HALF)
+    if N_ALIGNED:
+        rn_g = tl.max_contiguous(tl.multiple_of(pair, HALF), HALF)
+    else:
+        rn_g = tl.max_contiguous(tl.multiple_of(pair % INTER_N, PAIR_CONTIG), PAIR_CONTIG)
+    return rn_g, pair
+
+
+@triton.jit
+def _split_rows(t, BM: tl.constexpr, W: tl.constexpr):
+    """Halve a (BM, W) tile into its top and bottom row blocks."""
+    return tl.split(tl.permute(tl.reshape(t, (2, BM // 2, W)), (1, 2, 0)))
+
+
+@triton.jit
+def _chunk_rows(t, c: tl.constexpr, BM: tl.constexpr, W: tl.constexpr, C: tl.constexpr):
+    """Chunk ``c`` of ``C`` contiguous row slices of a (BM, W) register tile.
+
+    Not free: ``_split_rows`` permutes, and a permute crosses lanes through LDS
+    behind a barrier. Callers that only need the chunk at output precision
+    should round *before* chunking rather than after -- half the dtype is half
+    the LDS traffic, and for both epilogues here it also matches the unfused
+    path bit for bit, since that one round-trips the same tile through memory
+    in the stored dtype.
+    """
+    if C == 1:
+        out = t
+    elif C == 2:
+        lo, hi = _split_rows(t, BM, W)
+        out = lo if c == 0 else hi
+    elif C == 4:
+        lo, hi = _split_rows(t, BM, W)
+        half = lo if c < 2 else hi
+        a, b = _split_rows(half, BM // 2, W)
+        out = a if c % 2 == 0 else b
+    elif C == 8:
+        lo, hi = _split_rows(t, BM, W)
+        half = lo if c < 4 else hi
+        a, b = _split_rows(half, BM // 2, W)
+        quarter = a if (c // 2) % 2 == 0 else b
+        x, y = _split_rows(quarter, BM // 4, W)
+        out = x if c % 2 == 0 else y
+    else:
+        tl.static_assert(C == 16, "EPI_CHUNKS must be 1, 2, 4, 8 or 16")
+        lo, hi = _split_rows(t, BM, W)
+        half = lo if c < 8 else hi
+        a, b = _split_rows(half, BM // 2, W)
+        quarter = a if (c // 4) % 2 == 0 else b
+        x, y = _split_rows(quarter, BM // 4, W)
+        eighth = x if (c // 2) % 2 == 0 else y
+        p, q = _split_rows(eighth, BM // 8, W)
+        out = p if c % 2 == 0 else q
+    return out
+
+
+@triton.jit
+def _split_pair_cols(t, BM: tl.constexpr, HALF: tl.constexpr):
+    """Peel a (BM, 2*HALF) gate||up tile into its two (BM, HALF) halves.
+
+    The permute is what makes the gate/up axis innermost so ``tl.split`` can
+    take it, and it is the epilogue's single largest cost: ``silu(gate) * up``
+    needs columns ``c`` and ``c + HALF`` in one lane, and a 2*HALF-wide MFMA
+    result puts them in different ones. Three ways of removing it -- a bare
+    ``reshape(BM, HALF, 2)`` split, pre-packing B with gate/up interleaved, and
+    two HALF-wide dots into separate accumulators -- all measured worse than
+    paying it, the last one badly (two B operands live at once through the
+    k-loop). The permuted layout is also what lets the halves store as wide
+    contiguous writes.
+    """
+    return tl.split(tl.permute(tl.reshape(t, (BM, 2, HALF)), (0, 2, 1)))
+
+
+@triton.jit
+def _pair_tile_dot(
+    A,
+    B,
+    m_start_g,
+    M_g,
+    group_idx,
+    pid_m,
+    pid_n,
+    INTER_N,
+    K,
+    stride_am,
+    stride_bg,
+    stride_bn,
+    stride_ak: tl.constexpr,
+    stride_bk: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    N_ALIGNED: tl.constexpr,
+    PAIR_CONTIG: tl.constexpr,
+    CACHE_MODIFIER_A: tl.constexpr,
+    CACHE_MODIFIER_B: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+):
+    """Accumulate one pair-tile of fc1, still laid out as ``gate||up`` columns.
+
+    Returns ``(acc, rn_g, pair)``, where ``acc`` is (BLOCK_M, BLOCK_N) with the
+    gate slice in ``[0, HALF)`` and the up slice in ``[HALF, BLOCK_N)``,
+    ``rn_g`` indexes the tile's ``HALF`` columns within an ``I``-wide tensor,
+    and ``pair`` is the unwrapped version used for bounds masks.
+
+    The accumulator is fp32 and the operands are read as-is, so the caller gets
+    a *quantised* sum back and must apply the dequantisation scale to it before
+    the activation. The halves are peeled off by :func:`_split_pair_cols`.
+    """
+    HALF: tl.constexpr = BLOCK_SIZE_N // 2
+
+    # The tile owns gate columns [p, p+HALF) and up columns [I+p, I+p+HALF).
+    rm = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M_g
+    rn_g, pair = _pair_tile_cols(pid_n, INTER_N, BLOCK_SIZE_N, N_ALIGNED, PAIR_CONTIG)
+    rk = tl.arange(0, BLOCK_SIZE_K)
+
+    group_offset_b = group_idx.to(tl.int64) * stride_bg
+    A_BASE = A + m_start_g * stride_am + rm[:, None] * stride_am + rk[None, :] * stride_ak
+
+    loop_k = tl.cdiv(K, BLOCK_SIZE_K)
+    if not EVEN_K:
+        loop_k -= 1
+    tl.assume(loop_k >= 0)
+
+    # One full-width dot, same MFMA shape as the unfused kernel. rn holds the
+    # gate slice in [0, HALF) and the up slice in [HALF, BLOCK_N), so each half
+    # is a contiguous run of B columns.
+    cols = tl.arange(0, BLOCK_SIZE_N)
+    rn = pid_n * HALF + (cols % HALF)
+    if not N_ALIGNED:
+        rn = rn % INTER_N
+    rn += (cols // HALF) * INTER_N
+    # Restate the contiguity the wrap above hides. Runs of ``PAIR_CONTIG`` stay
+    # consecutive either way, but the runtime ``%`` loses that for the compiler
+    # and every B load degrades into a per-element gather.
+    rn = tl.max_contiguous(tl.multiple_of(rn, PAIR_CONTIG), PAIR_CONTIG)
+    B_BASE = B + group_offset_b + rk[:, None] * stride_bk + rn[None, :] * stride_bn
+
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, loop_k):
+        if stride_ak == 1:
+            a = tl.load(tl.multiple_of(A_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER_A)
+        else:
+            a = tl.load(tl.multiple_of(A_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER_A)
+        if stride_bk == 1:
+            b = tl.load(tl.multiple_of(B_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER_B)
+        else:
+            b = tl.load(tl.multiple_of(B_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER_B)
+        acc += tl.dot(a, b, allow_tf32=ALLOW_TF32)
+        A_BASE += BLOCK_SIZE_K * stride_ak
+        B_BASE += BLOCK_SIZE_K * stride_bk
+
+    if not EVEN_K:
+        rk_last = loop_k * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+        A_LAST = A + m_start_g * stride_am + rm[:, None] * stride_am + rk_last[None, :] * stride_ak
+        B_LAST = B + group_offset_b + rk_last[:, None] * stride_bk + rn[None, :] * stride_bn
+        a = tl.load(A_LAST, mask=rk_last[None, :] < K, other=0.0, cache_modifier=CACHE_MODIFIER_A)
+        b = tl.load(B_LAST, mask=rk_last[:, None] < K, other=0.0, cache_modifier=CACHE_MODIFIER_B)
+        acc += tl.dot(a, b, allow_tf32=ALLOW_TF32)
+
+    return acc, rn_g, pair
+
+
+# ===============================================================================
+# Launch-side resolution
+# ===============================================================================
+
+
+class PairTileShape(NamedTuple):
+    """Shapes and strides a pair-tile launch derives from its fc1 operands."""
+
+    M_total: int
+    G: int
+    K: int
+    inter_n: int
+    stride_bg: int
+    stride_bn: int
+    stride_ak: int
+    stride_bk: int
+
+
+class PairTileLaunch(NamedTuple):
+    """Everything the pair-tile kernel needs from shape + config resolution."""
+
+    inter_n: int
+    K: int
+    num_sms: int
+    stride_bg: int
+    stride_bn: int
+    stride_ak: int
+    stride_bk: int
+    even_k: bool
+    n_aligned: bool
+    pair_contig: int
+    grid: dict
+    knobs: dict
+    cache_a: str
+    cache_b: str
+    cache_out: str
+    cache_l1: str
+    epi_chunks: int
+
+
+def resolve_pair_tile_shape(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    trans_b: bool,
+    activation: str,
+) -> PairTileShape:
+    """Validate the fc1 operand shapes for a pair-tile launch.
+
+    Operand dtypes are checked separately by :func:`_check_fp8_operands`.
+    """
+    assert a.ndim == 2, f"a must be 2D, got {a.shape}"
+    assert b.ndim == 3, f"b must be 3D, got {b.shape}"
+    assert activation in SUPPORTED_ACTIVATIONS, (
+        f"Unsupported activation: {activation!r}, expected one of {SUPPORTED_ACTIVATIONS}"
+    )
+
+    M_total, K_a = a.shape
+    G = b.shape[0]
+    if trans_b:
+        N, K_b = b.shape[1], b.shape[2]
+        stride_bk, stride_bn = b.stride(2), b.stride(1)
+    else:
+        K_b, N = b.shape[1], b.shape[2]
+        stride_bk, stride_bn = b.stride(1), b.stride(2)
+
+    assert K_a == K_b, f"K mismatch: a has K={K_a}, b has K={K_b}"
+    assert N % 2 == 0, f"fc1 output width must be even (gate||up), got {N}"
+
+    return PairTileShape(
+        M_total=M_total,
+        G=G,
+        K=K_a,
+        inter_n=N // 2,
+        stride_bg=b.stride(0),
+        stride_bn=stride_bn,
+        stride_ak=a.stride(1),
+        stride_bk=stride_bk,
+    )
+
+
+def _check_probs(probs: torch.Tensor, m_total: int) -> None:
+    assert probs.ndim == 1 and probs.shape[0] == m_total, (
+        f"probs must be [{m_total}], got {tuple(probs.shape)}"
+    )
+    assert probs.dtype == torch.float32, f"probs must be float32, got {probs.dtype}"
+
+
+@triton.jit
+def _process_grouped_gemm_fp8_glu_tile(
+    global_tile_id,
+    A,  # [M_total, K] FP8
+    B,  # [G, ?, ?]  FP8
+    ACT,  # activation out [M_total, I], BF16/FP16
+    L1,  # fc1 pre-activation [M_total, 2I], gate||up, BF16/FP16
+    PROBS,  # [M_total] fp32 routing probs
+    group_offs_ptr,
+    scale,  # fp32 a_scale * b_scale, already reduced to a scalar by the caller
+    G,
+    INTER_N,  # I -- half of the fc1 output width
+    K,
+    stride_am,
+    stride_bg,
+    stride_bn,
+    stride_actm,
+    stride_actn,
+    stride_l1m,
+    stride_l1n,
+    stride_probs,
+    num_pid_n,
+    stride_ak: tl.constexpr,
+    stride_bk: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    N_ALIGNED: tl.constexpr,
+    PAIR_CONTIG: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    CACHE_MODIFIER_A: tl.constexpr,
+    CACHE_MODIFIER_B: tl.constexpr,
+    CACHE_MODIFIER_ACT: tl.constexpr,
+    CACHE_MODIFIER_L1: tl.constexpr,
+    EPI_CHUNKS: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+):
+    """Compute one pair-tile of ``HALF = BLOCK_N // 2`` gate/up columns."""
+    HALF: tl.constexpr = BLOCK_SIZE_N // 2
+
+    in_range, m_start_g, M_g, pid_m, pid_n, group_idx = _pair_tile_locate(
+        global_tile_id, group_offs_ptr, G, num_pid_n, BLOCK_SIZE_M, GROUP_SIZE_M
+    )
+    if not in_range:
+        return
+
+    acc, rn_g, pair = _pair_tile_dot(
+        A,
+        B,
+        m_start_g,
+        M_g,
+        group_idx,
+        pid_m,
+        pid_n,
+        INTER_N,
+        K,
+        stride_am,
+        stride_bg,
+        stride_bn,
+        stride_ak=stride_ak,
+        stride_bk=stride_bk,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        EVEN_K=EVEN_K,
+        N_ALIGNED=N_ALIGNED,
+        PAIR_CONTIG=PAIR_CONTIG,
+        CACHE_MODIFIER_A=CACHE_MODIFIER_A,
+        CACHE_MODIFIER_B=CACHE_MODIFIER_B,
+        ALLOW_TF32=ALLOW_TF32,
+    )
+    acc = acc * scale
+
+    # -- Epilogue --
+    # Row-chunked: the gate/up/act tiles sit on top of a live accumulator, so a
+    # full-width epilogue spills once l1 is also written.
+    if N_ALIGNED:
+        pair_ok = tl.full((1, HALF), True, tl.int1)
+    else:
+        pair_ok = (pair < INTER_N)[None, :]
+
+    l1_ty = L1.type.element_ty
+    act_ty = ACT.type.element_ty
+    R: tl.constexpr = BLOCK_SIZE_M // EPI_CHUNKS
+
+    # Rounded before the split, for the reason _chunk_rows gives, and split once
+    # for the whole tile rather than per chunk: the rounded halves hold whole.
+    gate_all, up_all = _split_pair_cols(acc.to(l1_ty), BLOCK_SIZE_M, HALF)
+
+    for c in tl.static_range(EPI_CHUNKS):
+        gate_s = _chunk_rows(gate_all, c, BLOCK_SIZE_M, HALF, EPI_CHUNKS)
+        up_s = _chunk_rows(up_all, c, BLOCK_SIZE_M, HALF, EPI_CHUNKS)
+        gate_c, up_c = gate_s.to(tl.float32), up_s.to(tl.float32)
+        raw_m = pid_m * BLOCK_SIZE_M + c * R + tl.arange(0, R)
+        rm_c = tl.minimum(raw_m, M_g - 1)
+        mask_c = (raw_m < M_g)[:, None] & pair_ok
+
+        probs_c = tl.load(
+            PROBS + (m_start_g + rm_c) * stride_probs,
+            mask=raw_m < M_g,
+            other=1.0,
+            cache_modifier=".ca",
+        ).to(tl.float32)
+        act_c = _glu_activation(gate_c, up_c, probs_c, ACTIVATION)
+
+        L1_ = L1 + (m_start_g + rm_c[:, None]) * stride_l1m
+        tl.store(
+            L1_ + rn_g[None, :] * stride_l1n,
+            gate_s,
+            mask_c,
+            cache_modifier=CACHE_MODIFIER_L1,
+        )
+        tl.store(
+            L1_ + (rn_g + INTER_N)[None, :] * stride_l1n,
+            up_s,
+            mask_c,
+            cache_modifier=CACHE_MODIFIER_L1,
+        )
+        ACT_ = ACT + (m_start_g + rm_c[:, None]) * stride_actm + rn_g[None, :] * stride_actn
+        tl.store(ACT_, act_c.to(act_ty), mask_c, cache_modifier=CACHE_MODIFIER_ACT)
+
+
+@triton.jit()
+def _grouped_fp8_glu_persistent_gemm_kernel(
+    # Pointers
+    A,  # [M_total, K] FP8
+    B,  # [G, ?, ?]  -- (K, 2I) or (2I, K) depending on trans_b, FP8
+    ACT,  # [M_total, I]
+    L1,  # [M_total, 2I]
+    PROBS,  # [M_total] fp32
+    A_scale_ptr,  # fp32 scalar
+    B_scale_ptr,  # fp32 scalar
+    group_offs_ptr,  # [G+1] int64
+    # Dimensions
+    G,
+    INTER_N,  # I
+    K,
+    # Strides
+    stride_am,
+    stride_bg,
+    stride_bn,
+    stride_actm,
+    stride_actn,
+    stride_l1m,
+    stride_l1n,
+    stride_probs,
+    # Constexpr strides
+    stride_ak: tl.constexpr,
+    stride_bk: tl.constexpr,
+    # Tile config
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    N_ALIGNED: tl.constexpr,
+    PAIR_CONTIG: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    CACHE_MODIFIER_A: tl.constexpr,
+    CACHE_MODIFIER_B: tl.constexpr,
+    CACHE_MODIFIER_ACT: tl.constexpr,
+    CACHE_MODIFIER_L1: tl.constexpr,
+    EPI_CHUNKS: tl.constexpr,
+    ALLOW_TF32: tl.constexpr = torch.backends.cuda.matmul.allow_tf32,
+):
+    """Persistent FP8 grouped GEMM + fused GLU activation (CPU-sync-free).
+
+    Tiles are counted over gate/up *pairs*, so ``num_pid_n`` spans I rather
+    than the 2I output width. The epilogue writes both ``act`` [M, I] and the
+    dequantised pre-activation ``l1`` [M, 2I] (gate||up, before the activation
+    and probs), both in the caller's high-precision dtype.
+    """
+    pid = tl.program_id(0)
+    if NUM_XCDS != 1:
+        pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
+
+    num_pid_n = tl.cdiv(INTER_N, BLOCK_SIZE_N // 2)
+    total_tiles = _count_group_tiles(group_offs_ptr, G, num_pid_n, BLOCK_SIZE_M)
+
+    # Hoisted above the tile loop so the tile body sees a plain register.
+    scale = tl.load(A_scale_ptr) * tl.load(B_scale_ptr)
+
+    tl.assume(stride_am > 0)
+    tl.assume(stride_ak > 0)
+    tl.assume(stride_bn > 0)
+    tl.assume(stride_bk > 0)
+    tl.assume(stride_actm > 0)
+    tl.assume(stride_actn > 0)
+    tl.assume(stride_l1m > 0)
+    tl.assume(stride_l1n > 0)
+    tl.assume(stride_probs > 0)
+
+    for global_tile_id in range(pid, total_tiles, NUM_SMS):
+        _process_grouped_gemm_fp8_glu_tile(
+            global_tile_id,
+            A,
+            B,
+            ACT,
+            L1,
+            PROBS,
+            group_offs_ptr,
+            scale,
+            G,
+            INTER_N,
+            K,
+            stride_am,
+            stride_bg,
+            stride_bn,
+            stride_actm,
+            stride_actn,
+            stride_l1m,
+            stride_l1n,
+            stride_probs,
+            num_pid_n,
+            stride_ak=stride_ak,
+            stride_bk=stride_bk,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=GROUP_SIZE_M,
+            EVEN_K=EVEN_K,
+            N_ALIGNED=N_ALIGNED,
+            PAIR_CONTIG=PAIR_CONTIG,
+            ACTIVATION=ACTIVATION,
+            CACHE_MODIFIER_A=CACHE_MODIFIER_A,
+            CACHE_MODIFIER_B=CACHE_MODIFIER_B,
+            CACHE_MODIFIER_ACT=CACHE_MODIFIER_ACT,
+            CACHE_MODIFIER_L1=CACHE_MODIFIER_L1,
+            EPI_CHUNKS=EPI_CHUNKS,
+            ALLOW_TF32=ALLOW_TF32,
+        )
+
+
+def _resolve_fp8_pair_tile_launch(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    trans_b: bool,
+    activation: str,
+    out_dtype: torch.dtype,
+    num_cu: int | None,
+) -> PairTileLaunch:
+    """Validate the fc1 operands and pick the tile config for an FP8 pair-tile launch."""
+    _check_fp8_operands(a, b)
+    _check_out_dtype(out_dtype)
+    shape = resolve_pair_tile_shape(a, b, trans_b, activation)
+    M_total, G, K, inter_n = shape.M_total, shape.G, shape.K, shape.inter_n
+    N = 2 * inter_n
+
+    device_num_cus = get_num_cus()
+    num_sms = min(num_cu, device_num_cus) if num_cu is not None and num_cu > 0 else device_num_cus
+    avg_m = max(M_total // max(G, 1), 256)
+    BLOCK_M, BLOCK_N, BLOCK_K, group_m, cache_a, cache_b, num_stages_val, chunk_size, _grid_sms = (
+        _get_gg_fp8_tw_fwd_config(
+            avg_m,
+            N,
+            K,
+            out_dtype,
+            a.dtype,
+            b.dtype,
+            trans_b,
+            G,
+            num_sms,
+            M_total,
+            shape.stride_ak,
+            shape.stride_bk,
+        )
+    )
+    # A pair-tile of a given BLOCK_N covers half as many output columns as the
+    # unfused GEMM's, but holds an fp32 accumulator of the same size, so the
+    # register ceiling caps it at the same 256.
+    if BLOCK_N > 256:
+        BLOCK_N = 256
+    # Three stages at BLOCK_K=128 overflow what the scheduler can hide, so the
+    # config helper's occasional 3 is clamped rather than trusted.
+    num_stages_val = min(num_stages_val, 2)
+    num_warps_val = 8
+    waves_per_eu_val, mfma_dim_val, kpack_val = 1, 32, 1
+    # act feeds the very next GEMM, so it keeps the default policy; l1 is not
+    # read again until the backward pass and only evicts the A/B tiles this
+    # kernel re-reads, so it asks not to be kept. Five alternating trials at
+    # I=5760 put the streaming hint ahead with no overlap (4.684-4.717 ms
+    # against 4.729-4.757). The same hint on act measured no better than .cg.
+    cache_out = ".cg"
+    cache_l1 = ".cs"
+    epi_chunks = 8
+    # Halving the effective N width halves the pair-tile grid, so re-derive the
+    # swizzle for the actual tile count rather than reusing the unfused one. A
+    # pair-tile reads two B column strips ``inter_n`` apart instead of one
+    # contiguous strip, so the shorter chunk keeps more of the tiles sharing
+    # those strips resident together.
+    est_tiles = -(-M_total // BLOCK_M) * -(-inter_n // (BLOCK_N // 2))
+    group_m, chunk_size = (2, 16) if est_tiles >= 512 else (4, 64)
+    # A pair-tile is BLOCK_N // 2 wide, and tl.dot needs at least 16 columns.
+    while BLOCK_N > 32 and inter_n * 2 < BLOCK_N:
+        BLOCK_N //= 2
+
+    return PairTileLaunch(
+        inter_n=inter_n,
+        K=K,
+        num_sms=num_sms,
+        stride_bg=shape.stride_bg,
+        stride_bn=shape.stride_bn,
+        stride_ak=shape.stride_ak,
+        stride_bk=shape.stride_bk,
+        even_k=(K % BLOCK_K == 0),
+        n_aligned=(inter_n % (BLOCK_N // 2) == 0),
+        pair_contig=math.gcd(BLOCK_N // 2, inter_n),
+        grid=dict(
+            BLOCK_SIZE_M=BLOCK_M,
+            BLOCK_SIZE_N=BLOCK_N,
+            BLOCK_SIZE_K=BLOCK_K,
+            GROUP_SIZE_M=group_m,
+            CHUNK_SIZE=chunk_size,
+        ),
+        knobs=dict(
+            num_warps=num_warps_val,
+            num_stages=num_stages_val,
+            waves_per_eu=waves_per_eu_val,
+            matrix_instr_nonkdim=mfma_dim_val,
+            kpack=kpack_val,
+        ),
+        cache_a=cache_a,
+        cache_b=cache_b,
+        cache_out=cache_out,
+        cache_l1=cache_l1,
+        epi_chunks=epi_chunks,
+    )
+
+
+def grouped_gemm_fp8_glu_triton_kernel(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scale: torch.Tensor,
+    b_scale: torch.Tensor,
+    probs: torch.Tensor,
+    group_offs: torch.Tensor,
+    act_out: torch.Tensor,
+    intermediate_out: torch.Tensor,
+    trans_b: bool = False,
+    *,
+    activation: str = "silu",
+    out_dtype: torch.dtype = torch.bfloat16,
+    num_cu: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Persistent FP8 grouped GEMM with a fused GLU-family activation epilogue.
+
+    Computes ``act[g] = f(gate) * up * probs`` where
+    ``l1 = [gate|up] = (a[g] @ B_view[g]) * a_scale * b_scale``, in a single
+    launch, both in ``out_dtype``. ``l1`` is written because backward's
+    :func:`grouped_gemm_fp8_dglu_triton_kernel` needs both halves.
+
+    Args:
+        probs: [M_total] float32 routing probabilities. The epilogue scales the
+            activation output -- but not ``l1`` -- by these, per row.
+        act_out: [M_total, I] buffer receiving the activation.
+        intermediate_out: [M_total, 2I] buffer receiving ``l1``. Both are the
+            caller's to allocate: every slot is written, so neither needs
+            initialising.
+        num_cu: Cap the persistent grid at this many CUs. None uses every CU.
+
+    Returns:
+        ``(act_out, intermediate_out)``, for call-site convenience.
+    """
+    _check_scales(a_scale, b_scale)
+    plan = _resolve_fp8_pair_tile_launch(a, b, trans_b, activation, out_dtype, num_cu)
+    M_total = a.shape[0]
+    assert act_out.shape == (M_total, plan.inter_n), (
+        f"act_out must be [{M_total}, {plan.inter_n}], got {tuple(act_out.shape)}"
+    )
+    assert act_out.device == a.device and act_out.dtype == out_dtype
+    assert intermediate_out.shape == (M_total, 2 * plan.inter_n), (
+        f"intermediate_out must be [{M_total}, {2 * plan.inter_n}], got {tuple(intermediate_out.shape)}"
+    )
+    assert intermediate_out.device == a.device and intermediate_out.dtype == out_dtype
+    _check_probs(probs, M_total)
+
+    act, l1 = act_out, intermediate_out
+    _grouped_fp8_glu_persistent_gemm_kernel[(plan.num_sms,)](
+        a,
+        b,
+        act,
+        l1,
+        probs,
+        a_scale,
+        b_scale,
+        group_offs,
+        b.shape[0],
+        plan.inter_n,
+        plan.K,
+        a.stride(0),
+        plan.stride_bg,
+        plan.stride_bn,
+        act.stride(0),
+        act.stride(1),
+        l1.stride(0),
+        l1.stride(1),
+        probs.stride(0),
+        stride_ak=plan.stride_ak,
+        stride_bk=plan.stride_bk,
+        NUM_SMS=plan.num_sms,
+        NUM_XCDS=NUM_XCDS,
+        EVEN_K=plan.even_k,
+        N_ALIGNED=plan.n_aligned,
+        PAIR_CONTIG=plan.pair_contig,
+        ACTIVATION=activation,
+        CACHE_MODIFIER_A=plan.cache_a,
+        CACHE_MODIFIER_B=plan.cache_b,
+        CACHE_MODIFIER_ACT=plan.cache_out,
+        CACHE_MODIFIER_L1=plan.cache_l1,
+        EPI_CHUNKS=plan.epi_chunks,
+        **plan.grid,
+        **plan.knobs,
+    )
+    return act, l1
+
+
+# ===============================================================================
+# fc2 dgrad + GLU-gradient epilogue -- Persistent Kernel (backward, CPU-sync-free)
+#
+# Computes: dl1[g] = dact_grad(l1[g], (a[g] @ B_view[g]) * a_scale * b_scale)
+#
+# The activation gradient hangs off the GEMM the backward has to run anyway --
+# fc2's dgrad, ``dact = a @ W2^T`` -- and reads the pre-activation the forward
+# saved, so ``dact`` never reaches HBM.
+#
+# Unlike the pair-tile kernel above, the GEMM here is an ordinary grouped GEMM
+# over an I-wide output; only the epilogue knows about the gate/up split.
+# ===============================================================================
+
+
+@triton.jit
+def _process_grouped_fp8_dglu_tile(
+    global_tile_id,
+    A,  # [M_total, K] FP8   incoming gradient wrt the fc2 output
+    B,  # [G, ?, ?]    FP8   fc2 weights, already oriented so the dot yields dact
+    L1,  # [M_total, 2N]      saved fc1 pre-activation, BF16/FP16
+    DL1,  # [M_total, 2N]
+    GRAD_PROBS_PARTIAL,  # [num_pid_n, M_total] fp32   this tile's slice of the grad_probs sum
+    PROBS,  # [M_total] fp32 routing probs
+    group_offs_ptr,
+    scale,  # fp32 a_scale * b_scale
+    G,
+    N,  # I
+    K,  # fc2 output width
+    stride_am,
+    stride_bg,
+    stride_bn,
+    stride_l1m,
+    stride_l1n,
+    stride_dl1m,
+    stride_dl1n,
+    stride_grad_probs_partial,
+    stride_probs,
+    num_pid_n,
+    stride_ak: tl.constexpr,
+    stride_bk: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    N_EXACT: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    CACHE_MODIFIER_A: tl.constexpr,
+    CACHE_MODIFIER_B: tl.constexpr,
+    CACHE_MODIFIER_L1: tl.constexpr,
+    CACHE_MODIFIER_DL1: tl.constexpr,
+    EPI_CHUNKS: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+):
+    """One I-wide dact tile, turned into both halves of dl1 before it leaves registers."""
+    group_idx, tile_start, total_tiles = _locate_group(
+        global_tile_id, group_offs_ptr, G, num_pid_n, BLOCK_SIZE_M
+    )
+    if global_tile_id >= total_tiles:
+        return
+
+    local_tile = global_tile_id - tile_start
+    m_start_g = tl.load(group_offs_ptr + group_idx)  # keep int64 to avoid address overflow
+    M_g = (tl.load(group_offs_ptr + group_idx + 1) - tl.load(group_offs_ptr + group_idx)).to(tl.int32)
+    pid_m, pid_n = _swizzle_tile(local_tile, tl.cdiv(M_g, BLOCK_SIZE_M), num_pid_n, GROUP_SIZE_M)
+
+    rm = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M_g
+    raw_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    rn = raw_n % N
+    rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
+
+    acc = _gemm_tile_dot(
+        A,
+        B,
+        m_start_g,
+        group_idx,
+        rm,
+        rn,
+        K,
+        stride_am,
+        stride_bg,
+        stride_bn,
+        stride_ak=stride_ak,
+        stride_bk=stride_bk,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        EVEN_K=EVEN_K,
+        CACHE_MODIFIER_A=CACHE_MODIFIER_A,
+        CACHE_MODIFIER_B=CACHE_MODIFIER_B,
+        ALLOW_TF32=ALLOW_TF32,
+    )
+    # Dequantise only. probs cannot fold in here: ``dact * act`` is the routing
+    # gradient term only if it comes off the gradient *before* probs, so the
+    # accumulator has to reach the epilogue unscaled and probs goes on per chunk.
+    acc = acc * scale
+
+    # -- Epilogue --
+    # Row-blocked: this epilogue needs *two* more input tiles (gate and up) on
+    # top of a live accumulator, so a full-width version spills hard. Rows keep
+    # every access BLOCK_N-wide.
+    out_ty = DL1.type.element_ty
+    R: tl.constexpr = BLOCK_SIZE_M // EPI_CHUNKS
+
+    # Rounded before chunking, for the reason _chunk_rows gives.
+    acc_r = acc.to(out_ty)
+
+    for c in tl.static_range(EPI_CHUNKS):
+        acc_c = _chunk_rows(acc_r, c, BLOCK_SIZE_M, BLOCK_SIZE_N, EPI_CHUNKS).to(tl.float32)
+
+        raw_m = pid_m * BLOCK_SIZE_M + c * R + tl.arange(0, R)
+        rm_c = tl.minimum(raw_m, M_g - 1)
+        mask_c = (raw_m < M_g)[:, None]
+
+        # gate at l1[:, n], up at l1[:, n + I]: two BLOCK_N-wide reads.
+        L1_ = L1 + (m_start_g + rm_c[:, None]) * stride_l1m
+        gate = tl.load(
+            L1_ + rn[None, :] * stride_l1n,
+            mask=mask_c,
+            other=0.0,
+            cache_modifier=CACHE_MODIFIER_L1,
+        )
+        up = tl.load(
+            L1_ + (rn + N)[None, :] * stride_l1n,
+            mask=mask_c,
+            other=0.0,
+            cache_modifier=CACHE_MODIFIER_L1,
+        )
+
+        dgate_c, dup_c, dact_act_c = _glu_activation_grad(
+            gate.to(tl.float32), up.to(tl.float32), acc_c, ACTIVATION
+        )
+        # Reduced in registers, in fp32: beats folding a buffer already rounded
+        # to bf16. Folding the whole BLOCK_N is cross-lane but still won -- a
+        # sweep of partial widths from 8 up to BLOCK_N was flat to within 3%.
+        #
+        # ``rn`` wraps modulo N, so when N is not a multiple of BLOCK_N the last
+        # tile revisits low columns. The dl1 stores below are idempotent about
+        # that, but a sum would count those columns twice.
+        if N_EXACT:
+            grad_probs_c = tl.sum(dact_act_c, axis=1)
+        else:
+            grad_probs_c = tl.sum(tl.where((raw_n < N)[None, :], dact_act_c, 0.0), axis=1)
+        tl.store(
+            GRAD_PROBS_PARTIAL + pid_n.to(tl.int64) * stride_grad_probs_partial + m_start_g + rm_c,
+            grad_probs_c,
+            mask=raw_m < M_g,
+        )
+
+        # acc_c reached the gradient unscaled, so the halves take probs here.
+        probs_c = tl.load(
+            PROBS + (m_start_g + rm_c) * stride_probs,
+            mask=raw_m < M_g,
+            other=1.0,
+        ).to(tl.float32)[:, None]
+        dgate_c = dgate_c * probs_c
+        dup_c = dup_c * probs_c
+
+        DL1_ = DL1 + (m_start_g + rm_c[:, None]) * stride_dl1m
+        tl.store(
+            DL1_ + rn[None, :] * stride_dl1n,
+            dgate_c.to(out_ty),
+            mask_c,
+            cache_modifier=CACHE_MODIFIER_DL1,
+        )
+        tl.store(
+            DL1_ + (rn + N)[None, :] * stride_dl1n,
+            dup_c.to(out_ty),
+            mask_c,
+            cache_modifier=CACHE_MODIFIER_DL1,
+        )
+
+
+@triton.jit()
+def _grouped_fp8_dglu_persistent_gemm_kernel(
+    A,
+    B,
+    L1,
+    DL1,
+    GRAD_PROBS_PARTIAL,
+    PROBS,
+    A_scale_ptr,
+    B_scale_ptr,
+    group_offs_ptr,
+    G,
+    N,
+    K,
+    stride_am,
+    stride_bg,
+    stride_bn,
+    stride_l1m,
+    stride_l1n,
+    stride_dl1m,
+    stride_dl1n,
+    stride_grad_probs_partial,
+    stride_probs,
+    stride_ak: tl.constexpr,
+    stride_bk: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    N_EXACT: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    CACHE_MODIFIER_A: tl.constexpr,
+    CACHE_MODIFIER_B: tl.constexpr,
+    CACHE_MODIFIER_L1: tl.constexpr,
+    CACHE_MODIFIER_DL1: tl.constexpr,
+    EPI_CHUNKS: tl.constexpr,
+    ALLOW_TF32: tl.constexpr = torch.backends.cuda.matmul.allow_tf32,
+):
+    """Persistent FP8 fc2 dgrad with a fused activation-gradient epilogue."""
+    pid = tl.program_id(0)
+    if NUM_XCDS != 1:
+        pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
+
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    total_tiles = _count_group_tiles(group_offs_ptr, G, num_pid_n, BLOCK_SIZE_M)
+
+    scale = tl.load(A_scale_ptr) * tl.load(B_scale_ptr)
+
+    tl.assume(stride_am > 0)
+    tl.assume(stride_ak > 0)
+    tl.assume(stride_bn > 0)
+    tl.assume(stride_bk > 0)
+    tl.assume(stride_l1m > 0)
+    tl.assume(stride_l1n > 0)
+    tl.assume(stride_dl1m > 0)
+    tl.assume(stride_dl1n > 0)
+    tl.assume(stride_probs > 0)
+    tl.assume(stride_grad_probs_partial > 0)
+
+    for global_tile_id in range(pid, total_tiles, NUM_SMS):
+        _process_grouped_fp8_dglu_tile(
+            global_tile_id,
+            A,
+            B,
+            L1,
+            DL1,
+            GRAD_PROBS_PARTIAL,
+            PROBS,
+            group_offs_ptr,
+            scale,
+            G,
+            N,
+            K,
+            stride_am,
+            stride_bg,
+            stride_bn,
+            stride_l1m,
+            stride_l1n,
+            stride_dl1m,
+            stride_dl1n,
+            stride_grad_probs_partial,
+            stride_probs,
+            num_pid_n,
+            stride_ak=stride_ak,
+            stride_bk=stride_bk,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=GROUP_SIZE_M,
+            EVEN_K=EVEN_K,
+            N_EXACT=N_EXACT,
+            ACTIVATION=ACTIVATION,
+            CACHE_MODIFIER_A=CACHE_MODIFIER_A,
+            CACHE_MODIFIER_B=CACHE_MODIFIER_B,
+            CACHE_MODIFIER_L1=CACHE_MODIFIER_L1,
+            CACHE_MODIFIER_DL1=CACHE_MODIFIER_DL1,
+            EPI_CHUNKS=EPI_CHUNKS,
+            ALLOW_TF32=ALLOW_TF32,
+        )
+
+
+class DgluLaunch(NamedTuple):
+    """Everything the fc2-dgrad kernel needs from shape + config resolution."""
+
+    M_total: int
+    N: int
+    K: int
+    G: int
+    num_sms: int
+    num_pid_n: int
+    stride_bn: int
+    stride_bk: int
+    even_k: bool
+    n_exact: bool
+    grid: dict
+    knobs: dict
+    cache_a: str
+    cache_b: str
+    cache_l1: str
+    cache_dl1: str
+    epi_chunks: int
+
+
+def _resolve_fp8_dglu_launch(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    intermediate: torch.Tensor,
+    trans_b: bool,
+    activation: str,
+    num_cu: int | None,
+) -> DgluLaunch:
+    """Validate the fc2-dgrad operands and pick the tile config.
+
+    ``num_pid_n``, the number of grad_probs partials the epilogue leaves behind,
+    follows from ``BLOCK_SIZE_N``. Resolving the tiling here rather than inline
+    at the launch is what lets :func:`grouped_gemm_fp8_dglu_grad_probs_partial_spec` report
+    a size the kernel is guaranteed to write.
+    """
+    assert a.ndim == 2, f"a must be 2D, got {a.shape}"
+    assert b.ndim == 3, f"b must be 3D, got {b.shape}"
+    assert intermediate.ndim == 2, f"intermediate must be 2D, got {intermediate.shape}"
+    _check_fp8_operands(a, b)
+    _check_out_dtype(intermediate.dtype)
+    assert activation in SUPPORTED_ACTIVATIONS, (
+        f"Unsupported activation: {activation!r}, expected one of {SUPPORTED_ACTIVATIONS}"
+    )
+
+    M_total, K_a = a.shape
+    G = b.shape[0]
+    if trans_b:
+        N, K_b = b.shape[1], b.shape[2]
+        stride_bk, stride_bn = b.stride(2), b.stride(1)
+    else:
+        K_b, N = b.shape[1], b.shape[2]
+        stride_bk, stride_bn = b.stride(1), b.stride(2)
+
+    assert K_a == K_b, f"K mismatch: a has K={K_a}, b has K={K_b}"
+    assert intermediate.shape == (M_total, 2 * N), (
+        f"intermediate must be [{M_total}, {2 * N}], got {tuple(intermediate.shape)}"
+    )
+    K = K_a
+
+    device_num_cus = get_num_cus()
+    num_sms = min(num_cu, device_num_cus) if num_cu is not None and num_cu > 0 else device_num_cus
+    avg_m = max(M_total // max(G, 1), 256)
+    BLOCK_M, BLOCK_N, BLOCK_K, group_m, cache_a, cache_b, num_stages_val, chunk_size, _grid_sms = (
+        _get_gg_fp8_tw_fwd_config(
+            avg_m,
+            N,
+            K,
+            intermediate.dtype,
+            a.dtype,
+            b.dtype,
+            trans_b,
+            G,
+            num_sms,
+            M_total,
+            a.stride(1),
+            stride_bk,
+        )
+    )
+    # A sharp local optimum: the knob space was swept against the fused total and
+    # falls off steeply both ways, for opposite reasons. A bigger tile or fewer
+    # epilogue chunks blows the accumulator past the register budget and spills; a
+    # smaller tile gives up the arithmetic intensity the GEMM half needs.
+    num_warps_val, waves_per_eu_val, mfma_dim_val, kpack_val = 8, 1, 32, 1
+    cache_l1 = ".cg"
+    # dl1 is streamed once and never read again here, so it wants an evict-first
+    # line rather than one that pushes out the GEMM operands, which are reused
+    # across tiles. Worth 1.191 -> 1.156 ms of epilogue at I=5760. The load side
+    # cannot match it: this Triton rejects ".cs"/".lu" on loads, and ".cv"
+    # bypasses the cache outright and costs 40%.
+    cache_dl1 = ".cs"
+    # Three stages at BLOCK_K=128 overflow what the scheduler can hide. One stage
+    # frees the 32 KB an epilogue prefetch would need, but losing the operand
+    # double-buffer costs more than such a prefetch could recover.
+    num_stages_val = min(num_stages_val, 2)
+    # The config helper is tuned for a bare GEMM, which wants the deepest K stage
+    # it can hold. This kernel carries a GLU-gradient epilogue on the same
+    # accumulator, so the shallower stage pays for itself: half the LDS, spills
+    # from 31 to 12, and faster at both production widths.
+    BLOCK_K = 64
+    if BLOCK_N > 256:
+        BLOCK_N = 256
+    if M_total >= 65536 and N >= 2048:
+        BLOCK_M = 256
+        BLOCK_N = 256
+    # Narrower row chunks shrink the epilogue's live set, but past a point the
+    # extra loop iterations cost more than the spills they save: 16 chunks reach
+    # zero spills and still lose to 8 at 12 spills, so spill count is not the
+    # thing to minimise. Four is worse than its spill count suggests, because the
+    # wider chunk stops the epilogue's loads from covering each other's latency.
+    epi_chunks = 8
+    est_tiles = -(-M_total // BLOCK_M) * -(-N // BLOCK_N)
+    group_m, chunk_size = (2, 16) if est_tiles >= 512 else (4, 64)
+
+    return DgluLaunch(
+        M_total=M_total,
+        N=N,
+        K=K,
+        G=G,
+        num_sms=num_sms,
+        num_pid_n=-(-N // BLOCK_N),
+        stride_bn=stride_bn,
+        stride_bk=stride_bk,
+        even_k=(K % BLOCK_K == 0),
+        n_exact=(N % BLOCK_N == 0),
+        grid=dict(
+            BLOCK_SIZE_M=BLOCK_M,
+            BLOCK_SIZE_N=BLOCK_N,
+            BLOCK_SIZE_K=BLOCK_K,
+            GROUP_SIZE_M=group_m,
+            CHUNK_SIZE=chunk_size,
+        ),
+        knobs=dict(
+            num_warps=num_warps_val,
+            num_stages=num_stages_val,
+            waves_per_eu=waves_per_eu_val,
+            matrix_instr_nonkdim=mfma_dim_val,
+            kpack=kpack_val,
+        ),
+        cache_a=cache_a,
+        cache_b=cache_b,
+        cache_l1=cache_l1,
+        cache_dl1=cache_dl1,
+        epi_chunks=epi_chunks,
+    )
+
+
+class GradProbsPartialSpec(NamedTuple):
+    """The grad_probs partial buffer a fused dgrad expects from its caller."""
+
+    shape: tuple[int, int]
+    needs_zero: bool
+
+
+def grouped_gemm_fp8_dglu_grad_probs_partial_spec(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    intermediate: torch.Tensor,
+    trans_b: bool = False,
+    *,
+    activation: str = "silu",
+    num_cu: int | None = None,
+) -> GradProbsPartialSpec:
+    """The ``grad_probs_partial`` buffer :func:`grouped_gemm_fp8_dglu_triton_kernel` expects.
+
+    One partial per tile column; ``grad_probs_partial.sum(0)`` is the gradient
+    wrt ``probs``. Allocating and folding stay with the caller, so this module
+    owns neither -- pass the same arguments here as to the kernel.
+
+    ``needs_zero`` is False: every row of every group is covered by a tile at
+    each tile column, so the kernel writes each slot exactly once. Whether a
+    slot is left untouched is a property of the epilogue, hence reported here
+    rather than left for the caller to guess.
+
+    Returns:
+        ``shape`` is ``(num_tile_cols, M_total)``, float32, M innermost to keep
+        the epilogue's partial writes coalesced.
+    """
+    plan = _resolve_fp8_dglu_launch(a, b, intermediate, trans_b, activation, num_cu)
+    return GradProbsPartialSpec(shape=(plan.num_pid_n, plan.M_total), needs_zero=False)
+
+
+def grouped_gemm_fp8_dglu_triton_kernel(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    a_scale: torch.Tensor,
+    b_scale: torch.Tensor,
+    intermediate: torch.Tensor,
+    group_offs: torch.Tensor,
+    probs: torch.Tensor,
+    out: torch.Tensor,
+    grad_probs_partial: torch.Tensor,
+    trans_b: bool = False,
+    *,
+    activation: str = "silu",
+    num_cu: int | None = None,
+) -> torch.Tensor:
+    """FP8 fc2 dgrad with the activation gradient fused into its epilogue.
+
+    Computes ``dact[g] = (a[g] @ B_view[g]) * a_scale * b_scale`` -- the
+    gradient wrt the probs-scaled fc2 input -- and consumes it in registers to
+    produce ``dl1 = [f'(gate) * up * (dact * probs) | f(gate) * (dact * probs)]``,
+    so ``dact`` never reaches HBM. ``b`` is the fc2 weight already oriented for
+    the dgrad, i.e. callers pass the ``trans_b`` they used in the forward,
+    flipped.
+
+    ``intermediate`` is the ``l1`` that
+    :func:`grouped_gemm_fp8_glu_triton_kernel` wrote, so it is always available
+    and there is no recompute variant to choose between.
+
+    The gradient wrt ``probs`` is produced here too, but only in partial form:
+    its sum runs over the whole of I, which a single tile does not span, so each
+    tile folds the columns it owns and writes one partial. The tiling is
+    resolved rather than autotuned, so the partial count is known up front and
+    no atomics are needed -- the result is bitwise reproducible.
+
+    Args:
+        intermediate: [M_total, 2I] saved fc1 pre-activation, gate in [:, :I],
+            up in [:, I:].
+        out: [M_total, 2I] buffer receiving ``dl1``, in ``intermediate``'s dtype.
+        grad_probs_partial: float32 buffer receiving the grad_probs partials,
+            sized by :func:`grouped_gemm_fp8_dglu_grad_probs_partial_spec`. Sum
+            over dim 0 for the gradient wrt ``probs``.
+        num_cu: Cap the persistent grid at this many CUs. None uses every CU.
+
+    Returns:
+        ``out``, for call-site convenience.
+    """
+    _check_scales(a_scale, b_scale)
+    plan = _resolve_fp8_dglu_launch(a, b, intermediate, trans_b, activation, num_cu)
+    M_total, N, K = plan.M_total, plan.N, plan.K
+    _check_probs(probs, M_total)
+
+    assert out.shape == (M_total, 2 * N), f"out must be [{M_total}, {2 * N}], got {tuple(out.shape)}"
+    assert out.device == a.device and out.dtype == intermediate.dtype
+    assert grad_probs_partial.shape == (plan.num_pid_n, M_total), (
+        f"grad_probs_partial must be [{plan.num_pid_n}, {M_total}], got {tuple(grad_probs_partial.shape)}; "
+        "size it with grouped_gemm_fp8_dglu_grad_probs_partial_spec"
+    )
+    assert grad_probs_partial.device == a.device and grad_probs_partial.dtype == torch.float32
+
+    _grouped_fp8_dglu_persistent_gemm_kernel[(plan.num_sms,)](
+        a,
+        b,
+        intermediate,
+        out,
+        grad_probs_partial,
+        probs,
+        a_scale,
+        b_scale,
+        group_offs,
+        plan.G,
+        N,
+        K,
+        a.stride(0),
+        b.stride(0),
+        plan.stride_bn,
+        intermediate.stride(0),
+        intermediate.stride(1),
+        out.stride(0),
+        out.stride(1),
+        grad_probs_partial.stride(0),
+        probs.stride(0),
+        stride_ak=a.stride(1),
+        stride_bk=plan.stride_bk,
+        NUM_SMS=plan.num_sms,
+        NUM_XCDS=NUM_XCDS,
+        EVEN_K=plan.even_k,
+        N_EXACT=plan.n_exact,
+        ACTIVATION=activation,
+        CACHE_MODIFIER_A=plan.cache_a,
+        CACHE_MODIFIER_B=plan.cache_b,
+        CACHE_MODIFIER_L1=plan.cache_l1,
+        CACHE_MODIFIER_DL1=plan.cache_dl1,
+        EPI_CHUNKS=plan.epi_chunks,
+        **plan.grid,
+        **plan.knobs,
+    )
+    return out

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -561,6 +561,7 @@ def grouped_gemm_fp8_tensorwise_triton_kernel(
     group_offs: torch.Tensor,
     trans_b: bool = False,
     out_dtype: torch.dtype = torch.bfloat16,
+    epilogue: str | None = None,
 ) -> torch.Tensor:
     """Persistent grouped FP8 GEMM (CPU-sync-free, per-tensor scaling) using Triton.
 
@@ -577,6 +578,9 @@ def grouped_gemm_fp8_tensorwise_triton_kernel(
         group_offs: [G+1] int64 prefix sum of group lengths.
         trans_b: If True, b[g] is [N, K] (transposed).
         out_dtype: Output dtype (default bfloat16).
+        epilogue: Optional fused activation epilogue. Routed here by
+            ``GroupedGEMMFP8TritonBackend`` for TENSORWISE only; the kernel
+            validates the epilogue type.
 
     Returns:
         [M_total, N] output in out_dtype.

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_helper.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_helper.py
@@ -1,0 +1,382 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Shared plumbing for the grouped-GEMM Triton persistent kernels.
+
+The persistent grouped-GEMM kernels (plain BF16/FP16, the fused GLU-activation
+epilogue variant, FP8, FP4) all wrap the same scaffolding around their
+per-tile compute body:
+
+  - map the AMD round-robin ``program_id`` onto XCD-contiguous chunks,
+  - count how many output tiles the whole batch of groups needs,
+  - resolve one global tile id to ``(group, pid_m, pid_n)``.
+
+Only the compute body in between actually differs per kernel, so that
+scaffolding lives here and every kernel module imports it. The same goes for
+the post-pass that zeroes an over-allocated output's padding tail, which every
+dtype's dispatcher runs and none of them implement differently.
+
+Anything specific to one kernel stays in that kernel's module -- the fused GLU
+epilogue's pair-tile addressing, register-tile surgery and activation math all
+live in ``grouped_gemm_fp8_glu_kernel``, since it is their only consumer.
+
+Contains:
+  - NUM_XCDS                        -- MI300/MI350 chiplet count
+  - _chiplet_transform_chunked      -- pid -> XCD-chunked pid
+  - _get_gg_bf16_fwd_config         -- cached tile config for the BF16 forward
+  - _count_group_tiles              -- total output tiles across all groups
+  - _locate_group                   -- global tile id -> owning group (O(G) scan)
+  - _gemm_tile_dot                  -- per-tile K-loop shared by the GEMM bodies
+  - _swizzle_tile                   -- group-local tile id -> (pid_m, pid_n)
+  - grouped_gemm_output_tail_kernel -- zero the uncovered padding rows
+
+``grouped_gemm_kernel`` re-exposes ``NUM_XCDS`` and
+``_chiplet_transform_chunked`` in its own namespace, so the FP8/FP4 modules
+that import them from there keep working.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import torch
+import triton
+import triton.language as tl
+
+from primus_turbo.pytorch.core.utils import get_num_cus, is_gfx950
+from primus_turbo.triton.utils.origami import origama_select_params
+
+# ===============================================================================
+# Hardware constants
+# ===============================================================================
+
+NUM_XCDS = 8
+
+
+# ===============================================================================
+# Cached config selection (avoids per-call origami / LDS overhead)
+# ===============================================================================
+
+
+@functools.lru_cache(maxsize=256)
+def _get_gg_bf16_fwd_config(avg_m, N, K, dtype_a, dtype_b, trans_b, G, num_sms):
+    """Cached kernel config for BF16 grouped GEMM forward."""
+    if is_gfx950():
+        is_tn = not trans_b
+        BLOCK_M, BLOCK_N = 256, 256
+        if is_tn:
+            BLOCK_K, num_stages_val = 64, 2
+        else:
+            BLOCK_K, num_stages_val = 32, 3
+        group_m = 4
+        cache_a, cache_b = ".ca", ".ca"
+        chunk_size = 32
+
+        origami_params = origama_select_params(
+            avg_m,
+            N,
+            K,
+            dtype_a,
+            dtype_a,
+            dtype_b,
+            trans_a=False,
+            trans_b=trans_b,
+        )
+        if origami_params is not None:
+            om, on, ok, ogm, oc_a, oc_b = origami_params
+            if min(om, on) >= 128 and ok == BLOCK_K:
+                BLOCK_M, BLOCK_N, group_m = om, on, ogm
+                cache_a, cache_b = oc_a, oc_b
+    else:
+        BLOCK_M, BLOCK_N, BLOCK_K = 256, 256, 64
+        group_m = 4
+        num_stages_val = 2
+        cache_a, cache_b = ".ca", ".ca"
+        chunk_size = 64 if num_sms >= NUM_XCDS * 64 else 32
+
+        origami_params = origama_select_params(
+            avg_m,
+            N,
+            K,
+            dtype_a,
+            dtype_a,
+            dtype_b,
+            trans_a=False,
+            trans_b=trans_b,
+        )
+        if origami_params is not None:
+            om, on, ok, ogm, oc_a, oc_b = origami_params
+            if ogm >= 2 and om * on >= 256 * 256:
+                BLOCK_M, BLOCK_N, BLOCK_K, group_m, cache_a, cache_b = (om, on, ok, ogm, oc_a, oc_b)
+
+    return BLOCK_M, BLOCK_N, BLOCK_K, group_m, cache_a, cache_b, num_stages_val, chunk_size
+
+
+# ===============================================================================
+# Chiplet transform
+# ===============================================================================
+
+
+@triton.jit
+def _chiplet_transform_chunked(
+    pid,
+    NUM_SMS: tl.constexpr,
+    NUM_XCDS: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+):
+    if pid > (NUM_SMS // (NUM_XCDS * CHUNK_SIZE)) * (NUM_XCDS * CHUNK_SIZE):
+        return pid
+    local_pid = pid // NUM_XCDS
+    chunk_idx = local_pid // CHUNK_SIZE
+    pos_in_chunk = local_pid % CHUNK_SIZE
+    xcd = pid % NUM_XCDS
+    return chunk_idx * NUM_XCDS * CHUNK_SIZE + xcd * CHUNK_SIZE + pos_in_chunk
+
+
+# ===============================================================================
+# Tile <-> group mapping
+#
+# The grouped GEMM's M extent is ragged (one variable-length slice of A per
+# group) while N and K are shared, so the tile grid is a concatenation of
+# per-group grids. Both the tile count and the tile -> group lookup are an
+# O(G) scan over ``group_offs``; G is small (<=256) and the prefix sum stays
+# resident in L2, so every CU can afford to redo the scan and no CPU sync or
+# host-side tile table is needed.
+#
+# ``num_pid_n`` is passed in rather than derived, because it is not always
+# ``cdiv(N, BLOCK_N)``: the fused GLU kernel tiles over gate/up *pairs*, so
+# its N grid spans half the output width.
+# ===============================================================================
+
+
+@triton.jit
+def _count_group_tiles(
+    group_offs_ptr,
+    G,
+    num_pid_n,
+    BLOCK_SIZE_M: tl.constexpr,
+):
+    """Total number of output tiles across all G groups."""
+    total_tiles: tl.int32 = 0
+    for _g in range(G):
+        m_g = (tl.load(group_offs_ptr + _g + 1) - tl.load(group_offs_ptr + _g)).to(tl.int32)
+        total_tiles += tl.cdiv(m_g, BLOCK_SIZE_M) * num_pid_n
+    return total_tiles
+
+
+@triton.jit
+def _locate_group(
+    global_tile_id,
+    group_offs_ptr,
+    G,
+    num_pid_n,
+    BLOCK_SIZE_M: tl.constexpr,
+):
+    """Resolve a global tile id to the group that owns it.
+
+    Returns ``(group_idx, tile_start, total_tiles)``, where ``tile_start`` is
+    the first global tile id belonging to ``group_idx`` (so the group-local id
+    is ``global_tile_id - tile_start``) and ``total_tiles`` is the full count
+    across all groups.
+
+    Callers must treat ``global_tile_id >= total_tiles`` as out of range and
+    skip the tile: past the end, ``group_idx`` has walked off group_offs and
+    loading ``group_offs_ptr + group_idx + 1`` would be OOB.
+    """
+    group_idx: tl.int32 = 0
+    tile_start: tl.int32 = 0
+    cumsum: tl.int32 = 0
+    for _g in range(G):
+        m_g_i = (tl.load(group_offs_ptr + _g + 1) - tl.load(group_offs_ptr + _g)).to(tl.int32)
+        tiles_g = tl.cdiv(m_g_i, BLOCK_SIZE_M) * num_pid_n
+        new_cumsum = cumsum + tiles_g
+        if global_tile_id >= new_cumsum:
+            group_idx = _g + 1
+            tile_start = new_cumsum
+        cumsum = new_cumsum
+    return group_idx, tile_start, cumsum
+
+
+@triton.jit
+def _gemm_tile_dot(
+    A,
+    B,
+    m_start_g,
+    group_idx,
+    rm,
+    rn,
+    K,
+    stride_am,
+    stride_bg,
+    stride_bn,
+    stride_ak: tl.constexpr,
+    stride_bk: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    CACHE_MODIFIER_A: tl.constexpr,
+    CACHE_MODIFIER_B: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+):
+    """``A[m_start_g + rm, :] @ B[group_idx][:, rn]`` as an fp32 accumulator.
+
+    Takes ``rm``/``rn`` already reduced modulo the group's M and the output N,
+    so the caller owns the tile-to-group mapping and any epilogue masking.
+    """
+    rk = tl.arange(0, BLOCK_SIZE_K)
+    # Cast group_idx to int64 to prevent overflow in B group offset
+    group_offset_b = group_idx.to(tl.int64) * stride_bg
+
+    A_BASE = A + m_start_g * stride_am + rm[:, None] * stride_am + rk[None, :] * stride_ak
+    B_BASE = B + group_offset_b + rk[:, None] * stride_bk + rn[None, :] * stride_bn
+
+    loop_k = tl.cdiv(K, BLOCK_SIZE_K)
+    if not EVEN_K:
+        loop_k -= 1
+    # ``tl.assume(loop_k > 1)`` would be a false assertion for shapes where
+    # K <= BLOCK_SIZE_K (loop_k == 1 when EVEN_K, 0 when not). Relax to a
+    # condition that always holds, so the compiler can still know the loop
+    # count is non-negative without risking miscompilation on tiny K.
+    tl.assume(loop_k >= 0)
+
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, loop_k):
+        if stride_ak == 1:
+            a = tl.load(tl.multiple_of(A_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER_A)
+        else:
+            a = tl.load(tl.multiple_of(A_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER_A)
+        if stride_bk == 1:
+            b = tl.load(tl.multiple_of(B_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER_B)
+        else:
+            b = tl.load(tl.multiple_of(B_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER_B)
+        acc += tl.dot(a, b, allow_tf32=ALLOW_TF32)
+        A_BASE += BLOCK_SIZE_K * stride_ak
+        B_BASE += BLOCK_SIZE_K * stride_bk
+
+    if not EVEN_K:
+        rk_last = loop_k * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
+        A_LAST = A + m_start_g * stride_am + rm[:, None] * stride_am + rk_last[None, :] * stride_ak
+        B_LAST = B + group_offset_b + rk_last[:, None] * stride_bk + rn[None, :] * stride_bn
+        if stride_ak == 1:
+            A_LAST = tl.multiple_of(A_LAST, (1, 16))
+        else:
+            A_LAST = tl.multiple_of(A_LAST, (16, 1))
+        if stride_bk == 1:
+            B_LAST = tl.multiple_of(B_LAST, (16, 1))
+        else:
+            B_LAST = tl.multiple_of(B_LAST, (1, 16))
+        a = tl.load(A_LAST, mask=rk_last[None, :] < K, other=0.0, cache_modifier=CACHE_MODIFIER_A)
+        b = tl.load(B_LAST, mask=rk_last[:, None] < K, other=0.0, cache_modifier=CACHE_MODIFIER_B)
+        acc += tl.dot(a, b, allow_tf32=ALLOW_TF32)
+
+    return acc
+
+
+@triton.jit
+def _swizzle_tile(
+    local_tile,
+    tiles_m,
+    tiles_n,
+    GROUP_SIZE_M: tl.constexpr,
+):
+    """Map a group-local tile id to ``(pid_m, pid_n)``, M-major in bands of GROUP_SIZE_M.
+
+    Walking GROUP_SIZE_M rows of tiles before advancing along N lets a band of
+    programs share the same B columns, which is what keeps B resident in L2.
+    ``tiles_m`` is clamped per band so a short final band stays rectangular.
+    """
+    num_pid_in_group = GROUP_SIZE_M * tiles_n
+    swizzle_group = local_tile // num_pid_in_group
+    first_pid_m = swizzle_group * GROUP_SIZE_M
+    group_size_m = min(tiles_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((local_tile % num_pid_in_group) % group_size_m)
+    pid_n = (local_tile % num_pid_in_group) // group_size_m
+    tl.assume(pid_m >= 0)
+    tl.assume(pid_n >= 0)
+    return pid_m, pid_n
+
+
+# ===============================================================================
+# Output padding tail
+# ===============================================================================
+
+
+@triton.jit
+def _grouped_gemm_output_tail_kernel(
+    C,
+    group_offs_ptr,
+    G,
+    M_total,
+    N,
+    stride_cm,
+    stride_cn,
+    NUM_SMS: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+):
+    covered = tl.load(group_offs_ptr + G).to(tl.int64)
+    m_total = tl.cast(M_total, tl.int64)
+    num_pad = m_total - covered
+    if num_pad <= 0:
+        return
+
+    num_m_blocks = tl.cdiv(num_pad, BLOCK_SIZE_M)
+    num_n_blocks = tl.cdiv(N, BLOCK_SIZE_N)
+    total_tiles = num_m_blocks * num_n_blocks
+
+    zeros = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=C.dtype.element_ty)
+
+    pid = tl.program_id(0)
+    for tile in range(pid, total_tiles, NUM_SMS):
+        bm = tile // num_n_blocks
+        bn = tile % num_n_blocks
+        rows = covered + bm * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+        cols = bn * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        mask = (rows[:, None] < m_total) & (cols[None, :] < N)
+        C_ = C + rows[:, None] * stride_cm + cols[None, :] * stride_cn
+        tl.store(C_, zeros, mask)
+
+
+def grouped_gemm_output_tail_kernel(
+    out: torch.Tensor,
+    group_offs: torch.Tensor,
+) -> torch.Tensor:
+    """Zero the uncovered padding tail of a grouped GEMM output, in place.
+
+    Clears rows ``[group_offs[-1], out.shape[0])`` -- the rows the persistent
+    forward/dgrad kernel never writes when the output is over-allocated to
+    padded token counts. CPU-sync-free (the covered boundary is read on device)
+    and a no-op when there is no padding.
+
+    Args:
+        out: [M_total, N] grouped GEMM output.
+        group_offs: [G+1] int64 prefix sum the kernel used to write ``out``.
+
+    Returns:
+        The same ``out`` tensor.
+    """
+    assert out.ndim == 2, f"expected 2D grouped GEMM output, got {tuple(out.shape)}"
+    M_total, N = out.shape
+    G = group_offs.shape[0] - 1
+    if G <= 0 or M_total == 0 or N == 0:
+        return out
+
+    num_sms = get_num_cus()
+    _grouped_gemm_output_tail_kernel[(num_sms,)](
+        out,
+        group_offs,
+        G,
+        M_total,
+        N,
+        out.stride(0),
+        out.stride(1),
+        NUM_SMS=num_sms,
+        BLOCK_SIZE_M=64,
+        BLOCK_SIZE_N=256,
+        num_warps=4,
+    )
+    return out

--- a/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
+++ b/primus_turbo/triton/grouped_gemm/grouped_gemm_kernel.py
@@ -22,6 +22,10 @@ Public API:
   - grouped_gemm_triton_kernel            -- BF16/FP16 forward (work_steal kwarg)
   - grouped_gemm_variable_k_triton_kernel -- variable-K backward (work_steal kwarg)
 
+The tile <-> group mapping, XCD swizzle, forward tile config and the output
+padding-tail pass are shared with the other grouped-GEMM kernels and live in
+grouped_gemm_helper.py.
+
 FP8 kernels (tensorwise + blockwise) are in grouped_gemm_fp8_kernel.py.
 
 Environment variable: PRIMUS_TURBO_GROUPED_GEMM_BACKEND=TRITON activates these kernels.
@@ -36,6 +40,15 @@ import triton
 import triton.language as tl
 
 from primus_turbo.pytorch.core.utils import get_num_cus, is_gfx950
+from primus_turbo.triton.grouped_gemm.grouped_gemm_helper import (
+    NUM_XCDS,
+    _chiplet_transform_chunked,
+    _count_group_tiles,
+    _gemm_tile_dot,
+    _get_gg_bf16_fwd_config,
+    _locate_group,
+    _swizzle_tile,
+)
 from primus_turbo.triton.utils.origami import origama_select_params
 from primus_turbo.triton.utils.triton_knobs_helper import scoped_amd_knobs
 
@@ -43,7 +56,6 @@ from primus_turbo.triton.utils.triton_knobs_helper import scoped_amd_knobs
 # Hardware constants (lazy init)
 # ===============================================================================
 
-NUM_XCDS = 8
 # Padding for the work-stealing per-XCD atomic counter slots: 64 * 4B = 256 B
 # = one MI355X L2 line per slot, so the eight XCDs do not false-share a cache
 # line. Used by the WS variants of the persistent kernels below.
@@ -80,60 +92,6 @@ def _get_triton_ws_counter(device: torch.device) -> torch.Tensor:
 # ===============================================================================
 # Cached config selection (avoids per-call origami / LDS overhead)
 # ===============================================================================
-
-
-@functools.lru_cache(maxsize=256)
-def _get_gg_bf16_fwd_config(avg_m, N, K, dtype_a, dtype_b, trans_b, G, num_sms):
-    """Cached kernel config for BF16 grouped GEMM forward."""
-    if is_gfx950():
-        is_tn = not trans_b
-        BLOCK_M, BLOCK_N = 256, 256
-        if is_tn:
-            BLOCK_K, num_stages_val = 64, 2
-        else:
-            BLOCK_K, num_stages_val = 32, 3
-        group_m = 4
-        cache_a, cache_b = ".ca", ".ca"
-        chunk_size = 32
-
-        origami_params = origama_select_params(
-            avg_m,
-            N,
-            K,
-            dtype_a,
-            dtype_a,
-            dtype_b,
-            trans_a=False,
-            trans_b=trans_b,
-        )
-        if origami_params is not None:
-            om, on, ok, ogm, oc_a, oc_b = origami_params
-            if min(om, on) >= 128 and ok == BLOCK_K:
-                BLOCK_M, BLOCK_N, group_m = om, on, ogm
-                cache_a, cache_b = oc_a, oc_b
-    else:
-        BLOCK_M, BLOCK_N, BLOCK_K = 256, 256, 64
-        group_m = 4
-        num_stages_val = 2
-        cache_a, cache_b = ".ca", ".ca"
-        chunk_size = 64 if num_sms >= NUM_XCDS * 64 else 32
-
-        origami_params = origama_select_params(
-            avg_m,
-            N,
-            K,
-            dtype_a,
-            dtype_a,
-            dtype_b,
-            trans_a=False,
-            trans_b=trans_b,
-        )
-        if origami_params is not None:
-            om, on, ok, ogm, oc_a, oc_b = origami_params
-            if ogm >= 2 and om * on >= 256 * 256:
-                BLOCK_M, BLOCK_N, BLOCK_K, group_m, cache_a, cache_b = (om, on, ok, ogm, oc_a, oc_b)
-
-    return BLOCK_M, BLOCK_N, BLOCK_K, group_m, cache_a, cache_b, num_stages_val, chunk_size
 
 
 @functools.lru_cache(maxsize=256)
@@ -174,27 +132,6 @@ def _get_gg_bf16_vk_config(OUT_M, OUT_N, avg_k, dtype_lhs, dtype_rhs, G, num_sms
         chunk_size = 64 if num_sms >= NUM_XCDS * 64 else 32
 
     return BLOCK_M, BLOCK_N, BLOCK_K, group_m, cache_a, cache_b, num_stages_val, chunk_size
-
-
-# ===============================================================================
-# Chiplet Transform (shared helper)
-# ===============================================================================
-
-
-@triton.jit
-def _chiplet_transform_chunked(
-    pid,
-    NUM_SMS: tl.constexpr,
-    NUM_XCDS: tl.constexpr,
-    CHUNK_SIZE: tl.constexpr,
-):
-    if pid > (NUM_SMS // (NUM_XCDS * CHUNK_SIZE)) * (NUM_XCDS * CHUNK_SIZE):
-        return pid
-    local_pid = pid // NUM_XCDS
-    chunk_idx = local_pid // CHUNK_SIZE
-    pos_in_chunk = local_pid % CHUNK_SIZE
-    xcd = pid % NUM_XCDS
-    return chunk_idx * NUM_XCDS * CHUNK_SIZE + xcd * CHUNK_SIZE + pos_in_chunk
 
 
 # ===============================================================================
@@ -245,92 +182,47 @@ def _process_grouped_gemm_tile(
     ALLOW_TF32: tl.constexpr,
 ):
     """Compute one output tile given its global tile id within the persistent loop."""
-    # -- Find group via linear scan (O(G)) --
-    group_idx: tl.int32 = 0
-    tile_start: tl.int32 = 0
-    cumsum: tl.int32 = 0
-    for _g in range(G):
-        m_g_i = (tl.load(group_offs_ptr + _g + 1) - tl.load(group_offs_ptr + _g)).to(tl.int32)
-        tiles_g = tl.cdiv(m_g_i, BLOCK_SIZE_M) * num_pid_n
-        new_cumsum = cumsum + tiles_g
-        if global_tile_id >= new_cumsum:
-            group_idx = _g + 1
-            tile_start = new_cumsum
-        cumsum = new_cumsum
-
-    # Defensive bound: when global_tile_id >= total_tiles (cumsum after the
-    # loop), group_idx would have walked off the end of group_offs and the
-    # subsequent loads at group_offs_ptr + group_idx + 1 would be OOB. All
-    # current callers bound-check, so this is a guard against future misuse.
-    if global_tile_id >= cumsum:
+    group_idx, tile_start, total_tiles = _locate_group(
+        global_tile_id, group_offs_ptr, G, num_pid_n, BLOCK_SIZE_M
+    )
+    # Defensive bound: past total_tiles, group_idx has walked off the end of
+    # group_offs and the loads below would be OOB. All current callers
+    # bound-check, so this is a guard against future misuse.
+    if global_tile_id >= total_tiles:
         return
 
-    # -- Group-local tile -> (pid_m, pid_n) with GROUP_SIZE_M swizzle --
     local_tile = global_tile_id - tile_start
     m_start_g = tl.load(group_offs_ptr + group_idx)  # keep int64 to avoid address overflow
     M_g = (tl.load(group_offs_ptr + group_idx + 1) - tl.load(group_offs_ptr + group_idx)).to(tl.int32)
     tiles_m_g = tl.cdiv(M_g, BLOCK_SIZE_M)
-
-    num_pid_in_group = GROUP_SIZE_M * num_pid_n
-    swizzle_group = local_tile // num_pid_in_group
-    first_pid_m = swizzle_group * GROUP_SIZE_M
-    group_size_m = min(tiles_m_g - first_pid_m, GROUP_SIZE_M)
-    pid_m = first_pid_m + ((local_tile % num_pid_in_group) % group_size_m)
-    pid_n = (local_tile % num_pid_in_group) // group_size_m
-    tl.assume(pid_m >= 0)
-    tl.assume(pid_n >= 0)
+    pid_m, pid_n = _swizzle_tile(local_tile, tiles_m_g, num_pid_n, GROUP_SIZE_M)
 
     # -- Address computation --
     rm = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M_g
     rn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
-    rk = tl.arange(0, BLOCK_SIZE_K)
     rn = tl.max_contiguous(tl.multiple_of(rn, BLOCK_SIZE_N), BLOCK_SIZE_N)
 
-    # Cast group_idx to int64 to prevent overflow in B group offset
-    group_offset_b = group_idx.to(tl.int64) * stride_bg
-
-    A_BASE = A + m_start_g * stride_am + rm[:, None] * stride_am + rk[None, :] * stride_ak
-    B_BASE = B + group_offset_b + rk[:, None] * stride_bk + rn[None, :] * stride_bn
-
-    # -- K-loop --
-    loop_k = tl.cdiv(K, BLOCK_SIZE_K)
-    if not EVEN_K:
-        loop_k -= 1
-    # ``tl.assume(loop_k > 1)`` would be a false assertion for shapes where
-    # K <= BLOCK_SIZE_K (loop_k == 1 when EVEN_K, 0 when not). Relax to a
-    # condition that always holds, so the compiler can still know the loop
-    # count is non-negative without risking miscompilation on tiny K.
-    tl.assume(loop_k >= 0)
-
-    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    for k in range(0, loop_k):
-        if stride_ak == 1:
-            a = tl.load(tl.multiple_of(A_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER_A)
-        else:
-            a = tl.load(tl.multiple_of(A_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER_A)
-        if stride_bk == 1:
-            b = tl.load(tl.multiple_of(B_BASE, (16, 1)), cache_modifier=CACHE_MODIFIER_B)
-        else:
-            b = tl.load(tl.multiple_of(B_BASE, (1, 16)), cache_modifier=CACHE_MODIFIER_B)
-        acc += tl.dot(a, b, allow_tf32=ALLOW_TF32)
-        A_BASE += BLOCK_SIZE_K * stride_ak
-        B_BASE += BLOCK_SIZE_K * stride_bk
-
-    if not EVEN_K:
-        rk_last = loop_k * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
-        A_LAST = A + m_start_g * stride_am + rm[:, None] * stride_am + rk_last[None, :] * stride_ak
-        B_LAST = B + group_offset_b + rk_last[:, None] * stride_bk + rn[None, :] * stride_bn
-        if stride_ak == 1:
-            A_LAST = tl.multiple_of(A_LAST, (1, 16))
-        else:
-            A_LAST = tl.multiple_of(A_LAST, (16, 1))
-        if stride_bk == 1:
-            B_LAST = tl.multiple_of(B_LAST, (16, 1))
-        else:
-            B_LAST = tl.multiple_of(B_LAST, (1, 16))
-        a = tl.load(A_LAST, mask=rk_last[None, :] < K, other=0.0, cache_modifier=CACHE_MODIFIER_A)
-        b = tl.load(B_LAST, mask=rk_last[:, None] < K, other=0.0, cache_modifier=CACHE_MODIFIER_B)
-        acc += tl.dot(a, b, allow_tf32=ALLOW_TF32)
+    acc = _gemm_tile_dot(
+        A,
+        B,
+        m_start_g,
+        group_idx,
+        rm,
+        rn,
+        K,
+        stride_am,
+        stride_bg,
+        stride_bn,
+        stride_ak=stride_ak,
+        stride_bk=stride_bk,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        EVEN_K=EVEN_K,
+        CACHE_MODIFIER_A=CACHE_MODIFIER_A,
+        CACHE_MODIFIER_B=CACHE_MODIFIER_B,
+        ALLOW_TF32=ALLOW_TF32,
+    )
 
     # -- Store --
     c = acc.to(C.type.element_ty)
@@ -386,12 +278,7 @@ def _grouped_bf16_persistent_gemm_kernel(
         pid = _chiplet_transform_chunked(pid, NUM_SMS, NUM_XCDS, CHUNK_SIZE)
 
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
-
-    # -- Compute total tiles across all groups (O(G) per CU) --
-    total_tiles: tl.int32 = 0
-    for _g in range(G):
-        m_g = (tl.load(group_offs_ptr + _g + 1) - tl.load(group_offs_ptr + _g)).to(tl.int32)
-        total_tiles += tl.cdiv(m_g, BLOCK_SIZE_M) * num_pid_n
+    total_tiles = _count_group_tiles(group_offs_ptr, G, num_pid_n, BLOCK_SIZE_M)
 
     tl.assume(stride_am > 0)
     tl.assume(stride_ak > 0)
@@ -488,12 +375,7 @@ def _grouped_bf16_persistent_gemm_kernel_ws(
     """Persistent grouped GEMM with per-XCD + global-fallback work stealing."""
     pid = tl.program_id(0)
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
-
-    # -- Compute total tiles across all groups (O(G) per CU) --
-    total_tiles: tl.int32 = 0
-    for _g in range(G):
-        m_g = (tl.load(group_offs_ptr + _g + 1) - tl.load(group_offs_ptr + _g)).to(tl.int32)
-        total_tiles += tl.cdiv(m_g, BLOCK_SIZE_M) * num_pid_n
+    total_tiles = _count_group_tiles(group_offs_ptr, G, num_pid_n, BLOCK_SIZE_M)
 
     tl.assume(stride_am > 0)
     tl.assume(stride_ak > 0)
@@ -810,15 +692,7 @@ def _process_variable_k_tile(
     group_idx = global_tile // tiles_per_group
     local_tile = global_tile - group_idx * tiles_per_group
 
-    # -- GROUP_SIZE_M swizzle on local_tile -> (pid_m, pid_n) --
-    num_pid_in_group = GROUP_SIZE_M * tiles_n
-    swizzle_group = local_tile // num_pid_in_group
-    first_pid_m = swizzle_group * GROUP_SIZE_M
-    group_size_m = min(tiles_m - first_pid_m, GROUP_SIZE_M)
-    pid_m = first_pid_m + ((local_tile % num_pid_in_group) % group_size_m)
-    pid_n = (local_tile % num_pid_in_group) // group_size_m
-    tl.assume(pid_m >= 0)
-    tl.assume(pid_n >= 0)
+    pid_m, pid_n = _swizzle_tile(local_tile, tiles_m, tiles_n, GROUP_SIZE_M)
 
     # -- Group boundaries --
     m_start = tl.load(group_offs_ptr + group_idx)
@@ -1287,82 +1161,5 @@ def grouped_gemm_variable_k_triton_kernel(
         waves_per_eu=0,
         matrix_instr_nonkdim=16,
         kpack=1,
-    )
-    return out
-
-
-@triton.jit
-def _grouped_gemm_output_tail_kernel(
-    C,
-    group_offs_ptr,
-    G,
-    M_total,
-    N,
-    stride_cm,
-    stride_cn,
-    NUM_SMS: tl.constexpr,
-    BLOCK_SIZE_M: tl.constexpr,
-    BLOCK_SIZE_N: tl.constexpr,
-):
-    covered = tl.load(group_offs_ptr + G).to(tl.int64)
-    m_total = tl.cast(M_total, tl.int64)
-    num_pad = m_total - covered
-    if num_pad <= 0:
-        return
-
-    num_m_blocks = tl.cdiv(num_pad, BLOCK_SIZE_M)
-    num_n_blocks = tl.cdiv(N, BLOCK_SIZE_N)
-    total_tiles = num_m_blocks * num_n_blocks
-
-    zeros = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=C.dtype.element_ty)
-
-    pid = tl.program_id(0)
-    for tile in range(pid, total_tiles, NUM_SMS):
-        bm = tile // num_n_blocks
-        bn = tile % num_n_blocks
-        rows = covered + bm * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
-        cols = bn * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-        mask = (rows[:, None] < m_total) & (cols[None, :] < N)
-        C_ = C + rows[:, None] * stride_cm + cols[None, :] * stride_cn
-        tl.store(C_, zeros, mask)
-
-
-def grouped_gemm_output_tail_kernel(
-    out: torch.Tensor,
-    group_offs: torch.Tensor,
-) -> torch.Tensor:
-    """Zero the uncovered padding tail of a grouped GEMM output, in place.
-
-    Clears rows ``[group_offs[-1], out.shape[0])`` -- the rows the persistent
-    forward/dgrad kernel never writes when the output is over-allocated to
-    padded token counts. CPU-sync-free (the covered boundary is read on device)
-    and a no-op when there is no padding.
-
-    Args:
-        out: [M_total, N] grouped GEMM output.
-        group_offs: [G+1] int64 prefix sum the kernel used to write ``out``.
-
-    Returns:
-        The same ``out`` tensor.
-    """
-    assert out.ndim == 2, f"expected 2D grouped GEMM output, got {tuple(out.shape)}"
-    M_total, N = out.shape
-    G = group_offs.shape[0] - 1
-    if G <= 0 or M_total == 0 or N == 0:
-        return out
-
-    num_sms = get_num_cus()
-    _grouped_gemm_output_tail_kernel[(num_sms,)](
-        out,
-        group_offs,
-        G,
-        M_total,
-        N,
-        out.stride(0),
-        out.stride(1),
-        NUM_SMS=num_sms,
-        BLOCK_SIZE_M=64,
-        BLOCK_SIZE_N=256,
-        num_warps=4,
     )
     return out

--- a/primus_turbo/triton/utils/silu.py
+++ b/primus_turbo/triton/utils/silu.py
@@ -1,0 +1,57 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""SwiGLU activation math on fp32 register tiles, for fused GLU epilogues.
+
+The sigmoid is spelled as ``exp2`` plus a raw ``v_rcp_f32``: every high-level
+form of ``x / (1 + exp(-x))`` -- ``tl.fdiv``, ``tl.sigmoid``, plain ``/`` --
+lowers to an IEEE-exact divide costing several times the VALU ops. That matters
+where these run, in an epilogue nothing hides: the waves of a workgroup share a
+tile, so they enter the epilogue together and the matrix pipe goes idle for its
+whole length. Skipping the Newton fixup leaves ``v_rcp_f32`` at ~1 ulp, orders
+below bf16's 8-bit mantissa, so stored results are unchanged in practice.
+
+AMDGCN-only: the reciprocal is inline asm.
+"""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _sigmoid_rcp(x):
+    """``sigmoid(x)`` via exp2 and the raw hardware reciprocal."""
+    log2e: tl.constexpr = 1.4426950408889634  # folds exp's log2e into exp2
+    d = 1.0 + tl.exp2(-x * log2e)
+    return tl.inline_asm_elementwise(
+        "v_rcp_f32_e32 $0, $1", "=v,v", [d], dtype=tl.float32, is_pure=True, pack=1
+    )
+
+
+@triton.jit
+def silu_mul_probs(gate, up, probs_row):
+    """``silu(gate) * up * probs`` with ``probs_row`` [BLOCK_M] broadcast over columns."""
+    return gate * _sigmoid_rcp(gate) * up * probs_row[:, None]
+
+
+@triton.jit
+def silu_mul_bwd_act(gate, up, dout):
+    """Gradients of ``silu(gate) * up``, as ``(dgate, dup, dout_act)``.
+
+    ``dout_act`` is ``dout * silu(gate) * up``: the per-element term a routed MLP
+    sums over the hidden dimension to get the gradient wrt the routing
+    probabilities. It costs one multiply on top of the gradients, since ``dup``
+    is already ``dout * silu(gate)``; it is only that gradient if ``dout`` is
+    unscaled by the probabilities, so the caller has to apply those to the halves
+    after.
+    """
+    s = _sigmoid_rcp(gate)
+    silu = s * gate
+    dup = dout * silu
+    # s * (1 + gate * (1 - s)) rewritten as s * (1 + gate - silu): silu is
+    # already live, so this drops a multiply per element.
+    dgate = dout * up * s * (1.0 + gate - silu)
+    return dgate, dup, dup * up

--- a/tests/pytorch/ops/test_grouped_mlp_fp8.py
+++ b/tests/pytorch/ops/test_grouped_mlp_fp8.py
@@ -1,0 +1,122 @@
+###############################################################################
+# Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""Fused FP8 grouped MLP, driven through its public op.
+
+``grouped_mlp_fp8`` runs fc1 with the silu-gated activation fused into its
+epilogue and fc2 after it, which is only worth doing if it agrees with doing
+the pieces separately. So the op is driven end to end -- output and all four
+gradients -- against an eager per-expert reference computed in fp32.
+
+Two fp8 quantisations sit on that path, the input and the fc1 activation, and
+the backward adds its own. That is what puts the SNR floor here well below a
+single GEMM's; the threshold only has to catch a wrong answer, not the
+quantisation. Which backend answers is decided by the device rather than the
+caller: FlyDSL takes the fused path where it is supported, Triton covers the
+rest.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from primus_turbo.pytorch.core.low_precision import Float8QuantConfig
+from primus_turbo.pytorch.ops.grouped_mlp_fp8 import grouped_mlp_fp8
+from tests.pytorch.test_utils import compute_snr
+
+# fp8 puts a floor of ~55 dB on a single GEMM; stacking two of them and their
+# quantisations costs roughly half of that, and the whole op measures ~23.7 dB
+# across these shapes, forward and backward alike.
+SNR_THRESHOLD = 20.0
+
+# (M, K, I, G). I=320 leaves a masked column tail (I % 256 != 0), and the uneven
+# split exercises a group whose last M-tile is clamped mid-tile.
+SHAPES = [(2048, 1024, 512, 4), (2048, 1024, 320, 4), (1536, 1152, 384, 3)]
+
+
+def _mlp_leaves(M, K, I, G, seed=42):
+    """bf16 leaves for the fused MLP, which does its own quantisation.
+
+    One group boundary is pushed off the tile grid. fc2's weight is [G, K, I],
+    so the op's output is as wide as its input.
+    """
+    dev = "cuda"
+    gen = torch.Generator(device=dev).manual_seed(seed)
+    base = M // G
+    lens = [base] * G
+    lens[0] += M - base * G
+    if G > 1:
+        lens[0] -= 17
+        lens[1] += 17
+    offs = torch.tensor([0] + torch.tensor(lens).cumsum(0).tolist(), device=dev, dtype=torch.int64)
+    x = (torch.randn(M, K, device=dev, generator=gen) * 0.1).bfloat16()
+    w1 = (torch.randn(G, 2 * I, K, device=dev, generator=gen) * 0.02).bfloat16()
+    w2 = (torch.randn(G, K, I, device=dev, generator=gen) * 0.02).bfloat16()
+    probs = torch.rand(M, device=dev, dtype=torch.float32, generator=gen) + 0.25
+    return offs, offs[1:] - offs[:-1], (x, w1, w2, probs)
+
+
+def _fused_mlp(x, w1, w2, probs, group_lens):
+    return grouped_mlp_fp8(
+        x,
+        w1,
+        w2,
+        group_lens,
+        probs=probs,
+        trans_w1=True,
+        trans_w2=True,
+        config=Float8QuantConfig(),
+        activation="silu",
+    )
+
+
+def _mlp_ref(x, w1, w2, probs, offs):
+    """Per-expert fc1, silu-gated and scaled by probs, then fc2 -- all in fp32."""
+    outs = []
+    for g in range(w1.shape[0]):
+        lo, hi = int(offs[g]), int(offs[g + 1])
+        l1 = x[lo:hi].float() @ w1[g].float().t()
+        gate, up = torch.chunk(l1, 2, dim=-1)
+        act = F.silu(gate) * up * probs[lo:hi, None].float()
+        outs.append(act @ w2[g].float().t())
+    return torch.cat(outs, dim=0)
+
+
+def _run(fn, leaves, cotangent):
+    """``fn`` on fresh leaves, returning its output and the gradients it produced.
+
+    The reference runs in fp32 and the op in bf16, so the cotangent is cast to
+    whichever the output is rather than being pinned to one of them.
+    """
+    args = [t.clone().detach().requires_grad_(True) for t in leaves]
+    out = fn(*args)
+    out.backward(cotangent.to(out.dtype))
+    return out.detach(), [t.grad for t in args]
+
+
+@pytest.mark.parametrize("shape", SHAPES)
+def test_grouped_mlp_fp8(shape):
+    """The fused op against the same arithmetic done eagerly, expert by expert.
+
+    Output and gradients in one pass: the gradients need the forward anyway, so
+    splitting them would only pay for the same kernels twice.
+    """
+    M, K, I, G = shape
+    offs, group_lens, leaves = _mlp_leaves(M, K, I, G)
+    gen = torch.Generator(device="cuda").manual_seed(7)
+    # Random rather than ones: a cotangent that varies keeps a per-row term
+    # like grad_probs from passing on symmetry alone.
+    cotangent = torch.randn(M, K, device="cuda", generator=gen)
+
+    out, grads = _run(lambda x, w1, w2, p: _fused_mlp(x, w1, w2, p, group_lens), leaves, cotangent)
+    ref, ref_grads = _run(lambda x, w1, w2, p: _mlp_ref(x, w1, w2, p, offs), leaves, cotangent)
+
+    assert out.shape == (M, K)
+    assert compute_snr(ref, out) > SNR_THRESHOLD, "out"
+    for name, got, want in zip(("grad_x", "grad_w1", "grad_w2", "grad_probs"), grads, ref_grads):
+        assert got is not None, f"{name} was not produced"
+        assert got.shape == want.shape, name
+        assert compute_snr(want, got) > SNR_THRESHOLD, name

--- a/tests/pytorch/ops/test_grouped_mlp_fp8.py
+++ b/tests/pytorch/ops/test_grouped_mlp_fp8.py
@@ -24,6 +24,7 @@ import torch
 import torch.nn.functional as F
 
 from primus_turbo.pytorch.core.low_precision import Float8QuantConfig
+from primus_turbo.pytorch.core.utils import is_gfx942
 from primus_turbo.pytorch.ops.grouped_mlp_fp8 import grouped_mlp_fp8
 from tests.pytorch.test_utils import compute_snr
 
@@ -104,6 +105,9 @@ def test_grouped_mlp_fp8(shape):
     Output and gradients in one pass: the gradients need the forward anyway, so
     splitting them would only pay for the same kernels twice.
     """
+    if is_gfx942():
+        pytest.skip("grouped_mlp_fp8 is not supported on gfx942 currently.")
+
     M, K, I, G = shape
     offs, group_lens, leaves = _mlp_leaves(M, K, I, G)
     gen = torch.Generator(device="cuda").manual_seed(7)


### PR DESCRIPTION
# Description

This PR adds a fused FP8 grouped MLP operator for MoE expert computation and fuses SwiGLU (SiLU-gated) activation into the grouped GEMM kernel epilogue for both forward and backward passes.

MoE expert MLPs typically run fc1 (gate/up projection), apply SwiGLU with routing probabilities, then run fc2. Doing these as separate kernels forces intermediate activations through HBM and adds launch overhead. This change keeps the activation math in registers at the GEMM epilogue: fc1 forward emits both the pre-activation and the scaled SwiGLU output in one FlyDSL kernel, and fc2 dgrad fuses the SwiGLU backward so the post-activation gradient never needs to be materialized. A new high-level `grouped_mlp_fp8` op wires fc1, fc2, quantization, and autograd together for end-to-end use in training stacks such as Megatron.

The fused GLU path is implemented on gfx950 (MI355) via FlyDSL, with a matching Triton kernel module and shared helper extraction for future backend coverage. Tensorwise FP8 quantization and `activation="silu"` are supported today.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `grouped_mlp_fp8` PyTorch op with `FP8GroupedMLPTensorFunc` autograd: fc1 fused GLU GEMM, activation re-quantization, fc2 grouped GEMM, full backward (dgrad/wgrad for x, w1, w2, and routing probs), and optional fused wgrad accumulation for Megatron
- Add FlyDSL fused GLU grouped GEMM kernels (`grouped_gemm_fp8_glu_kernel.py`): forward (`grouped_gemm_fp8_glu_tensorwise_flydsl_kernel`) writes pre-activation `l1 [M, 2I]` and scaled SwiGLU activation `act [M, I]`; backward (`grouped_gemm_fp8_dglu_tensorwise_flydsl_kernel`) fuses SwiGLU gradient into fc2 dgrad and accumulates `grad_probs` partials
- Extend FlyDSL `grouped_gemm_fp8_kernel.py` with `glu` / `dglu` epilogue flags so fusion reuses the existing NT/NN mainloops instead of forking them
- Add Triton fused GLU grouped GEMM kernels (`grouped_gemm_fp8_glu_kernel.py`) and shared SwiGLU register-tile math (`triton/utils/silu.py`) using an exp2 + hardware-reciprocal sigmoid for epilogue efficiency
- Expose `grouped_gemm_fp8_glu_impl` and `grouped_gemm_fp8_dglu_impl` custom ops in `grouped_gemm_fp8_impl.py` (gfx950 + tensorwise FP8 dispatch)
- Refactor shared grouped-GEMM scaffolding into `flydsl/utils/gemm_helper.py` and `triton/grouped_gemm/grouped_gemm_helper.py` (XCD swizzle, tile/group mapping, dot loop, output tail zeroing); slim down `grouped_gemm_kernel.py` accordingly
- Add end-to-end unit tests in `tests/pytorch/ops/test_grouped_mlp_fp8.py` comparing fused op output and all four gradients against an eager per-expert fp32 reference across multiple MoE shapes (SNR threshold 20 dB)

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
