### PR TITLE
fix: compile warning and remove odc dead code

### DIFF
--- a/csrc/include/primus_turbo/odc_rocshmem/api.h
+++ b/csrc/include/primus_turbo/odc_rocshmem/api.h
@@ -29,7 +29,6 @@ namespace host {
 int       rs_uid_bytes();
 void      rs_get_uid(char *out);
 void      rs_init_uid(int rank, int nranks, const char *bytes);
-void      rs_get_ctx_fields(long long *a, long long *b);
 int       rs_my_pe();
 int       rs_n_pes();
 long long rs_malloc(std::size_t n);

--- a/csrc/kernels/odc_rocshmem/odc_rocshmem_host.cu
+++ b/csrc/kernels/odc_rocshmem/odc_rocshmem_host.cu
@@ -41,13 +41,6 @@ void rs_init_uid(int rank, int nranks, const char *bytes) {
     rocshmem_set_attr_uniqueid_args(rank, nranks, &uid, &attr);
     rocshmem_init_attr(ROCSHMEM_INIT_WITH_UNIQUEID, &attr);
 }
-void rs_get_ctx_fields(long long *a, long long *b) {
-    void          *dctx = rocshmem_get_device_ctx();
-    rocshmem_ctx_t h;
-    hipMemcpy(&h, dctx, sizeof(rocshmem_ctx_t), hipMemcpyDeviceToHost);
-    *a = (long long) h.ctx_opaque;
-    *b = (long long) h.team_opaque;
-}
 int rs_my_pe() {
     return rocshmem_my_pe();
 }


### PR DESCRIPTION
# Description

Building `libprimus_turbo_kernels.so` for gfx950 emits two warnings from `csrc/kernels/odc_rocshmem/odc_rocshmem_host.cu`, both inside `rs_get_ctx_fields`, and both duplicated because hipcc compiles the TU twice (once for device, once for host):

- `-Wdeprecated-declarations` on `rocshmem_get_device_ctx()`, which the ROCm SDK marks `[[deprecated("Use rocshmem_hipmodule_init() instead")]]`.
- `-Wunused-value` on the following `hipMemcpy`, whose `hipError_t` return is `nodiscard` but was neither captured nor checked.

The suggested replacement is not a drop-in substitute.
`rocshmem_get_device_ctx()` hands back a device pointer to the `ROCSHMEM_CTX_DEFAULT` symbol and leaves the caller to copy it host-side and dig out the two `void*` fields (`ctx_opaque`, `team_opaque`), whereas `rocshmem_hipmodule_init(hipModule_t, hipStream_t)` does the entire job in one call: it queries `ROCSHMEM_CTX_DEFAULT` out of a caller-supplied HIP module and initialises it with stream-ordered memory operations, which is what makes it HIP-graph-capturable where the old blocking `hipMemcpy` was not.
Using it therefore requires a `hipModule_t` handle, and Primus-Turbo has none: its device code is statically linked into `libprimus_turbo_kernels.so` rather than loaded through `hipModuleLoad`.

No migration is needed, though, because `rs_get_ctx_fields` is dead code.
It appears exactly twice in the repository -- its definition and its declaration -- with no caller anywhere.
The pybind layer in `csrc/pytorch/dist/odc_rocshmem_host.cpp` exports the other nine `rs_*` entry points one by one and skips this one; the JAX bindings never mention it; and ODC's Python backend in `Primus/primus/core/odc/primitives/_rocshmem_backend.py` references the context fields in neither its pybind path nor its ctypes fallback.
Because the kernels library is built with `-fvisibility=hidden` and the function is absent from the pybind export list, it is not even reachable in the produced `.so`.

It is a leftover from the migration this file's own header comment describes.
The host surface used to ship as a standalone `librs_host5.so` loaded via ctypes, and in that design the Python side had to hand-carry the context fields into its own kernel's `ROCSHMEM_CTX_DEFAULT`.
Now that the host and device code sit in the same `libprimus_turbo_kernels.so` and share the symbol directly, the accessor serves no purpose.

Deleting it clears both warnings at once and, since the symbol was unreachable, changes no behaviour.

Fixes # (no tracking issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [x] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Remove the `rs_get_ctx_fields` definition from `csrc/kernels/odc_rocshmem/odc_rocshmem_host.cu`, which held the only two calls that warned: the deprecated `rocshmem_get_device_ctx()` and the unchecked `hipMemcpy` of the `rocshmem_ctx_t` back to the host.
- Remove the matching declaration from the `primus_turbo::odc_rocshmem::host` surface in `csrc/include/primus_turbo/odc_rocshmem/api.h`. The remaining nine entry points, which are the ones the pybind and ctypes consumers actually use, are untouched.
- Leave both includes in place: `<cstring>` is still required by `rs_get_uid` / `rs_init_uid` for `memcpy`, and `<hip/hip_runtime.h>` is pulled in by `rocshmem/rocshmem.hpp` regardless and is conventional for a `.cu` TU.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Verification

- Recompiled the modified TU with the exact hipcc command from the original build log (`--offload-arch=gfx950`, `-fgpu-rdc`, `-std=c++20`): exit 0 with no diagnostics at all, down from two warnings per pass across both passes.
- Compiled `csrc/include/primus_turbo/odc_rocshmem/api.h` standalone under `g++ -Wall -std=c++20` to confirm the header still stands on its own for a rocSHMEM-agnostic translation unit.
