### PR TITLE
feat: hipblaslt mxfp4 backend add inplace_add_to_out support

### DIFF
--- a/csrc/pytorch/bindings_pytorch.cpp
+++ b/csrc/pytorch/bindings_pytorch.cpp
@@ -20,9 +20,9 @@ TORCH_LIBRARY(primus_turbo_cpp_extension, m) {
     m.def("hipblaslt_gemm_fp8(Tensor A, Tensor scaleA_inv, Tensor B, Tensor scaleB_inv,"
           "ScalarType out_dtype, bool transA, bool transB, bool transC, str granularity,"
           "float beta=0.0, Tensor(a!)? out=None) -> Tensor");
-    m.def(
-        "hipblaslt_gemm_fp4(Tensor A, Tensor scaleA_inv, Tensor B, Tensor scaleB_inv,"
-        "ScalarType out_dtype, bool transA, bool transB, bool transC, str granularity) -> Tensor");
+    m.def("hipblaslt_gemm_fp4(Tensor A, Tensor scaleA_inv, Tensor B, Tensor scaleB_inv,"
+          "ScalarType out_dtype, bool transA, bool transB, bool transC, str granularity,"
+          "float beta=0.0, Tensor(a!)? out=None) -> Tensor");
     m.def("ck_gemm_fp8(Tensor a, Tensor b, Tensor a_scales, Tensor b_scales, bool transA,"
           "bool transB, ScalarType out_dtype, str granularity) -> Tensor");
 

--- a/csrc/pytorch/extensions.h
+++ b/csrc/pytorch/extensions.h
@@ -243,12 +243,14 @@ at::Tensor hipblaslt_gemm_fp8_meta(at::Tensor A, at::Tensor scaleA_inv, at::Tens
 
 at::Tensor hipblaslt_gemm_fp4(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
                               at::Tensor scaleB_inv, const at::ScalarType out_dtype, bool transA,
-                              bool transB, bool transC, const std::string &granularity);
+                              bool transB, bool transC, const std::string &granularity,
+                              const double beta, c10::optional<at::Tensor> out);
 
 at::Tensor hipblaslt_gemm_fp4_meta(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
                                    at::Tensor scaleB_inv, const at::ScalarType out_dtype,
                                    bool transA, bool transB, bool transC,
-                                   const std::string &granularity);
+                                   const std::string &granularity, const double beta,
+                                   c10::optional<at::Tensor> out);
 
 at::Tensor ck_gemm_fp8(at::Tensor &a, at::Tensor &b, at::Tensor &a_scales, at::Tensor &b_scales,
                        const bool transA, const bool transB, at::ScalarType out_dtype,

--- a/csrc/pytorch/gemm/hipblaslt_gemm.cpp
+++ b/csrc/pytorch/gemm/hipblaslt_gemm.cpp
@@ -258,7 +258,8 @@ at::Tensor hipblaslt_gemm_fp8(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
 
 at::Tensor hipblaslt_gemm_fp4(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
                               at::Tensor scaleB_inv, const at::ScalarType out_dtype, bool transA,
-                              bool transB, bool transC, const std::string &granularity) {
+                              bool transB, bool transC, const std::string &granularity,
+                              const double beta, c10::optional<at::Tensor> out) {
     const bool use_fp4 = is_4bit_floating_point_dtype(A.scalar_type()) &&
                          is_4bit_floating_point_dtype(B.scalar_type());
 
@@ -274,7 +275,13 @@ at::Tensor hipblaslt_gemm_fp4(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
 
     PRIMUS_TURBO_CHECK(is_4bit_floating_point_dtype(A.scalar_type()));
     PRIMUS_TURBO_CHECK(is_4bit_floating_point_dtype(B.scalar_type()));
-    PRIMUS_TURBO_CHECK(is_16bit_floating_point_dtype(out_dtype));
+    if (out.has_value()) {
+        PRIMUS_TURBO_CHECK(is_floating_point_dtype(out->scalar_type()),
+                           "out must be a fp16/bf16/fp32 Tensor.");
+    } else {
+        PRIMUS_TURBO_CHECK(beta == 0.0, "beta != 0 requires an `out` Tensor to accumulate into.");
+        PRIMUS_TURBO_CHECK(is_16bit_floating_point_dtype(out_dtype));
+    }
 
     if (granularity == "MX_BLOCKWISE") {
         // scaling factor is e8m0 format.
@@ -342,7 +349,14 @@ at::Tensor hipblaslt_gemm_fp4(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
         PRIMUS_TURBO_CHECK(scaleB_inv.dim() == 2, "Scale B must be a 2-D tensor.");
     }
 
-    at::Tensor C = at::empty({m, n}, torch::dtype(out_dtype).device(at::kCUDA));
+    at::Tensor C;
+    if (out.has_value()) {
+        C = out.value();
+        PRIMUS_TURBO_CHECK(C.is_contiguous(), "out must be contiguous");
+        PRIMUS_TURBO_CHECK(C.dim() == 2 && C.size(0) == m && C.size(1) == n, "out shape mismatch");
+    } else {
+        C = at::empty({m, n}, torch::dtype(out_dtype).device(at::kCUDA));
+    }
 
     auto stream = at::cuda::getCurrentCUDAStream();
     auto handle = at::cuda::getCurrentCUDABlasLtHandle();
@@ -370,7 +384,7 @@ at::Tensor hipblaslt_gemm_fp4(at::Tensor A, at::Tensor scaleA_inv, at::Tensor B,
         trans_operation_A,
         static_cast<void *>(C.data_ptr()), C_type,
         rows_d, cols_d, ldd,
-        0.0f,
+        static_cast<float>(beta),
         static_cast<void *>(workspace.data_ptr()), workspace_size,
         use_fp4,
         scale_mode,

--- a/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/gemm/gemm_fp4_impl.py
@@ -78,6 +78,7 @@ class GEMMFP4HipBLASLtBackend(KernelBackend):
         granularity: ScalingGranularity,
         preshuffled: bool = False,
         inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
         **kwargs,
     ) -> bool:
         # HipBLASLt vendor wrapper has no preshuffle plumbing (see
@@ -87,8 +88,13 @@ class GEMMFP4HipBLASLtBackend(KernelBackend):
             return False
 
         supported = True
-        # TODO: this backend has no beta=1 accumulate epilogue yet.
-        supported &= not inplace_add_to_out
+        if inplace_add_to_out:
+            supported &= out is not None and out.is_contiguous()
+            supported &= out is not None and out.dtype in (
+                torch.float32,
+                torch.bfloat16,
+                torch.float16,
+            )
         supported &= not is_gfx942()
         # check ScalingGranularity
         supported &= granularity in GEMMFP4HipBLASLtBackend.SUPPORTED_GRANULARITIES
@@ -121,6 +127,9 @@ class GEMMFP4HipBLASLtBackend(KernelBackend):
         trans_c: bool,
         granularity: ScalingGranularity,
         preshuffled: bool = False,
+        inplace_add_to_out: bool = False,
+        out: torch.Tensor | None = None,
+        **kwargs,
     ):
         # preshuffled is accepted only so the dispatcher's uniform
         # execute(**kwargs) call works; can_handle already rejected the
@@ -128,7 +137,17 @@ class GEMMFP4HipBLASLtBackend(KernelBackend):
         del preshuffled
         # TODO(ruibin): Add padding
         return torch.ops.primus_turbo_cpp_extension.hipblaslt_gemm_fp4(
-            a, a_scale_inv, b, b_scale_inv, out_dtype, trans_a, trans_b, trans_c, granularity.name
+            a,
+            a_scale_inv,
+            b,
+            b_scale_inv,
+            out_dtype,
+            trans_a,
+            trans_b,
+            trans_c,
+            granularity.name,
+            1.0 if inplace_add_to_out else 0.0,
+            out if inplace_add_to_out else None,
         )
 
 
@@ -331,9 +350,37 @@ class GEMMFP4KernelDispatcher(AutoKernelDispatcher):
     _cache = TuneCache(1024)
 
     @classmethod
-    def make_key(cls, a, b, trans_a, trans_b, trans_c, out_dtype, granularity, preshuffled=False, **kwargs):
+    def make_key(
+        cls,
+        a,
+        b,
+        trans_a,
+        trans_b,
+        trans_c,
+        out_dtype,
+        granularity,
+        preshuffled=False,
+        inplace_add_to_out=False,
+        **kwargs,
+    ):
         m, n, k = get_gemm_logical_shape(a, b, trans_a, trans_b)
-        return (m, n, k, a.dtype, b.dtype, out_dtype, trans_a, trans_b, trans_c, granularity, preshuffled)
+        # Not every backend carries the beta=1 epilogue, so a choice tuned for the
+        # plain GEMM must not be reused for the accumulating one (a cache hit skips
+        # can_handle and would call a backend that ignores `out`).
+        return (
+            m,
+            n,
+            k,
+            a.dtype,
+            b.dtype,
+            out_dtype,
+            trans_a,
+            trans_b,
+            trans_c,
+            granularity,
+            preshuffled,
+            inplace_add_to_out,
+        )
 
 
 @_torch_custom_op_wrapper("primus_turbo::gemm_fp4_impl", mutates_args=(), device_types="cuda")

--- a/primus_turbo/pytorch/ops/gemm_fp4.py
+++ b/primus_turbo/pytorch/ops/gemm_fp4.py
@@ -349,10 +349,11 @@ def gemm_fp4(
             into the wgrad GEMM epilogue, so backward writes ``b.main_grad``
             directly instead of returning a gradient the framework then adds.
             ``"megatron"`` is the only supported pattern; ``b`` must carry
-            ``main_grad`` / ``grad_added_to_main_grad``. FlyDSL is the only backend
-            with the FP4 accumulate epilogue, so this requires ``use_preshuffle=False``
-            and a ``main_grad`` in the weight's own dtype (its store is 16-bit).
-            Defaults to None (no fusion).
+            ``main_grad`` / ``grad_added_to_main_grad``. The accumulate epilogue is
+            carried by the hipBLASLt and FlyDSL backends, so this requires
+            ``use_preshuffle=False``. hipBLASLt accumulates into an fp32 / bf16 / fp16
+            ``main_grad``; FlyDSL needs it in the weight's own dtype (its store is
+            16-bit). Defaults to None (no fusion).
 
     Returns:
         torch.Tensor: Output matrix with shape (M, N)
@@ -395,8 +396,9 @@ def gemm_fp4(
         out_dtype = torch.promote_types(a_data.dtype, b_data.dtype)
 
     assert not (fuse_bgrad_accum_pattern is not None and config.use_preshuffle), (
-        "fuse_bgrad_accum_pattern requires use_preshuffle=False: only the FlyDSL backend "
-        "carries the FP4 beta=1 wgrad epilogue, and it takes raw (non-preshuffled) E8M0 scales."
+        "fuse_bgrad_accum_pattern requires use_preshuffle=False: the FP4 beta=1 wgrad epilogue "
+        "lives in the hipBLASLt and FlyDSL backends, both of which take raw (non-preshuffled) "
+        "E8M0 scales; the AITER preshuffled path has no accumulate epilogue."
     )
 
     if config.granularity == ScalingGranularity.MX_BLOCKWISE:


### PR DESCRIPTION
# Description

The dense MXFP4 `beta=1` wgrad epilogue was only carried by the FlyDSL backend, so `gemm_fp4(fuse_bgrad_accum_pattern="megatron")` was usable only where that backend applies: gfx950, M/N/K all multiples of 256, and a `main_grad` in the weight's own 16-bit dtype (its store is 16-bit).
Megatron keeps `main_grad` in fp32 by default and its layer shapes are not all 256-aligned, so on most real configurations the accumulating dispatch had no backend to land on and the fusion could not be used at all.

hipBLASLt already exposes the accumulate path for FP8 -- `hipblaslt_gemm_fp8` has taken `float beta` and an optional in-place `out` since the FP8 wgrad fusion landed.
This PR gives `hipblaslt_gemm_fp4` the same two arguments and teaches the FP4 hipBLASLt backend to advertise them, which makes the fused wgrad accumulation available on the ordinary 16-aligned MXFP4 shapes and, because the D-matrix hipBLASLt type is read off the `out` tensor rather than from `out_dtype`, on an fp32 `main_grad` as well.

The vendor call itself is unchanged when `out` is absent: `beta` defaults to `0.0`, the 16-bit `out_dtype` check still applies, and a fresh output tensor is still allocated, so every existing FP4 GEMM call site keeps its current behaviour.
Passing `beta != 0` without an `out` tensor is rejected explicitly rather than silently reading uninitialised memory.

One correctness detail is worth calling out.
`GEMMFP4KernelDispatcher.make_key` did not include `inplace_add_to_out`, so the plain GEMM and the accumulating GEMM shared a tune-cache entry whenever their logical shape and dtypes matched.
A cache hit skips `can_handle`, so the accumulating call could be routed to a backend that never opted into the epilogue (AITER still declines it) and would drop the accumulation or fail on the extra arguments.
The key now carries the flag, keeping the two dispatch decisions separate.

Fixes # (no tracking issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Add `float beta=0.0` and `Tensor(a!)? out=None` to `hipblaslt_gemm_fp4` -- the schema in `bindings_pytorch.cpp`, both declarations in `extensions.h` (real and meta), and the implementation in `hipblaslt_gemm.cpp`. The signature now mirrors `hipblaslt_gemm_fp8`.
- Accumulate into the caller's buffer when `out` is given: `C` is bound to `out` instead of a fresh `at::empty`, and `beta` is forwarded to `hipblaslt_gemm_impl` in place of the hard-coded `0.0f`. `C_type` is derived from `C.scalar_type()`, so an fp32 `out` works while the operands stay FP4.
- Guard the new argument: `out` must be contiguous, 2-D and of shape `(m, n)`, and its dtype must be floating point (fp32/bf16/fp16). When `out` is absent the previous `is_16bit_floating_point_dtype(out_dtype)` check is kept and `beta` must be `0.0`.
- Let `GEMMFP4HipBLASLtBackend.can_handle` accept `inplace_add_to_out` instead of unconditionally refusing it, on the condition that `out` is present, contiguous and fp32/bf16/fp16. The `preshuffled` refusal and the gfx942 / granularity / dtype / layout / alignment checks are untouched.
- Forward the epilogue from `GEMMFP4HipBLASLtBackend.execute`: it now takes `inplace_add_to_out`, `out` and `**kwargs` (so the dispatcher's uniform `execute(**kwargs)` call works) and passes `beta=1.0` with the caller's `out` when accumulation is requested, `0.0` and `None` otherwise.
- Add `inplace_add_to_out` to the `GEMMFP4KernelDispatcher.make_key` tune-cache key, with a comment explaining why a plain-GEMM choice must not be reused for the accumulating one.
- Update the `fuse_bgrad_accum_pattern` docstring and the `use_preshuffle` assertion message in `ops/gemm_fp4.py`: the accumulate epilogue now lives in both the hipBLASLt and FlyDSL backends, hipBLASLt takes fp32/bf16/fp16 `main_grad` while FlyDSL still needs the weight's own dtype, and the AITER preshuffled path remains the one without an accumulate epilogue.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
