### PR TITLE
fix(flydsl): restore the LDS-repack cache modifiers dropped by the grouped-GEMM rewrite

### DIFF
--- a/primus_turbo/flydsl/utils/gemm_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_helper.py
@@ -1784,10 +1784,19 @@ def _emit_lds_repack(
     pack=1,
     kbound=None,
     k128p=None,
+    rd_cm=0,
+    st_cm=0,
 ):
     # LDS-tiled transpose body (one workgroup, one (grp,k-chunk)). rd_base/wr_base
     # (default 0) shift the flat read/write offset to a group's slab (0 = dense).
     # kbound (default K128) bounds this chunk's k index; k128p (default ceildiv(K128,pack)) is the output k-stride, so the variable-K wgrad packs each group from its own k0.
+    # rd_cm/st_cm (default 0 = cached): CPol bits on the raw load / broadcast store. On gfx950
+    # 1 emits sc0, 16 emits sc1, 2 emits nt. Host-side preshuffle callers
+    # (build_preshuffle_ab_kernel, the grouped mxfp8 kernels) keep the defaults: producer and
+    # consumer are in one kernel, so a barrier is enough. A fused-kernel preshuffle role, whose
+    # producer is a peer rank and whose consumer may sit on another XCD, passes rd_cm=1 (sc0
+    # acquire) + st_cm=16 (sc1 write-through release) so the transpose itself carries the fence --
+    # no whole-L2 buffer_inv before it and no device-wide buffer_wbl2 after it.
     NT = 4
     TILE = 64 * KT
     assert KT % pack == 0 and TILE % BLK == 0 and ((KT // pack) * 64) % BLK == 0
@@ -1809,6 +1818,7 @@ def _emit_lds_repack(
             vec_width=1,
             dtype=T.i32,
             mask=(gk < KBND) & (grow < dim),
+            cache_modifier=rd_cm,
         )
         fx.make_view(fx.add_offset(tile.ptr, fx.make_int_tuple(idx)), fx.make_layout(1, 1)).store(
             Vec.from_elements([fx.Int32(dw)], fx.Int32)
@@ -1844,6 +1854,7 @@ def _emit_lds_repack(
             rout,
             ((grp * K128p + gkp) * 64 + lane) * 4 + wr_base,
             mask=(k0 + kkp * PACK) < KBND,
+            cache_modifier=st_cm,
         )
 
 


### PR DESCRIPTION
## Summary
`_emit_lds_repack` lost its `rd_cm` / `st_cm` cache modifiers in a merge, which leaves the fused MXFP8 mega MoE unable to trace at all.
- #456 added `rd_cm`/`st_cm` to `_emit_lds_repack`.
- #436 later rewrote the same helper, added `kbound`/`k128p`, and dropped both — but `mega/fp8/dispatch_grouped_gemm_mxfp8_kernel.py:450` still passes `rd_cm=1, st_cm=16`.
So on `main` today, any run with `use_turbo_mega_moe=True` at `turbo_mega_moe_precision=mxfp8` dies during tracing:
```
TypeError: _emit_lds_repack() got an unexpected keyword argument 'rd_cm'
```
This re-adds the two parameters next to `kbound`/`k128p`. The two changes are orthogonal, so the merge is mechanical, and both default to `0` — every other caller (`build_preshuffle_ab_kernel`, the grouped MXFP8 kernels) emits byte-identical code.
## Why these are not just a perf hint
`cache_modifier` is passed straight through as the CPol/aux operand of `llvm.amdgcn.raw.ptr.buffer.load/store`. Disassembling the compiled kernel on gfx950 confirms the mapping:
| `cache_modifier` | emitted suffix |
| --- | --- |
| 0 | none |
| 1 | `sc0` |
| 2 | `nt` |
| 16 | `sc1` |
In the fused preshuffle role the producer is a peer rank (scales pushed over IPC) and the consumer is a GEMM role that may sit on another XCD, so the LDS transpose is the only thing touching the data between the two. `sc0` on the load is the acquire, `sc1` on the store is the write-through release; together they replace a whole-L2 `buffer_inv` before and a device-wide `buffer_wbl2` after.
Passing `0` would still compile and run — it would just silently drop that fence, which is a data-dependent correctness bug rather than a slowdown.
## Test plan
- [x] `ruff check` / `ruff format` / `tools/check_license.py` clean on the changed file
- [x] DeepSeek-V3 (4 layers + MTP, EP8, 1×8 MI355X gfx950, global batch 512, 50 iters), `use_turbo_mega_moe=True` + `turbo_mega_moe_precision=mxfp8`: traces and trains, 7503 ms/iter at ±0.3% spread. Fails at trace time without this patch.
- [x] Same config at `bf16`, and both `use_turbo_mega_moe=False` arms: unchanged, confirming the `0` defaults are a no-op for existing callers.
