### PR TITLE
feat(fp8): pad-aware fused grouped MLP for gpt-oss-20b MoE

### DIFF
--- a/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_glu_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_glu_kernel.py
@@ -202,6 +202,12 @@ def grouped_gemm_fp8_tensorwise_epi_glu_flydsl_kernel(
                 BLOCK_M=256,
                 BLOCK_N=256,
                 nt_vmcnt=3,
+                # "vgpr" keeps the accumulator in VGPR (mma mode 3) so the fused
+                # SwiGLU epilogue -- its only consumer -- reads it as a VALU source
+                # without the v_accvgpr_read shuffle an AGPR accumulator would need.
+                # The NT feed is S2RLoader, not transpose asm, so the register budget
+                # is unchanged.
+                acc_mode="vgpr",
                 # Raced per shape over _GLU_NT_CANDS, not defaulted: taking the
                 # plain entry's row-major default literally cost 0.66 ms of L2
                 # reuse at I=5760 (8.2 GB of extra HBM reads).
@@ -289,7 +295,7 @@ class GradProbsPartialSpec(NamedTuple):
 
 
 def grouped_gemm_fp8_dglu_grad_probs_partial_spec(
-    a: "torch.Tensor", b: "torch.Tensor"
+    a: "torch.Tensor", b: "torch.Tensor", i_real: "int | None" = None
 ) -> GradProbsPartialSpec:
     """The buffer :func:`grouped_gemm_fp8_tensorwise_epi_dglu_flydsl_kernel` expects.
 
@@ -309,7 +315,8 @@ def grouped_gemm_fp8_dglu_grad_probs_partial_spec(
         ``shape`` is ``(n_blocks * 2, M_total)``, float32.
     """
     M_total = a.shape[0]
-    I = b.shape[2]
+    # The reduction spans the real I, not the padded storage pitch b.shape[2].
+    I = i_real if i_real is not None else b.shape[2]
     n_blocks = -(-I // _DGLU_BLOCK_N)
     return GradProbsPartialSpec(shape=(n_blocks * 2, M_total), needs_zero=True)
 
@@ -328,6 +335,7 @@ def grouped_gemm_fp8_tensorwise_epi_dglu_flydsl_kernel(
     *,
     activation: str = "silu",
     num_cu: "int | None" = None,
+    i_real: "int | None" = None,
 ) -> "torch.Tensor":
     """FlyDSL fc2 dgrad with the SwiGLU gradient fused into its epilogue.
 
@@ -359,7 +367,14 @@ def grouped_gemm_fp8_tensorwise_epi_dglu_flydsl_kernel(
     assert not trans_b, "FlyDSL fused dGLU is NN only: pass b as [G, K, I]"
     assert a.ndim == 2 and b.ndim == 3 and intermediate.ndim == 2
     M_total, K = a.shape
-    G, K_b, I = b.shape
+    G, K_b, N_pitch = b.shape
+    # b (w2) may be padded on its I axis to N_pitch; i_real is the tight I. The
+    # kernel reads B at the N_pitch storage stride (n_stride) but computes,
+    # indexes intermediate, and stores dl1 at the real I width.
+    if i_real is not None and i_real != N_pitch:
+        n_stride, I = N_pitch, i_real
+    else:
+        n_stride, I = 0, N_pitch
     assert K == K_b, f"K mismatch a={K} b={K_b}"
     assert intermediate.shape == (M_total, 2 * I), (
         f"intermediate must be [{M_total}, {2 * I}], got {tuple(intermediate.shape)}"
@@ -368,7 +383,7 @@ def grouped_gemm_fp8_tensorwise_epi_dglu_flydsl_kernel(
 
     out_dtype = intermediate.dtype
     assert out.shape == (M_total, 2 * I) and out.dtype == out_dtype
-    partial_shape = grouped_gemm_fp8_dglu_grad_probs_partial_spec(a, b).shape
+    partial_shape = grouped_gemm_fp8_dglu_grad_probs_partial_spec(a, b, i_real=I).shape
     assert grad_probs_partial.shape == partial_shape and grad_probs_partial.dtype == torch.float32, (
         f"grad_probs_partial must be {list(partial_shape)} float32, got "
         f"{list(grad_probs_partial.shape)} {grad_probs_partial.dtype}; "
@@ -382,7 +397,7 @@ def grouped_gemm_fp8_tensorwise_epi_dglu_flydsl_kernel(
     cbsz = 1 if a.dtype == torch.float8_e5m2 else 0
     blgp = 1 if b.dtype == torch.float8_e5m2 else 0
     _capped = num_cu is not None and num_cu > 0
-    ckey = (I, K, G, out_fp16, cbsz, blgp, num_cu if _capped else 0)
+    ckey = (I, K, G, out_fp16, cbsz, blgp, num_cu if _capped else 0, n_stride)
 
     launch = _GROUPED_DGLU_CACHE.get(ckey)
     if launch is None:
@@ -408,6 +423,7 @@ def grouped_gemm_fp8_tensorwise_epi_dglu_flydsl_kernel(
                 persistent=_capped,
                 cap_cu=(num_cu if _capped else -1),
                 N=I,
+                n_stride=n_stride,
                 dglu=True,
                 glu_i=I,
                 # Non-temporal, as in the forward, but this only pays because the

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -1257,6 +1257,7 @@ def grouped_gemm_fp8_glu_impl(
     out_row_scaling_recipe: ScalingRecipe,
     out_col_scaling_recipe: ScalingRecipe,
     activation: str = "silu",
+    k_align: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """fc1 grouped GEMM with the GLU activation and its quantisation fused in.
 
@@ -1297,7 +1298,7 @@ def grouped_gemm_fp8_glu_impl(
         grouped_gemm_fp8_tensorwise_epi_glu_flydsl_kernel,
     )
     from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
-        quantize_fp8_tensorwise_impl,
+        quantize_fp8_tensorwise_pad_impl,
     )
 
     grouped_gemm_fp8_tensorwise_epi_glu_flydsl_kernel(
@@ -1315,7 +1316,10 @@ def grouped_gemm_fp8_glu_impl(
         num_cu=num_cu,
     )
 
-    act_fp8, act_scale_inv = quantize_fp8_tensorwise_impl(act, out_quant_dtype)
+    # k_align pads the activation's I -> Ip (fc2's contraction K), copy-free: the
+    # quantiser writes the padded buffer directly and zeroes the tail, so w2's own
+    # padded-K contraction reads zeros there and fc2 stays bitwise-identical.
+    act_fp8, act_scale_inv = quantize_fp8_tensorwise_pad_impl(act, out_quant_dtype, k_align=k_align)
     return intermediate, act_fp8, act_scale_inv
 
 
@@ -1338,6 +1342,7 @@ def grouped_gemm_fp8_dglu_impl(
     out_row_scaling_recipe: ScalingRecipe,
     out_col_scaling_recipe: ScalingRecipe,
     activation: str = "silu",
+    i_real: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """fc2 dgrad with the GLU activation gradient and its quantisation fused in.
 
@@ -1365,19 +1370,21 @@ def grouped_gemm_fp8_dglu_impl(
     assert a.shape[1] >= 129, "a.shape[1] must be >= 129 for grouped_gemm_fp8_dglu_impl"
 
     M = a.shape[0]
-    N = b.shape[1] if trans_b else b.shape[2]
+    # b is w2 padded to Ip on its I axis; i_real recovers the tight I so out/grad
+    # stay [M, 2I] and the entry feeds the padded Ip as an N storage pitch (n_stride).
+    N = i_real if i_real is not None else (b.shape[1] if trans_b else b.shape[2])
 
     from primus_turbo.flydsl.grouped_gemm.grouped_gemm_fp8_glu_kernel import (
         grouped_gemm_fp8_dglu_grad_probs_partial_spec,
         grouped_gemm_fp8_tensorwise_epi_dglu_flydsl_kernel,
     )
     from primus_turbo.pytorch.kernels.quantization.quantization_impl import (
-        quantize_fp8_tensorwise_impl,
+        quantize_fp8_tensorwise_pad_impl,
     )
 
     out = torch.empty((M, N * 2), device=a.device, dtype=out_dtype)
     grad_probs_partial = _alloc_grad_probs_partial(
-        grouped_gemm_fp8_dglu_grad_probs_partial_spec(a, b), a.device
+        grouped_gemm_fp8_dglu_grad_probs_partial_spec(a, b, i_real=N), a.device
     )
     grouped_gemm_fp8_tensorwise_epi_dglu_flydsl_kernel(
         a,
@@ -1392,9 +1399,10 @@ def grouped_gemm_fp8_dglu_impl(
         trans_b=trans_b,
         activation=activation,
         num_cu=num_cu,
+        i_real=i_real,
     )
 
-    out_fp8, out_scale_inv = quantize_fp8_tensorwise_impl(out, out_quant_dtype)
+    out_fp8, out_scale_inv = quantize_fp8_tensorwise_pad_impl(out, out_quant_dtype, k_align=1)
     return torch.sum(grad_probs_partial, dim=0), out_fp8, out_scale_inv
 
 
@@ -1416,6 +1424,7 @@ def grouped_gemm_fp8_glu_impl_meta(
     out_row_scaling_recipe: ScalingRecipe,
     out_col_scaling_recipe: ScalingRecipe,
     activation: str = "silu",
+    k_align: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     _check_glu_dispatch(config, trans_a)
     _check_out_recipes(out_row_scaling_recipe, out_col_scaling_recipe)
@@ -1429,11 +1438,14 @@ def grouped_gemm_fp8_glu_impl_meta(
         torch.bfloat16,
     ], f"out_dtype must be float16 or bfloat16, got {out_dtype}"
 
-    # b holds gate||up, so its N is twice the activation's width.
+    # b holds gate||up, so its N is twice the activation's width. The activation is
+    # padded to Ip = ceil(I, k_align) for fc2's contraction.
     m = a.shape[0]
     n = b.shape[1] if trans_b else b.shape[2]
+    ni = n // 2
+    ni = ((ni + k_align - 1) // k_align) * k_align
     intermediate = torch.empty((m, n), device=a.device, dtype=out_dtype)
-    act = torch.empty((m, n // 2), device=a.device, dtype=out_quant_dtype)
+    act = torch.empty((m, ni), device=a.device, dtype=out_quant_dtype)
     # Tensorwise: one scalar scale over the whole activation.
     act_scale_inv = torch.empty((), device=a.device, dtype=torch.float32)
     return intermediate, act, act_scale_inv
@@ -1458,6 +1470,7 @@ def grouped_gemm_fp8_dglu_impl_meta(
     out_row_scaling_recipe: ScalingRecipe,
     out_col_scaling_recipe: ScalingRecipe,
     activation: str = "silu",
+    i_real: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     _check_glu_dispatch(config, trans_a)
     _check_out_recipes(out_row_scaling_recipe, out_col_scaling_recipe)
@@ -1473,8 +1486,9 @@ def grouped_gemm_fp8_dglu_impl_meta(
 
     # This is the dgrad wrt the activation, so the gate||up gradient it writes
     # is twice as wide. grad_probs is per-row and always fp32, whatever out_dtype is.
+    # i_real recovers the tight I when b is padded on its I axis.
     m = a.shape[0]
-    n = b.shape[1] if trans_b else b.shape[2]
+    n = i_real if i_real is not None else (b.shape[1] if trans_b else b.shape[2])
     grad_probs = torch.empty((m,), device=a.device, dtype=torch.float32)
     grad_intermediate = torch.empty((m, n * 2), device=a.device, dtype=out_quant_dtype)
     # Tensorwise: one scalar scale over the whole gradient.

--- a/primus_turbo/pytorch/ops/grouped_mlp_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_mlp_fp8.py
@@ -19,6 +19,7 @@ from primus_turbo.pytorch.core.quantized_tensor import (
     QuantizedTensorPair,
     check_quantized_tensor,
 )
+from primus_turbo.pytorch.core.utils import is_gfx950
 from primus_turbo.pytorch.kernels.grouped_gemm.grouped_gemm_fp8_impl import (
     grouped_gemm_fp8_dglu_impl,
     grouped_gemm_fp8_glu_impl,
@@ -44,6 +45,19 @@ __all__ = [
 _SUPPORTED_ACTIVATIONS = ("silu",)
 
 
+# Pad the fp8 grouped-MLP contraction/feature dims to 128. gpt-oss-20b runs
+# H = I = 2880, and 2880 % 128 == 64: an unpadded fp8 GEMM splits every
+# cache line across two L1->L2 requests (+50% traffic) for identical MFMA math.
+# Padding H (fc1/fc2 K and the fc2-output N) and the fc2 contraction I up to
+# the next multiple recovers the aligned access; real-shape recovery keeps the
+# stored tensors tight, so this is copy-free on the padded quantiser buffers.
+_FP8_PAD_ALIGN = 128
+
+
+def _default_gemm_backend() -> int:
+    return BackendType.FLYDSL.value if is_gfx950() else BackendType.TRITON.value
+
+
 def _grouped_gemm_fp8_variable_k_impl_wrapper(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -60,6 +74,8 @@ def _grouped_gemm_fp8_variable_k_impl_wrapper(
     default_backend: int,
     inplace_add_to_out: bool = False,
     out: Optional[torch.Tensor] = None,
+    m_real: Optional[int] = None,
+    n_real: Optional[int] = None,
 ) -> Optional[torch.Tensor]:
     """Run the variable-K wgrad GEMM, accumulating into ``out`` when asked to.
 
@@ -79,6 +95,8 @@ def _grouped_gemm_fp8_variable_k_impl_wrapper(
         granularity=granularity,
         num_cu=num_cu,
         default_backend=default_backend,
+        m_real=m_real,
+        n_real=n_real,
     )
 
     if not inplace_add_to_out:
@@ -139,6 +157,7 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
                 axis=-1,
                 block_size=config.block_size,
                 group_lens=group_lens,
+                pad_align_last=_FP8_PAD_ALIGN,
             )
 
         if isinstance(w1, QuantizedTensor):
@@ -153,6 +172,7 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
                 config.granularity,
                 axis=-1,
                 block_size=config.block_size,
+                pad_align_last=_FP8_PAD_ALIGN,
             )
 
         if isinstance(w2, QuantizedTensor):
@@ -167,6 +187,8 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
                 config.granularity,
                 axis=-1,
                 block_size=config.block_size,
+                pad_align_penultimate=_FP8_PAD_ALIGN,
+                pad_align_last=_FP8_PAD_ALIGN,
             )
 
         # The activation is quantised inside the GLU op: it feeds nothing but the
