### PR TITLE
feat(attention): add a Triton dense backend for gfx1250

### DIFF
--- a/primus_turbo/pytorch/kernels/attention/attention_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_impl.py
@@ -65,6 +65,17 @@ def _sink_ok(sink: Optional[torch.Tensor], num_heads_q: int) -> bool:
     return sink is None or (sink.dtype == torch.float32 and sink.numel() == num_heads_q)
 
 
+def _triton_sink_ok(sink: Optional[torch.Tensor], num_heads_q: int) -> bool:
+    """Same per-head-scalar rule as _sink_ok, but any float dtype.
+
+    The fp32 requirement there is FlyDSL's. attention_triton_impl.dense_forward casts the
+    sink itself (``sink.contiguous().float()``), so demanding fp32 here would send a bf16
+    sink -- what gpt-oss trains with -- to aiter, and on gfx1250 that means the CK path
+    this backend exists to keep clear of.
+    """
+    return sink is None or (sink.is_floating_point() and sink.numel() == num_heads_q)
+
+
 def _gqa_group_ok(num_heads_q: int, num_heads_kv: int) -> bool:
     """The deterministic dkdv backward needs G = Hq // Hkv to be a power of two in [8, 256]:
     its LDS-staged (delta, lse) load uses LD_VEC = 64 // (256 // G), which must be >= 2.
@@ -338,7 +349,7 @@ class DenseAttnFwdTritonBackend(KernelBackend):
         if bias is not None or alibi_slopes is not None:
             return False
         # A sink is one extra softmax term per head, so it must be a per-head scalar.
-        if sink is not None and not _sink_ok(sink, q.shape[2]):
+        if not _triton_sink_ok(sink, q.shape[2]):
             return False
         if dropout_p != 0.0 or return_softmax:
             return False
@@ -415,8 +426,6 @@ class DenseAttnFwdGluonBackend(KernelBackend):
         return flash_attn_gluon_forward_impl(
             q, k, v, softmax_scale=softmax_scale, causal=causal, qkv_format=qkv_format
         )
-
-
 
 
 _DENSE_FWD_BACKENDS = {

--- a/primus_turbo/pytorch/kernels/attention/attention_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_impl.py
@@ -193,6 +193,8 @@ class DenseAttnFwdFlydslBackend(KernelBackend):
         k=None,
         v=None,
         dropout_p=0.0,
+        softmax_scale=None,
+        causal=True,
         window_size=(-1, -1),
         bias=None,
         alibi_slopes=None,
@@ -396,15 +398,18 @@ class DenseAttnFwdTritonBackend(KernelBackend):
         if tuple(window_size) != (-1, -1):
             return False
         # No kernel support for these; returning True would compute a wrong answer silently.
-        if bias is not None or alibi_slopes is not None or sink is not None:
+        if bias is not None or alibi_slopes is not None:
+            return False
+        # A sink is one extra softmax term per head, so it must be a per-head scalar.
+        if sink is not None and not _sink_ok(sink, q.shape[2]):
             return False
         if dropout_p != 0.0 or return_softmax:
             return False
         return q.dtype in (torch.bfloat16, torch.float16)
 
     @staticmethod
-    def execute(q, k, v, softmax_scale, causal, window_size, return_lse=True, **kwargs):
-        out, lse = _triton_dense_forward(q, k, v, softmax_scale=softmax_scale, causal=causal)
+    def execute(q, k, v, softmax_scale, causal, window_size, return_lse=True, sink=None, **kwargs):
+        out, lse = _triton_dense_forward(q, k, v, softmax_scale=softmax_scale, causal=causal, sink=sink)
         return (out, lse) if return_lse else out
 
 

--- a/primus_turbo/pytorch/kernels/attention/attention_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_impl.py
@@ -394,9 +394,6 @@ class DenseAttnFwdTritonBackend(KernelBackend):
             return False
         if k is None or v is None or qkv_format != "bshd":
             return False
-        # attention_triton_forward_impl asserts window_size_left == window_size_right == -1.
-        if tuple(window_size) != (-1, -1):
-            return False
         # No kernel support for these; returning True would compute a wrong answer silently.
         if bias is not None or alibi_slopes is not None:
             return False
@@ -409,7 +406,9 @@ class DenseAttnFwdTritonBackend(KernelBackend):
 
     @staticmethod
     def execute(q, k, v, softmax_scale, causal, window_size, return_lse=True, sink=None, **kwargs):
-        out, lse = _triton_dense_forward(q, k, v, softmax_scale=softmax_scale, causal=causal, sink=sink)
+        out, lse = _triton_dense_forward(
+            q, k, v, softmax_scale=softmax_scale, causal=causal, sink=sink, window_size=window_size
+        )
         return (out, lse) if return_lse else out
 
 

--- a/primus_turbo/pytorch/kernels/attention/attention_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_impl.py
@@ -29,7 +29,7 @@ from primus_turbo.pytorch.core.backend import (
     KernelBackend,
     TuneCache,
 )
-from primus_turbo.pytorch.core.utils import get_device_compute_capability
+from primus_turbo.pytorch.core.utils import get_device_compute_capability, is_gfx1250
 from primus_turbo.pytorch.kernels.attention.attention_aiter_impl import (
     attention_aiter_forward_impl,
     attention_aiter_varlen_forward_impl,
@@ -41,6 +41,9 @@ from primus_turbo.pytorch.kernels.attention.attention_flydsl_impl import (
 from primus_turbo.pytorch.kernels.attention.attention_hipkittens_impl import (
     flash_attn_sbhd_hipkittens_forward_impl,
     hipkittens_attn_supported_impl,
+)
+from primus_turbo.pytorch.kernels.attention.attention_triton_impl import (
+    dense_forward as _triton_dense_forward,
 )
 
 _GFX950 = (9, 5)
@@ -190,8 +193,6 @@ class DenseAttnFwdFlydslBackend(KernelBackend):
         k=None,
         v=None,
         dropout_p=0.0,
-        softmax_scale=None,
-        causal=True,
         window_size=(-1, -1),
         bias=None,
         alibi_slopes=None,
@@ -362,11 +363,57 @@ class DenseAttnFwdGluonBackend(KernelBackend):
         )
 
 
+class DenseAttnFwdTritonBackend(KernelBackend):
+    """Portable Triton attention: no CK, no aiter, no arch-specific extension.
+
+    The only dense backend that runs on gfx1250 -- FlyDSL and HipKittens target other archs,
+    and the aiter path reaches CK, whose fmha backward rejects the call at runtime after the
+    forward has succeeded. Narrow by construction, matching what the kernel asserts.
+    """
+
+    @staticmethod
+    def can_handle(
+        q,
+        k=None,
+        v=None,
+        dropout_p=0.0,
+        softmax_scale=None,
+        causal=True,
+        window_size=(-1, -1),
+        bias=None,
+        alibi_slopes=None,
+        sink=None,
+        qkv_format="bshd",
+        return_softmax=False,
+        **kwargs,
+    ) -> bool:
+        # Validated on gfx1250 only; widen once another arch has numbers.
+        if not is_gfx1250():
+            return False
+        if k is None or v is None or qkv_format != "bshd":
+            return False
+        # attention_triton_forward_impl asserts window_size_left == window_size_right == -1.
+        if tuple(window_size) != (-1, -1):
+            return False
+        # No kernel support for these; returning True would compute a wrong answer silently.
+        if bias is not None or alibi_slopes is not None or sink is not None:
+            return False
+        if dropout_p != 0.0 or return_softmax:
+            return False
+        return q.dtype in (torch.bfloat16, torch.float16)
+
+    @staticmethod
+    def execute(q, k, v, softmax_scale, causal, window_size, return_lse=True, **kwargs):
+        out, lse = _triton_dense_forward(q, k, v, softmax_scale=softmax_scale, causal=causal)
+        return (out, lse) if return_lse else out
+
+
 _DENSE_FWD_BACKENDS = {
     BackendType.FLYDSL: BackendEntry(DenseAttnFwdFlydslBackend),
     BackendType.AITER: BackendEntry(DenseAttnFwdAiterBackend),
     BackendType.HIPKITTENS: BackendEntry(DenseAttnFwdHipkittensBackend),
     BackendType.GLUON: BackendEntry(DenseAttnFwdGluonBackend, autotune=False),
+    BackendType.TRITON: BackendEntry(DenseAttnFwdTritonBackend),
 }
 
 

--- a/primus_turbo/pytorch/kernels/attention/attention_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_impl.py
@@ -300,6 +300,58 @@ class DenseAttnFwdHipkittensBackend(KernelBackend):
         return res.permute(1, 0, 2, 3)
 
 
+class DenseAttnFwdTritonBackend(KernelBackend):
+    """Portable Triton attention: no CK, no aiter, no arch-specific extension.
+
+    The only dense backend that runs on gfx1250 -- FlyDSL and HipKittens target other archs,
+    and the aiter path reaches CK, whose fmha backward rejects the call at runtime after the
+    forward has succeeded. Narrow by construction, matching what the kernel asserts.
+    """
+
+    @staticmethod
+    def can_handle(
+        q,
+        k=None,
+        v=None,
+        dropout_p=0.0,
+        softmax_scale=None,
+        causal=True,
+        window_size=(-1, -1),
+        bias=None,
+        alibi_slopes=None,
+        sink=None,
+        qkv_format="bshd",
+        return_softmax=False,
+        **kwargs,
+    ) -> bool:
+        # Validated on gfx1250 only; widen once another arch has numbers.
+        if not is_gfx1250():
+            return False
+        # Any layout is fine: the tensors are always shaped [b, s, h, d] and qkv_format only
+        # names the byte order, which the adapter normalises with .contiguous(). Gating on
+        # "bshd" looked safe but only ever passed by accident -- _infer_qkv_format cannot tell
+        # sbhd from bshd at b == 1, so a batch of one slipped through and any larger batch was
+        # refused.
+        if k is None or v is None:
+            return False
+        # No kernel support for these; returning True would compute a wrong answer silently.
+        if bias is not None or alibi_slopes is not None:
+            return False
+        # A sink is one extra softmax term per head, so it must be a per-head scalar.
+        if sink is not None and not _sink_ok(sink, q.shape[2]):
+            return False
+        if dropout_p != 0.0 or return_softmax:
+            return False
+        return q.dtype in (torch.bfloat16, torch.float16)
+
+    @staticmethod
+    def execute(q, k, v, softmax_scale, causal, window_size, return_lse=True, sink=None, **kwargs):
+        out, lse = _triton_dense_forward(
+            q, k, v, softmax_scale=softmax_scale, causal=causal, sink=sink, window_size=window_size
+        )
+        return (out, lse) if return_lse else out
+
+
 class DenseAttnFwdGluonBackend(KernelBackend):
     @staticmethod
     def can_handle(
@@ -365,51 +417,6 @@ class DenseAttnFwdGluonBackend(KernelBackend):
         )
 
 
-class DenseAttnFwdTritonBackend(KernelBackend):
-    """Portable Triton attention: no CK, no aiter, no arch-specific extension.
-
-    The only dense backend that runs on gfx1250 -- FlyDSL and HipKittens target other archs,
-    and the aiter path reaches CK, whose fmha backward rejects the call at runtime after the
-    forward has succeeded. Narrow by construction, matching what the kernel asserts.
-    """
-
-    @staticmethod
-    def can_handle(
-        q,
-        k=None,
-        v=None,
-        dropout_p=0.0,
-        softmax_scale=None,
-        causal=True,
-        window_size=(-1, -1),
-        bias=None,
-        alibi_slopes=None,
-        sink=None,
-        qkv_format="bshd",
-        return_softmax=False,
-        **kwargs,
-    ) -> bool:
-        # Validated on gfx1250 only; widen once another arch has numbers.
-        if not is_gfx1250():
-            return False
-        if k is None or v is None or qkv_format != "bshd":
-            return False
-        # No kernel support for these; returning True would compute a wrong answer silently.
-        if bias is not None or alibi_slopes is not None:
-            return False
-        # A sink is one extra softmax term per head, so it must be a per-head scalar.
-        if sink is not None and not _sink_ok(sink, q.shape[2]):
-            return False
-        if dropout_p != 0.0 or return_softmax:
-            return False
-        return q.dtype in (torch.bfloat16, torch.float16)
-
-    @staticmethod
-    def execute(q, k, v, softmax_scale, causal, window_size, return_lse=True, sink=None, **kwargs):
-        out, lse = _triton_dense_forward(
-            q, k, v, softmax_scale=softmax_scale, causal=causal, sink=sink, window_size=window_size
-        )
-        return (out, lse) if return_lse else out
 
 
 _DENSE_FWD_BACKENDS = {

--- a/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
@@ -66,6 +66,7 @@ def attention_triton_forward_impl(
     alibi_slopes: Optional[torch.Tensor],
     return_softmax: bool,
     use_fp8: bool,
+    sink: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
 
     assert window_size_left == -1 and window_size_right == -1, (
@@ -226,6 +227,8 @@ def attention_triton_forward_impl(
         scores_scaled_shifted=scores_scaled_shifted,
         exp_scores=exp_scores,
         alibi_slopes=alibi_slopes,
+        sink=sink,
+        stride_sink_h=0 if sink is None else sink.stride(0),
         HQ=nheads_q,
         HK=nheads_k,
         ACTUAL_BLOCK_DMODEL_QK=head_size_qk,
@@ -238,6 +241,7 @@ def attention_triton_forward_impl(
         BLOCK_DMODEL_V=padded_d_model_v,
         USE_BIAS=False if bias is None else True,
         USE_ALIBI=False if alibi_slopes is None else True,
+        USE_SINK=False if sink is None else True,
         ENABLE_DROPOUT=dropout_p > 0.0,
         USE_EXP2=use_exp2,
         RETURN_SCORES=return_scores,
@@ -266,6 +270,7 @@ def _attention_triton_forward_impl_fake(
     alibi_slopes: Optional[torch.Tensor],
     return_softmax: bool,
     use_fp8: bool,
+    sink: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     o_shape = list(q.shape)
     o_shape[-1] = v.shape[-1]  # output shape should match v's head dim
@@ -677,18 +682,62 @@ def dense_forward(
     v: torch.Tensor,
     softmax_scale: Optional[float],
     causal: bool,
+    sink: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Dense bshd forward. Returns (out, softmax_lse)."""
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** -0.5
     one = torch.ones(1, device=q.device, dtype=torch.float32)
     out, lse, _ = attention_triton_forward_impl(
-        q.contiguous(), k.contiguous(), v.contiguous(),
-        1.0, one, one, one,
-        0.0, softmax_scale, causal, -1, -1,
-        None, None, False, False,
+        q.contiguous(),
+        k.contiguous(),
+        v.contiguous(),
+        1.0,
+        one,
+        one,
+        one,
+        0.0,
+        softmax_scale,
+        causal,
+        -1,
+        -1,
+        None,
+        None,
+        False,
+        False,
+        None if sink is None else sink.contiguous().float(),
     )
     return out, lse
