### PR TITLE
fix(flydsl): stop recompiling the mxfp4 grouped quant and wgrad on every token count

### DIFF
--- a/primus_turbo/flydsl/grouped_gemm/grouped_gemm_mxfp4_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/grouped_gemm_mxfp4_kernel.py
@@ -542,7 +542,7 @@ def _build_grouped_mxfp4_nt_kernel(
 
 _GMXFP4_LAUNCH_CACHE: dict = {}
 _GMXFP4_WS_CACHE: dict = {}
-_GMXFP4_AT_CACHE: dict = {}  # (total_M, N, K, G, gm, xcd, gn, out_fp16) -> [raw_launch, compiled]
+_GMXFP4_AT_CACHE: dict = {}  # (N, K, G, gm, xcd, gn, span, nt, out_fp16, k_real) -> [raw, compiled]
 _GMXFP4_NT_CFG = (4, 8, 0, 16, False)
 # Thin groups: the write-only C stream evicts re-read weights, so non-temporal buys them back.
 _GMXFP4_NT_CFG_THIN = (4, 8, 0, 16, True)
@@ -699,7 +699,6 @@ def _build_grouped_mxfp4_wgrad_kernel(
     OUT_M,
     OUT_N,
     G,
-    M_total,
     group_m=4,
     num_xcds=8,
     group_n=0,
@@ -716,7 +715,6 @@ def _build_grouped_mxfp4_wgrad_kernel(
     N_SUB = BLOCK_K // 128
     BPR = BLOCK_K // 2
     KSTEP = BPR
-    M2 = M_total // 2  # operand row stride (bytes) = full contraction
     N_TILES_A = BLOCK_M // 32
     LDS_BN_HALF = BLOCK_N // 2
     N_TILES_BH = LDS_BN_HALF // 32
@@ -727,7 +725,6 @@ def _build_grouped_mxfp4_wgrad_kernel(
     N_LDS_STEPS_A = BLOCK_M // _ROWS_PER_STEP
     N_LDS_STEPS_BH = LDS_BN_HALF // _ROWS_PER_STEP
     _PRELL, _NSCBUF = 2, 2
-    K128m = M_total // 128  # scale packed row stride (contraction blocks)
     _SCBUF = 4 * 4 * (BLOCK_K // 128) * 64
     _SCW = 4 * N_SUB * 64
     _SCVSTEP = 64 * (2 * N_SUB) * 4  # scale byte advance per 256-K iter (whole-loop internal)
@@ -761,6 +758,7 @@ def _build_grouped_mxfp4_wgrad_kernel(
         A_scale: fx.Tensor,  # packed lhs scale (whole-tensor)
         B_scale: fx.Tensor,  # packed rhs scale
         GO: fx.Tensor,  # padded per-group M offs (int32 view int64 [G+1])
+        m_total: fx.Int32,  # padded contraction length (A / B_T leading dim)
     ):
         F8 = fx.Float8E4M3FN.ir_type
         lds = fx.SharedAllocator().allocate(SS).peek()
@@ -774,15 +772,21 @@ def _build_grouped_mxfp4_wgrad_kernel(
         wave_n = wave_id % 2
         I32 = fx.Int32
 
+        # Both operand strides follow the padded contraction, which is a launch argument:
+        # m2 is the fp4 row stride in bytes, k128m the packed-scale row stride in K-blocks.
+        m2 = m_total // I32(2)
+        k128m = m_total // I32(128)
+        m2_idx = arith.index_cast(T.index, m2)
+
         mfma = MfmaScaleFp4(N_TILES_A, N_TILES_BH, packed=True, wlv=wlv, elgk=elgk)
-        gl_off_a = fp4_g2s_offsets(lane_id, wave_id, M_total, N_LDS_STEPS_A, BPR, swizzle=swizzle)
-        gl_off_b = fp4_g2s_offsets(lane_id, wave_id, M_total, N_LDS_STEPS_BH, BPR, swizzle=swizzle, ilv=_BILV)
+        gl_off_a = fp4_g2s_offsets(lane_id, wave_id, m_total, N_LDS_STEPS_A, BPR, swizzle=swizzle)
+        gl_off_b = fp4_g2s_offsets(lane_id, wave_id, m_total, N_LDS_STEPS_BH, BPR, swizzle=swizzle, ilv=_BILV)
         a_s2r = S2RLoaderFp4(wave_m, N_TILES_A, LDS_ROW_STRIDE, swizzle=swizzle)
         b_s2r = S2RLoaderFp4(wave_n, N_TILES_BH, LDS_ROW_STRIDE, swizzle=swizzle)
         _qm = ceildiv(OUT_M, 256) * 256
         _qn = ceildiv(OUT_N, 256) * 256
-        sa_s2r = ScaleS2RPacked(A_scale, _qm, M_total, 4)
-        sb_s2r = ScaleS2RPacked(B_scale, _qn, M_total, 4)
+        sa_s2r = ScaleS2RPacked(A_scale, _qm, m_total, 4)
+        sb_s2r = ScaleS2RPacked(B_scale, _qn, m_total, 4)
         wave_m_off = wave_m * (N_TILES_A * 16)
         wave_n_off = wave_n * (N_TILES_BH * 16)
 
@@ -829,9 +833,7 @@ def _build_grouped_mxfp4_wgrad_kernel(
 
         def _scsoff(base, extra, ksb):
             grp = (base + fx.Int32(extra)) // fx.Int32(64)
-            return rocdl.readfirstlane(
-                T.i32, (grp * fx.Int32(K128m) + fx.Int32(_PRELL * N_SUB)) * fx.Int32(256) + ksb
-            )
+            return rocdl.readfirstlane(T.i32, (grp * k128m + fx.Int32(_PRELL * N_SUB)) * fx.Int32(256) + ksb)
 
         # Lane-resident group table: bounds cost a v_readlane, not a load occ=1 cannot hide.
         go_rs = buffer_ops.create_buffer_resource(GO, max_size=False, num_records_bytes=(G + 1) * 8)
@@ -863,10 +865,10 @@ def _build_grouped_mxfp4_wgrad_kernel(
             b_row = block_n * I32(BLOCK_N)
             # fold row base + contraction start into the int64 SRDs: large OUT_M/M_total pass 2^31
             _ms2 = arith.index_cast(T.index, m_start >> 1)
-            a_base_e = arith.index_cast(T.index, a_row) * arith.index(M2) + _ms2
-            b_base_e = arith.index_cast(T.index, b_row) * arith.index(M2) + _ms2
-            a_nrec = arith.index(OUT_M) * arith.index(M2) - a_base_e
-            b_nrec = arith.index(OUT_N) * arith.index(M2) - b_base_e
+            a_base_e = arith.index_cast(T.index, a_row) * m2_idx + _ms2
+            b_base_e = arith.index_cast(T.index, b_row) * m2_idx + _ms2
+            a_nrec = arith.index(OUT_M) * m2_idx - a_base_e
+            b_nrec = arith.index(OUT_N) * m2_idx - b_base_e
             gA, rsrc_a = make_fp8_rebased_tensor_and_srd(A, F8, a_base_e, a_nrec)
             gB, rsrc_b = make_fp8_rebased_tensor_and_srd(B_T, F8, b_base_e, b_nrec)
             a_div = fx.logical_divide(gA, fx.make_layout(1, 1))
@@ -876,7 +878,7 @@ def _build_grouped_mxfp4_wgrad_kernel(
             br_g2s = G2SLoader(b_div, gl_off_b, N_LDS_STEPS_BH, F8, wave_id)
             a_off = I32(0)  # tile row base + contraction start folded into the SRDs above; only
             bl_off = I32(0)  # br's LDS-half row shift survives as an int32-safe residual.
-            br_off = I32(LDS_BN_HALF) * I32(M2)
+            br_off = I32(LDS_BN_HALF) * m2
             sa_b = a_row + I32(wave_m_off)
             sbl_b = b_row + I32(wave_n_off)
             sbr_b = b_row + I32(LDS_BN_HALF) + I32(wave_n_off)
@@ -900,8 +902,8 @@ def _build_grouped_mxfp4_wgrad_kernel(
             _sc3 = _scsoff(sbr_b, 0, ksb)
             _wia = sa_b // I32(128)
             _wib = (sbl_b // I32(256)) * I32(2) + (sbl_b % I32(256)) // I32(64)
-            _sob_v = _wib * I32(K128m) * I32(512) + ksb
-            _soa = rocdl.readfirstlane(T.i32, _wia * I32(K128m) * I32(512) + ksb)
+            _sob_v = _wib * k128m * I32(512) + ksb
+            _soa = rocdl.readfirstlane(T.i32, _wia * k128m * I32(512) + ksb)
             _sob = rocdl.readfirstlane(T.i32, _sob_v)
             sc_soff06 = [_soa, _sc1, _sob, _sc3]
             _half_n = None
@@ -974,20 +976,22 @@ def _build_grouped_mxfp4_wgrad_kernel(
 
 _GMXFP4_WGRAD_LAUNCH_CACHE: dict = {}
 _GMXFP4_WGRAD_WS_CACHE: dict = {}
-_GMXFP4_WGRAD_AT_CACHE: dict = {}  # (OUT_M_p, OUT_N_p, M_alloc, G, out_fp16, beta1) -> [raw, compiled]
+_GMXFP4_WGRAD_AT_CACHE: dict = {}  # (OUT_M, OUT_N, G, cfg..., out_fp16, beta1) -> [raw, compiled]
 
 
 def _get_grouped_mxfp4_wgrad_ws(OUT_M, OUT_N, K128m, device):
-    key = (OUT_M, OUT_N, K128m, device)
+    # key on the static shape and grow the slabs only for a longer contraction, so a
+    # per-step token count re-uses one pair instead of stranding a pair per length
+    key = (OUT_M, OUT_N, device)
     e = _GMXFP4_WGRAD_WS_CACHE.get(key)
-    if e is None:
+    if e is None or e[2] < K128m:
         qm = ceildiv(OUT_M, 256) * 256
         qn = ceildiv(OUT_N, 256) * 256
         a_sp = torch.empty(qm * K128m, dtype=torch.int32, device=device)
         b_sp = torch.empty(qn * K128m, dtype=torch.int32, device=device)
-        e = (a_sp, b_sp)
+        e = (a_sp, b_sp, K128m)
         _GMXFP4_WGRAD_WS_CACHE[key] = e
-    return e
+    return e[0], e[1]
 
 
 def _select_gmxfp4_wgrad_cfg(M_total, G, OUT_M=0, OUT_N=0):
@@ -1002,14 +1006,12 @@ def _select_gmxfp4_wgrad_cfg(M_total, G, OUT_M=0, OUT_N=0):
 
 
 def _compile_grouped_mxfp4_wgrad_fused(
-    OUT_M, OUT_N, G, M_total, gm, xcd, gn, nt, wgt, wlv, elgk, out_fp16, beta_is_one=False
+    OUT_M, OUT_N, G, gm, xcd, gn, nt, wgt, wlv, elgk, out_fp16, beta_is_one=False
 ):
-    K128m = M_total // 128
     gemm_k, attrs, GRID, b_ilv = _build_grouped_mxfp4_wgrad_kernel(
         OUT_M,
         OUT_N,
         G,
-        M_total,
         group_m=gm,
         num_xcds=xcd,
         group_n=gn,
@@ -1035,10 +1037,12 @@ def _compile_grouped_mxfp4_wgrad_fused(
         a_sp: fx.Tensor,
         b_sp: fx.Tensor,
         GO: fx.Tensor,
+        m_total: fx.Int32,
         stream: fx.Stream,
     ):
-        grid_a = ceildiv(fx.Int32(QM) * fx.Int32(K128m), _PGRID)
-        grid_b = ceildiv(fx.Int32(QN) * fx.Int32(K128m), _PGRID)
+        k128m = m_total // fx.Int32(128)
+        grid_a = ceildiv(fx.Int32(QM) * k128m, _PGRID)
+        grid_b = ceildiv(fx.Int32(QN) * k128m, _PGRID)
         pre_ab(
             a_raw,
             a_sp,
@@ -1048,10 +1052,10 @@ def _compile_grouped_mxfp4_wgrad_fused(
             fx.Int32(QN),
             fx.Int32(OUT_M),
             fx.Int32(OUT_N),
-            fx.Int32(K128m),
+            k128m,
             grid_a,
         ).launch(grid=(grid_a + grid_b, 1, 1), block=(_MXFP4_PRESHUF_BLK, 1, 1), stream=stream)
-        gemm_k(a8, b8, C, a_sp, b_sp, GO, value_attrs=attrs).launch(
+        gemm_k(a8, b8, C, a_sp, b_sp, GO, m_total, value_attrs=attrs).launch(
             grid=(GRID, 1, 1), block=(256, 1, 1), stream=stream
         )
 
@@ -1112,18 +1116,18 @@ def grouped_gemm_mxfp4_variable_k_flydsl_kernel(
     # standalone store and the 9 it was tuned with -- draining it there costs correctness.
     wlv = 10
     elgk = 9 if out_fp16 else 0
-    args = (a8, b8, out, a_raw, b_raw, a_sp, b_sp, go_pad, stream)
+    args = (a8, b8, out, a_raw, b_raw, a_sp, b_sp, go_pad, M_total, stream)
 
     def _entry(cfg):
         gm, xcd, gn, nt, wgt = cfg
-        lk = (OUT_M, OUT_N, G, M_total, gm, xcd, gn, nt, wgt, wlv, elgk, out_fp16, beta_is_one)
+        lk = (OUT_M, OUT_N, G, gm, xcd, gn, nt, wgt, wlv, elgk, out_fp16, beta_is_one)
         ent = _GMXFP4_WGRAD_LAUNCH_CACHE.get(lk)
         if ent is None:
             ent = _compile_grouped_mxfp4_wgrad_fused(
-                OUT_M, OUT_N, G, M_total, gm, xcd, gn, nt, wgt, wlv, elgk, out_fp16, beta_is_one
+                OUT_M, OUT_N, G, gm, xcd, gn, nt, wgt, wlv, elgk, out_fp16, beta_is_one
             )
             _GMXFP4_WGRAD_LAUNCH_CACHE[lk] = ent
-        atk = (OUT_M, OUT_N, M_total, G, gm, xcd, gn, nt, wgt, out_fp16, beta_is_one)
+        atk = (OUT_M, OUT_N, G, gm, xcd, gn, nt, wgt, out_fp16, beta_is_one)
         e2 = _GMXFP4_WGRAD_AT_CACHE.get(atk)
         if e2 is None:
             e2 = [ent[0], None]

--- a/primus_turbo/flydsl/quantization/mxfp4_grouped_quant.py
+++ b/primus_turbo/flydsl/quantization/mxfp4_grouped_quant.py
@@ -25,8 +25,6 @@ native cvt_scalef32_pk_fp4); bf16 matches the C++ dual byte-for-byte, fp16
 upcasts via fpext.
 """
 
-import gc
-
 import flydsl.compiler as flyc
 import flydsl.expr as fx
 import torch
@@ -53,7 +51,7 @@ from primus_turbo.flydsl.utils.gemm_helper import (
     ceildiv_pow2,
     current_stream,
     make_row_band_resource,
-    xcd_remap_pid_blocked,
+    xcd_remap_pid_blocked_dyn,
 )
 
 MB = 32  # MXFP4 microblock (elems per E8M0)
@@ -175,11 +173,16 @@ def _col_microblock(rows, chalf, is_fp16, use_rht, seed):
     return _cvt_microblock_to_fp4(vf, arith.bitcast(T.f32, native_bits), seed), biased
 
 
+def grouped_mxfp4_qdual_grid(M_pad_col, N_pad, bm=256, bk=128):
+    """Grid (in workgroups) for ``compile_grouped_mxfp4_qdual``'s kernel at this runtime
+    M_pad_col. The padded-M extent is a launch argument, so the host owns the tiling
+    arithmetic and one compiled kernel serves every token count."""
+    return (M_pad_col // bm) * ((N_pad + bk - 1) // bk)
+
+
 def compile_grouped_mxfp4_qdual(
-    total_M,
     N,
     G,
-    M_pad_col,
     N_pad,
     row_rht,
     col_rht,
@@ -189,7 +192,8 @@ def compile_grouped_mxfp4_qdual(
     row_sr=False,
     col_sr=False,
 ):
-    """Compile the fused grouped mxfp4 dual quant. Shapes/recipes are baked.
+    """Compile the fused grouped mxfp4 dual quant. The N-side shapes and the recipes are
+    baked; the padded-M extent is not, so a changing per-step token count reuses one kernel.
 
     ``bm`` (tile rows) must divide the 256 col-pad alignment, so one tile stays within one
     group. The ldsc write-back walks the stage as ``4 words x nth`` per iteration and masks
@@ -236,12 +240,12 @@ def compile_grouped_mxfp4_qdual(
     assert 0 < _NCP <= nth and _NCP % 64 == 0, "col pair tasks must fit nth, wave-aligned"
     _CWIT = (LDSC_DW + nth * 4 - 1) // (nth * 4)  # col write-back vec4 iters
     _CWTAIL = LDSC_DW % (nth * 4) != 0  # last write-back iteration is partial -> mask it
-    NBM = M_pad_col // BM  # padded-M blocks (col layout)
     NBK = (N_pad + BK - 1) // BK  # N blocks (ceil; BK may overshoot 128-aligned N_pad)
     ROW_SC_N = N_pad // 32  # rowwise scale cols
-    COL_SC_N = M_pad_col // 32  # colwise scale cols
     ROW_OUT_W = 4 * ROW_SC_N  # rowwise fp4 i32 words per row (N_pad/8)
-    COL_OUT_W = 4 * COL_SC_N  # colwise fp4 i32 words per col (M_pad_col/8)
+    # The colwise widths scale with the padded M, so they arrive as launch arguments
+    # (col_sc_n = M_pad_col/32, and the fp4 word width 4*col_sc_n = M_pad_col/8) rather
+    # than as baked constants; NBM likewise only exists host-side, in the grid.
 
     @fx.struct
     class Smem:
@@ -259,6 +263,8 @@ def compile_grouped_mxfp4_qdual(
         LC: fx.Tensor,  # OUT: 256-aligned per-group lens (int64 [G])
         OC: fx.Tensor,  # OUT: 256-aligned per-group offs (int64 [G+1])
         SR_SEED: fx.Int32,  # per-launch stochastic-rounding seed (0 when SR off)
+        n_tiles: fx.Int32,  # NBM * NBK, i.e. the launched grid
+        col_sc_n: fx.Int32,  # colwise scale cols = M_pad_col // 32
     ):
         # Fused dual tile (one BM x BK tile / WG, one microblock/thread). The per-tile
         # group metadata is computed INLINE (no meta prologue kernel) from a lane-resident
@@ -279,9 +285,10 @@ def compile_grouped_mxfp4_qdual(
         # tile. Measured on the scored regime: the round-robin hand-out is worth nothing
         # on its own and so is the padding fast path below, but together they are -4.3%,
         # because the balance is what turns the skipped work into a shorter kernel.
-        pid = xcd_remap_pid_blocked(fx.block_idx.x, I32(NBM * NBK), 8, NBK)
+        pid = xcd_remap_pid_blocked_dyn(fx.block_idx.x, n_tiles, 8, NBK)
         bt = pid // I32(NBK)  # padded-M block
         bkc = pid - bt * I32(NBK)  # N block
+        col_out_w = col_sc_n * I32(4)  # colwise fp4 i32 words per col (M_pad_col/8)
 
         # Lane-resident group table (entry g in lane g%64 of chunk g//64), the same
         # primitives the grouped GEMM prologue uses: one buffer_load per chunk plus a wave
@@ -328,14 +335,14 @@ def compile_grouped_mxfp4_qdual(
             buffer_ops.extract_base_index(COL_OUT),
             col_base,
             I32(N),
-            I32(COL_OUT_W),
+            col_out_w,
             4,
         )
         cscrsrc = make_row_band_resource(
             buffer_ops.extract_base_index(COL_SC),
             col_base,
             I32(N),
-            I32(COL_SC_N),
+            col_sc_n,
             1,
         )
 
@@ -466,18 +473,18 @@ def compile_grouped_mxfp4_qdual(
                 crows.append(fx.Int32(_lds_load1(lds.buf.ptr, (row0 + row) * I32(_TCW) + cw)))
             gmmb = bt * I32(_RMB) + mblk
             cdw0 = cw * I32(2 * DWPC) + mblk * I32(4)
-            csc0 = cw * I32(2 * COL_SC_N) + gmmb
+            csc0 = cw * (col_sc_n * I32(2)) + gmmb
             gcol0 = bkc * I32(BK) + cw * I32(2)
             for ch in range_constexpr(2):
                 # grid-unique col-microblock seed = its colwise-scale linear index (salted
                 # apart from row)
-                cseed = _sr_hash((SR_SEED ^ _SR_COL_SALT) ^ (csc0 + I32(ch * COL_SC_N))) if col_sr else None
+                cseed = _sr_hash((SR_SEED ^ _SR_COL_SALT) ^ (csc0 + I32(ch) * col_sc_n)) if col_sr else None
                 cwords, cbiased = _col_microblock(crows, I32(ch), is_fp16, col_rht, cseed)
                 _lds_store_vec4(lds.ldsc.ptr, cdw0 + I32(ch * DWPC), Vec.from_elements(cwords, fx.Int32))
                 buffer_ops.buffer_store(
                     arith.trunci(T.i8, cbiased & 0xFF),
                     cscrsrc,
-                    csc0 + I32(ch * COL_SC_N),
+                    csc0 + I32(ch) * col_sc_n,
                     mask=gcol0 + I32(ch) < I32(N),
                 )
 
@@ -500,7 +507,7 @@ def compile_grouped_mxfp4_qdual(
                     else Vec.from_elements([z, z, z, z], fx.Int32)
                 )
                 gcol = bkc * I32(BK) + cc
-                cob = cc * I32(COL_OUT_W) + bt * I32(DWPC) + dwi0  # band-local
+                cob = cc * col_out_w + bt * I32(DWPC) + dwi0  # band-local
                 cok = (gcol < I32(N)) & (raw < I32(LDSC_DW)) if _CWTAIL else gcol < I32(N)
                 buffer_ops.buffer_store(v4, corsrc, cok.select(cob, I32(_OOB)), cache_modifier=_CM_STREAM)
 
@@ -518,12 +525,12 @@ def compile_grouped_mxfp4_qdual(
             for kk in range_constexpr(_NCPT):
                 task = kk * I32(nth) + tid
                 cw = task // I32(_RMB)
-                csc0 = cw * I32(2 * COL_SC_N) + bt * I32(_RMB) + (task - cw * I32(_RMB))
+                csc0 = cw * (col_sc_n * I32(2)) + bt * I32(_RMB) + (task - cw * I32(_RMB))
                 gcol0 = bkc * I32(BK) + cw * I32(2)
                 for ch in range_constexpr(2):
                     ok = gcol0 + I32(ch) < I32(N)
                     ok = ok & (task < I32(_NCP)) if _NCTAIL else ok
-                    buffer_ops.buffer_store(fx.Int8(0), cscrsrc, csc0 + I32(ch * COL_SC_N), mask=ok)
+                    buffer_ops.buffer_store(fx.Int8(0), cscrsrc, csc0 + I32(ch) * col_sc_n, mask=ok)
             _col_writeback(False)
 
         if span > z:
@@ -543,19 +550,20 @@ def compile_grouped_mxfp4_qdual(
         LC: fx.Tensor,
         OC: fx.Tensor,
         SR_SEED: fx.Int32,
+        n_tiles: fx.Int32,  # NBM * NBK: both the grid and the remap's id-space bound
+        col_sc_n: fx.Int32,
         stream: fx.Stream,
     ):
         # Single kernel: per-tile group metadata computed inline (no meta prologue),
         # padded lens/offs emitted by the pid==0 WG.
-        kern(X, ROW_OUT, ROW_SC, COL_OUT, COL_SC, GO, LC, OC, SR_SEED).launch(
-            grid=(NBM * NBK, 1, 1), block=(nth, 1, 1), stream=stream
+        kern(X, ROW_OUT, ROW_SC, COL_OUT, COL_SC, GO, LC, OC, SR_SEED, n_tiles, col_sc_n).launch(
+            grid=(n_tiles, 1, 1), block=(nth, 1, 1), stream=stream
         )
 
     return launch
 
 
 _GQ_MXFP4_CACHE: dict = {}
-_GQ_MXFP4_CACHE_CAP = 64  # bound the per-(total_M) compiled-quant cache (broad-sweep OOM guard)
 
 
 def grouped_quant_mxfp4_raw(
@@ -599,11 +607,11 @@ def grouped_quant_mxfp4_raw(
     lc = lens_col.view(torch.int32)
     oc = offs_col.view(torch.int32)
 
+    # The padded-M extent rides along as a launch argument, so the key carries only what
+    # the kernel bakes: one compiled quant serves every per-step token count.
     key = (
-        total_M,
         N,
         G,
-        M_pad_col,
         N_pad,
         bool(row_rht),
         bool(col_rht),
@@ -618,12 +626,12 @@ def grouped_quant_mxfp4_raw(
     xi = x.view(torch.int32)
     roi = row_out.view(torch.int32)
     coi = col_out.view(torch.int32)
+    n_tiles = grouped_mxfp4_qdual_grid(M_pad_col, N_pad, bm, bk)
+    col_sc_n = M_pad_col // 32
     if comp is None:
         launch = compile_grouped_mxfp4_qdual(
-            total_M,
             N,
             G,
-            M_pad_col,
             N_pad,
             bool(row_rht),
             bool(col_rht),
@@ -633,16 +641,10 @@ def grouped_quant_mxfp4_raw(
             row_sr=bool(row_sr),
             col_sr=bool(col_sr),
         )
-        comp = flyc.compile(launch, xi, roi, row_sc, coi, col_sc, go, lc, oc, 0, stream)
-        # The cache key includes total_M (a per-step token count), so a broad shape sweep
-        # accumulates many compiled quant kernels -> bound it (the live ``comp`` is kept by
-        # the local ref, so dropping the dict frees the rest). Real workloads stay under it.
-        if len(_GQ_MXFP4_CACHE) >= _GQ_MXFP4_CACHE_CAP:
-            _GQ_MXFP4_CACHE.clear()
-            gc.collect()
+        comp = flyc.compile(launch, xi, roi, row_sc, coi, col_sc, go, lc, oc, 0, n_tiles, col_sc_n, stream)
         _GQ_MXFP4_CACHE[key] = comp
     sr_seed = _next_sr_seed() if (row_sr or col_sr) else 0
-    comp(xi, roi, row_sc, coi, col_sc, go, lc, oc, sr_seed, stream)
+    comp(xi, roi, row_sc, coi, col_sc, go, lc, oc, sr_seed, n_tiles, col_sc_n, stream)
 
     e8 = getattr(torch, "float8_e8m0fnu", torch.uint8)
     _fp4_view = out_dtype != torch.uint8  # an identity dtype view is still a dispatcher round trip

--- a/primus_turbo/flydsl/utils/gemm_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_helper.py
@@ -1980,6 +1980,26 @@ def xcd_remap_pid_blocked(pid, total_pids, num_xcd, blk):
     return mapped if full == total_pids else arith.select(pid < fx.Int32(full), mapped, pid)
 
 
+def xcd_remap_pid_blocked_dyn(pid, total_pids, num_xcd, blk):
+    """``xcd_remap_pid_blocked`` for a ``total_pids`` only known at runtime (a kernel argument,
+    not a folded constant). A separate entry point so the constant callers keep byte-identical
+    ISA: this one cannot take their two Python-level shortcuts -- the `full == 0` bail-out and
+    the `full == total_pids` select-free path -- because both branch on a value that no longer
+    folds, so it always emits the select.
+
+    Same bijection over [0, total_pids) as the constant version wherever that one takes its
+    general path. They differ only for a grid shorter than one num_xcd*blk round (full == 0),
+    where the constant version falls back to ``xcd_remap_pid`` and this one is the identity;
+    still a bijection, and at that size no hand-out spreads work any better."""
+    if num_xcd <= 1 or blk <= 1:
+        return xcd_remap_pid(pid, total_pids, num_xcd)
+    full = (total_pids // (num_xcd * blk)) * (num_xcd * blk)
+    xcd = pid % num_xcd
+    local = pid // num_xcd
+    mapped = ((local // blk) * num_xcd + xcd) * blk + local % blk
+    return arith.select(pid < full, mapped, pid)
+
+
 def _inttoptr_lds(byte_addr):
     """Integer byte address -> !llvm.ptr<3> (LDS). Parsed per call: the type is
     bound to the current MLIRContext and cannot be cached across compiles."""


### PR DESCRIPTION
# Description

#473 removed `m_total` from the mxfp8 compile keys. The same defect exists on the mxfp4 side, in
the grouped quant and the variable-K wgrad — but it does **not** take the same fix.

In mxfp8 `m_total` was already a launch argument, so striking it from the key was enough. In mxfp4
the padded-M extent is **baked into the generated code** (grid, SRD record counts, fp4 row stride,
packed-scale row stride). Dropping it from the key alone would return a kernel built for a different
contraction length, off by a stride — no fault, no warning, just wrong results. It has to become a
launch argument first.

Since that extent follows the per-step token count (`M_pad_col = ceil256(total_M + G*256)`), a MoE
run recompiled both kernels every step: ~1.97 s of JIT against a 0.74 ms steady state.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

- **Grouped quant**: `NBM` moves host-side into `grouped_mxfp4_qdual_grid()`; the two colwise output
  widths become launch arguments (`col_out_w = col_sc_n << 2` in-kernel). `total_M` was only ever in
  comments. The key keeps just what the kernel still bakes.
- **Removed the 64-entry cap on `_GQ_MXFP4_CACHE`** — a band-aid that cleared the whole dict instead
  of evicting one, making the thrash worse than no cap.
- **Wgrad**: `M_total` becomes an `fx.Int32` argument. It only fed addressing, never the grid, so the
  kernel derives `m2` and `k128m` from it and threads those into `fp4_g2s_offsets`,
  `ScaleS2RPacked`, the rebased int64 SRDs, the `br` LDS-half shift and the scale soffsets — all
  already runtime-capable, as the mxfp8 wgrad shows. Preshuffle grid follows.
- **Wgrad workspace** keyed on `K128m`, stranding a slab pair per length; now keys on the static
  shape and grows in place, like the NT path.
- **`xcd_remap_pid_blocked_dyn()`**: the existing remap branches on `full == 0` / `full ==
  total_pids` in Python, valid only while `total_pids` folds to a constant. The new variant always
  emits the select. Separate entry point so constant callers keep byte-identical ISA, per
  `xcd_remap_pid_u`.
- **Corrected the NT AT-cache comment**, which advertised a `total_M` the key never contained. The NT
  path itself was already M-generic and is unchanged.
- The tile-config selectors keep `M_total` on purpose: thresholds over 2 and 3 fixed configs, already
  in the launch key, so bounded compiles rather than one per token count.

## Validation

MI355X, gpt-oss-20b MoE (`G=32`, `N=2880`, `OUT_M=OUT_N=2880`), token count jittering around 131072
over 8 steps, cleared FlyDSL cache per arm.

**Compiled kernels after 7 distinct `total_M`** — quant / wgrad-launch / wgrad-artifact /
wgrad-workspace: **7,7,7,7 → 1,1,1,1**.

**First call at a new token count**: 1.97 s before (0.22 quant + 1.74 wgrad) vs 0.74 ms after — the
cache-hit cost. Over the 8 steps: **14.09 s → 2.23 s**.

**Bit-exact**: all 5 outputs byte-identical to the old kernels at all 7 token counts (35/35).

**Steady state** (20 iters, `total_M=131072`): quant 0.232 → 0.233 ms, wgrad 0.509 → 0.514 ms (min);
medians move −0.5% / +0.4%. Within noise both directions.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Unticked deliberately: validation came from an out-of-tree A/B harness, not a committed test — a
regression test asserting `len(_GQ_MXFP4_CACHE) == 1` across several `total_M` would be worth having,
happy to add it here. No docs: internal kernel plumbing, no user-facing surface.

Not covered: I did not diff VGPR counts. The flat steady-state timings argue against new spill; if
you want it hard, a `FLYDSL_DUMP_IR=1` register-count comparison is the check to ask for.