@@ -189,8 +211,17 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
             out_row_scaling_recipe=ScalingRecipe(),
             out_col_scaling_recipe=ScalingRecipe(),
             activation=activation,
+            # Pad the fused activation's I -> Ip so fc2's contraction matches w2's
+            # padded I; copy-free (the quantiser writes the padded buffer directly).
+            k_align=_FP8_PAD_ALIGN,
         )
 
+        # padN+padK recovers the tight fc2 output (N = H) from the padded w2, and
+        # routes fc2 through FLYDSL so the padded contraction is actually consumed.
+        h_real = quantized_x.shape[-1]
+        # Tight I (fc2 contraction), for dglu/grad_w2 to recover from padded Ip.
+        i_real = quantized_w2.shape[-1]
+        fc2_n_pitch = quantized_w2.qdata.shape[-2] if trans_w2 else quantized_w2.qdata.shape[-1]
         fc2_out = grouped_gemm_fp8_impl(
             act_fp8,
             quantized_w2.qdata,
@@ -203,8 +234,9 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
             out_dtype=out_dtype,
             granularity=config.granularity.value,
             num_cu=num_cu,
-            default_backend=BackendType.TRITON.value,
+            default_backend=_default_gemm_backend(),
             maybe_pre_sync=True,
+            n_real=h_real if h_real != fc2_n_pitch else None,
         )
 
         ctx.save_for_backward(
@@ -227,6 +259,8 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
         ctx.config = config
         ctx.out_dtype = out_dtype
         ctx.num_cu = num_cu
+        ctx.h_real = h_real
+        ctx.i_real = i_real
         ctx.fuse_w1_accum = fuse_w1_accum
         ctx.fuse_w2_accum = fuse_w2_accum
         # Kept off save_for_backward on purpose: the wgrad GEMM writes into these
@@ -263,7 +297,15 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
             axis=-1,
             block_size=ctx.config.block_size,
             group_lens=group_lens,
+            pad_align_last=_FP8_PAD_ALIGN,
         )