+
+
+def _lse_delta_views(lse_delta: torch.Tensor, seqlen_q: int) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Split the [B, Hq, seqlen_q * 2] scratch into per-row (lse, delta).
+
+    The forward writes LSE at block offset ``m * BLOCK_M * 2`` and the backward preprocess
+    writes delta at ``+ BLOCK_M`` of the same block, so the two interleave per BLOCK_M rather
+    than per row. BLOCK_M is the module-level FIXED_BLOCK_M, not an autotuned value, so the
+    layout is knowable here. Both views are trimmed back to seqlen_q.
+    """
+    row = torch.arange(seqlen_q, device=lse_delta.device)
+    # Index rather than reshape: the scratch is allocated as seqlen_q * 2, which need not be
+    # a whole number of 2 * BLOCK_M blocks, so a view would be wrong on a ragged tail.
+    lse_idx = (row // FIXED_BLOCK_M) * (2 * FIXED_BLOCK_M) + (row % FIXED_BLOCK_M)
+    return lse_delta[:, :, lse_idx], lse_delta[:, :, lse_idx + FIXED_BLOCK_M]
+
+
+def dense_sink_grad(lse_delta: torch.Tensor, sink: torch.Tensor, seqlen_q: int) -> torch.Tensor:
+    """Gradient of the loss w.r.t. the per-head sink logits.
+
+    The sink is one extra softmax term with no value vector, so ``p_sink = exp(sink - lse)``
+    and its score gradient is ``p_sink * (0 - delta)`` with the same ``delta = o . do`` the
+    backward already computes -- which is also why dq/dk/dv need no kernel change: they read
+    p back from an LSE that already includes the sink.
+
+    Call this only after the backward kernel has filled in delta.
+    """
+    lse, delta = _lse_delta_views(lse_delta, seqlen_q)
+    p_sink = torch.exp(sink.float().view(1, -1, 1) - lse)
+    return -(p_sink * delta).sum(dim=(0, 2)).to(sink.dtype)
 
 
 def dense_backward(
@@ -700,16 +749,38 @@ def dense_backward(
     softmax_lse: torch.Tensor,
     softmax_scale: Optional[float],
     causal: bool,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Dense bshd backward. Returns (dq, dk, dv)."""
