### PR TITLE
feat: Add more activation type support for grouped gemm glu kernel

### DIFF
--- a/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_glu_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_glu_kernel.py
@@ -33,6 +33,10 @@ from primus_turbo.flydsl.grouped_gemm.grouped_gemm_fp8_kernel import (
     _compile_grouped_nn,
     _compile_grouped_nt,
 )
+from primus_turbo.flydsl.utils.gemm_epilogue_helper import (
+    _check_activation,
+    _check_clamp_limit,
+)
 
 _GROUPED_GLU_CACHE: dict = {}
 
@@ -142,13 +146,14 @@ def grouped_gemm_fp8_tensorwise_epi_glu_flydsl_kernel(
     trans_b: bool = False,
     *,
     activation: str = "silu",
+    clamp_limit: "float | None" = None,
     out_dtype=torch.bfloat16,
     num_cu: "int | None" = None,
 ) -> "tuple[torch.Tensor, torch.Tensor]":
-    """FlyDSL fc1 grouped fp8 GEMM with a fused SwiGLU epilogue, matching the Triton entry.
+    """FlyDSL fc1 grouped fp8 GEMM with a fused GLU epilogue, matching the Triton entry.
 
     Computes ``l1 = [gate|up] = (a[g] @ b[g]^T) * a_scale * b_scale`` [M, 2I] and
-    ``act = silu(gate) * up * probs`` [M, I] in one launch, both in ``out_dtype``.
+    ``act = f(gate) * up * probs`` [M, I] in one launch, both in ``out_dtype``.
     ``l1`` is written because backward's dswiglu needs both halves; ``act`` is the
     only one that carries ``probs``.
 