+        # H is padded on the fc2-output side (grad_out last, w2 penult, x/w1
+        # contraction); real recovers tight H on every GEMM whose output or wgrad
+        # feature is H. I stays tight in M1, so its real is left None.
+        h_real = ctx.h_real
+        i_real = ctx.i_real
+        default_backend = _default_gemm_backend()
+        go_pitch = quantized_grad_out.qdata.shape[-1]
 
         # grad_w2 = act^T @ grad_out, both operands already in hand.
         grad_w2 = _grouped_gemm_fp8_variable_k_impl_wrapper(
@@ -279,9 +321,12 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
             out_dtype=ctx.out_dtype,
             granularity=ctx.config.granularity.value,
             num_cu=ctx.num_cu,
-            default_backend=BackendType.TRITON.value,
+            default_backend=default_backend,
             inplace_add_to_out=ctx.fuse_w2_accum,
             out=ctx.w2_main_grad,
+            m_real=h_real if h_real != go_pitch else None,
+            # a = act, padded on its I axis; n_real recovers the tight I (grad_w2 N).
+            n_real=i_real if i_real != act_fp8.shape[-1] else None,
         )
 
         # fc2 dgrad (grad_out @ w2^T) with the activation gradient fused into its
@@ -305,9 +350,14 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
             out_row_scaling_recipe=ScalingRecipe(),
             out_col_scaling_recipe=ScalingRecipe(),
             activation=ctx.activation,