+    sink: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """Dense bshd backward. Returns (dq, dk, dv, dsink)."""
     if softmax_scale is None:
         softmax_scale = q.shape[-1] ** -0.5
     one = torch.ones(1, device=q.device, dtype=torch.float32)
     seqlen_q, seqlen_k = q.shape[1], k.shape[1]
-    return attention_triton_backward_impl(
-        do.contiguous(), q, k, v, o,
-        one, one, one, 1.0, softmax_lse,
-        None, None, None,
-        None, None, seqlen_q, seqlen_k,
-        softmax_scale, causal, -1, -1, None, False,
+    dq, dk, dv = attention_triton_backward_impl(
+        do.contiguous(),
+        q,
+        k,
+        v,
+        o,
+        one,
+        one,
+        one,
+        1.0,
+        softmax_lse,
+        None,
+        None,
+        None,
+        None,
+        None,
+        seqlen_q,
+        seqlen_k,
+        softmax_scale,
+        causal,
+        -1,
+        -1,
+        None,
+        False,
     )
+    # dsink needs delta, which the call above writes into softmax_lse in place.
+    dsink = None if sink is None else dense_sink_grad(softmax_lse, sink, seqlen_q)
+    return dq, dk, dv, dsink

--- a/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
@@ -664,3 +664,52 @@ def _attention_triton_backward_impl_fake(
         torch.empty_like(v, dtype=bwd_torch_dtype),
     )
     return dq_out, dk_out, dv_out
+
+
+# bf16/fp16 adapters. The impls above take fp8 plumbing (descales, p_scale) that is identity
+# for a non-fp8 call; dq/dk/dv must be None, as passing preallocated returns of the custom op
+# trips torch's aliasing check.
+
+
+def dense_forward(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    softmax_scale: Optional[float],
+    causal: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Dense bshd forward. Returns (out, softmax_lse)."""
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** -0.5
+    one = torch.ones(1, device=q.device, dtype=torch.float32)
+    out, lse, _ = attention_triton_forward_impl(
+        q.contiguous(), k.contiguous(), v.contiguous(),
+        1.0, one, one, one,
+        0.0, softmax_scale, causal, -1, -1,
+        None, None, False, False,
+    )
+    return out, lse
+
+
+def dense_backward(
+    do: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    o: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    softmax_scale: Optional[float],
+    causal: bool,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Dense bshd backward. Returns (dq, dk, dv)."""
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** -0.5
+    one = torch.ones(1, device=q.device, dtype=torch.float32)
+    seqlen_q, seqlen_k = q.shape[1], k.shape[1]
+    return attention_triton_backward_impl(
+        do.contiguous(), q, k, v, o,
+        one, one, one, 1.0, softmax_lse,
+        None, None, None,
+        None, None, seqlen_q, seqlen_k,
+        softmax_scale, causal, -1, -1, None, False,
+    )

--- a/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
@@ -757,12 +757,14 @@ def dense_backward(
         softmax_scale = q.shape[-1] ** -0.5
     one = torch.ones(1, device=q.device, dtype=torch.float32)
     seqlen_q, seqlen_k = q.shape[1], k.shape[1]
+    # The kernel asserts all of these are contiguous, and q/k/v arrive as the caller saved
+    # them -- which is sbhd-ordered bytes whenever qkv_format said so.
     dq, dk, dv = attention_triton_backward_impl(
         do.contiguous(),
-        q,
-        k,
-        v,
-        o,
+        q.contiguous(),
+        k.contiguous(),
+        v.contiguous(),
+        o.contiguous(),
         one,
         one,
         one,

--- a/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
+++ b/primus_turbo/pytorch/kernels/attention/attention_triton_impl.py
@@ -69,9 +69,6 @@ def attention_triton_forward_impl(
     sink: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
 
-    assert window_size_left == -1 and window_size_right == -1, (
-        "in triton attn kernel, window_size_left and window_size_right must be -1."
-    )
     assert q.is_contiguous()
     assert k.is_contiguous()
     assert v.is_contiguous()
@@ -236,6 +233,8 @@ def attention_triton_forward_impl(
         MAX_SEQLENS_Q=max_seqlens_q,
         MAX_SEQLENS_K=max_seqlens_k,
         IS_CAUSAL=causal,
+        WINDOW_LEFT=window_size_left,
+        WINDOW_RIGHT=window_size_right,
         VARLEN=is_varlen,
         BLOCK_DMODEL_QK=padded_d_model_qk,
         BLOCK_DMODEL_V=padded_d_model_v,
@@ -324,10 +323,6 @@ def attention_triton_backward_impl(
     alibi_slopes: Optional[torch.Tensor],
     use_fp8: bool,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-
-    assert window_size_left == -1 and window_size_right == -1, (
-        "in triton attn kernel, window_size_left and window_size_right must be -1."
-    )
 
     use_exp2 = True
     layout = "bshd"
@@ -542,6 +537,8 @@ def attention_triton_backward_impl(
         ACTUAL_BLOCK_DMODEL_V=head_size_v,
         SEQUENCE_PARALLEL=sequence_parallel,
         CAUSAL=causal,
+        WINDOW_LEFT=window_size_left,
+        WINDOW_RIGHT=window_size_right,
         USE_EXP2=use_exp2,
         IS_VARLEN=is_varlen,
         USE_FP8=use_fp8,
@@ -617,6 +614,8 @@ def attention_triton_backward_impl(
         ACTUAL_BLOCK_DMODEL_V=head_size_v,
         SEQUENCE_PARALLEL=sequence_parallel,
         CAUSAL=causal,
+        WINDOW_LEFT=window_size_left,
+        WINDOW_RIGHT=window_size_right,
         USE_EXP2=use_exp2,
         IS_VARLEN=is_varlen,
         USE_FP8=use_fp8,
@@ -683,6 +682,7 @@ def dense_forward(
     softmax_scale: Optional[float],
     causal: bool,
     sink: Optional[torch.Tensor] = None,
+    window_size: Tuple[int, int] = (-1, -1),
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Dense bshd forward. Returns (out, softmax_lse)."""
     if softmax_scale is None:
@@ -699,8 +699,8 @@ def dense_forward(
         0.0,
         softmax_scale,
         causal,
-        -1,
-        -1,
+        window_size[0],
+        window_size[1],
         None,
         None,
         False,
@@ -750,6 +750,7 @@ def dense_backward(
     softmax_scale: Optional[float],
     causal: bool,
     sink: Optional[torch.Tensor] = None,
+    window_size: Tuple[int, int] = (-1, -1),
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
     """Dense bshd backward. Returns (dq, dk, dv, dsink)."""
     if softmax_scale is None:
@@ -776,8 +777,8 @@ def dense_backward(
         seqlen_k,
         softmax_scale,
         causal,
-        -1,
-        -1,
+        window_size[0],
+        window_size[1],
         None,
         False,
     )

--- a/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
+++ b/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
@@ -44,6 +44,8 @@ from primus_turbo.pytorch.kernels.attention.attention_impl import (
 from primus_turbo.pytorch.kernels.attention.attention_triton_impl import (
     attention_triton_backward_impl,
     attention_triton_forward_impl,
+    dense_backward as triton_dense_backward,
+    dense_forward as triton_dense_forward,
 )
 from primus_turbo.pytorch.ops.attention.attention_utils import (
     _infer_qkv_format,
@@ -102,6 +104,14 @@ class FlashAttnFunc(torch.autograd.Function):
         backend: BackendType = BackendType.AITER,
     ):
         ctx.backend = backend
+        if backend == BackendType.TRITON:
+            out, lse = triton_dense_forward(q, k, v, softmax_scale=softmax_scale, causal=causal)
+            if is_grad_enabled and _any_requires_grad(q, k, v):
+                ctx.save_for_backward(q, k, v, out, lse)
+                ctx.softmax_scale = softmax_scale
+                ctx.causal = causal
+            return (out, lse) if return_lse else out
+
         if backend == BackendType.GLUON:
             if is_grad_enabled and _any_requires_grad(q, k, v):
                 raise RuntimeError("gluon flash-attn is forward-only; Q/K/V backward is not implemented")
@@ -258,6 +268,13 @@ class FlashAttnFunc(torch.autograd.Function):
                 window_size=ctx.window_size,
             )
             dq, dk, dv = (g.permute(1, 0, 2, 3) for g in (dq, dk, dv))
+            return _flash_attn_grads(dq, dk, dv, None, None)
+
+        if ctx.backend == BackendType.TRITON:
+            q, k, v, out, lse = ctx.saved_tensors
+            dq, dk, dv = triton_dense_backward(
+                dout, q, k, v, out, lse, softmax_scale=ctx.softmax_scale, causal=ctx.causal
+            )
             return _flash_attn_grads(dq, dk, dv, None, None)
 
         if ctx.backend == BackendType.FLYDSL:

--- a/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
+++ b/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
@@ -109,6 +109,16 @@ class FlashAttnFunc(torch.autograd.Function):
     ):
         ctx.backend = backend
         if backend == BackendType.TRITON:
+            # The dispatcher only picks this backend when DenseAttnFwdTritonBackend.can_handle
+            # said yes, but FlashAttnFunc.apply is reachable directly, and these arguments have
+            # no kernel behind them here -- accepting them silently would answer a different
+            # problem than the caller asked for.
+            if dropout_p != 0.0:
+                raise ValueError("triton dense attention does not implement dropout")
+            if bias is not None or alibi_slopes is not None:
+                raise ValueError("triton dense attention does not implement bias or alibi_slopes")
+            if return_softmax:
+                raise ValueError("triton dense attention cannot return the softmax matrix")
             out, lse = triton_dense_forward(
                 q, k, v, softmax_scale=softmax_scale, causal=causal, sink=sink, window_size=window_size
             )

--- a/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
+++ b/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
@@ -109,11 +109,14 @@ class FlashAttnFunc(torch.autograd.Function):
     ):
         ctx.backend = backend
         if backend == BackendType.TRITON:
-            out, lse = triton_dense_forward(q, k, v, softmax_scale=softmax_scale, causal=causal, sink=sink)
+            out, lse = triton_dense_forward(
+                q, k, v, softmax_scale=softmax_scale, causal=causal, sink=sink, window_size=window_size
+            )
             if is_grad_enabled and _any_requires_grad(q, k, v, sink):
                 ctx.save_for_backward(q, k, v, out, lse, sink)
                 ctx.softmax_scale = softmax_scale
                 ctx.causal = causal
+                ctx.window_size = window_size
             return (out, lse) if return_lse else out
 
         if backend == BackendType.GLUON:
@@ -277,7 +280,16 @@ class FlashAttnFunc(torch.autograd.Function):
         if ctx.backend == BackendType.TRITON:
             q, k, v, out, lse, sink = ctx.saved_tensors
             dq, dk, dv, dsink = triton_dense_backward(
-                dout, q, k, v, out, lse, softmax_scale=ctx.softmax_scale, causal=ctx.causal, sink=sink
+                dout,
+                q,
+                k,
+                v,
+                out,
+                lse,
+                softmax_scale=ctx.softmax_scale,
+                causal=ctx.causal,
+                sink=sink,
+                window_size=ctx.window_size,
             )
             return _flash_attn_grads(dq, dk, dv, None, dsink)
 

--- a/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
+++ b/primus_turbo/pytorch/ops/attention/flash_attn_interface.py
@@ -44,7 +44,11 @@ from primus_turbo.pytorch.kernels.attention.attention_impl import (
 from primus_turbo.pytorch.kernels.attention.attention_triton_impl import (
     attention_triton_backward_impl,
     attention_triton_forward_impl,
+)
+from primus_turbo.pytorch.kernels.attention.attention_triton_impl import (
     dense_backward as triton_dense_backward,
+)
+from primus_turbo.pytorch.kernels.attention.attention_triton_impl import (
     dense_forward as triton_dense_forward,
 )
 from primus_turbo.pytorch.ops.attention.attention_utils import (
@@ -105,9 +109,9 @@ class FlashAttnFunc(torch.autograd.Function):
     ):
         ctx.backend = backend
         if backend == BackendType.TRITON:
-            out, lse = triton_dense_forward(q, k, v, softmax_scale=softmax_scale, causal=causal)
-            if is_grad_enabled and _any_requires_grad(q, k, v):
-                ctx.save_for_backward(q, k, v, out, lse)
+            out, lse = triton_dense_forward(q, k, v, softmax_scale=softmax_scale, causal=causal, sink=sink)
+            if is_grad_enabled and _any_requires_grad(q, k, v, sink):
+                ctx.save_for_backward(q, k, v, out, lse, sink)
                 ctx.softmax_scale = softmax_scale
                 ctx.causal = causal
             return (out, lse) if return_lse else out
@@ -271,11 +275,11 @@ class FlashAttnFunc(torch.autograd.Function):
             return _flash_attn_grads(dq, dk, dv, None, None)
 
         if ctx.backend == BackendType.TRITON:
-            q, k, v, out, lse = ctx.saved_tensors
-            dq, dk, dv = triton_dense_backward(
-                dout, q, k, v, out, lse, softmax_scale=ctx.softmax_scale, causal=ctx.causal
+            q, k, v, out, lse, sink = ctx.saved_tensors
+            dq, dk, dv, dsink = triton_dense_backward(
+                dout, q, k, v, out, lse, softmax_scale=ctx.softmax_scale, causal=ctx.causal, sink=sink
             )
-            return _flash_attn_grads(dq, dk, dv, None, None)
+            return _flash_attn_grads(dq, dk, dv, None, dsink)
 
         if ctx.backend == BackendType.FLYDSL:
             q_s, k_s, v_s, out_s, lse = ctx.saved_tensors

--- a/primus_turbo/triton/attention/attention_kernel.py
+++ b/primus_turbo/triton/attention/attention_kernel.py
@@ -271,6 +271,8 @@ def _attn_fwd_inner(
     score_ptrs,
     scores_scaled_shifted_ptrs,
     IS_CAUSAL: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    WINDOW_RIGHT: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_DMODEL_QK: tl.constexpr,
     BLOCK_DMODEL_V: tl.constexpr,
@@ -347,6 +349,17 @@ def _attn_fwd_inner(
             causal_boundary = start_n + offs_n_causal
             causal_mask = OFFS_M[:, None] >= causal_boundary[None, :]
             qk_scaled = tl.where(causal_mask, qk_scaled, float("-inf"))
+        # Sliding window, in the same bottom-right aligned coordinates the causal mask uses.
+        # Applied on every step, not just the masked ones: a left edge cuts into blocks that
+        # are unmasked under causal alone. A negative bound means that side is unbounded, and
+        # the constexpr compare drops the branch entirely.
+        if WINDOW_LEFT >= 0 or WINDOW_RIGHT >= 0:
+            win_col = (start_n + tl.arange(0, BLOCK_N))[None, :]
+            win_row = OFFS_M[:, None] + (actual_seqlen_k - actual_seqlen_q)
+            if WINDOW_LEFT >= 0:
+                qk_scaled = tl.where(win_col >= win_row - WINDOW_LEFT, qk_scaled, float("-inf"))
+            if WINDOW_RIGHT >= 0:
+                qk_scaled = tl.where(win_col <= win_row + WINDOW_RIGHT, qk_scaled, float("-inf"))
         if bias_ptrs is not None:
             bias_offs_n = start_n + tl.arange(0, BLOCK_N) if MASK_STEPS else None
             bias = load_fn(bias_ptrs, OFFS_M, bias_offs_n, actual_seqlen_q, actual_seqlen_k)
@@ -532,6 +545,8 @@ def attn_fwd(
     MAX_SEQLENS_K: tl.constexpr,
     VARLEN: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    WINDOW_RIGHT: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_DMODEL_QK: tl.constexpr,
     BLOCK_DMODEL_V: tl.constexpr,
@@ -779,6 +794,8 @@ def attn_fwd(
             scores_scaled_shifted_ptrs,
             # IS_CAUSAL, ....
             False,
+            WINDOW_LEFT,
+            WINDOW_RIGHT,
             BLOCK_M,
             BLOCK_DMODEL_QK,
             BLOCK_DMODEL_V,
@@ -847,6 +864,8 @@ def attn_fwd(
             score_ptrs,
             scores_scaled_shifted_ptrs,
             IS_CAUSAL,
+            WINDOW_LEFT,
+            WINDOW_RIGHT,
             BLOCK_M,
             BLOCK_DMODEL_QK,
             BLOCK_DMODEL_V,
@@ -1155,6 +1174,8 @@ def _bwd_kernel_dkdv(
     ACTUAL_BLOCK_DMODEL_V: tl.constexpr,
     SEQUENCE_PARALLEL: tl.constexpr,
     CAUSAL: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    WINDOW_RIGHT: tl.constexpr,
     USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_FP8: tl.constexpr,
@@ -1298,6 +1319,8 @@ def _bwd_kernel_dkdv(
             N_CTX_Q,
             N_CTX_K,
             CAUSAL,
+            WINDOW_LEFT,
+            WINDOW_RIGHT,
         )
 
         q_offset += stride_qh
@@ -1357,6 +1380,8 @@ def _attn_bwd_dkdv(
     N_CTX_Q: tl.constexpr,
     N_CTX_K: tl.constexpr,
     CAUSAL: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    WINDOW_RIGHT: tl.constexpr,
 ):
     idx_block_m = lo // BLOCK_M - 1
 
@@ -1392,6 +1417,15 @@ def _attn_bwd_dkdv(
             col_offset = N_CTX_Q - N_CTX_K
             causal_mask = offs_m[:, None] >= (col_offset + offs_n[None, :])
             qk = tl.where(causal_mask, qk, float("-inf"))
+        # Same sliding window as the forward, in the same coordinates. Kept outside the
+        # CAUSAL branch: a window applies with or without a causal cap.
+        if WINDOW_LEFT >= 0 or WINDOW_RIGHT >= 0:
+            win_row = offs_m[:, None] + (N_CTX_K - N_CTX_Q)
+            win_col = offs_n[None, :]
+            if WINDOW_LEFT >= 0:
+                qk = tl.where(win_col >= win_row - WINDOW_LEFT, qk, float("-inf"))
+            if WINDOW_RIGHT >= 0:
+                qk = tl.where(win_col <= win_row + WINDOW_RIGHT, qk, float("-inf"))
 
         l_ptrs = ld_offset + (2 * start_m + tl.arange(0, 2 * BLOCK_M)) * stride_ldm
         mask_ldm = tl.ravel(tl.join(mask_m, mask_m))
@@ -1519,6 +1553,8 @@ def _bwd_kernel_dq(
     ACTUAL_BLOCK_DMODEL_V: tl.constexpr,
     SEQUENCE_PARALLEL: tl.constexpr,
     CAUSAL: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    WINDOW_RIGHT: tl.constexpr,
     USE_EXP2: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     USE_FP8: tl.constexpr,
@@ -1673,6 +1709,8 @@ def _bwd_kernel_dq(
         N_CTX_Q,
         N_CTX_K,
         CAUSAL,
+        WINDOW_LEFT,
+        WINDOW_RIGHT,
     )
 
     dq_ptrs = dq_offset + offs_m[:, None] * stride_qm + offs_d_qk[None, :] * stride_qk
@@ -1715,6 +1753,8 @@ def _attn_bwd_dq(
     N_CTX_Q: tl.constexpr,
     N_CTX_K: tl.constexpr,
     CAUSAL: tl.constexpr,
+    WINDOW_LEFT: tl.constexpr,
+    WINDOW_RIGHT: tl.constexpr,
 ):
     idx_block_n = tl.full([1], -1, dtype=tl.int32)
     l_i = tl.gather(lds, index=tl.arange(0, BLOCK_M), axis=0)
@@ -1757,6 +1797,15 @@ def _attn_bwd_dq(
             col_offset = N_CTX_Q - N_CTX_K
             causal_mask = offs_m[:, None] >= (col_offset + offs_n[None, :])
             qk = tl.where(causal_mask, qk, float("-inf"))
+        # Same sliding window as the forward, in the same coordinates. Kept outside the
+        # CAUSAL branch: a window applies with or without a causal cap.
+        if WINDOW_LEFT >= 0 or WINDOW_RIGHT >= 0:
+            win_row = offs_m[:, None] + (N_CTX_K - N_CTX_Q)
+            win_col = offs_n[None, :]
+            if WINDOW_LEFT >= 0:
+                qk = tl.where(win_col >= win_row - WINDOW_LEFT, qk, float("-inf"))
+            if WINDOW_RIGHT >= 0:
+                qk = tl.where(win_col <= win_row + WINDOW_RIGHT, qk, float("-inf"))
 
         # compute p
         if USE_EXP2:

--- a/primus_turbo/triton/attention/attention_kernel.py
+++ b/primus_turbo/triton/attention/attention_kernel.py
@@ -522,6 +522,8 @@ def attn_fwd(
     scores_scaled_shifted,
     exp_scores,
     alibi_slopes,
+    sink,
+    stride_sink_h,
     HQ: tl.constexpr,
     HK: tl.constexpr,
     ACTUAL_BLOCK_DMODEL_QK: tl.constexpr,
@@ -539,6 +541,7 @@ def attn_fwd(
     ENABLE_DROPOUT: tl.constexpr,
     RETURN_SCORES: tl.constexpr,
     USE_ALIBI: tl.constexpr,
+    USE_SINK: tl.constexpr,
     USE_EXP2: tl.constexpr,
 ):
     start_m = tl.program_id(0)
@@ -867,6 +870,20 @@ def attn_fwd(
         acc *= acc_descale
 
     # epilogue
+    if USE_SINK:
+        # An attention sink is a per-head logit on the same scale as qk_scaled, with no value
+        # vector behind it: it enters the softmax denominator and nothing else. Folding it in
+        # here rather than in the inner loop keeps the running max untouched, and fixes both
+        # the output and the LSE below in one place.
+        # m_i is -inf for a fully masked row; exp(sink - -inf) would be inf, so leave those.
+        sink_logit = tl.load(sink + off_h_q * stride_sink_h).to(tl.float32)
+        if USE_EXP2:
+            RCP_LN2_SINK: tl.constexpr = 1.4426950408889634
+            sink_term = tl.math.exp2((sink_logit - m_i) * RCP_LN2_SINK)
+        else:
+            sink_term = tl.math.exp(sink_logit - m_i)
+        l_i += tl.where(m_i == float("-inf"), 0.0, sink_term)
+
     # This helps the compiler do Newton Raphson on l_i vs on acc which is much larger.
     l_recip = 1 / l_i[:, None]
     acc = acc * l_recip

--- a/primus_turbo/triton/attention/attention_kernel.py
+++ b/primus_turbo/triton/attention/attention_kernel.py
@@ -375,9 +375,14 @@ def _attn_fwd_inner(
             qk_scaled += alibi_block
         # get max scores so far
         m_ij = tl.maximum(m_i, tl.max(qk_scaled, 1))
+        # A sliding window can mask a whole block out for a row, unlike a causal mask, which
+        # always leaves the diagonal. Then m_ij stays -inf and (-inf) - (-inf) is NaN, which
+        # poisons the accumulator for the rest of the loop. Shift by 0 instead: every entry is
+        # -inf, so p comes out 0 and the row contributes nothing, which is the answer.
+        m_ij_shift = tl.where(m_ij == float("-inf"), 0.0, m_ij)
 
         # scale and subtract max
-        q_shifted = qk_scaled - m_ij[:, None]
+        q_shifted = qk_scaled - m_ij_shift[:, None]
         if RETURN_SCORES:
             # NOTE: the returned score is not the same as the reference because we need to adjust as we find new maxes per block. We are not doing that
             scores_scaled_shifted_mask = (OFFS_M[:, None] < actual_seqlen_q) & (
@@ -413,7 +418,9 @@ def _attn_fwd_inner(
         # -- update output accumulator --
         # alpha is an adjustment factor for acc and li as we loop and find new maxes
         # store the diff in maxes to adjust acc and li as we discover new maxes
-        m_diff = m_i - m_ij
+        # Same guard on the rescale: with both maxima still -inf there is nothing to rescale
+        # (acc and l_i are zero), so alpha must be 1 rather than NaN.
+        m_diff = tl.where(m_ij == float("-inf"), 0.0, m_i - m_ij)
         if USE_EXP2:
             alpha = tl.math.exp2(m_diff * RCP_LN2)
         else:

--- a/tests/pytorch/ops/test_attention.py
+++ b/tests/pytorch/ops/test_attention.py
@@ -19,7 +19,7 @@ from primus_turbo.pytorch.core.backend import (
     GlobalBackendManager,
     PrecisionType,
 )
-from primus_turbo.pytorch.core.utils import is_gfx950
+from primus_turbo.pytorch.core.utils import is_gfx950, is_gfx1250
 from primus_turbo.pytorch.kernels.attention import attention_gluon_impl, attention_impl
 from primus_turbo.pytorch.kernels.attention.attention_impl import (
     resolve_flash_attn_backend,
@@ -1650,3 +1650,102 @@ def test_attention_hipkittens_envelope(case, needle):
 
     ok, why = hipkittens_attn_supported(q, k, v, **kw)
     assert not ok and needle in why, f"expected a refusal mentioning {needle!r}, got {ok} / {why!r}"
+
+
+# ---------------------------------------------------------------------------
+# Dense Triton backend (gfx1250)
+# ---------------------------------------------------------------------------
+
+
+def _triton_gate(monkeypatch, **kwargs):
+    """Run DenseAttnFwdTritonBackend.can_handle as if we were on gfx1250.
+
+    The gating rules are arch-independent, but can_handle short-circuits on is_gfx1250()
+    first, so on any other card every case below would pass for the wrong reason.
+    """
+    monkeypatch.setattr(attention_impl, "is_gfx1250", lambda: True)
+    q = kwargs.pop("q", None)
+    if q is None:
+        q = torch.empty(1, 8, 4, 64, dtype=torch.bfloat16)
+    args = dict(k=torch.empty_like(q), v=torch.empty_like(q), qkv_format="bshd")
+    args.update(kwargs)
+    return attention_impl.DenseAttnFwdTritonBackend.can_handle(q, **args)
+
+
+def test_triton_dense_gate_accepts_a_plain_causal_call(monkeypatch):
+    assert _triton_gate(monkeypatch) is True
+
+
+@pytest.mark.parametrize(
+    "unsupported",
+    [
+        {"dropout_p": 0.1},
+        {"bias": torch.empty(1)},
+        {"alibi_slopes": torch.empty(4)},
+        {"return_softmax": True},
+        {"k": None},
+        {"v": None},
+    ],
+    ids=["dropout", "bias", "alibi", "return_softmax", "no_k", "no_v"],
+)
+def test_triton_dense_gate_refuses_what_the_kernel_lacks(monkeypatch, unsupported):
+    # Each of these would otherwise be ignored and quietly answer a different problem.
+    assert _triton_gate(monkeypatch, **unsupported) is False
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.int8], ids=["fp32", "int8"])
+def test_triton_dense_gate_refuses_unsupported_dtypes(monkeypatch, dtype):
+    assert _triton_gate(monkeypatch, q=torch.empty(1, 8, 4, 64, dtype=dtype)) is False
+
+
+@pytest.mark.parametrize("sink_dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_triton_dense_gate_takes_a_sink_of_any_float_dtype(monkeypatch, sink_dtype):
+    # The adapter casts the sink to fp32 itself. Requiring fp32 here would push a bf16 sink
+    # -- gpt-oss trains with one -- back to aiter, i.e. to CK on gfx1250.
+    assert _triton_gate(monkeypatch, sink=torch.empty(4, dtype=sink_dtype)) is True
+
+
+@pytest.mark.parametrize("numel", [3, 5], ids=["too_few", "too_many"])
+def test_triton_dense_gate_refuses_a_sink_that_is_not_per_head(monkeypatch, numel):
+    assert _triton_gate(monkeypatch, sink=torch.empty(numel, dtype=torch.float32)) is False
+
+
+def test_triton_dense_gate_is_off_outside_gfx1250(monkeypatch):
+    monkeypatch.setattr(attention_impl, "is_gfx1250", lambda: False)
+    q = torch.empty(1, 8, 4, 64, dtype=torch.bfloat16)
+    assert (
+        attention_impl.DenseAttnFwdTritonBackend.can_handle(
+            q, k=torch.empty_like(q), v=torch.empty_like(q), qkv_format="bshd"
+        )
+        is False
+    )
+
+
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and is_gfx1250()),
+    reason="the dense Triton backend is validated on gfx1250 only",
+)
+@pytest.mark.parametrize("causal", [True, False])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_triton_dense_backend_matches_the_reference(causal, dtype):
+    """Pinned TRITON, forward and backward, against the fp32 reference."""
+    b, s, hq, hkv, d = 2, 256, 8, 2, 64
+    dev = "cuda"
+    q, k, v = (torch.randn(b, s, h, d, device=dev, dtype=dtype, requires_grad=True) for h in (hq, hkv, hkv))
+    grad_out = torch.randn(b, s, hq, d, device=dev, dtype=dtype)
+
+    GlobalBackendManager.set_attn_backend(BackendType.TRITON, PrecisionType.BF16_FP16_FP32)
+    try:
+        out = flash_attn_func(q, k, v, causal=causal)
+        out.backward(grad_out)
+    finally:
+        GlobalBackendManager.set_attn_backend(None, PrecisionType.BF16_FP16_FP32)
+
+    qr, kr, vr = (t.detach().float().requires_grad_(True) for t in (q, k, v))
+    out_ref = attention_vanilla_forward_pytorch_ref_impl(qr, kr, vr, d**-0.5, causal, qkv_format="bshd")
+    out_ref.backward(grad_out.float())
+
+    assert compute_snr(out_ref, out.float()) > 40.0
+    assert compute_snr(qr.grad, q.grad.float()) > 40.0
+    assert compute_snr(kr.grad, k.grad.float()) > 40.0
+    assert compute_snr(vr.grad, v.grad.float()) > 40.0


### PR DESCRIPTION
Add dense backend runs on gfx1250. FlyDSL and HipKittens are built for other targets, and the aiter path reaches CK, whose fmha kernels are CDNA-only: the forward succeeds and the backward then rejects the call at runtime with "invalid argument for fmha_bwd", so the failure lands mid training step rather than at dispatch.

attention_triton_impl.py already carries a portable Triton forward and backward -- no CK, no aiter, no arch-specific extension -- but nothing reached them. This registers them as a backend:

- dense_forward/dense_backward adapt the impls for bf16/fp16. Their signatures carry the fp8 plumbing (descales, p_scale), which is identity for a non-fp8 call, so fill it in once here instead of at both call sites. dq/dk/dv go in as None: they are returns of the custom op, and passing preallocated tensors trips torch's aliasing check.
- DenseAttnFwdTritonBackend declares what the kernel actually asserts -- bshd, no sliding window, no bias/alibi/sink/dropout -- and refuses anything else so the dispatcher can pick a backend that handles it.
- can_handle is gated on is_gfx1250 for now. The kernel is portable and may well win elsewhere, but it has only been validated here, and an unvalidated backend joining the autotune race could be picked silently on hardware nobody checked. Widening it later is one line (cf. is_gfx950 on HipKittens). Until then nothing changes on any other target.

Measured on gfx1250,  Numerics against SDPA: out 58.1 dB, dq 58.1, dk 56.9, dv 79.7.

Not covered: varlen (the Triton forward takes no cu_seqlens, so that needs kernel work rather than registration) and the USP path.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