@@ -161,6 +166,8 @@ def grouped_gemm_fp8_tensorwise_epi_glu_flydsl_kernel(
     quadrant registers, and the NN twin has no equivalent hook yet.
 
     Args:
+        clamp_limit: pre-multiplication clamp bound, or None for no clamp; silu only.
+            See :func:`~primus_turbo.flydsl.utils.gemm_epilogue_helper._glu_clamp`.
         act_out: [M_total, I] buffer receiving the activation.
         intermediate_out: [M_total, 2I] buffer receiving ``l1``. Both are the
             caller's to allocate: every slot is written, so neither needs
@@ -169,7 +176,8 @@ def grouped_gemm_fp8_tensorwise_epi_glu_flydsl_kernel(
     Returns:
         ``(act_out, intermediate_out)``.
     """
-    assert activation == "silu", f"FlyDSL fused GLU implements silu only, got {activation}"
+    _check_activation(activation)
+    _check_clamp_limit(activation, clamp_limit)
     assert trans_b, "FlyDSL fused GLU is NT only: pass b as [G, 2I, K]"
     assert a.ndim == 2 and b.ndim == 3
     M_total, K = a.shape
@@ -190,7 +198,7 @@ def grouped_gemm_fp8_tensorwise_epi_glu_flydsl_kernel(
     cbsz = 1 if a.dtype == torch.float8_e5m2 else 0
     blgp = 1 if b.dtype == torch.float8_e5m2 else 0
     _capped = num_cu is not None and num_cu > 0
-    ckey = (I, K, G, out_fp16, cbsz, blgp, num_cu if _capped else 0)
+    ckey = (I, K, G, out_fp16, cbsz, blgp, num_cu if _capped else 0, activation, clamp_limit)
 
     launch = _GROUPED_GLU_CACHE.get(ckey)
     if launch is None:
@@ -235,6 +243,8 @@ def grouped_gemm_fp8_tensorwise_epi_glu_flydsl_kernel(
                 # (aux=16) costs 1.5x, so this is not a monotone knob.
                 cstore_aux=2,
                 glu_act_aux=2,
+                activation=activation,
+                clamp_limit=clamp_limit,
             )
 
         def _probe():
@@ -334,10 +344,11 @@ def grouped_gemm_fp8_tensorwise_epi_dglu_flydsl_kernel(
     trans_b: bool = False,
     *,
     activation: str = "silu",
+    clamp_limit: "float | None" = None,
     num_cu: "int | None" = None,
     i_real: "int | None" = None,
 ) -> "torch.Tensor":
-    """FlyDSL fc2 dgrad with the SwiGLU gradient fused into its epilogue.
+    """FlyDSL fc2 dgrad with the GLU gradient fused into its epilogue.
 
     Computes ``dact = (a[g] @ b[g]) * a_scale * b_scale`` and consumes it in
     registers, so ``dact`` never reaches HBM:
@@ -354,6 +365,8 @@ def grouped_gemm_fp8_tensorwise_epi_dglu_flydsl_kernel(
     NN only (``trans_b=False``, b [G, K, I]).
 
     Args:
+        clamp_limit: pre-multiplication clamp bound, or None for no clamp; silu only.
+            Must match the forward's, which decided the values this differentiates.
         out: [M_total, 2I] buffer receiving ``dl1``, in ``intermediate``'s dtype,
             gate gradient in [:, :I] and up in [:, I:].
         grad_probs_partial: float32 buffer receiving the grad_probs partials, as
@@ -363,7 +376,8 @@ def grouped_gemm_fp8_tensorwise_epi_dglu_flydsl_kernel(
     Returns:
         ``out``, for call-site convenience.
     """
-    assert activation == "silu", f"FlyDSL fused dGLU implements silu only, got {activation}"
+    _check_activation(activation)
+    _check_clamp_limit(activation, clamp_limit)
     assert not trans_b, "FlyDSL fused dGLU is NN only: pass b as [G, K, I]"
     assert a.ndim == 2 and b.ndim == 3 and intermediate.ndim == 2
     M_total, K = a.shape
@@ -397,7 +411,18 @@ def grouped_gemm_fp8_tensorwise_epi_dglu_flydsl_kernel(
     cbsz = 1 if a.dtype == torch.float8_e5m2 else 0
     blgp = 1 if b.dtype == torch.float8_e5m2 else 0
     _capped = num_cu is not None and num_cu > 0
-    ckey = (I, K, G, out_fp16, cbsz, blgp, num_cu if _capped else 0, n_stride)
+    ckey = (
+        I,
+        K,
+        G,
+        out_fp16,
+        cbsz,
+        blgp,
+        num_cu if _capped else 0,
+        n_stride,
+        activation,
+        clamp_limit,
+    )
 
     launch = _GROUPED_DGLU_CACHE.get(ckey)
     if launch is None:
@@ -432,6 +457,8 @@ def grouped_gemm_fp8_tensorwise_epi_dglu_flydsl_kernel(
                 # wave, and the two have to meet in L2 to form one, which
                 # non-temporal prevents. Per-wave staging preferred aux=0.
                 cstore_aux=2,
+                activation=activation,
+                clamp_limit=clamp_limit,
             )
 
         def _probe():

--- a/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/grouped_gemm_fp8_kernel.py
@@ -218,6 +218,8 @@ def _compile_grouped_nn(
     beta_is_one: bool = False,  # epilogue accumulates (C += acc) instead of overwriting
     dglu: bool = False,  # fuse the SwiGLU gradient into the epilogue: read l1, write dl1 [M,2I] and grad_probs partials, so dact never reaches HBM
     glu_i: int = 0,  # activation width I; the GEMM's N already equals it, so no geometry changes (unlike the fwd)
+    activation: str = "silu",  # (with dglu) the GLU gate; see SUPPORTED_ACTIVATIONS
+    clamp_limit=None,  # (with dglu) clamp bound; see _glu_clamp
 ):
     """Persistent (CPU-sync-free) grouped NN dgrad: a fixed grid of WGs strides the tile
     space via scf.for, amortising per-WG fixed cost. ``group_m``/``group_n`` port the NT
@@ -509,6 +511,8 @@ def _compile_grouped_nn(
                     wave_id,
                     col_safe=_col_safe,
                     store_aux=cstore_aux,
+                    activation=activation,
+                    clamp_limit=clamp_limit,
                 )
             elif const_expr(store_cshuffle):
                 store_c = StoreCPerTensorCShuffle(
@@ -912,6 +916,8 @@ def _compile_grouped_nt(
     glu: bool = False,  # fuse a SwiGLU epilogue: B_T is [2I, K] gate||up, the tile pairs the two bands in registers and writes l1 [M,2I] + act [M,I]
     glu_i: int = 0,  # gate half width I (required when glu); N is this same I, i.e. the activation's width
     glu_act_aux: int = 0,  # aux immediate for the act store alone (it is pure streaming output, so evict-first may pay where it would not for l1)
+    activation: str = "silu",  # (with glu) the GLU gate; see SUPPORTED_ACTIVATIONS
+    clamp_limit=None,  # (with glu) clamp bound; see _glu_clamp
 ):
     """Grouped NT forward (out = a @ b^T). persistent=True: a fixed grid of WGs strides the
     tile space via scf.for (cap_cu reserves CUs for comm overlap); persistent=False: one tile
@@ -1165,6 +1171,8 @@ def _compile_grouped_nt(
                     col_safe=_col_safe,
                     store_aux=_cstore_aux,
                     act_aux=glu_act_aux,
+                    activation=activation,
+                    clamp_limit=clamp_limit,
                 )
             elif const_expr(store_cshuffle):
                 store_c = StoreCPerTensorCShuffle(

--- a/primus_turbo/flydsl/grouped_gemm/grouped_gemm_mxfp4_glu_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/grouped_gemm_mxfp4_glu_kernel.py
@@ -37,6 +37,10 @@ from primus_turbo.flydsl.grouped_gemm.grouped_gemm_mxfp4_kernel import (
     _select_gmxfp4_nt_cfg,
 )
 from primus_turbo.flydsl.quantization.mxfp4_quant_kernel import MB, _next_sr_seed
+from primus_turbo.flydsl.utils.gemm_epilogue_helper import (
+    _check_activation,
+    _check_clamp_limit,
+)
 from primus_turbo.flydsl.utils.prims import ceildiv
 
 _GMXFP4_GLU_CACHE: dict = {}  # -> [launch, compiled, n_blocks]
@@ -65,6 +69,8 @@ def _glu_entry(
     dglu_epi_quant=False,
     epi_row_sr=False,
     epi_col_sr=False,
+    activation="silu",
+    clamp_limit=None,
 ):
     """Compiled launch for one fused shape, cached on the static shape + blocking."""
     gm, xcd, gn, span, _nt = cfg
@@ -86,6 +92,8 @@ def _glu_entry(
         dglu_epi_quant,
         epi_row_sr,
         epi_col_sr,
+        activation,
+        clamp_limit,
     )
     ent = _GMXFP4_GLU_CACHE.get(key)
     if ent is None:
@@ -111,6 +119,8 @@ def _glu_entry(
             dglu_epi_quant=dglu_epi_quant,
             epi_row_sr=epi_row_sr,
             epi_col_sr=epi_col_sr,
+            activation=activation,
+            clamp_limit=clamp_limit,
         )
         ent = [launch, None, n_blocks]
         _GMXFP4_GLU_CACHE[key] = ent
@@ -169,6 +179,7 @@ def grouped_gemm_mxfp4_epi_glu_quant_flydsl_kernel(
     K: int,
     *,
     activation: str = "silu",
+    clamp_limit: "float | None" = None,
     row_use_sr: bool = False,
     col_use_sr: bool = False,
     out_dtype=torch.bfloat16,
@@ -176,7 +187,7 @@ def grouped_gemm_mxfp4_epi_glu_quant_flydsl_kernel(
     """fc1 GLU whose activation is quantised in the epilogue, never reaching bf16.
 
     Computes ``l1 = [gate|up] = a[g] @ b[g]^T`` [M, 2I] under the MX block scales, and
-    ``act = silu(gate) * up * probs`` [M, I] straight into the two MXFP4 operands the
+    ``act = f(gate) * up * probs`` [M, I] straight into the two MXFP4 operands the
     MLP actually consumes -- row-wise for fc2 and col-wise (RHT) for the wgrad --
     computed from the accumulators. Against staging ``act`` in bf16 that removes an
     [M, I] write, the quantiser's read of it, and a kernel launch.
@@ -192,13 +203,16 @@ def grouped_gemm_mxfp4_epi_glu_quant_flydsl_kernel(
     tail is handled here because a tile covers it.
 
     Args:
+        clamp_limit: pre-multiplication clamp bound, or None for no clamp; silu only.
+            See :func:`~primus_turbo.flydsl.utils.gemm_epilogue_helper._glu_clamp`.
         row_use_sr: stochastic-round the row-wise operand, seeded per micro-block from
             its linear index in the scale tensor, the same id the standalone quantiser
             uses.
         col_use_sr: the same for the col-wise operand, off a salted seed so a block the
             two share does not draw one sequence twice.
     """
-    assert activation == "silu", f"FlyDSL fused GLU implements silu only, got {activation}"
+    _check_activation(activation)
+    _check_clamp_limit(activation, clamp_limit)
     assert a.ndim == 2 and b.ndim == 3
     assert N % 2 == 0, f"fc1 width must be even (gate||up), got {N}"
     I = N // 2
@@ -222,6 +236,8 @@ def grouped_gemm_mxfp4_epi_glu_quant_flydsl_kernel(
         epi_act_quant=True,
         epi_row_sr=row_use_sr,
         epi_col_sr=col_use_sr,
+        activation=activation,
+        clamp_limit=clamp_limit,
     )
     # The col-wise operand's row stride: one 256-block per tile row, per group.
     col_rows = col_out.shape[1] * 2
@@ -303,6 +319,7 @@ def grouped_gemm_mxfp4_epi_dglu_quant_flydsl_kernel(
     K: int,
     *,
     activation: str = "silu",
+    clamp_limit: "float | None" = None,
     row_use_sr: bool = False,
     col_use_sr: bool = False,
     out_dtype=torch.bfloat16,
@@ -327,6 +344,8 @@ def grouped_gemm_mxfp4_epi_dglu_quant_flydsl_kernel(
     Args:
         N: the weight's row count per expert, i.e. ``I``.
         K: the true contraction, unpadded.
+        clamp_limit: pre-multiplication clamp bound, or None for no clamp; silu only.
+            Must match the forward's, which decided the values this differentiates.
         row_use_sr: stochastic-round the row-wise operand, as the gradient recipe
             asks. Seeded per micro-block from its linear index in the scale tensor,
             the same id the standalone quantiser uses.
@@ -336,7 +355,8 @@ def grouped_gemm_mxfp4_epi_dglu_quant_flydsl_kernel(
     Returns:
         ``(row_out, row_sc, col_out, col_sc)``.
     """
-    assert activation == "silu", f"FlyDSL fused dGLU implements silu only, got {activation}"
+    _check_activation(activation)
+    _check_clamp_limit(activation, clamp_limit)
     assert a.ndim == 2 and b.ndim == 3 and intermediate.ndim == 2
     I = N
     assert dglu_epi_quant_supported(K, I, out_dtype), (
@@ -370,6 +390,8 @@ def grouped_gemm_mxfp4_epi_dglu_quant_flydsl_kernel(
         dglu_epi_quant=True,
         epi_row_sr=row_use_sr,
         epi_col_sr=col_use_sr,
+        activation=activation,
+        clamp_limit=clamp_limit,
     )
     # The col-wise operand's row stride: one 256-block per tile row, per group.
     col_rows = col_out.shape[1] * 2

--- a/primus_turbo/flydsl/grouped_gemm/grouped_gemm_mxfp4_kernel.py
+++ b/primus_turbo/flydsl/grouped_gemm/grouped_gemm_mxfp4_kernel.py
@@ -275,6 +275,8 @@ def _build_grouped_mxfp4_nt_kernel(
     dglu_act_quant=False,
     epi_row_sr=False,
     epi_col_sr=False,
+    activation="silu",  # the GLU gate; see SUPPORTED_ACTIVATIONS
+    clamp_limit=None,  # clamp bound; see _glu_clamp
 ):
     """Grouped MXFP4 NT (out = a @ b^T), per-group A rows + per-expert B, whole-loop compute.
     K is the 256-rounded scale extent; ``k_real`` (<=K, 128-multiple) is the operands' true
@@ -594,6 +596,8 @@ def _build_grouped_mxfp4_nt_kernel(
                 band_drop=(not _COL_SAFE) and _GLU_BAND,
                 cst=_CSTORE,
                 act_aux=_GLU_ACT_AUX,
+                activation=activation,
+                clamp_limit=clamp_limit,
             )
             _glu_args = (
                 None,
@@ -664,6 +668,8 @@ def _build_grouped_mxfp4_nt_kernel(
                 row_pad=_dglu_pad,
                 col_safe=_COL_SAFE,
                 store_aux=_DGLU_AUX,
+                activation=activation,
+                clamp_limit=clamp_limit,
             )
             if const_expr(dglu_act_quant):
                 _row_stride = 2 * N_TILES_BH * 16 + _dglu_pad
@@ -1001,6 +1007,8 @@ def _compile_grouped_mxfp4_nt_glu(
     dglu_epi_quant=False,
     epi_row_sr=False,
     epi_col_sr=False,
+    activation="silu",
+    clamp_limit=None,
 ):
     """The NT compile of :func:`_compile_grouped_mxfp4_nt_fused` with a fused GLU epilogue.
 
@@ -1037,6 +1045,8 @@ def _compile_grouped_mxfp4_nt_glu(
         dglu_act_quant=dglu_epi_quant,
         epi_row_sr=epi_row_sr,
         epi_col_sr=epi_col_sr,
+        activation=activation,
+        clamp_limit=clamp_limit,
     )
     ab_pre_shuf = _build_grouped_mxfp4_ab_preshuffle(
         K128, G, N_b, k128_rd, b_ilv=b_ilv, glu_i=glu_i if glu else 0

--- a/primus_turbo/flydsl/utils/gemm_epilogue_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_epilogue_helper.py
@@ -624,8 +624,78 @@ def _sigmoid_rcp(x):
     return fx.Float32(rocdl.rcp(T.f32, _raw(d)))
 
 
+SUPPORTED_ACTIVATIONS = ("silu", "gelu")
+
+_GELU_A = 0.7978845608028654
+_GELU_B = 0.044715
+_GELU_A2 = 2.0 * _GELU_A
+_GELU_C2 = 6.0 * _GELU_A * _GELU_B
+
+
+def _check_activation(activation: str) -> str:
+    assert activation in SUPPORTED_ACTIVATIONS, (
+        f"Unsupported activation: {activation!r}, expected one of {SUPPORTED_ACTIVATIONS}"
+    )
+    return activation
+
+
+SUPPORTED_CLAMPABLE_ACTIVATIONS = ("silu",)
+
+
+def _check_clamp_limit(activation: str, clamp_limit):
+    if clamp_limit is None:
+        return None
+    assert activation in SUPPORTED_CLAMPABLE_ACTIVATIONS, (
+        f"clamp_limit is only supported for activation in {SUPPORTED_CLAMPABLE_ACTIVATIONS}, got {activation!r}"
+    )
+    clamp_limit = float(clamp_limit)
+    assert clamp_limit > 0.0, f"clamp_limit must be positive, got {clamp_limit}"
+    return clamp_limit
+
+
+def _glu_act(x, activation: str):
+    """The gate ``f(x)`` of a GLU, on one fp32 register value."""
+    if activation == "silu":
+        return x * _sigmoid_rcp(x)
+    xx = x * x
+    u = x * fx.Float32(_GELU_A2) * (fx.Float32(1.0) + xx * fx.Float32(_GELU_B))
+    return x * _sigmoid_rcp(u)
+
+
+def _glu_act_grad(x, activation: str):
+    """``(f(x), f'(x))``, sharing the subexpressions the value and derivative have in common."""
+    one = fx.Float32(1.0)
+    if activation == "silu":
+        s = _sigmoid_rcp(x)
+        act = s * x
+        return act, s * (one + x - act)
+    xx = x * x
+    s = _sigmoid_rcp(x * fx.Float32(_GELU_A2) * (one + xx * fx.Float32(_GELU_B)))
+    return x * s, s + x * s * (one - s) * (fx.Float32(_GELU_A2) + xx * fx.Float32(_GELU_C2))
+
+
+def _glu_clamp(g, u, clamp_limit):
+    """``min(gate, L)`` and ``clamp(linear, -L, L)``, plus the straight-through masks."""
+    if clamp_limit is None:
+        return g, u, None, None
+    hi, lo = _raw(fx.Float32(clamp_limit)), _raw(fx.Float32(-clamp_limit))
+    g_c = fx.Float32(arith.minimumf(_raw(g), hi))
+    u_c = fx.Float32(arith.minimumf(arith.maximumf(_raw(u), lo), hi))
+    eq = arith.CmpFPredicate.OEQ
+    return g_c, u_c, arith.cmpf(eq, _raw(g), _raw(g_c)), arith.cmpf(eq, _raw(u), _raw(u_c))
+
+
+def _glu_kept(v, mask):
+    """``v`` where the clamp kept it and zero where it bit; identity when unclamped."""
+    if mask is None:
+        return v
+    return fx.Float32(arith.select(mask, _raw(v), _raw(fx.Float32(0.0))))
+
+
 class StoreCSwiGLU(StoreCPerTensor):
-    """Fused SwiGLU epilogue: consumes a *pair* of accumulator fragments.
+    """Fused GLU epilogue: consumes a *pair* of accumulator fragments.
+
+    The gate is whichever of :data:`SUPPORTED_ACTIVATIONS` ``activation`` names.
 
     The GEMM writes [M, 2I] as gate||up, and the activation needs column ``j``
     beside column ``j + I`` of the same row -- thousands of columns apart, so a
@@ -662,6 +732,9 @@ class StoreCSwiGLU(StoreCPerTensor):
         band_drop=False,
         cst=False,
         skip_act=False,
+        *,
+        activation,
+        clamp_limit,
     ):
         # c_cols is l1's width, twice the activation's. The inherited store() is
         # unused here, but the scale loading and lane geometry are not.
@@ -681,6 +754,8 @@ class StoreCSwiGLU(StoreCPerTensor):
         self.glu_i = glu_i
         self.act_base = _buffer_ops.extract_base_index(ACT)
         self.act_aux = act_aux
+        self.activation = _check_activation(activation)
+        self.clamp_limit = _check_clamp_limit(activation, clamp_limit)
         self.ilv = ilv
         # With I in whole 64-column bands every band is either fully inside it or
         # fully past it, so the edge is a zero num_records on the band's SRD rather
@@ -803,7 +878,8 @@ class StoreCSwiGLU(StoreCPerTensor):
                         )
 
             def _act(tj, i, gv=gv, uv=uv, pr=pr):
-                return gv[tj][i] * _sigmoid_rcp(gv[tj][i]) * uv[tj][i] * pr[i]
+                gc, uc, _, _ = _glu_clamp(gv[tj][i], uv[tj][i], self.clamp_limit)
+                return _glu_act(gc, self.activation) * uc * pr[i]
 
             if const_expr(not self.cst):
                 _emit(l1_rs, l1_off, lambda tj, i, gv=gv: gv[tj][i], self.store_aux)
@@ -834,15 +910,16 @@ class StoreCSwiGLU(StoreCPerTensor):
 
 
 class StoreCdSwiGLUCShuffle:
-    """Fused SwiGLU-gradient epilogue for the fc2 dgrad, staged through LDS.
+    """Fused GLU-gradient epilogue for the fc2 dgrad, staged through LDS.
 
-    The accumulator *is* ``dact`` -- the GEMM's N axis is already I -- so per
-    element, with ``d_raw`` the unscaled accumulator:
+    The accumulator *is* ``dact`` -- the GEMM's N axis is already I -- so per element,
+    with ``d_raw`` the unscaled accumulator, ``f`` the gate and ``gate`` / ``up`` already
+    clamped (whose masks zero the ``dl1`` columns the clamp bit):
 
-        s = sigmoid(gate);  silu = s * gate;  d = d_raw * probs[m]
-        dl1[m, j]     = d * up * s * (1 + gate - silu)      (dgate)
-        dl1[m, j + I] = d * silu                            (dup)
-        grad_probs[m] += d_raw * silu * up                  (probs unscaled)
+        a = f(gate);  d = d_raw * probs[m]
+        dl1[m, j]     = d * up * f'(gate)               (dgate)
+        dl1[m, j + I] = d * a                           (dup)
+        grad_probs[m] += d_raw * a * up                 (probs unscaled)
 
     ``grad_probs`` sums over all of I, which one tile does not span, so this
     writes partials for the caller to fold -- no atomics, bitwise reproducible,
@@ -886,8 +963,13 @@ class StoreCdSwiGLUCShuffle:
         row_pad=0,
         col_safe=False,
         store_aux=0,
+        *,
+        activation,
+        clamp_limit,
     ):
         self.BAND_COLS = 256
+        self.activation = _check_activation(activation)
+        self.clamp_limit = _check_clamp_limit(activation, clamp_limit)
         self.row_pad = row_pad
         self.col_safe = col_safe
         self.c_rows = c_rows
@@ -950,7 +1032,6 @@ class StoreCdSwiGLUCShuffle:
         """
         scale = self._load_scalar(self.sa_div) * self._load_scalar(self.sb_div) if self.scaled else None
         lds_base = fx.Int32(fx.ptrtoint(self.c_lds.ptr))
-        one = fx.Float32(1.0)
         zero = fx.Float32(0.0)
         wave_n = self.wave_id % 4
         wave_m = self.wave_id // 4
@@ -1023,13 +1104,13 @@ class StoreCdSwiGLUCShuffle:
                 pr = prs[c]
                 dg, du, grad_probs = [], [], zero
                 for k in range_constexpr(self.VEC):
-                    s = _sigmoid_rcp(g[k])
-                    silu = s * g[k]
+                    gc, uc, kept_g, kept_u = _glu_clamp(g[k], u[k], self.clamp_limit)
+                    act, dact_dg = _glu_act_grad(gc, self.activation)
                     d_raw = dact[k]
-                    grad_probs = grad_probs + d_raw * silu * u[k]
+                    grad_probs = grad_probs + d_raw * act * uc
                     d = d_raw * pr
-                    du.append((d * silu).to(self.out_ty))
-                    dg.append((d * u[k] * s * (one + g[k] - silu)).to(self.out_ty))
+                    du.append(_glu_kept(d * act, kept_u).to(self.out_ty))
+                    dg.append(_glu_kept(d * uc * dact_dg, kept_g).to(self.out_ty))
                 off = eoff * 2
                 for vals, dcol in ((dg, 0), (du, self.glu_i * 2)):
                     _buffer_ops.buffer_store(
@@ -1076,7 +1157,7 @@ class StoreCdSwiGLUCShuffle:
 
 
 class StoreCdSwiGLUQuadCShuffle:
-    """Fused SwiGLU-gradient epilogue for a 4-wave NT dgrad, staged through LDS.
+    """Fused GLU-gradient epilogue for a 4-wave NT dgrad, staged through LDS.
 
     Same arithmetic as :class:`StoreCdSwiGLUCShuffle` -- the accumulator *is*
     ``dact``, the GEMM's N axis being I already -- and the same reason to go
@@ -1114,7 +1195,12 @@ class StoreCdSwiGLUQuadCShuffle:
         row_pad=4,
         col_safe=False,
         store_aux=0,
+        *,
+        activation,
+        clamp_limit,
     ):
+        self.activation = _check_activation(activation)
+        self.clamp_limit = _check_clamp_limit(activation, clamp_limit)
         self.VEC = 8  # 16b elements in a 128b global access
         self.Cc = n_tiles_b * 16  # columns one wave owns in a 16-row sub-tile
         self.BAND_COLS = 2 * self.Cc  # the two wave_n of a wave_m group
@@ -1156,7 +1242,6 @@ class StoreCdSwiGLUQuadCShuffle:
     def store_pair(self, c_lo, c_hi, base_row, base_col_l, base_col_r):
         """Both column quadrants of one row block, two waves staging one band each."""
         lds_base = fx.Int32(fx.ptrtoint(self.c_lds.ptr))
-        one = fx.Float32(1.0)
         zero = fx.Float32(0.0)
         wave_n = self.wave_id % 2
         wave_m = self.wave_id // 2
@@ -1246,13 +1331,13 @@ class StoreCdSwiGLUQuadCShuffle:
                     pr = prs[c]
                     dg, du, grad_probs = [], [], zero
                     for k in range_constexpr(self.VEC):
-                        s = _sigmoid_rcp(g[k])
-                        silu = s * g[k]
+                        gc, uc, kept_g, kept_u = _glu_clamp(g[k], u[k], self.clamp_limit)
+                        act, dact_dg = _glu_act_grad(gc, self.activation)
                         d_raw = dact[k]
-                        grad_probs = grad_probs + d_raw * silu * u[k]
+                        grad_probs = grad_probs + d_raw * act * uc
                         d = d_raw * pr
-                        du.append((d * silu).to(self.out_ty))
-                        dg.append((d * u[k] * s * (one + g[k] - silu)).to(self.out_ty))
+                        du.append(_glu_kept(d * act, kept_u).to(self.out_ty))
+                        dg.append(_glu_kept(d * uc * dact_dg, kept_g).to(self.out_ty))
                     off = eoffs[c] * 2
                     for vals, dcol in ((dg, 0), (du, self.glu_i * 2)):
                         _buffer_ops.buffer_store(
@@ -1331,7 +1416,6 @@ class StoreCdSwiGLUQuadQuant(StoreCdSwiGLUQuadCShuffle):
     def store_pair_quant(self, c_lo, c_hi, base_row, base_col_l, base_col_r, pad_row_base, row_limit):
         """Both column quadrants, a whole col-wise micro-block per band."""
         lds_base = fx.Int32(fx.ptrtoint(self.c_lds.ptr))
-        one = fx.Float32(1.0)
         zero = fx.Float32(0.0)
         wave_n = self.wave_id % 2
         wave_m = self.wave_id // 2
@@ -1433,13 +1517,13 @@ class StoreCdSwiGLUQuadQuant(StoreCdSwiGLUQuadCShuffle):
                         pr = s["prs"][c]
                         dg, du, grad_probs = [], [], zero
                         for k in range_constexpr(self.VEC):
-                            sig = _sigmoid_rcp(g[k])
-                            silu = sig * g[k]
+                            gc, uc, kept_g, kept_u = _glu_clamp(g[k], u[k], self.clamp_limit)
+                            act, dact_dg = _glu_act_grad(gc, self.activation)
                             d_raw = dact[k]
-                            grad_probs = grad_probs + d_raw * silu * u[k]
+                            grad_probs = grad_probs + d_raw * act * uc
                             d = d_raw * pr
-                            du.append(d * silu)
-                            dg.append(d * u[k] * sig * (one + g[k] - silu))
+                            du.append(_glu_kept(d * act, kept_u))
+                            dg.append(_glu_kept(d * uc * dact_dg, kept_g))
                         if valid is not None:
                             grad_probs = fx.Float32(arith.select(valid, grad_probs, zero))
                         gp_run.append(grad_probs)
@@ -1508,7 +1592,7 @@ class StoreCdSwiGLUQuadQuant(StoreCdSwiGLUQuadCShuffle):
 
 
 class StoreCSwiGLUQuant(StoreCSwiGLU):
-    """SwiGLU epilogue whose activation leaves as MXFP4 operands, not bf16.
+    """GLU epilogue whose activation leaves as MXFP4 operands, not bf16.
 
     ``l1`` still goes out in the mainloop's store slot, unchanged -- backward reads
     it and it is not the traffic worth removing. Only the activation is diverted:
@@ -1557,9 +1641,10 @@ class StoreCSwiGLUQuant(StoreCSwiGLU):
                     gv.append(g)
                     uv.append(u)
                 for i in range_constexpr(4):
-                    vals4 = [
-                        gv[tj][i] * _sigmoid_rcp(gv[tj][i]) * uv[tj][i] * pr[i] for tj in range_constexpr(NTB)
-                    ]
+                    vals4 = []
+                    for tj in range_constexpr(NTB):
+                        gc, uc, _, _ = _glu_clamp(gv[tj][i], uv[tj][i], self.clamp_limit)
+                        vals4.append(_glu_act(gc, self.activation) * uc * pr[i])
                     rows.append((fx.Int32(sub * 16) + quad + fx.Int32(i), vals4))
             off = fx.Int32(band * BAND_ROWS)
             self.q.store_band(

--- a/primus_turbo/pytorch/kernels/activation/swiglu_impl.py
+++ b/primus_turbo/pytorch/kernels/activation/swiglu_impl.py
@@ -17,12 +17,19 @@ from primus_turbo.triton.activation.swiglu_kernel import (
 )
 
 
-def swiglu_fwd_with_probs(x: torch.Tensor, probs: torch.Tensor, row_mask: Optional[torch.Tensor] = None):
+def swiglu_fwd_with_probs(
+    x: torch.Tensor,
+    probs: torch.Tensor,
+    row_mask: Optional[torch.Tensor] = None,
+    clamp_limit: Optional[float] = None,
+):
     num_tokens, double_hidden_size = x.size()
 
     probs = probs.unsqueeze(-1)
 
     out = torch.empty(num_tokens, double_hidden_size // 2, dtype=x.dtype, device=x.device)
+
+    has_clamp = clamp_limit is not None
 
     if row_mask is None:
         grid = (num_tokens,)
@@ -34,7 +41,9 @@ def swiglu_fwd_with_probs(x: torch.Tensor, probs: torch.Tensor, row_mask: Option
             stride_x_token=x.stride(0),
             stride_probs_token=probs.stride(0),
             stride_out_token=out.stride(0),
+            clamp_limit=float(clamp_limit) if has_clamp else 0.0,
             LOAD_WIDTH=triton.next_power_of_2(double_hidden_size // 2),
+            HAS_CLAMP=has_clamp,
         )
     else:
         assert row_mask.is_cuda, "row_mask must be a CUDA tensor"
@@ -50,8 +59,10 @@ def swiglu_fwd_with_probs(x: torch.Tensor, probs: torch.Tensor, row_mask: Option
             stride_x_token=x.stride(0),
             stride_probs_token=probs.stride(0),
             stride_out_token=out.stride(0),
+            clamp_limit=float(clamp_limit) if has_clamp else 0.0,
             LOAD_WIDTH=triton.next_power_of_2(double_hidden_size // 2),
             BLOCK_SIZE=BLOCK_SIZE,
+            HAS_CLAMP=has_clamp,
         )
 
     return out
@@ -62,11 +73,14 @@ def swiglu_bwd_with_probs(
     x: torch.Tensor,
     probs: torch.Tensor,
     row_mask: Optional[torch.Tensor] = None,
+    clamp_limit: Optional[float] = None,
 ):
     num_tokens, hidden_size = grad_out.size()
 
     grad_x = torch.empty_like(x)
     grad_probs = torch.empty_like(probs)
+
+    has_clamp = clamp_limit is not None
 
     if row_mask is None:
         grid = (num_tokens,)
@@ -82,7 +96,9 @@ def swiglu_bwd_with_probs(
             stride_probs_token=probs.stride(0),
             stride_grad_x_token=grad_x.stride(0),
             stride_grad_probs_token=grad_probs.stride(0),
+            clamp_limit=float(clamp_limit) if has_clamp else 0.0,
             LOAD_WIDTH=triton.next_power_of_2(hidden_size),
+            HAS_CLAMP=has_clamp,
         )
     else:
         assert row_mask.is_cuda, "tokens_per_expert must be a CUDA tensor"
@@ -102,8 +118,10 @@ def swiglu_bwd_with_probs(
             stride_probs_token=probs.stride(0),
             stride_grad_x_token=grad_x.stride(0),
             stride_grad_probs_token=grad_probs.stride(0),
+            clamp_limit=float(clamp_limit) if has_clamp else 0.0,
             LOAD_WIDTH=triton.next_power_of_2(hidden_size),
             BLOCK_SIZE=BLOCK_SIZE,
+            HAS_CLAMP=has_clamp,
         )
 
     return grad_x, grad_probs

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp4_impl.py
@@ -690,6 +690,7 @@ def grouped_gemm_fp4_glu_impl(
     out_row_scaling_recipe: ScalingRecipe,
     out_col_scaling_recipe: ScalingRecipe,
     activation: str = "silu",
+    clamp_limit: float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """fc1 grouped MXFP4 GEMM with the GLU activation and its quantisation fused in.
 
@@ -738,6 +739,7 @@ def grouped_gemm_fp4_glu_impl(
         N,
         K,
         activation=activation,
+        clamp_limit=clamp_limit,
         row_use_sr=row_sr,
         col_use_sr=col_sr,
         out_dtype=out_dtype,
@@ -763,6 +765,7 @@ def grouped_gemm_fp4_dglu_impl(
     out_row_scaling_recipe: ScalingRecipe,
     out_col_scaling_recipe: ScalingRecipe,
     activation: str = "silu",
+    clamp_limit: float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """fc2 dgrad with the GLU activation gradient and its quantisation fused in.
 
@@ -816,6 +819,7 @@ def grouped_gemm_fp4_dglu_impl(
         I,
         K,
         activation=activation,
+        clamp_limit=clamp_limit,
         row_use_sr=row_sr,
         col_use_sr=col_sr,
         out_dtype=out_dtype,
@@ -841,6 +845,7 @@ def grouped_gemm_fp4_dglu_impl_meta(
     out_row_scaling_recipe: ScalingRecipe,
     out_col_scaling_recipe: ScalingRecipe,
     activation: str = "silu",
+    clamp_limit: float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     assert a.dim() == 2 and b.dim() == 3, f"a must be 2D and b 3D, got {a.shape} {b.shape}"
     assert a.dtype == float4_e2m1fn_x2 and b.dtype == float4_e2m1fn_x2, "operands must be fp4"
@@ -869,6 +874,7 @@ def grouped_gemm_fp4_glu_impl_meta(
     out_row_scaling_recipe: ScalingRecipe,
     out_col_scaling_recipe: ScalingRecipe,
     activation: str = "silu",
+    clamp_limit: float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     assert a.dim() == 2 and b.dim() == 3, f"a must be 2D and b 3D, got {a.shape} {b.shape}"
     assert a.dtype == float4_e2m1fn_x2 and b.dtype == float4_e2m1fn_x2, "operands must be fp4"

--- a/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
+++ b/primus_turbo/pytorch/kernels/grouped_gemm/grouped_gemm_fp8_impl.py
@@ -1257,6 +1257,7 @@ def grouped_gemm_fp8_glu_impl(
     out_row_scaling_recipe: ScalingRecipe,
     out_col_scaling_recipe: ScalingRecipe,
     activation: str = "silu",
+    clamp_limit: float | None = None,
     k_align: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """fc1 grouped GEMM with the GLU activation and its quantisation fused in.
@@ -1312,6 +1313,7 @@ def grouped_gemm_fp8_glu_impl(
         intermediate,
         trans_b=trans_b,
         activation=activation,
+        clamp_limit=clamp_limit,
         out_dtype=out_dtype,
         num_cu=num_cu,
     )
@@ -1342,6 +1344,7 @@ def grouped_gemm_fp8_dglu_impl(
     out_row_scaling_recipe: ScalingRecipe,
     out_col_scaling_recipe: ScalingRecipe,
     activation: str = "silu",
+    clamp_limit: float | None = None,
     i_real: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """fc2 dgrad with the GLU activation gradient and its quantisation fused in.
@@ -1398,6 +1401,7 @@ def grouped_gemm_fp8_dglu_impl(
         grad_probs_partial,
         trans_b=trans_b,
         activation=activation,
+        clamp_limit=clamp_limit,
         num_cu=num_cu,
         i_real=i_real,
     )
@@ -1424,6 +1428,7 @@ def grouped_gemm_fp8_glu_impl_meta(
     out_row_scaling_recipe: ScalingRecipe,
     out_col_scaling_recipe: ScalingRecipe,
     activation: str = "silu",
+    clamp_limit: float | None = None,
     k_align: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     _check_glu_dispatch(config, trans_a)
@@ -1470,6 +1475,7 @@ def grouped_gemm_fp8_dglu_impl_meta(
     out_row_scaling_recipe: ScalingRecipe,
     out_col_scaling_recipe: ScalingRecipe,
     activation: str = "silu",
+    clamp_limit: float | None = None,
     i_real: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     _check_glu_dispatch(config, trans_a)

--- a/primus_turbo/pytorch/ops/activation.py
+++ b/primus_turbo/pytorch/ops/activation.py
@@ -4,7 +4,7 @@
 # See LICENSE for license information.
 ###############################################################################
 
-from typing import Union
+from typing import Optional, Union
 
 import torch
 
@@ -17,13 +17,20 @@ from primus_turbo.pytorch.kernels.activation.swiglu_impl import (
     swiglu_fwd_with_probs,
 )
 
-__all__ = ["swiglu_with_probs", "geglu_with_probs"]
+__all__ = ["swiglu_with_probs", "geglu_with_probs", "clamped_swiglu_with_probs"]
+
+DEFAULT_CLAMP_LIMIT = 7.0
 
 
 class GLUWithProbs(torch.autograd.Function):
     @staticmethod
     def forward(
-        ctx, x: torch.Tensor, probs: torch.Tensor, row_mask: Union[torch.Tensor, None], act_type: str
+        ctx,
+        x: torch.Tensor,
+        probs: torch.Tensor,
+        row_mask: Union[torch.Tensor, None],
+        act_type: str,
+        clamp_limit: Optional[float] = None,
     ):
         x_origin_shape = x.size()
         probs_origin_shape = probs.size()
@@ -39,6 +46,11 @@ class GLUWithProbs(torch.autograd.Function):
             f"Unsupported act_type: {act_type}. Supported types: {SUPPORTED_ACT_TYPES}"
         )
 
+        if clamp_limit is not None:
+            assert act_type == "silu", f"clamp_limit is only supported for act_type 'silu', got {act_type}"
+            clamp_limit = float(clamp_limit)
+            assert clamp_limit > 0.0, f"clamp_limit must be positive, got {clamp_limit}"
+
         if row_mask is not None:
             assert row_mask.is_cuda, "row_mask must be a CUDA tensor"
             assert x.size(0) == row_mask.size(0), "first dimension of x and row_mask must be the same"
@@ -46,12 +58,13 @@ class GLUWithProbs(torch.autograd.Function):
             assert row_mask.dtype == torch.int64, "The dtype of row_mask must be torch.int64."
 
         if act_type == "silu":
-            out = swiglu_fwd_with_probs(x, probs, row_mask)
+            out = swiglu_fwd_with_probs(x, probs, row_mask, clamp_limit)
         elif act_type == "gelu":
             out = geglu_fwd_with_probs(x, probs, row_mask)
 
         ctx.save_for_backward(x, probs, row_mask)
         ctx.act_type = act_type
+        ctx.clamp_limit = clamp_limit
         ctx.x_origin_shape = x_origin_shape
         ctx.probs_origin_shape = probs_origin_shape
 
@@ -64,11 +77,11 @@ class GLUWithProbs(torch.autograd.Function):
         x, probs, row_mask = ctx.saved_tensors
 
         if ctx.act_type == "silu":
-            grad_x, grad_probs = swiglu_bwd_with_probs(grad_output, x, probs, row_mask)
+            grad_x, grad_probs = swiglu_bwd_with_probs(grad_output, x, probs, row_mask, ctx.clamp_limit)
         elif ctx.act_type == "gelu":
             grad_x, grad_probs = geglu_bwd_with_probs(grad_output, x, probs, row_mask)
 
-        return grad_x.view(ctx.x_origin_shape), grad_probs.view(ctx.probs_origin_shape), None, None
+        return grad_x.view(ctx.x_origin_shape), grad_probs.view(ctx.probs_origin_shape), None, None, None
 
 
 def swiglu_with_probs(
@@ -81,3 +94,17 @@ def geglu_with_probs(
     x: torch.Tensor, probs: torch.Tensor, row_mask: Union[torch.Tensor, None]
 ) -> torch.Tensor:
     return GLUWithProbs.apply(x, probs, row_mask, "gelu")
+
+
+def clamped_swiglu_with_probs(
+    x: torch.Tensor,
+    probs: torch.Tensor,
+    row_mask: Union[torch.Tensor, None],
+    clamp_limit: float = DEFAULT_CLAMP_LIMIT,
+) -> torch.Tensor:
+    """``silu(min(gate, L)) * clamp(up, -L, L) * probs``, with ``L = clamp_limit``.
+
+    ``gate`` / ``up`` are the halves of ``x``'s last dim. The clamp backward is
+    straight-through, matching ``torch.clamp``.
+    """
+    return GLUWithProbs.apply(x, probs, row_mask, "silu", clamp_limit)

--- a/primus_turbo/pytorch/ops/grouped_mlp_fp4.py
+++ b/primus_turbo/pytorch/ops/grouped_mlp_fp4.py
@@ -57,7 +57,23 @@ from primus_turbo.pytorch.ops.utils import (
 __all__ = ["grouped_mlp_fp4"]
 
 
-_SUPPORTED_ACTIVATIONS = ("silu",)
+_SUPPORTED_ACTIVATIONS = ("silu", "gelu")
+
+_SUPPORTED_CLAMPABLE_ACTIVATIONS = ("silu",)
+
+
+def _check_activation(activation: str, clamp_limit: Union[None, float]) -> Union[None, float]:
+    assert activation in _SUPPORTED_ACTIVATIONS, (
+        f"Unsupported activation: {activation!r}, expected one of {_SUPPORTED_ACTIVATIONS}"
+    )
+    if clamp_limit is None:
+        return None
+    assert activation in _SUPPORTED_CLAMPABLE_ACTIVATIONS, (
+        f"clamp_limit is only supported for activation in {_SUPPORTED_CLAMPABLE_ACTIVATIONS}, got {activation!r}"
+    )
+    clamp_limit = float(clamp_limit)
+    assert clamp_limit > 0.0, f"clamp_limit must be positive, got {clamp_limit}"
+    return clamp_limit
 
 
 def _wgrad_grouped_gemm_fp4_impl_wrapper(
@@ -150,14 +166,13 @@ class FP4GroupedMLPMXFunc(torch.autograd.Function):
         trans_w1: bool,
         trans_w2: bool,
         activation: str,
+        clamp_limit: Union[None, float],
         out_dtype: torch.dtype,
         config: Float4QuantConfig,
         num_cu: int | None,
         fuse_wgrad_accum_pattern: Union[None, str] = None,
     ):
-        assert activation in _SUPPORTED_ACTIVATIONS, (
-            f"Unsupported activation: {activation!r}, expected one of {_SUPPORTED_ACTIVATIONS}"
-        )
+        clamp_limit = _check_activation(activation, clamp_limit)
         # MXFP4 has no non-NT layout, so the weights can only be given as
         # w1 [G, 2I, K] / w2 [G, K_out, I], which is what both flags being set means.
         assert trans_w1 and trans_w2, (
@@ -239,6 +254,7 @@ class FP4GroupedMLPMXFunc(torch.autograd.Function):
             out_row_scaling_recipe=ScalingRecipe(),
             out_col_scaling_recipe=ScalingRecipe(use_rht=True),
             activation=activation,
+            clamp_limit=clamp_limit,
         )
 
         out = grouped_gemm_fp4_impl(
@@ -272,6 +288,7 @@ class FP4GroupedMLPMXFunc(torch.autograd.Function):
             group_offs,
         )
         ctx.activation = activation
+        ctx.clamp_limit = clamp_limit
         ctx.config = config
         ctx.out_dtype = out_dtype
         ctx.num_cu = num_cu
@@ -358,6 +375,7 @@ class FP4GroupedMLPMXFunc(torch.autograd.Function):
             out_row_scaling_recipe=ScalingRecipe(use_sr=sr),
             out_col_scaling_recipe=ScalingRecipe(use_sr=sr, use_rht=True),
             activation=ctx.activation,
+            clamp_limit=ctx.clamp_limit,
         )
         gl_offs_row, gl_lens_col, gl_offs_col = group_offs, go_lens_col, go_offs_col
 
@@ -405,6 +423,7 @@ class FP4GroupedMLPMXFunc(torch.autograd.Function):
             None,  # trans_w1
             None,  # trans_w2
             None,  # activation
+            None,  # clamp_limit
             None,  # out_dtype
             None,  # config
             None,  # num_cu
@@ -434,8 +453,9 @@ def grouped_mlp_fp4(
     num_cu: int | None = None,
     fuse_wgrad_accum_pattern: Union[None, str] = None,
     activation: Union[None, str] = None,
+    clamp_limit: Union[None, float] = None,
 ) -> torch.Tensor:
-    """MoE expert MLP in MXFP4: ``fc2(silu(gate) * up * probs)`` over ``group_lens``.
+    """MoE expert MLP in MXFP4: ``fc2(f(gate) * up * probs)`` over ``group_lens``.
 
     Args:
         x: [total_m, K] activations, grouped along M. May instead be a
@@ -450,6 +470,11 @@ def grouped_mlp_fp4(
             the col-wise dgrad operand and so carries no RHT.
         probs: [total_m] float32 routing probabilities. Required -- the fused
             epilogues always scale by it and reduce its gradient.
+        activation: the gate ``f``, one of ``_SUPPORTED_ACTIVATIONS``. ``"gelu"`` is
+            the tanh approximation, i.e. ``F.gelu(approximate="tanh")``.
+        clamp_limit: DeepSeek-V4's pre-multiplication clamp bound ``L``, or None for no
+            clamp. With it the activation is ``silu(min(gate, L)) * clamp(up, -L, L)``,
+            whose backward is straight-through. Supported for ``"silu"`` only.
 
     Returns:
         [total_m, K_out] in ``out_dtype``.
@@ -457,9 +482,7 @@ def grouped_mlp_fp4(
     if config is None:
         config = Float4QuantConfig()
 
-    assert activation in _SUPPORTED_ACTIVATIONS, (
-        f"Unsupported activation: {activation!r}, expected one of {_SUPPORTED_ACTIVATIONS}"
-    )
+    clamp_limit = _check_activation(activation, clamp_limit)
     assert probs is not None, "probs is required: the fused GLU epilogues always scale by it"
 
     if group_offs is None:
@@ -500,6 +523,7 @@ def grouped_mlp_fp4(
         trans_w1,
         trans_w2,
         activation,
+        clamp_limit,
         out_dtype,
         config,
         num_cu,

--- a/primus_turbo/pytorch/ops/grouped_mlp_fp8.py
+++ b/primus_turbo/pytorch/ops/grouped_mlp_fp8.py
@@ -42,7 +42,23 @@ __all__ = [
 ]
 
 
-_SUPPORTED_ACTIVATIONS = ("silu",)
+_SUPPORTED_ACTIVATIONS = ("silu", "gelu")
+
+_SUPPORTED_CLAMPABLE_ACTIVATIONS = ("silu",)
+
+
+def _check_activation(activation: str, clamp_limit: Union[None, float]) -> Union[None, float]:
+    assert activation in _SUPPORTED_ACTIVATIONS, (
+        f"Unsupported activation: {activation!r}, expected one of {_SUPPORTED_ACTIVATIONS}"
+    )
+    if clamp_limit is None:
+        return None
+    assert activation in _SUPPORTED_CLAMPABLE_ACTIVATIONS, (
+        f"clamp_limit is only supported for activation in {_SUPPORTED_CLAMPABLE_ACTIVATIONS}, got {activation!r}"
+    )
+    clamp_limit = float(clamp_limit)
+    assert clamp_limit > 0.0, f"clamp_limit must be positive, got {clamp_limit}"
+    return clamp_limit
 
 
 # Pad the fp8 grouped-MLP contraction/feature dims to 128. gpt-oss-20b runs
@@ -124,14 +140,13 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
         trans_w1: bool,
         trans_w2: bool,
         activation: str,
+        clamp_limit: Union[None, float],
         out_dtype: torch.dtype,
         config: Float8QuantConfig,
         num_cu: int | None,
         fuse_wgrad_accum_pattern: Union[None, str] = None,
     ):
-        assert activation in _SUPPORTED_ACTIVATIONS, (
-            f"Unsupported activation: {activation!r}, expected one of {_SUPPORTED_ACTIVATIONS}"
-        )
+        clamp_limit = _check_activation(activation, clamp_limit)
 
         # Each weight carries its own accumulation buffer, so the two wgrads
         # cannot share one: resolve them separately while the parameter objects
@@ -211,6 +226,7 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
             out_row_scaling_recipe=ScalingRecipe(),
             out_col_scaling_recipe=ScalingRecipe(),
             activation=activation,
+            clamp_limit=clamp_limit,
             # Pad the fused activation's I -> Ip so fc2's contraction matches w2's
             # padded I; copy-free (the quantiser writes the padded buffer directly).
             k_align=_FP8_PAD_ALIGN,
@@ -256,6 +272,7 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
         ctx.trans_w1 = trans_w1
         ctx.trans_w2 = trans_w2
         ctx.activation = activation
+        ctx.clamp_limit = clamp_limit
         ctx.config = config
         ctx.out_dtype = out_dtype
         ctx.num_cu = num_cu
@@ -350,6 +367,7 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
             out_row_scaling_recipe=ScalingRecipe(),
             out_col_scaling_recipe=ScalingRecipe(),
             activation=ctx.activation,
+            clamp_limit=ctx.clamp_limit,
             # w2 (b) is padded on its I axis to w2_fp8.shape[-1]; i_real recovers the
             # tight I so grad_fc1_out stays [M, 2I] and the padded Ip rides as n_stride.
             i_real=i_real if i_real != w2_fp8.shape[-1] else None,
@@ -408,6 +426,7 @@ class FP8GroupedMLPTensorFunc(torch.autograd.Function):
             None,  # trans_w1
             None,  # trans_w2
             None,  # activation
+            None,  # clamp_limit
             None,  # out_dtype
             None,  # config
             None,  # num_cu
@@ -439,13 +458,21 @@ def grouped_mlp_fp8(
     num_cu: int | None = None,
     fuse_wgrad_accum_pattern: Union[None, str] = None,
     activation: Union[None, str] = None,
+    clamp_limit: Union[None, float] = None,
 ) -> torch.Tensor:
+    """Grouped FP8 MLP: ``fc2(f(gate) * up * probs)`` with fc1's GLU fused into its epilogue.
+
+    Args:
+        activation: the GLU gate, one of ``("silu", "gelu")``. "gelu" is the tanh
+            approximation, i.e. ``F.gelu(approximate="tanh")``.
+        clamp_limit: DeepSeek-V4's pre-multiplication clamp bound ``L``, or None for no
+            clamp. With it the activation is ``silu(min(gate, L)) * clamp(up, -L, L)``,
+            whose backward is straight-through. Supported for "silu" only.
+    """
     if config is None:
         config = Float8QuantConfig()
 
-    assert activation in _SUPPORTED_ACTIVATIONS, (
-        f"Unsupported activation: {activation!r}, expected one of {_SUPPORTED_ACTIVATIONS}"
-    )
+    clamp_limit = _check_activation(activation, clamp_limit)
 
     assert probs is not None, "probs is required: the fused GLU epilogues always scale by it"
 
@@ -487,6 +514,7 @@ def grouped_mlp_fp8(
             trans_w1,
             trans_w2,
             activation,
+            clamp_limit,
             out_dtype,
             config,
             num_cu,

--- a/primus_turbo/triton/activation/geglu_kernel.py
+++ b/primus_turbo/triton/activation/geglu_kernel.py
@@ -53,7 +53,7 @@ def geglu_with_mask_fwd_kernel(
         up = gelu_none(up)
         out = up * down
 
-        probs = tl.load(probs_ptr + row_idx * stride_probs_token)
+        probs = tl.load(probs_ptr + row_idx * stride_probs_token, mask=row_mask)
         out = out * probs
 
         tl.store(out_ptr + row_idx * stride_out_token + col_off, out.to(data_type), mask=mask)
@@ -119,12 +119,11 @@ def geglu_with_mask_bwd_kernel(
             mask=row_mask,
         )
 
-        probs = tl.load(probs_ptr + row_idx * stride_probs_token).to(compute_type)
+        probs = tl.load(probs_ptr + row_idx * stride_probs_token, mask=row_mask).to(compute_type)
 
         grad_out_with_probs = grad_out * probs
         grad_down = grad_out_with_probs * gelu
-        grad_gelu = gelu_bwd_none(up, grad_out)
-        grad_up = grad_out_with_probs * down * grad_gelu
+        grad_up = gelu_bwd_none(up, grad_out_with_probs * down)
 
         tl.store(
             grad_x_ptr + row_idx * stride_grad_x_token + col_off, grad_up.to(grad_x_data_type), mask=mask
@@ -237,8 +236,7 @@ def geglu_bwd_kernel(
 
     grad_out_with_probs = grad_out * probs
     grad_down = grad_out_with_probs * gelu
-    grad_gelu = gelu_bwd_none(up, grad_out)
-    grad_up = grad_out_with_probs * down * grad_gelu
+    grad_up = gelu_bwd_none(up, grad_out_with_probs * down)
 
     tl.store(grad_x_ptr + row_idx * stride_grad_x_token + col_off, grad_up.to(grad_x_data_type), mask=mask)
     tl.store(

--- a/primus_turbo/triton/activation/swiglu_kernel.py
+++ b/primus_turbo/triton/activation/swiglu_kernel.py
@@ -21,9 +21,12 @@ def swiglu_with_mask_fwd_kernel(
     stride_x_token,
     stride_probs_token,
     stride_out_token,
+    # clamp
+    clamp_limit,
     # metas
     LOAD_WIDTH: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    HAS_CLAMP: tl.constexpr,
 ):
     pid = tl.program_id(0)
 
@@ -48,10 +51,15 @@ def swiglu_with_mask_fwd_kernel(
         up = tl.load(up_ptr + col_off, mask=mask).to(compute_type)
         down = tl.load(down_ptr + col_off, mask=mask).to(compute_type)
 
+        if HAS_CLAMP:
+            limit = clamp_limit.to(compute_type)
+            up = tl.minimum(up, limit)
+            down = tl.minimum(tl.maximum(down, -limit), limit)
+
         up = tl.fdiv(up, (1.0 + tl.exp(-up)))
         out = up * down
 
-        probs = tl.load(probs_ptr + row_idx * stride_probs_token)
+        probs = tl.load(probs_ptr + row_idx * stride_probs_token, mask=row_mask)
         out = out * probs
 
         tl.store(out_ptr + row_idx * stride_out_token + col_off, out.to(data_type), mask=mask)
@@ -74,9 +82,12 @@ def swiglu_with_mask_bwd_kernel(
     stride_probs_token,
     stride_grad_x_token,
     stride_grad_probs_token,
+    # clamp
+    clamp_limit,
     # metas
     LOAD_WIDTH: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    HAS_CLAMP: tl.constexpr,
 ):
     pid = tl.program_id(0)
 
@@ -102,6 +113,13 @@ def swiglu_with_mask_bwd_kernel(
         up = tl.load(up_ptr + col_off, mask=mask).to(compute_type)
         down = tl.load(down_ptr + col_off, mask=mask).to(compute_type)
 
+        if HAS_CLAMP:
+            limit = clamp_limit.to(compute_type)
+            up_kept = up <= limit
+            down_kept = (down >= -limit) & (down <= limit)
+            up = tl.minimum(up, limit)
+            down = tl.minimum(tl.maximum(down, -limit), limit)
+
         sigmoid = tl.sigmoid(up)
         silu = sigmoid * up
 
@@ -118,12 +136,16 @@ def swiglu_with_mask_bwd_kernel(
             mask=row_mask,
         )
 
-        probs = tl.load(probs_ptr + row_idx * stride_probs_token).to(compute_type)
+        probs = tl.load(probs_ptr + row_idx * stride_probs_token, mask=row_mask).to(compute_type)
 
         grad_out_with_probs = grad_out * probs
         grad_down = grad_out_with_probs * silu
         grad_silu = sigmoid * (1.0 + up * (1.0 - sigmoid))
         grad_up = grad_out_with_probs * (down * grad_silu)
+
+        if HAS_CLAMP:
+            grad_up = tl.where(up_kept, grad_up, 0.0)
+            grad_down = tl.where(down_kept, grad_down, 0.0)
 
         tl.store(
             grad_x_ptr + row_idx * stride_grad_x_token + col_off, grad_up.to(grad_x_data_type), mask=mask
@@ -147,8 +169,11 @@ def swiglu_fwd_kernel(
     stride_x_token: tl.constexpr,
     stride_probs_token: tl.constexpr,
     stride_out_token: tl.constexpr,
+    # clamp
+    clamp_limit,
     # metas
     LOAD_WIDTH: tl.constexpr,
+    HAS_CLAMP: tl.constexpr,
 ):
     pid = tl.program_id(0)
 
@@ -169,6 +194,11 @@ def swiglu_fwd_kernel(
 
     up = tl.load(up_ptr + col_off, mask=mask).to(compute_type)
     down = tl.load(down_ptr + col_off, mask=mask).to(compute_type)
+
+    if HAS_CLAMP:
+        limit = clamp_limit.to(compute_type)
+        up = tl.minimum(up, limit)
+        down = tl.minimum(tl.maximum(down, -limit), limit)
 
     up = tl.fdiv(up, (1.0 + tl.exp(-up)))
     out = up * down
@@ -195,8 +225,11 @@ def swiglu_bwd_kernel(
     stride_probs_token: tl.constexpr,
     stride_grad_x_token: tl.constexpr,
     stride_grad_probs_token: tl.constexpr,
+    # clamp
+    clamp_limit,
     # metas
     LOAD_WIDTH: tl.constexpr,
+    HAS_CLAMP: tl.constexpr,
 ):
     pid = tl.program_id(0)
 
@@ -219,6 +252,13 @@ def swiglu_bwd_kernel(
     up = tl.load(up_ptr + col_off, mask=mask).to(compute_type)
     down = tl.load(down_ptr + col_off, mask=mask).to(compute_type)
 
+    if HAS_CLAMP:
+        limit = clamp_limit.to(compute_type)
+        up_kept = up <= limit
+        down_kept = (down >= -limit) & (down <= limit)
+        up = tl.minimum(up, limit)
+        down = tl.minimum(tl.maximum(down, -limit), limit)
+
     sigmoid = tl.sigmoid(up)
     silu = sigmoid * up
 
@@ -239,6 +279,10 @@ def swiglu_bwd_kernel(
     grad_down = grad_out_with_probs * silu
     grad_silu = sigmoid * (1.0 + up * (1.0 - sigmoid))
     grad_up = grad_out_with_probs * (down * grad_silu)
+
+    if HAS_CLAMP:
+        grad_up = tl.where(up_kept, grad_up, 0.0)
+        grad_down = tl.where(down_kept, grad_down, 0.0)
 
     tl.store(grad_x_ptr + row_idx * stride_grad_x_token + col_off, grad_up.to(grad_x_data_type), mask=mask)
     tl.store(

--- a/tests/pytorch/ops/test_activation.py
+++ b/tests/pytorch/ops/test_activation.py
@@ -5,16 +5,23 @@
 ###############################################################################
 
 import random
+from functools import partial
 
 import pytest
 import torch
 import torch.nn.functional as F
 
-from primus_turbo.pytorch.ops.activation import geglu_with_probs, swiglu_with_probs
+from primus_turbo.pytorch.ops.activation import (
+    clamped_swiglu_with_probs,
+    geglu_with_probs,
+    swiglu_with_probs,
+)
 from tests.pytorch.test_utils import get_tolerances
 
 torch.manual_seed(42)
 random.seed(42)
+
+CLAMP_LIMIT = 1.0
 
 
 # NOTE: Align precision with torch.compile
@@ -23,6 +30,17 @@ def swiglu_with_probs_ref(x: torch.Tensor, probs: torch.Tensor):
     dtype = x.dtype
     x = torch.chunk(x, 2, dim=-1)
     res = F.silu(x[0]) * x[1]
+    return (res * probs).to(dtype)
+
+
+# NOTE: Align precision with torch.compile
+@torch.compile
+def clamped_swiglu_with_probs_ref(x: torch.Tensor, probs: torch.Tensor, clamp_limit: float):
+    dtype = x.dtype
+    gate, up = torch.chunk(x, 2, dim=-1)
+    gate = torch.clamp(gate, max=clamp_limit)
+    up = torch.clamp(up, min=-clamp_limit, max=clamp_limit)
+    res = F.silu(gate) * up
     return (res * probs).to(dtype)
 
 
@@ -75,7 +93,7 @@ def geglu_with_probs_ref(x: torch.Tensor, probs: torch.Tensor):
 )
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("with_tokens_per_expert", [False, True])
-@pytest.mark.parametrize("act_type", ["swiglu", "geglu"])
+@pytest.mark.parametrize("act_type", ["swiglu", "geglu", "clamped_swiglu"])
 def test_glu_with_probs(batch_size, sequence_length, hidden_size, dtype, with_tokens_per_expert, act_type):
     if not torch.cuda.is_available():
         pytest.skip("CUDA not available")
@@ -86,6 +104,9 @@ def test_glu_with_probs(batch_size, sequence_length, hidden_size, dtype, with_to
     elif act_type == "geglu":
         func = geglu_with_probs
         ref_func = geglu_with_probs_ref
+    elif act_type == "clamped_swiglu":
+        func = partial(clamped_swiglu_with_probs, clamp_limit=CLAMP_LIMIT)
+        ref_func = partial(clamped_swiglu_with_probs_ref, clamp_limit=CLAMP_LIMIT)
 
     device = "cuda"
 

--- a/tests/pytorch/ops/test_grouped_mlp_fp4.py
+++ b/tests/pytorch/ops/test_grouped_mlp_fp4.py
@@ -7,9 +7,10 @@
 """Fused MXFP4 grouped MLP, driven through its public op.
 
 The op runs end to end -- output and all four gradients -- against an eager
-per-expert fp32 reference. The floor is low because MXFP4 carries ~2 mantissa
-bits and this path stacks four quantisations plus the wgrad operands' RHT, so
-the bar is here to catch a wrong answer rather than the quantisation.
+per-expert fp32 reference, for every gate it takes. The floor is low because
+MXFP4 carries ~2 mantissa bits and this path stacks four quantisations plus the
+wgrad operands' RHT, so the bar is here to catch a wrong answer rather than the
+quantisation.
 """
 
 import pytest
@@ -37,6 +38,13 @@ SNR_THRESHOLD = 10.0
 # ``glu_epi_quant_supported``.
 SHAPES = [(2048, 896, 512, 4), (2048, 1408, 320, 4), (1536, 1152, 384, 3)]
 
+GATES = {"silu": F.silu, "gelu": lambda t: F.gelu(t, approximate="tanh")}
+
+CLAMP_LIMIT = 0.10
+GATE_CASES = [("silu", None), ("gelu", None), ("silu", CLAMP_LIMIT)]
+
+CLAMP_SNR_THRESHOLD = 8.0
+
 
 def _mlp_leaves(M, K, I, G, seed=42):
     """bf16 leaves for the fused MLP, which does its own quantisation.
@@ -59,14 +67,18 @@ def _mlp_leaves(M, K, I, G, seed=42):
     return offs, offs[1:] - offs[:-1], (x, w1, w2, probs)
 
 
-def _mlp_ref(x, w1, w2, probs, offs):
-    """Per-expert fc1, silu-gated and scaled by probs, then fc2 -- all in fp32."""
+def _mlp_ref(x, w1, w2, probs, offs, activation, clamp_limit=None):
+    """Per-expert fc1, gated and scaled by probs, then fc2 -- all in fp32."""
+    gate_fn = GATES[activation]
     outs = []
     for g in range(w1.shape[0]):
         lo, hi = int(offs[g]), int(offs[g + 1])
         l1 = x[lo:hi].float() @ w1[g].float().t()
         gate, up = torch.chunk(l1, 2, dim=-1)
-        act = F.silu(gate) * up * probs[lo:hi, None].float()
+        if clamp_limit is not None:
+            gate = gate.clamp(max=clamp_limit)
+            up = up.clamp(min=-clamp_limit, max=clamp_limit)
+        act = gate_fn(gate) * up * probs[lo:hi, None].float()
         outs.append(act @ w2[g].float().t())
     return torch.cat(outs, dim=0)
 
@@ -79,8 +91,9 @@ def _run(fn, leaves, cotangent):
     return out.detach(), [t.grad for t in args]
 
 
+@pytest.mark.parametrize("activation,clamp_limit", GATE_CASES)
 @pytest.mark.parametrize("shape", SHAPES)
-def test_grouped_mlp_fp4(shape):
+def test_grouped_mlp_fp4(shape, activation, clamp_limit):
     """The fused op against the same arithmetic done eagerly, expert by expert."""
     supported, reason = check_mxfp4_support()
     if not supported:
@@ -103,16 +116,21 @@ def test_grouped_mlp_fp4(shape):
             trans_w1=True,
             trans_w2=True,
             config=Float4QuantConfig(),
-            activation="silu",
+            activation=activation,
+            clamp_limit=clamp_limit,
         ),
         leaves,
         cotangent,
     )
-    ref, ref_grads = _run(lambda x, w1, w2, p: _mlp_ref(x, w1, w2, p, offs), leaves, cotangent)
+    ref, ref_grads = _run(
+        lambda x, w1, w2, p: _mlp_ref(x, w1, w2, p, offs, activation, clamp_limit), leaves, cotangent
+    )
+
+    grad_threshold = SNR_THRESHOLD if clamp_limit is None else CLAMP_SNR_THRESHOLD
 
     assert out.shape == (M, K)
     assert compute_snr(ref, out) > SNR_THRESHOLD, "out"
     for name, got, want in zip(("grad_x", "grad_w1", "grad_w2", "grad_probs"), grads, ref_grads):
         assert got is not None, f"{name} was not produced"
         assert got.shape == want.shape, name
-        assert compute_snr(want, got) > SNR_THRESHOLD, name
+        assert compute_snr(want, got) > grad_threshold, name

--- a/tests/pytorch/ops/test_grouped_mlp_fp8.py
+++ b/tests/pytorch/ops/test_grouped_mlp_fp8.py
@@ -6,10 +6,10 @@
 
 """Fused FP8 grouped MLP, driven through its public op.
 
-``grouped_mlp_fp8`` runs fc1 with the silu-gated activation fused into its
-epilogue and fc2 after it, which is only worth doing if it agrees with doing
-the pieces separately. So the op is driven end to end -- output and all four
-gradients -- against an eager per-expert reference computed in fp32.
+``grouped_mlp_fp8`` runs fc1 with the gated activation fused into its epilogue
+and fc2 after it, which is only worth doing if it agrees with doing the pieces
+separately. So the op is driven end to end -- output and all four gradients --
+against an eager per-expert fp32 reference, for every gate it takes.
 
 Two fp8 quantisations sit on that path, the input and the fc1 activation, and
 the backward adds its own. That is what puts the SNR floor here well below a
@@ -37,6 +37,13 @@ SNR_THRESHOLD = 20.0
 # split exercises a group whose last M-tile is clamped mid-tile.
 SHAPES = [(2048, 1024, 512, 4), (2048, 1024, 320, 4), (1536, 1152, 384, 3)]
 
+GATES = {"silu": F.silu, "gelu": lambda t: F.gelu(t, approximate="tanh")}
+
+CLAMP_LIMIT = 1.0
+GATE_CASES = [("silu", None), ("gelu", None), ("silu", CLAMP_LIMIT)]
+
+CLAMP_SNR_THRESHOLD = 12.0
+
 
 def _mlp_leaves(M, K, I, G, seed=42):
     """bf16 leaves for the fused MLP, which does its own quantisation.
@@ -54,13 +61,13 @@ def _mlp_leaves(M, K, I, G, seed=42):
         lens[1] += 17
     offs = torch.tensor([0] + torch.tensor(lens).cumsum(0).tolist(), device=dev, dtype=torch.int64)
     x = (torch.randn(M, K, device=dev, generator=gen) * 0.1).bfloat16()
-    w1 = (torch.randn(G, 2 * I, K, device=dev, generator=gen) * 0.02).bfloat16()
+    w1 = (torch.randn(G, 2 * I, K, device=dev, generator=gen) * 0.3).bfloat16()
     w2 = (torch.randn(G, K, I, device=dev, generator=gen) * 0.02).bfloat16()
     probs = torch.rand(M, device=dev, dtype=torch.float32, generator=gen) + 0.25
     return offs, offs[1:] - offs[:-1], (x, w1, w2, probs)
 
 
-def _fused_mlp(x, w1, w2, probs, group_lens):
+def _fused_mlp(x, w1, w2, probs, group_lens, activation, clamp_limit=None):
     return grouped_mlp_fp8(
         x,
         w1,
@@ -70,18 +77,23 @@ def _fused_mlp(x, w1, w2, probs, group_lens):
         trans_w1=True,
         trans_w2=True,
         config=Float8QuantConfig(),
-        activation="silu",
+        activation=activation,
+        clamp_limit=clamp_limit,
     )
 
 
-def _mlp_ref(x, w1, w2, probs, offs):
-    """Per-expert fc1, silu-gated and scaled by probs, then fc2 -- all in fp32."""
+def _mlp_ref(x, w1, w2, probs, offs, activation, clamp_limit=None):
+    """Per-expert fc1, gated and scaled by probs, then fc2 -- all in fp32."""
+    gate_fn = GATES[activation]
     outs = []
     for g in range(w1.shape[0]):
         lo, hi = int(offs[g]), int(offs[g + 1])
         l1 = x[lo:hi].float() @ w1[g].float().t()
         gate, up = torch.chunk(l1, 2, dim=-1)
-        act = F.silu(gate) * up * probs[lo:hi, None].float()
+        if clamp_limit is not None:
+            gate = gate.clamp(max=clamp_limit)
+            up = up.clamp(min=-clamp_limit, max=clamp_limit)
+        act = gate_fn(gate) * up * probs[lo:hi, None].float()
         outs.append(act @ w2[g].float().t())
     return torch.cat(outs, dim=0)
 
@@ -98,8 +110,9 @@ def _run(fn, leaves, cotangent):
     return out.detach(), [t.grad for t in args]
 
 
+@pytest.mark.parametrize("activation,clamp_limit", GATE_CASES)
 @pytest.mark.parametrize("shape", SHAPES)
-def test_grouped_mlp_fp8(shape):
+def test_grouped_mlp_fp8(shape, activation, clamp_limit):
     """The fused op against the same arithmetic done eagerly, expert by expert.
 
     Output and gradients in one pass: the gradients need the forward anyway, so
@@ -115,12 +128,20 @@ def test_grouped_mlp_fp8(shape):
     # like grad_probs from passing on symmetry alone.
     cotangent = torch.randn(M, K, device="cuda", generator=gen)
 
-    out, grads = _run(lambda x, w1, w2, p: _fused_mlp(x, w1, w2, p, group_lens), leaves, cotangent)
-    ref, ref_grads = _run(lambda x, w1, w2, p: _mlp_ref(x, w1, w2, p, offs), leaves, cotangent)
+    out, grads = _run(
+        lambda x, w1, w2, p: _fused_mlp(x, w1, w2, p, group_lens, activation, clamp_limit),
+        leaves,
+        cotangent,
+    )
+    ref, ref_grads = _run(
+        lambda x, w1, w2, p: _mlp_ref(x, w1, w2, p, offs, activation, clamp_limit), leaves, cotangent
+    )
+
+    grad_threshold = SNR_THRESHOLD if clamp_limit is None else CLAMP_SNR_THRESHOLD
 
     assert out.shape == (M, K)
     assert compute_snr(ref, out) > SNR_THRESHOLD, "out"
     for name, got, want in zip(("grad_x", "grad_w1", "grad_w2", "grad_probs"), grads, ref_grads):
         assert got is not None, f"{name} was not produced"
         assert got.shape == want.shape, name
-        assert compute_snr(want, got) > SNR_THRESHOLD, name
+        assert compute_snr(want, got) > grad_threshold, name


### PR DESCRIPTION
# Description

This PR extends the fused grouped-GEMM GLU epilogue beyond SwiGLU so the same fc1 / fc2-dgrad kernels can run GeGLU and clamped SwiGLU.

The previous fused path hard-coded `silu(gate) * up`. Models that use tanh-approximated GELU (GeGLU) or gpt-oss-style clamped SwiGLU (`silu(min(gate, L)) * clamp(up, -L, L)`) had to fall back to a separate activation. The epilogue now takes an `activation` (`"silu"` or `"gelu"`) and an optional `clamp_limit` (SiLU only), and the same helpers drive FP8 and MXFP4 FlyDSL kernels, the public `grouped_mlp_fp8` / `grouped_mlp_fp4` ops, and the standalone `*_with_probs` activations.

Default behavior is unchanged: `activation="silu"` with `clamp_limit=None` remains SwiGLU. Clamp backward is straight-through, matching `torch.clamp`.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Generalize the FlyDSL GLU epilogue in `gemm_epilogue_helper.py`: factor `_glu_act` / `_glu_act_grad` / `_glu_clamp` so forward and backward stores share one gate implementation for SiLU, tanh-GELU, and optional SiLU clamp.
- Thread `activation` and `clamp_limit` through the FP8 and MXFP4 grouped-GEMM GLU kernels and include them in the compile cache key.
- Expose the new gates on `grouped_mlp_fp8` and `grouped_mlp_fp4` (`"silu"` / `"gelu"`, plus `clamp_limit` for SiLU).
- Add `clamped_swiglu_with_probs` and plumb `clamp_limit` through the Triton SwiGLU kernels used by the standalone activation op.
- Extend `test_activation`, `test_grouped_mlp_fp8`, and `test_grouped_mlp_fp4` to cover GeGLU and clamped SwiGLU against eager references.

# Checklist:

- [x] The functionality is complete
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
