### PR TITLE
fix(deep_ep): stop defaulting to the cheap fence

### DIFF
--- a/csrc/include/primus_turbo/deep_ep/configs.h
+++ b/csrc/include/primus_turbo/deep_ep/configs.h
@@ -83,10 +83,20 @@ static inline int get_num_cpu_timeout_secs() {
     return timeout;
 }
 
+// The cheap fence replaces the release store's system-scope write-back with a per-wave s_waitcnt
+// (st_release_sys_global in the deep_ep utils header). That waitcnt covers only the wave that
+// publishes the channel tail, while the payload rows are written by the other waves of the group,
+// and the RELAXED store drops the write-back the receiver needs -- so a receiver can see the new
+// tail while those rows still sit in the sender's L2 and read the previous round's contents
+// instead. Measured on gfx950 (EP=8, DSv3, intranode dispatch): 7 of 8 short runs carried 1-6
+// corrupted rows out of 8192, and 50-iter bf16 loss landed at 6.2066 against a 4.5206 DeepEP-off
+// reference. The corruption is silent -- it lands in gradients -- so it must not be what a caller
+// gets by default. The plain release store costs 2.7% more per step; set
+// PRIMUS_TURBO_DEEPEP_DISABLE_CHEAP_FENCE=0 to take the cheap fence back, and its hazard with it.
 inline static bool is_enable_cheap_fence() {
     char const *v = std::getenv("PRIMUS_TURBO_DEEPEP_DISABLE_CHEAP_FENCE");
     if (!v || v[0] == '\0')
-        return true;
+        return false;
     return std::stoi(v) == 0;
 }
 


### PR DESCRIPTION

`intranode` dispatch/combine publish a channel tail with `st_release_sys_global<kUseCheapFence>`.
With `kUseCheapFence` -- the default -- that "release" is:

```cpp
__atomic_signal_fence(SEQ_CST);          // compiler barrier only
asm volatile("s_waitcnt lgkmcnt(0) vmcnt(0)");
__hip_atomic_store(ptr, val, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);
```

`s_waitcnt` is per-wave: it waits on the memory operations of the wave that publishes the tail,
while the payload rows are written by the *other* waves of the sending group. `__ATOMIC_RELAXED`
drops the system-scope write-back on top of that, and the `sync_barrier` above the publish fences
only at block scope. Nothing on the path forces the rows out to where the peer can observe them,
so a receiver that sees the new tail can read the ring buffer's previous contents instead.

Row-level probe on gfx950 (EP=8, DSv3, 8 short runs): 7 of 8 runs carried 1-6 corrupted rows out
of 8192, values 352x-41442x the legitimate bound, rank and row differing every run. The corruption
is silent -- it lands in gradients -- and intermittent: the same configuration produced 4.9737 and
5.5935 on two identical 50-iter reps, so a single healthy-looking run proves nothing.

## The change

One line in `csrc/include/primus_turbo/deep_ep/configs.h`, plus the comment that explains why:

```diff
 inline static bool is_enable_cheap_fence() {
     char const *v = std::getenv("PRIMUS_TURBO_DEEPEP_DISABLE_CHEAP_FENCE");
     if (!v || v[0] == '\0')
-        return true;
+        return false;
     return std::stoi(v) == 0;
 }
```

The variable and its meaning are untouched, so nothing that already sets it changes behaviour:

| value | fence | correct |
|---|---|---|
| unset | real release store | yes -- new default |
| `DISABLE=1` | real release store | yes -- what it already meant |
| `DISABLE=0` | cheap fence | **no** -- opt in only if you want the 2.7% and the hazard |

## Evidence

One node, one container, one stack, same day, bf16 DSv3 4-layer, GBS 512, 50 iterations,
Primus 8494b0a5. The turbo build is the only variable.

| arm | env | lm loss @50 | ms/iter |
|---|---|---|---|
| DeepEP off (reference) | - | 4.5206 / 4.5210 | 10688.5 |
| DeepEP on, `DISABLE=1` (the new default) | `DISABLE=1` | 4.5211 | 9913.1 |
| DeepEP on, cheap fence (today's default) | none | **6.2066** | 9648.6 |
<img width="1173" height="716" alt="image" src="https://github.com/user-attachments/assets/9b6eb015-c7f2-4627-8c63-54f2da148e1b" />

The bad arm diverges from the reference by iteration 10 (10.4275 vs 10.1209). The fixed arm tracks
the reference at every checkpoint (it25 6.9033 vs 6.9031/6.9032), closer than the two reference
reps are to each other.

## Cost

2.7% per step: 9648.6 -> 9913.1 ms/iter. DeepEP with the real release fence is still 7.3% faster
per step than DeepEP off, so turning DeepEP off is the worst way to avoid this bug.
<img width="1015" height="453" alt="image" src="https://github.com/user-attachments/assets/a3614ccf-1db6-4c22-9bcc-0c09e8718ead" />


## Reproducing

DeepSeek-V3 4-layer, bf16, stock MoE, EP=8 on one MI355X node, `--mock_data`, 50 iterations,
`--turbo_sync_free_moe_stage 0` so sync-free does not force DeepEP's own switches:

```bash
# fails on turbo main: loss plateaus above 5 and moves between reps
python3 -m primus.cli.main ... --use_turbo_deepep True

# passes, and is what this PR makes the default
PRIMUS_TURBO_DEEPEP_DISABLE_CHEAP_FENCE=1 python3 -m primus.cli.main ... --use_turbo_deepep True
```

The loss endpoint alone is a weak test -- the fault is intermittent. The sensitive check is the
row-level one: dispatch only moves gradients between ranks, so every output row's absmax is bounded
by the largest absmax across all ranks' inputs, and rows above that bound were never written by the
collective. Counting those rows separates "rarer" from "gone" in a way a single loss number cannot.
Note that any probe doing a device-to-host sync in the hot path suppresses the bug it is measuring.

## Test plan

- [x] 50-iter loss, three arms, one node / one container / one stack / same day, turbo build the
      only variable -- table above.
- [x] Row-level bound check, 8 short runs per arm: 13 corrupted rows with the cheap fence, 0 with
      the release store.
- [x] Step-time measured on the same runs, iterations 11+ -- +2.74%.
- [ ] Multi-node (internode path) unaffected by inspection -- `internode.cu` has no
      `st_release_sys_global`/`sync_barrier` pair -- but not measured here.

## Follow-up, not in this PR

The cheap path can be repaired rather than avoided: the barrier every sending wave passes before
the publish is the only place that can write back the payload rows, and it currently fences at
block scope. Changing it to system scope on the cheap-fence path measured 4.5214 -- clean -- in a
single 50-iter run, at 9910.0 ms/iter, i.e. the same cost as the plain release store. That is one
run against eight for the plain release path, so it is left for separate work with its own
evidence.

Two unrelated defects noticed while reading this code, worth separate issues:
- `moe_permute.py:262` claims "Buffers are already zero" one line after a `torch.empty`.
- `unpermute_impl` sizes its grid from the host-side `num_dispatched_max` while the kernel exits
  early on a device-side count; the two are not synchronised.