+            # w2 (b) is padded on its I axis to w2_fp8.shape[-1]; i_real recovers the
+            # tight I so grad_fc1_out stays [M, 2I] and the padded Ip rides as n_stride.
+            i_real=i_real if i_real != w2_fp8.shape[-1] else None,
         )
 
-        # grad_x = grad_fc1_out @ w1^T
+        # grad_x = grad_fc1_out @ w1^T; output feature N = H (padded on w1), recovered.
+        gx_trans_b = not ctx.trans_w1
+        gx_n_pitch = w1_fp8.shape[-2] if gx_trans_b else w1_fp8.shape[-1]
         grad_x = grouped_gemm_fp8_impl(
             grad_fc1_out_fp8,
             w1_fp8,
@@ -316,11 +366,12 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
             group_lens,
             group_offs,
             trans_a=False,
-            trans_b=not ctx.trans_w1,
+            trans_b=gx_trans_b,
             out_dtype=ctx.out_dtype,
             granularity=ctx.config.granularity.value,
             num_cu=ctx.num_cu,
-            default_backend=BackendType.TRITON.value,
+            default_backend=default_backend,
+            n_real=h_real if h_real != gx_n_pitch else None,
         )
 
         # grad_w1 = x^T @ grad_fc1_out
@@ -337,9 +388,11 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
             out_dtype=ctx.out_dtype,
             granularity=ctx.config.granularity.value,
             num_cu=ctx.num_cu,
-            default_backend=BackendType.TRITON.value,
+            default_backend=default_backend,
             inplace_add_to_out=ctx.fuse_w1_accum,
             out=ctx.w1_main_grad,
+            m_real=None,
+            n_real=h_real if h_real != x_fp8.shape[-1] else None,
         )
 
         return (


### PR DESCRIPTION
# Description

Pad the fp8 fused grouped-MLP (`FP8GroupedMLPTensorFunc`) contraction/feature dims
up to 128, mirroring the pad-into-`QuantizedTensor.quantize` pattern already used by
the plain grouped-fp8 GEMM (#470/#483).

gpt-oss-20b MoE runs H = I = 2880, and `2880 % 128 == 64`: an unpadded fp8 GEMM
splits every cache line across two L1->L2 requests (+50% traffic) for identical MFMA
math. Padding H and the fc2 contraction I up to 128 recovers aligned access; real-shape
recovery keeps the stored tensors tight (copy-free, grads stay tight).

## Bench (MI355X / gfx950, H=I=2880, G=32, MTOT=131072, FLYDSL, same-process A/B)

Pre-quantized (cached) weights — deploy-representative:

| | pad-0 (before) | pad-128 (after) | delta |
|---|---|---|---|
| fwd     | 3.785 ms  | 3.473 ms  | -8.24%          |
| bwd     | 6.969 ms  | 6.791 ms  | -2.55%          |
| fwd+bwd | 10.755 ms | 10.265 ms | -4.56% (1.048x) |

bf16 weights (per-step re-quant) — for reference:

| | pad-0 (before) | pad-128 (after) | delta |
|---|---|---|---|
| fwd     | 4.277 ms  | 4.111 ms  | -3.88%          |
| bwd     | 6.923 ms  | 6.803 ms  | -1.73%          |
| fwd+bwd | 11.200 ms | 10.914 ms | -2.55% (1.026x) |

Backward reuses the fwd-saved fp8 weights, so weight pre-quantization affects fwd only.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Changes

- `ops/grouped_mlp_fp8.py`: pad x / w1 / w2 / grad_out to 128, pass real dims to fc2 N
  and the wgrad m/n; QuantizedTensor weight inputs used directly (weight-cache path skips re-quant).
- `kernels/grouped_gemm/grouped_gemm_fp8_impl.py`: thread `i_real` / `k_align` through glu/dglu.
- `flydsl/grouped_gemm/grouped_gemm_fp8_glu_kernel.py`: pitch-vs-real split in glu kernel geometry.
- Pin fused GLU accumulator to `vgpr` acc-mode (preferred by the padded-K path).

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

