### PR TITLE
flydsl: tune dense FP8 tensorwise GEMM tile/geometry for gpt-oss-20b on MI355X

### DIFF
--- a/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
@@ -2149,7 +2149,7 @@ def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN
     n_main = (k_iters // phases) * phases
     tail = k_iters - n_main
     assert n_main >= phases, "the NT whole-loop needs a K of at least one main-loop pass"
-    n_spec = _nt4_spec_phases(k_iters, phases)
+    n_spec = _nt4_spec_phases(k_iters, phases, max(p.nbuf for p in pools) if carry else 1)
     pad = geom.pad
     ds_sep = f"\n{_TN4_ISSUE_PAD}\n" if "d" in pad else "\n"
     g2s_sep = f"\n{_TN4_ISSUE_PAD}\n" if "g" in pad else "\n"
@@ -2311,9 +2311,14 @@ def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN
     # accumulating, sparing the zero-init; the closing phase is peeled the other way and
     # handed back, its mfma the window an occ=1 epilogue has nowhere else to sink into.
     if tail:
+        # One more pass out of the loop body when the K-tail alone peels fewer closing phases
+        # than the deepest pool has buffers to hand on (_nt4_spec_phases).
+        xtra = phases if n_spec > tail - 1 else 0
         L += pass_block(True, False)
-        if n_main > phases:
-            L += loop_block(n_main - phases)
+        if n_main > phases + xtra:
+            L += loop_block(n_main - phases - xtra)
+        if xtra:
+            L += pass_block(False, False, n_spec)
         L += ["s_waitcnt vmcnt(0) lgkmcnt(0)", "s_barrier"]
         for j in range(tail - 1):
             L += phase_block(j, left=(tail - 1 - j) if carry else None)
@@ -2402,12 +2407,17 @@ def _nt4_prime(pools, pool_lds, g2s, bufs, K, b_kstep, tr_b):
                 )
 
 
-def _nt4_spec_phases(k_iters, phases):
+def _nt4_spec_phases(k_iters, phases, deep=1):
     """Closing phases the emitter can specialise, counted as ``left`` (phases still to run, the
     peel included). Everything before them sits in the shared main-loop body, which cannot carry
-    because it is entered once per pass."""
+    because it is entered once per pass. A K-tail shorter than the deepest pool would leave that
+    pool short of carry, so one more pass is unrolled out of the loop whenever K can spare it."""
     tail = k_iters % phases
-    return (tail - 1) if tail else (phases - 1)
+    if not tail:
+        return phases - 1
+    if tail < deep and k_iters - tail >= 2 * phases:
+        return tail - 1 + phases
+    return tail - 1
 
 
 def _nt4_carry_bufs(pools, carry, k_iters, phases):
@@ -2416,7 +2426,7 @@ def _nt4_carry_bufs(pools, carry, k_iters, phases):
     index alone, so any K aligns as long as the tile top primes whichever one is left over."""
     if not carry:
         return [[] for _ in pools]
-    spec = _nt4_spec_phases(k_iters, phases)
+    spec = _nt4_spec_phases(k_iters, phases, max(p.nbuf for p in pools))
     return [sorted((k_iters - 1 - l) % p.nbuf for l in range(1, min(p.nbuf, spec + 1))) for p in pools]
 
 
@@ -2726,7 +2736,7 @@ def _compile_dense_wave4(
     assert K_ITERS >= phases, "the dense whole loop needs a K of at least one main-loop pass"
     # The ring needs a closing phase outside the shared loop body to redirect, and a successor
     # to redirect into: a beta=1 tile loop runs once, and K_ITERS%phases==1 peels nothing.
-    carry = ring and tiles_per_wg > 1 and _nt4_spec_phases(K_ITERS, phases) >= 1
+    carry = ring and tiles_per_wg > 1 and _nt4_spec_phases(K_ITERS, phases, max(p.nbuf for p in _pools)) >= 1
     _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
 
     SharedStorage = fx.struct(

--- a/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
@@ -78,6 +78,8 @@ _CSTORE_AUX_BURST = 19
 # three macro tiles and four workgroup counts: 22.5 / 24.0 MiB cost +0.4 / +2.2%, while
 # 28.0 / 30.0 / 32.0 MiB win 1.2 / 2.0 / 4.7%. Per XCD the crossover is ~3.3 MiB of C against
 # an 8 MiB L2 slice, i.e. the point where the burst stops fitting beside the operand band.
+# The FlyDSL FP8 backend is gfx950-only, so this MI355X/L2-specific threshold cannot
+# leak onto GPUs with a different cache topology.
 _CSTORE_BURST_BYTES = 26 << 20
 _CSTORE_OUT_BYTES = 2  # both output dtypes are 16-bit; C's bytes per element
 
@@ -1801,12 +1803,6 @@ def _dense_tn_wave4_tile(
     row_q = bm_off + wave_m * fx.Int32(apool[0].tiles * 16)
     base_row = row_q if row_shift is None else row_q + row_shift
     # The staging scratch is borrowed from a buffer the body reads: retire those reads first.
-    # Both NT operands are K-contiguous, so a partial last K-block over-reads into the next
-    # row instead of past the SRD. Quantized weights cannot contain E4M3 NaN encodings, so
-    # zeroing A's out-of-range K columns is sufficient to drop the tail terms.
-    if k_tail:
-        na = sum(p.tiles for p in apool)
-        frg[:na] = mask_a_tail(frg[:na], lane_id, k_tail)
     if any(s.stages_lds for s in store_c.values()):
         _lds_barrier()
 
@@ -2096,7 +2092,6 @@ _NT4_W320 = _NT4_SQUARE._replace(
     # read-back live at once, which is 120 values here and spills; this keeps it to 24.
     store_split_flat=5,
 )
-_NT4_GEOMS = (_NT4_SQUARE, _NT4_M192, _NT4_W320)
 _NT4_ASM_CACHE: dict = {}
 _NT4_BAND = 64  # B rows one wave's four n-fragments span in a pool
 
@@ -2114,15 +2109,22 @@ def _nt4_intensity(geom):
     return (geom.bm + geom.bn) / (geom.bm * geom.bn)
 
 
-def _nt4_geoms(M, N, square_bands, rect_bands):
-    """Macro tiles the whole loop races for this shape, each with the bands it races. The
-    narrower tile trades arithmetic intensity for CU coverage, so it only joins where the
-    coverage it wakes outweighs the extra operand bytes it pulls."""
+def _nt4_geoms(M, N, beta_is_one, square_bands, rect_bands):
+    """Macro tiles eligible for the whole-loop autotune race. Main's N-narrow tile keeps
+    its coverage/intensity gate; the PR's tiles join only when they divide both extents, fit
+    within one CU pass, and shorten every workgroup's critical path versus the square tile."""
     geoms = [(_NT4_SQUARE, square_bands)]
     ncu = _dense_num_cus()
     coverage = _nt4_resident(M, N, _NT4_RECT, ncu) / _nt4_resident(M, N, _NT4_SQUARE, ncu)
     if N % _NT4_RECT.bn == 0 and coverage > _nt4_intensity(_NT4_RECT) / _nt4_intensity(_NT4_SQUARE):
         geoms.append((_NT4_RECT, rect_bands))
+    square_path = _nt4_wg_path(M, N, _NT4_SQUARE, beta_is_one, ncu)[1]
+    for geom in (_NT4_M192, _NT4_W320):
+        if M % geom.bm or N % geom.bn:
+            continue
+        wg, path = _nt4_wg_path(M, N, geom, beta_is_one, ncu)
+        if wg <= ncu and path < square_path:
+            geoms.append((geom, rect_bands))
     return geoms
 
 
@@ -2148,21 +2150,6 @@ def _nt4_wg_path(M, N, geom, beta_is_one, ncu):
     pools = _tn4_pools(geom)
     nacc = sum(p.tiles for p in pools if p.side == 0) * sum(p.tiles for p in pools if p.side == 1)
     return ceildiv(n_tile, tiles_per_wg), tiles_per_wg * nacc
-
-
-def _nt4_geom(M, N, beta_is_one):
-    """Macro tile for the shape: the square one, unless a smaller tile divides both extents
-    exactly, still fits the CUs in one pass, and leaves every workgroup a shorter path."""
-    ncu = _dense_num_cus()
-    best = _NT4_SQUARE
-    path = _nt4_wg_path(M, N, best, beta_is_one, ncu)[1]
-    for g in _NT4_GEOMS[1:]:
-        if M % g.bm or N % g.bn:  # a tile the shape pads gains nothing by being smaller
-            continue
-        wg, p = _nt4_wg_path(M, N, g, beta_is_one, ncu)
-        if wg <= ncu and p < path:
-            best, path = g, p
-    return best
 
 
 def _nt4_fold_gl_off(lane_id, wave_id, K, n_rounds, gq, fold):
@@ -2207,9 +2194,7 @@ def _tn4_mfma_order(geom, nt, nb, na, nacc, ap, bp, bcol, qoff, pools, bstep=0):
                         )
 
 
-def _dense_nt_wave4_asm(
-    geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN4_BLOCK_K, carry=False
-):
+def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN4_BLOCK_K, carry=False):
     """Bare-asm K body for one NT output tile; ``carry`` hands the closing fills to the next tile."""
     key = (geom, k_iters, cbsz, blgp, fold, tr_b, b_kstep, carry)
     if key in _NT4_ASM_CACHE:
@@ -2457,7 +2442,8 @@ def _nt4_raster(NBM, NBN, group_m, n_tile, n_wg, num_xcd, tr_b):
     if num_xcd <= 1 or n_wg % num_xcd:
         return 0
     slots = n_wg // num_xcd
-    if (group_m * NBN) % slots == 0:
+    super_row = group_m * NBN
+    if super_row % slots == 0 or slots % super_row == 0:
         return 0
     ok = [
         w
@@ -2728,9 +2714,7 @@ def _dense_nt_wave4_tile(
     ins += [fx.Int32(_nt4_buf_off(p, b, K, b_kstep, tr_b)) for i, p in enumerate(pools) for b in cbuf[i]]
     nacc = sum(p.tiles for p in apool) * sum(p.tiles for p in bpool)  # over the pools it reads
 
-    asm, cons, st, peel = _dense_nt_wave4_asm(
-        geom, K_ITERS, cbsz, blgp, fold, tr_b, b_kstep, carry
-    )
+    asm, cons, st, peel = _dense_nt_wave4_asm(geom, K_ITERS, cbsz, blgp, fold, tr_b, b_kstep, carry)
     r = _llvm.inline_asm(ir.Type.parse(st), [arith._to_raw(v) for v in ins], asm, cons, has_side_effects=True)
     acc_ty = ir.Type.parse("vector<4xf32>")
     res = [Vec(_llvm.extractvalue(acc_ty, r, [q])) for q in range_constexpr(nacc)]
@@ -2826,7 +2810,7 @@ def _compile_dense_wave4(
     group_n: int = 0,
     num_xcd: int = 8,
     raster: int = -1,  # aligned per-step XCD window, win_m block rows; -1 = pick, 0 = GROUP_M
-    geom=None,  # None = pick the macro tile the shape divides best, see _nt4_geom
+    geom=_NT4_SQUARE,
     cbsz: int = 0,  # srcA fp8 fmt: 0=E4M3, 1=E5M2
     blgp: int = 0,  # srcB fp8 fmt: 0=E4M3, 1=E5M2
     out_fp16: bool = False,
@@ -2836,11 +2820,9 @@ def _compile_dense_wave4(
     tr_b: bool = False,  # B is K-major (NN), so its side pays the transpose reader
     ring: bool = False,  # carry the pool fills across the tile boundary
 ):
-    """Whole-loop dense NT (``tr_b=False``) or NN over ``geom``'s macro tile: a resident
-    workgroup per CU walks a column of tiles. A partial last BLOCK_K block is fine: both
-    operands are K-contiguous, so its over-read lands in the next row rather than out of the
-    SRD, and the peel masks A's out-of-range K columns (see _dense_nt_wave4_tile)."""
-    geom = geom or _nt4_geom(M, N, beta_is_one)
+    """Whole-loop dense NT (``tr_b=False``) or NN over ``geom``'s macro tile. NT's
+    operands are K-contiguous, so it supports a partial final K block by masking A's tail.
+    NN keeps its exact-K dispatcher gate because its K-major B has different over-read bounds."""
     BM, BN = geom.bm, geom.bn
     NTHR = _tn4_nthr(geom)
     phases = _tn4_phases(geom)
@@ -3214,7 +3196,7 @@ def _autotune_nn_dispatch(
                     col_safe=N % geom.bn == 0,
                 ),
             )
-            for geom, bands in _nt4_geoms(M, N, _NN4_BANDS, _NN4_RECT_BANDS)
+            for geom, bands in _nt4_geoms(M, N, beta_is_one, _NN4_BANDS, _NN4_RECT_BANDS)
             for gm, gn, xcd in bands
         ]
     return _dense_race(_NN_AUTOTUNE_CACHE, key, args, "NN", builders, beta_is_one)
@@ -3291,7 +3273,7 @@ def _autotune_nt_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, beta_is
                     col_safe=N % geom.bn == 0,
                 ),
             )
-            for geom, bands in _nt4_geoms(M, N, _NT4_BANDS, _NT4_RECT_BANDS)
+            for geom, bands in _nt4_geoms(M, N, beta_is_one, _NT4_BANDS, _NT4_RECT_BANDS)
             for gm, xcd in bands
         ]
     return _dense_race(_NT_AUTOTUNE_CACHE, key, args, "NT", builders, beta_is_one)

--- a/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
@@ -72,6 +72,7 @@ from flydsl.expr.typing import Vector as Vec
 _CSTORE_AUX = 2
 
 _PICK_RAMP_ITERS = 200  # throwaway launches before timing: the leading candidate else pays the ramp
+_PICK_PASSES = 3  # reversed round trips over the candidates; one does not resolve the dense bands
 
 
 @functools.lru_cache(maxsize=256)
@@ -1790,6 +1791,12 @@ def _dense_tn_wave4_tile(
     row_q = bm_off + wave_m * fx.Int32(apool[0].tiles * 16)
     base_row = row_q if row_shift is None else row_q + row_shift
     # The staging scratch is borrowed from a buffer the body reads: retire those reads first.
+    # Both NT operands are K-contiguous, so a partial last K-block over-reads into the next
+    # row instead of past the SRD. Quantized weights cannot contain E4M3 NaN encodings, so
+    # zeroing A's out-of-range K columns is sufficient to drop the tail terms.
+    if k_tail:
+        na = sum(p.tiles for p in apool)
+        frg[:na] = mask_a_tail(frg[:na], lane_id, k_tail)
     if any(s.stages_lds for s in store_c.values()):
         _lds_barrier()
 
@@ -2142,7 +2149,7 @@ def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN
     n_main = (k_iters // phases) * phases
     tail = k_iters - n_main
     assert n_main >= phases, "the NT whole-loop needs a K of at least one main-loop pass"
-    assert not (carry and tail), "a carried ring needs the trip to end on a whole pass"
+    n_spec = _nt4_spec_phases(k_iters, phases)
     pad = geom.pad
     ds_sep = f"\n{_TN4_ISSUE_PAD}\n" if "d" in pad else "\n"
     g2s_sep = f"\n{_TN4_ISSUE_PAD}\n" if "g" in pad else "\n"
@@ -2178,8 +2185,8 @@ def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN
     i_rsrc_a, i_rsrc_b = take(1)[0], take(1)[0]
     i_rsrc2 = [take(1)[0], take(1)[0]] if carry else []
     i_soff0 = take(npool)
-    cbuf = _nt4_carry_bufs(pools, carry)
-    i_pfsoff = [take(len(b)) for b in cbuf]
+    cbuf = _nt4_carry_bufs(pools, carry, k_iters, phases)
+    i_pfsoff = [dict(zip(b, take(len(b)))) for b in cbuf]
     i_gl = [gl[_tn4_gl_key(p)] for p in pools]
     i_rsrc = [(i_rsrc_a, i_rsrc_b)[p.side] for p in pools]
     i_pfrsrc = [i_rsrc2[p.side] for p in pools] if carry else []
@@ -2207,13 +2214,14 @@ def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN
         return "0" if init else f"${q}"
 
     def carried(p, left):
-        # Past the last phase a fill would fetch a K-block nothing reads; a successor takes it.
-        return carry and pools[p].nbuf > left
+        # Past the last phase a fill would fetch a K-block nothing reads; a successor takes it,
+        # but only from a phase the emitter peeled out of the shared main-loop body.
+        return carry and left <= min(pools[p].nbuf - 1, n_spec)
 
     def emit_g2s(wbuf, left):
         order = [(p, st) for st in range(pools[0].steps) for p in ap]
         order += [(p, st) for p in bp for st in range(pools[p].steps)]
-        assert all(not carried(p, left) or wbuf[p] < len(i_pfsoff[p]) for p, _st in order), (
+        assert all(not carried(p, left) or wbuf[p] in i_pfsoff[p] for p, _st in order), (
             "a carried fill must aim at a buffer the next tile top leaves alone"
         )
         return [
@@ -2258,7 +2266,9 @@ def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN
     tailp = [i for i, p in enumerate(pools) if p.nbuf > 2]
     assert tailp == list(range(npool - len(tailp), npool)), "deep pools must be issued last"
     assert all(phases % p.nbuf == 0 for p in pools), "a pass must end on every pool's buf 0"
-    n_out = sum(pools[i].steps for i in tailp)
+    # The tile top primes buffer-major, so the prologue may leave outstanding exactly the fills
+    # aimed past buffer 1; everything phase 0 reads has to have landed by then.
+    n_out = sum(p.steps * sum(1 for b in t if b > 1) for p, t in zip(pools, _nt4_top_bufs(pools, cbuf)))
 
     def n_flight(lf):
         """Fills the phase drain may leave outstanding: the trailing run nothing later waits on."""
@@ -2306,7 +2316,7 @@ def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN
             L += loop_block(n_main - phases)
         L += ["s_waitcnt vmcnt(0) lgkmcnt(0)", "s_barrier"]
         for j in range(tail - 1):
-            L += phase_block(j)
+            L += phase_block(j, left=(tail - 1 - j) if carry else None)
     else:
         _tl = phases - 1 if carry else None
         L += pass_block(True, n_main == phases, _tl if n_main == phases else None)
@@ -2392,9 +2402,27 @@ def _nt4_prime(pools, pool_lds, g2s, bufs, K, b_kstep, tr_b):
                 )
 
 
-def _nt4_carry_bufs(pools, carry):
-    """Buffers the closing phases hand on: all but the last, whose K-block this trip still reads."""
-    return [list(range(p.nbuf - 1)) if carry else [] for p in pools]
+def _nt4_spec_phases(k_iters, phases):
+    """Closing phases the emitter can specialise, counted as ``left`` (phases still to run, the
+    peel included). Everything before them sits in the shared main-loop body, which cannot carry
+    because it is entered once per pass."""
+    tail = k_iters % phases
+    return (tail - 1) if tail else (phases - 1)
+
+
+def _nt4_carry_bufs(pools, carry, k_iters, phases):
+    """Buffers the closing phases hand on. A phase whose fill would fetch a K-block past this
+    tile's end writes the successor's buffer instead; which buffer that is follows from the phase
+    index alone, so any K aligns as long as the tile top primes whichever one is left over."""
+    if not carry:
+        return [[] for _ in pools]
+    spec = _nt4_spec_phases(k_iters, phases)
+    return [sorted((k_iters - 1 - l) % p.nbuf for l in range(1, min(p.nbuf, spec + 1))) for p in pools]
+
+
+def _nt4_top_bufs(pools, cbuf):
+    """Buffers the tile top primes itself: whatever the closing phases did not hand over."""
+    return [[b for b in range(p.nbuf) if b not in c] for p, c in zip(pools, cbuf)]
 
 
 def _nt4_line_extents(fold, col_safe, gtiles):
@@ -2423,6 +2451,8 @@ def _dense_nt_wave4_tile(
     N,
     K,
     K_ITERS,
+    k_tail,
+    lane_id,
     NBM,
     NBN,
     group_m,
@@ -2459,7 +2489,7 @@ def _dense_nt_wave4_tile(
     pool_lds = [getattr(lds, f"p{i}") for i in range(len(pools))]
     n_waves = _tn4_nthr(geom) // 64
     carry = d_next is not None
-    cbuf = _nt4_carry_bufs(pools, carry)
+    cbuf = _nt4_carry_bufs(pools, carry, K_ITERS, _tn4_phases(geom))
     wargs = (M, N, K, NBM, NBN, group_m, group_n, num_xcd, geom, tr_b)
     bm_off, bn_off, win = _nt4_tile_window(d, *wargs)
 
@@ -2494,6 +2524,10 @@ def _dense_nt_wave4_tile(
     line = _nt4_line_extents(fold, col_safe, gtiles)
 
     def _store(nfold):
+        if fold:
+            # A folded store carries one column mask per lane run, so every group extent
+            # must be an exact number of runs.
+            assert geom.bn % fold == 0 and (nfold * 16) % fold == 0 and (npg * bpool[0].width) % fold == 0
         cls = (
             StoreCPerTensorQuadN
             if fold
@@ -2527,7 +2561,7 @@ def _dense_nt_wave4_tile(
 
     g2s = _nt4_g2s(A, B, win, pools, gl_off, wave_id)
     _lds_barrier()
-    top = [[p.nbuf - 1] if carry else list(range(p.nbuf)) for p in pools]
+    top = _nt4_top_bufs(pools, cbuf)
     _nt4_prime(pools, pool_lds, g2s, top, K, b_kstep, tr_b)
     wait_barrier(sum(p.steps * sum(1 for b in t if b) for p, t in zip(pools, top)))
 
@@ -2573,6 +2607,12 @@ def _dense_nt_wave4_tile(
     frag_ty = ir.Type.parse("vector<8xi32>")
     n_frag = sum(p.tiles for p in apool + bpool)
     frg = [Vec(_llvm.extractvalue(frag_ty, r, [nacc + f])) for f in range_constexpr(n_frag)]
+    # Both NT operands are K-contiguous, so a partial last K-block over-reads into the next
+    # row instead of past the SRD. Quantized weights cannot contain E4M3 NaN encodings, so
+    # zeroing A's out-of-range K columns is sufficient to drop the tail terms.
+    if k_tail:
+        na = sum(p.tiles for p in apool)
+        frg[:na] = mask_a_tail(frg[:na], lane_id, k_tail)
     if any(s.stages_lds for s in store_c.values()):
         _lds_barrier()
 
@@ -2661,15 +2701,18 @@ def _compile_dense_wave4(
     ring: bool = False,  # carry the pool fills across the tile boundary
 ):
     """Whole-loop dense NT (``tr_b=False``) or NN over ``geom``'s macro tile: a resident
-    workgroup per CU walks a column of tiles. K must be whole BLOCK_K blocks -- a partial one
-    would need the read-ahead to mask, and the 8-wave kernel carries the native K-tail."""
+    workgroup per CU walks a column of tiles. A partial last BLOCK_K block is fine: both
+    operands are K-contiguous, so its over-read lands in the next row rather than out of the
+    SRD, and the peel masks A's out-of-range K columns (see _dense_nt_wave4_tile)."""
     BM, BN = geom.bm, geom.bn
     NTHR = _tn4_nthr(geom)
     phases = _tn4_phases(geom)
     # The whole-line epilogue interleaves the n-fragments by permuting B's global row order,
-    # which a K-major B cannot be given; the fold must also divide the wave's n-extent.
+    # which a K-major B cannot be given; the fold must also divide the wave's n-extent. A
+    # ragged column window is fine as long as N is a whole number of runs: the folded store
+    # then masks per run, and the dropped runs' operands were never in range to begin with.
     _bt = sum(p.tiles for p in _tn4_pools(geom) if p.side == geom.gl_side)
-    fold = 0 if tr_b else (geom.fold if col_safe and _bt % geom.fold == 0 else 0)
+    fold = 0 if tr_b else (geom.fold if N % geom.fold == 0 and _bt % geom.fold == 0 else 0)
     _pools = _nt4_pools(geom, fold)
     NBM, NBN = ceildiv(M, BM), ceildiv(N, BN)
     n_tile = NBM * NBN
@@ -2678,10 +2721,12 @@ def _compile_dense_wave4(
     # in twice, so beta=1 gives up residency and takes one tile per group.
     tiles_per_wg = 1 if beta_is_one else ceildiv(n_tile, min(n_tile, _dense_num_cus()))
     n_wg = ceildiv(n_tile, tiles_per_wg)
-    K_ITERS = K // _TN4_BLOCK_K
-    assert K % _TN4_BLOCK_K == 0, "the dense whole loop has no K-tail path"
+    K_ITERS = ceildiv(K, _TN4_BLOCK_K)
+    K_TAIL = K % _TN4_BLOCK_K
     assert K_ITERS >= phases, "the dense whole loop needs a K of at least one main-loop pass"
-    carry = ring and K_ITERS % phases == 0
+    # The ring needs a closing phase outside the shared loop body to redirect, and a successor
+    # to redirect into: a beta=1 tile loop runs once, and K_ITERS%phases==1 peels nothing.
+    carry = ring and tiles_per_wg > 1 and _nt4_spec_phases(K_ITERS, phases) >= 1
     _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
 
     SharedStorage = fx.struct(
@@ -2725,6 +2770,8 @@ def _compile_dense_wave4(
             N=N,
             K=K,
             K_ITERS=K_ITERS,
+            k_tail=K_TAIL,
+            lane_id=lane_id,
             NBM=NBM,
             NBN=NBN,
             group_m=group_m,
@@ -2757,7 +2804,7 @@ def _compile_dense_wave4(
                 _pools,
                 [getattr(lds, f"p{i}") for i in range(len(_pools))],
                 _nt4_g2s(A, B, w0[2], _pools, gl_off, wave_id),
-                _nt4_carry_bufs(_pools, True),
+                _nt4_carry_bufs(_pools, True, K_ITERS, phases),
                 K,
                 _TN4_BLOCK_K * N if tr_b else _TN4_BLOCK_K,
                 tr_b,
@@ -2898,16 +2945,18 @@ def _dense_race(cache, key, args, layout, builders, beta_is_one):
 
 
 def _pick_dense_candidate(cands, args):
-    """Fastest of ``cands`` = [[launch, cfg, compiled, factory], ...], sampled twice with the second
-    pass reversed and kept at its min, behind a throwaway pass: the leading candidates sit
-    closer than one sample's spread, so otherwise clock drift and warm-up do the ranking."""
+    """Fastest of ``cands`` = [[launch, cfg, compiled, factory], ...], sampled over reversed
+    passes and kept at its min, behind a throwaway pass: the leading candidates sit closer than
+    one sample's spread, so otherwise clock drift and warm-up do the ranking. One round trip of
+    a two-sample median does not resolve them -- it re-picked a different band on half the dense
+    shapes from run to run, which costs more than the bands are apart."""
     for _ in range(_PICK_RAMP_ITERS):
         cands[0][2](*args)
     torch.cuda.synchronize()
     order = list(range(len(cands)))
     ts = [float("inf")] * len(cands)
-    for i in order + order[::-1]:
-        ts[i] = min(ts[i], _robust_time(cands[i][2], args, warmup=2, reps=2, iters=40))
+    for i in (order + order[::-1]) * _PICK_PASSES:
+        ts[i] = min(ts[i], _robust_time(cands[i][2], args, warmup=2, reps=3, iters=40))
     return cands[min(order, key=ts.__getitem__)]
 
 
@@ -3048,7 +3097,7 @@ def _autotune_nt_dispatch(args, M, N, K, cbsz=0, blgp=0, out_fp16=False, beta_is
     if hit is not None:
         return hit
     pair_n, col_safe = N % 2 == 0 and not out_fp16, N % 256 == 0
-    w4 = K % _TN4_BLOCK_K == 0 and K // _TN4_BLOCK_K >= _NT4_MIN_K_ITERS
+    w4 = ceildiv(K, _TN4_BLOCK_K) >= _NT4_MIN_K_ITERS
     wide = 4 * 256 * K > _NT_BAND_L2_BYTES  # GROUP_M * BLOCK_M * K of the leading cfg
     builders = [
         (

--- a/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
@@ -47,6 +47,7 @@ from primus_turbo.flydsl.utils.gemm_helper import (
     StoreCPerTensorQuadN,
     wait_barrier,
     xcd_remap_pid,
+    xcd_window_mn,
     XPOSE_SLOT,
     XPOSE_SLOTS,
 )
@@ -2032,7 +2033,10 @@ _NT4_SQUARE = _Tn4Geom(
     256,
     256,
     ((0, 128, 2), (0, 128, 2), (1, 128, 3), (1, 128, 3)),
-    0,
+    # One whole accumulator block per issue step, so each srcA fragment feeds every column it
+    # ever reaches before the next one is read; on NT's plain reads that beats the diagonal.
+    8,
+    mstep=4,
     drain_lgkm=6,  # NT's plain reads leave fewer in flight than the transpose path's
 )
 # Narrower N edge for tile counts between whole CU passes; 128+64 is the widest LDS-legal cut.
@@ -2042,6 +2046,7 @@ _NT4_RECT = _Tn4Geom(
     ((0, 128, 2), (0, 128, 2), (1, 128, 3), (1, 64, 3)),
     0,
     bstep_tr=6,  # this tile's phase leaves the diagonal too little to spread a refill over
+    mstep=2,
     drain_lgkm=6,
 )
 _NT4_ASM_CACHE: dict = {}
@@ -2128,7 +2133,9 @@ def _tn4_mfma_order(geom, nt, nb, na, nacc, ap, bp, bcol, qoff, pools, bstep=0):
                         )
 
 
-def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN4_BLOCK_K, carry=False):
+def _dense_nt_wave4_asm(
+    geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN4_BLOCK_K, carry=False
+):
     """Bare-asm K body for one NT output tile; ``carry`` hands the closing fills to the next tile."""
     key = (geom, k_iters, cbsz, blgp, fold, tr_b, b_kstep, carry)
     if key in _NT4_ASM_CACHE:
@@ -2319,7 +2326,10 @@ def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN
             L += loop_block(n_main - phases - xtra)
         if xtra:
             L += pass_block(False, False, n_spec)
-        L += ["s_waitcnt vmcnt(0) lgkmcnt(0)", "s_barrier"]
+        # Entry to the closing phases. The pass that just ran already ended on the graded drain
+        # and barrier the main loop's back edge relies on, so grade this rendezvous the same way
+        # the phases do rather than draining the fill pipeline that is feeding the next tile.
+        L += [f"s_waitcnt vmcnt({n_flight(tail - 1 if carry else k_iters)}) lgkmcnt(0)", "s_barrier"]
         for j in range(tail - 1):
             L += phase_block(j, left=(tail - 1 - j) if carry else None)
     else:
@@ -2353,10 +2363,44 @@ def _dense_nt_wave4_asm(geom, k_iters, cbsz, blgp, fold, tr_b=False, b_kstep=_TN
     return _NT4_ASM_CACHE[key]
 
 
-def _nt4_tile_window(d, M, N, K, NBM, NBN, group_m, group_n, num_xcd, geom, tr_b):
+def _nt4_window_ok(raster, NBM, NBN, n_tile, n_wg, num_xcd, tr_b):
+    """Whether ``xcd_window_mn``'s aligned per-step rectangle tiles this grid."""
+    if raster <= 0 or tr_b or num_xcd <= 1 or n_tile % n_wg or n_wg % num_xcd or NBM % num_xcd:
+        return False
+    slots = n_wg // num_xcd
+    return not (slots % raster or (NBM // num_xcd) % raster or NBN % (slots // raster))
+
+
+def _nt4_raster(NBM, NBN, group_m, n_tile, n_wg, num_xcd, tr_b):
+    """Pick the aligned window, or 0 to keep the GROUP_M raster.
+
+    A super-row is ``group_m*NBN`` tiles and an XCD takes ``slots`` of them per step, so the step
+    straddles two super-rows unless one divides the other; a straddling step pulls two half-width
+    windows into the XCD's L2 instead of one whole one. Where the super-row already divides
+    evenly there is nothing to fix, and the emitted mapping stays bit-identical. Otherwise take
+    the squarest legal rectangle -- a step reads ``win_m + slots/win_m`` operand slabs, and a
+    rectangle far out of square measured worse than the ragged window it replaces."""
+    if num_xcd <= 1 or n_wg % num_xcd:
+        return 0
+    slots = n_wg // num_xcd
+    if (group_m * NBN) % slots == 0:
+        return 0
+    ok = [
+        w
+        for w in range(1, slots + 1)
+        if max(w, slots // w) <= 2 * min(w, slots // w)
+        and _nt4_window_ok(w, NBM, NBN, n_tile, n_wg, num_xcd, tr_b)
+    ]
+    return min(ok, key=lambda w: (w + slots // w, w), default=0)
+
+
+def _nt4_tile_window(d, M, N, K, NBM, NBN, group_m, group_n, num_xcd, geom, tr_b, raster=0, n_wg=0):
     """One dispatch id's operand windows, num_records bounded so read-ahead past the tile drops."""
-    pid = xcd_remap_pid(d, NBM * NBN, num_xcd)
-    block_m, block_n = block_mn(pid, fx.Int32(NBM), fx.Int32(NBN), group_m, group_n)
+    if raster:
+        block_m, block_n = xcd_window_mn(d, n_wg, NBM, NBN, num_xcd, raster)
+    else:
+        pid = xcd_remap_pid(d, NBM * NBN, num_xcd)
+        block_m, block_n = block_mn(pid, fx.Int32(NBM), fx.Int32(NBN), group_m, group_n)
     bm_off = _readfirstlane_i32(block_m) * fx.Int32(geom.bm)
     bn_off = _readfirstlane_i32(block_n) * fx.Int32(geom.bn)
     a_base = arith.index_cast(T.index, bm_off) * arith.index(K)
@@ -2468,6 +2512,8 @@ def _dense_nt_wave4_tile(
     group_m,
     group_n,
     num_xcd,
+    raster,
+    n_wg,
     store_aux,
     lds,
     geom,
@@ -2500,7 +2546,7 @@ def _dense_nt_wave4_tile(
     n_waves = _tn4_nthr(geom) // 64
     carry = d_next is not None
     cbuf = _nt4_carry_bufs(pools, carry, K_ITERS, _tn4_phases(geom))
-    wargs = (M, N, K, NBM, NBN, group_m, group_n, num_xcd, geom, tr_b)
+    wargs = (M, N, K, NBM, NBN, group_m, group_n, num_xcd, geom, tr_b, raster, n_wg)
     bm_off, bn_off, win = _nt4_tile_window(d, *wargs)
 
     s2r = {}
@@ -2560,8 +2606,9 @@ def _dense_nt_wave4_tile(
             col_safe=col_safe,
             store_aux=store_aux,
             beta_is_one=beta_is_one,
+            scale=scale,
             **(
-                {"lds_xpose": _nt4_xpose_lds(pools[0], pool_lds[0], wave_id, n_waves), "scale": scale}
+                {"lds_xpose": _nt4_xpose_lds(pools[0], pool_lds[0], wave_id, n_waves)}
                 if nfold in line
                 else {}
             ),
@@ -2607,7 +2654,9 @@ def _dense_nt_wave4_tile(
     ins += [fx.Int32(_nt4_buf_off(p, b, K, b_kstep, tr_b)) for i, p in enumerate(pools) for b in cbuf[i]]
     nacc = sum(p.tiles for p in apool) * sum(p.tiles for p in bpool)  # over the pools it reads
 
-    asm, cons, st, peel = _dense_nt_wave4_asm(geom, K_ITERS, cbsz, blgp, fold, tr_b, b_kstep, carry)
+    asm, cons, st, peel = _dense_nt_wave4_asm(
+        geom, K_ITERS, cbsz, blgp, fold, tr_b, b_kstep, carry
+    )
     r = _llvm.inline_asm(ir.Type.parse(st), [arith._to_raw(v) for v in ins], asm, cons, has_side_effects=True)
     acc_ty = ir.Type.parse("vector<4xf32>")
     res = [Vec(_llvm.extractvalue(acc_ty, r, [q])) for q in range_constexpr(nacc)]
@@ -2681,6 +2730,8 @@ def _dense_nt_wave4_tile(
             for m in ahead:  # a group wider than the slots the unit offered
                 emit_mfma(m)
     else:
+        # A store reads accumulators the peel's mfma have just written, so it trails by one
+        # group; the barrier keeps the next group's mfma from clobbering them first.
         for i in range_constexpr(len(unit)):
             for m in grp[i]:
                 emit_mfma(m)
@@ -2700,6 +2751,7 @@ def _compile_dense_wave4(
     group_m: int = 4,
     group_n: int = 0,
     num_xcd: int = 8,
+    raster: int = -1,  # aligned per-step XCD window, win_m block rows; -1 = pick, 0 = GROUP_M
     geom=_NT4_SQUARE,
     cbsz: int = 0,  # srcA fp8 fmt: 0=E4M3, 1=E5M2
     blgp: int = 0,  # srcB fp8 fmt: 0=E4M3, 1=E5M2
@@ -2737,6 +2789,13 @@ def _compile_dense_wave4(
     # The ring needs a closing phase outside the shared loop body to redirect, and a successor
     # to redirect into: a beta=1 tile loop runs once, and K_ITERS%phases==1 peels nothing.
     carry = ring and tiles_per_wg > 1 and _nt4_spec_phases(K_ITERS, phases, max(p.nbuf for p in _pools)) >= 1
+    # The aligned per-step window needs the tile loop to be a clean grid walk and the rectangle to
+    # tile both axes; anything else keeps the GROUP_M raster. Plain-B only, as the transposed-B
+    # body reads its column block through a different global swizzle.
+    if raster < 0:
+        raster = _nt4_raster(NBM, NBN, group_m, n_tile, n_wg, num_xcd, tr_b)
+    elif not _nt4_window_ok(raster, NBM, NBN, n_tile, n_wg, num_xcd, tr_b):
+        raster = 0
     _out_ty = fx.Float16 if out_fp16 else fx.BFloat16
 
     SharedStorage = fx.struct(
@@ -2787,6 +2846,8 @@ def _compile_dense_wave4(
             group_m=group_m,
             group_n=group_n,
             num_xcd=num_xcd,
+            raster=raster,
+            n_wg=n_wg,
             store_aux=_CSTORE_AUX,
             lds=lds,
             geom=geom,
@@ -2808,8 +2869,17 @@ def _compile_dense_wave4(
             tr_b=tr_b,
         )
 
+        # The output scale is loop-invariant, and it is a global load: emitted inside the tile
+        # loop its first use pins an s_waitcnt vmcnt(0) into every epilogue, which drains the
+        # fills the closing phases just issued for the next tile. Load it ahead of the prime so
+        # its own wait has nothing else in flight. Only on the plain-B path: the transposed-B
+        # body has no register headroom to keep the value live across the tile loop.
+        scale = None if tr_b else load_per_tensor_scale(A_scale, B_scale)
+
         if const_expr(carry):
-            w0 = _nt4_tile_window(fx.block_idx.x, M, N, K, NBM, NBN, group_m, group_n, num_xcd, geom, tr_b)
+            w0 = _nt4_tile_window(
+                fx.block_idx.x, M, N, K, NBM, NBN, group_m, group_n, num_xcd, geom, tr_b, raster, n_wg
+            )
             _nt4_prime(
                 _pools,
                 [getattr(lds, f"p{i}") for i in range(len(_pools))],
@@ -2819,8 +2889,6 @@ def _compile_dense_wave4(
                 _TN4_BLOCK_K * N if tr_b else _TN4_BLOCK_K,
                 tr_b,
             )
-
-        scale = load_per_tensor_scale(A_scale, B_scale) if carry else None
 
         for t in range(fx.Int32(0), fx.Int32(tiles_per_wg), fx.Int32(1)):
             d = fx.block_idx.x + t * n_wg

--- a/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
@@ -74,7 +74,12 @@ _CSTORE_AUX = 2
 # `sc0|sc1|nt`: device scope on top, for an epilogue every workgroup reaches at the same
 # instant. Only pays when the burst is actually contended -- see _cstore_aux.
 _CSTORE_AUX_BURST = 19
-_CSTORE_BURST_FILL = (7, 8)  # least CU fill, as a fraction, at which the wide scope wins
+# C bytes in one device-wide beta=1 burst at or above which the wide scope wins. Measured over
+# three macro tiles and four workgroup counts: 22.5 / 24.0 MiB cost +0.4 / +2.2%, while
+# 28.0 / 30.0 / 32.0 MiB win 1.2 / 2.0 / 4.7%. Per XCD the crossover is ~3.3 MiB of C against
+# an 8 MiB L2 slice, i.e. the point where the burst stops fitting beside the operand band.
+_CSTORE_BURST_BYTES = 26 << 20
+_CSTORE_OUT_BYTES = 2  # both output dtypes are 16-bit; C's bytes per element
 
 _PICK_RAMP_ITERS = 200  # throwaway launches before timing: the leading candidate else pays the ramp
 _PICK_PASSES = 3  # reversed round trips over the candidates; one does not resolve the dense bands
@@ -1878,13 +1883,14 @@ def _dense_num_cus():
     return _NUM_CUS
 
 
-def _cstore_aux(beta_is_one, tiles_per_wg, n_wg):
+def _cstore_aux(beta_is_one, tiles_per_wg, n_wg, tile_bytes):
     """C store cache policy. One tile per workgroup lands every epilogue in the same instant, so
     a beta=1 tile's read-modify-write arrives device-wide as one burst with no successor tile to
-    hide it behind; past ~7/8 CU fill that burst outruns the near cache and the wider store scope
-    measures faster. Below it the idle CUs absorb the burst and the longer path only costs."""
-    num, den = _CSTORE_BURST_FILL
-    if beta_is_one and tiles_per_wg == 1 and n_wg * den >= _dense_num_cus() * num:
+    hide it behind. Once that burst outgrows the L2 it outruns the near cache and the wider store
+    scope measures faster; below it the cache absorbs the burst and the longer path only costs.
+    The predicate is the burst's bytes, not the CU fill: two 240-workgroup beta=1 shapes land on
+    opposite sides of it because their macro tiles carry different amounts of C."""
+    if beta_is_one and tiles_per_wg == 1 and n_wg * tile_bytes >= _CSTORE_BURST_BYTES:
         return _CSTORE_AUX_BURST
     return _CSTORE_AUX
 
@@ -2073,7 +2079,24 @@ _NT4_M192 = _NT4_SQUARE._replace(
     pools=((0, 96, 2), (0, 96, 2), (1, 128, 3), (1, 128, 3)),
     mstep=3,  # still one whole accumulator block per issue step, as above: mstep == nt
 )
-_NT4_GEOMS = (_NT4_SQUARE, _NT4_M192)
+# The same on both axes at once, for a shape neither extent divides: 5120 rows are 16 of
+# these and 2880 columns 15, against 20 and 11.25 of the square's. The workgroup count is
+# unchanged, so the shorter path (64 accumulators to 60) comes off every one of them rather
+# than idling some, and bm+bn is still 512 so a K block moves the same operand bytes. Six
+# n-fragments do not divide the epilogue's fold, so the store is the paired one; no tile
+# that divides 2880 can avoid that, since a fold of four needs a B group of 128 columns and
+# 2880 has no divisor that is a multiple of 128.
+_NT4_W320 = _NT4_SQUARE._replace(
+    bm=320,
+    bn=192,
+    pools=((0, 160, 2), (0, 160, 2), (1, 192, 3)),
+    bstep=6,
+    mstep=5,  # still one whole accumulator block per issue step, as above: mstep == nt
+    # One store unit per fragment row. A coarser split holds a whole quadrant's beta=1
+    # read-back live at once, which is 120 values here and spills; this keeps it to 24.
+    store_split_flat=5,
+)
+_NT4_GEOMS = (_NT4_SQUARE, _NT4_M192, _NT4_W320)
 _NT4_ASM_CACHE: dict = {}
 _NT4_BAND = 64  # B rows one wave's four n-fragments span in a pool
 
@@ -2900,7 +2923,7 @@ def _compile_dense_wave4(
             num_xcd=num_xcd,
             raster=raster,
             n_wg=n_wg,
-            store_aux=_cstore_aux(beta_is_one, tiles_per_wg, n_wg),
+            store_aux=_cstore_aux(beta_is_one, tiles_per_wg, n_wg, BM * BN * _CSTORE_OUT_BYTES),
             lds=lds,
             geom=geom,
             A=A,

--- a/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
+++ b/primus_turbo/flydsl/gemm/gemm_fp8_kernel.py
@@ -71,6 +71,10 @@ from flydsl.expr.typing import Vector as Vec
 
 # `nt` aux bit: C is write-once, so caching it evicts the A/B band the L2 swizzle keeps.
 _CSTORE_AUX = 2
+# `sc0|sc1|nt`: device scope on top, for an epilogue every workgroup reaches at the same
+# instant. Only pays when the burst is actually contended -- see _cstore_aux.
+_CSTORE_AUX_BURST = 19
+_CSTORE_BURST_FILL = (7, 8)  # least CU fill, as a fraction, at which the wide scope wins
 
 _PICK_RAMP_ITERS = 200  # throwaway launches before timing: the leading candidate else pays the ramp
 _PICK_PASSES = 3  # reversed round trips over the candidates; one does not resolve the dense bands
@@ -1874,6 +1878,17 @@ def _dense_num_cus():
     return _NUM_CUS
 
 
+def _cstore_aux(beta_is_one, tiles_per_wg, n_wg):
+    """C store cache policy. One tile per workgroup lands every epilogue in the same instant, so
+    a beta=1 tile's read-modify-write arrives device-wide as one burst with no successor tile to
+    hide it behind; past ~7/8 CU fill that burst outruns the near cache and the wider store scope
+    measures faster. Below it the idle CUs absorb the burst and the longer path only costs."""
+    num, den = _CSTORE_BURST_FILL
+    if beta_is_one and tiles_per_wg == 1 and n_wg * den >= _dense_num_cus() * num:
+        return _CSTORE_AUX_BURST
+    return _CSTORE_AUX
+
+
 def _compile_dense_tn_wave4(
     M: int,
     N: int,
@@ -2049,6 +2064,16 @@ _NT4_RECT = _Tn4Geom(
     mstep=2,
     drain_lgkm=6,
 )
+# A block the extent does not divide still issues its dead quadrants' mfma: only the operand
+# fetches and the stores are dropped, by the num_records clamp. So an extent with a smaller
+# exact tile is better served by it, and the freed work shortens every workgroup's own path
+# rather than idling some -- 2880 rows are 15 of these against 11.25 of the square's.
+_NT4_M192 = _NT4_SQUARE._replace(
+    bm=192,
+    pools=((0, 96, 2), (0, 96, 2), (1, 128, 3), (1, 128, 3)),
+    mstep=3,  # still one whole accumulator block per issue step, as above: mstep == nt
+)
+_NT4_GEOMS = (_NT4_SQUARE, _NT4_M192)
 _NT4_ASM_CACHE: dict = {}
 _NT4_BAND = 64  # B rows one wave's four n-fragments span in a pool
 
@@ -2089,6 +2114,32 @@ def _nt4_pools(geom, fold):
         p.gq = i % npg
         p.gcol = p.col - p.gq * p.width
     return pools
+
+
+def _nt4_wg_path(M, N, geom, beta_is_one, ncu):
+    """(workgroups, mfma a workgroup issues per K block) of the whole loop over ``geom``. The
+    second is the critical path every workgroup walks, which is what the wall follows: freeing
+    work on only some of them returns about half as much (the idle CUs come back as clock)."""
+    n_tile = ceildiv(M, geom.bm) * ceildiv(N, geom.bn)
+    tiles_per_wg = 1 if beta_is_one else ceildiv(n_tile, min(n_tile, ncu))
+    pools = _tn4_pools(geom)
+    nacc = sum(p.tiles for p in pools if p.side == 0) * sum(p.tiles for p in pools if p.side == 1)
+    return ceildiv(n_tile, tiles_per_wg), tiles_per_wg * nacc
+
+
+def _nt4_geom(M, N, beta_is_one):
+    """Macro tile for the shape: the square one, unless a smaller tile divides both extents
+    exactly, still fits the CUs in one pass, and leaves every workgroup a shorter path."""
+    ncu = _dense_num_cus()
+    best = _NT4_SQUARE
+    path = _nt4_wg_path(M, N, best, beta_is_one, ncu)[1]
+    for g in _NT4_GEOMS[1:]:
+        if M % g.bm or N % g.bn:  # a tile the shape pads gains nothing by being smaller
+            continue
+        wg, p = _nt4_wg_path(M, N, g, beta_is_one, ncu)
+        if wg <= ncu and p < path:
+            best, path = g, p
+    return best
 
 
 def _nt4_fold_gl_off(lane_id, wave_id, K, n_rounds, gq, fold):
@@ -2752,7 +2803,7 @@ def _compile_dense_wave4(
     group_n: int = 0,
     num_xcd: int = 8,
     raster: int = -1,  # aligned per-step XCD window, win_m block rows; -1 = pick, 0 = GROUP_M
-    geom=_NT4_SQUARE,
+    geom=None,  # None = pick the macro tile the shape divides best, see _nt4_geom
     cbsz: int = 0,  # srcA fp8 fmt: 0=E4M3, 1=E5M2
     blgp: int = 0,  # srcB fp8 fmt: 0=E4M3, 1=E5M2
     out_fp16: bool = False,
@@ -2766,6 +2817,7 @@ def _compile_dense_wave4(
     workgroup per CU walks a column of tiles. A partial last BLOCK_K block is fine: both
     operands are K-contiguous, so its over-read lands in the next row rather than out of the
     SRD, and the peel masks A's out-of-range K columns (see _dense_nt_wave4_tile)."""
+    geom = geom or _nt4_geom(M, N, beta_is_one)
     BM, BN = geom.bm, geom.bn
     NTHR = _tn4_nthr(geom)
     phases = _tn4_phases(geom)
@@ -2848,7 +2900,7 @@ def _compile_dense_wave4(
             num_xcd=num_xcd,
             raster=raster,
             n_wg=n_wg,
-            store_aux=_CSTORE_AUX,
+            store_aux=_cstore_aux(beta_is_one, tiles_per_wg, n_wg),
             lds=lds,
             geom=geom,
             A=A,

--- a/primus_turbo/flydsl/utils/gemm_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_helper.py
@@ -719,6 +719,7 @@ class StoreCPerTensor:
         rd_base=None,
         rd_rows=None,
         rd_shift=None,
+        scale=None,
     ):
         self.beta_is_one = beta_is_one
         self.c_rows = c_rows
@@ -747,8 +748,13 @@ class StoreCPerTensor:
         # Optional f32->f32 epilogue node chain (bias/act), post-scale pre-cast.
         self.elem_fn = elem_fn
         self.scaled = A_scale is not None
+        # a_scale*b_scale is loop-invariant, so a caller that emits this store inside a tile
+        # loop should hoist the load and pass the value: the load is what forces a full
+        # s_waitcnt vmcnt(0) at the first use, and inside a loop that drains every fill the
+        # previous phases issued for the next tile.
+        self._scale_pre = scale
         self.c_base = _buffer_ops.extract_base_index(C) if c_base is None else c_base  # byte base address
-        if self.scaled:
+        if self.scaled and scale is None:
             gSA = fx.rocdl.make_buffer_tensor(A_scale, max_size=False, num_records_bytes=4)  # 1 fp32
             gSB = fx.rocdl.make_buffer_tensor(B_scale, max_size=False, num_records_bytes=4)  # 1 fp32
             self.sa_div = fx.logical_divide(gSA, fx.make_layout(1, 1))
@@ -762,11 +768,14 @@ class StoreCPerTensor:
         return Vec(fx.memref_load_vec(self.reg_f32_1))[0]
 
     def _scale(self):
-        """a_scale*b_scale, loaded once per emitting block so the quadrant stores share one
+        """a_scale*b_scale. A value the caller hoisted out of its tile loop is used as is;
+        otherwise it is loaded once per emitting block so the quadrant stores share one
         instance instead of re-issuing both scalar loads. Cached per MLIR block: sibling regions
         each get their own load, since a value in one does not dominate a use in another."""
         if not self.scaled:
             return None
+        if self._scale_pre is not None:
+            return self._scale_pre
         blk = ir.InsertionPoint.current.block
         if self._scale_v is None or self._scale_v[0] != blk:
             self._scale_v = (blk, self._load_scalar(self.sa_div) * self._load_scalar(self.sb_div))
@@ -1047,14 +1056,13 @@ class StoreCPerTensorLineN(StoreCPerTensorPairN):
 
     stages_lds = True
 
-    def __init__(self, *args, lds_xpose, scale, **kwargs):
+    def __init__(self, *args, lds_xpose, **kwargs):
         super().__init__(*args, **kwargs)
         assert self.n_tiles_b % 4 == 0, "a line run gathers four n-fragments"
         assert self.col_safe, "a whole-line run has no column mask"
         lane16 = self.lane_id % 16
         quad = lane16 % 4
         self.line_col = quad * 16 + (lane16 // 4) * 4
-        self.scale = scale
         blk = (self.lane_id // 16) * 128
         self._xp_wr = _lds_ptr_from_i32(lds_xpose + blk + quad * 32 + (lane16 // 4) * 8)
         self._xp_rd = _lds_ptr_from_i32(lds_xpose + blk + lane16 * 8)
@@ -1083,7 +1091,7 @@ class StoreCPerTensorLineN(StoreCPerTensorPairN):
             self._retire()
 
     def store(self, c_frag, base_row, base_col, prev=None, tap=None):
-        scale = self.scale
+        scale = self._scale()
         if const_expr(self.beta_is_one) and prev is None:
             prev = self.prefetch(base_row, base_col)
         rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
@@ -1830,6 +1838,29 @@ def block_mn(pid, num_pid_m, n_blocks, GM, GN):
     rem_m = num_pid_m - fpm
     gsm = arith.select(rem_m < GM, rem_m, fx.Int32(GM))
     return fpm + (pig % gsm), pig // gsm
+
+
+def xcd_window_mn(d, n_wg, num_pid_m, n_blocks, num_xcd, win_m):
+    """Tile-id -> (block_m, block_n) for a persistent tile loop whose id is ``wg + step*n_wg``.
+
+    A plain GROUP_M raster fixes the super-row width but not where a super-row starts relative
+    to the slots one XCD owns, so whenever ``GM*n_blocks`` does not divide those slots a step
+    straddles two super-rows and its operand footprint jumps from ``GM + slots/GM`` slabs to
+    twice the smaller side. Here the step's window is an aligned ``win_m x (slots/win_m)``
+    rectangle instead, so every step costs the same. Windows advance along n first, which keeps
+    a workgroup's A slab addressed for a whole row of them. Bijection over the tile range;
+    the caller must check ``num_xcd | num_pid_m``, ``win_m | num_pid_m/num_xcd``,
+    ``win_m | slots`` and ``slots/win_m | n_blocks``."""
+    slots = n_wg // num_xcd
+    win_n = slots // win_m
+    rows = num_pid_m // num_xcd
+    n_win_n = n_blocks // win_n
+    wg = d % n_wg
+    step = d // n_wg
+    return (
+        (wg % num_xcd) * rows + (step // n_win_n) * win_m + (wg // num_xcd) % win_m,
+        (step % n_win_n) * win_n + (wg // num_xcd) // win_m,
+    )
 
 
 def make_row_band_resource(c_base, base_row, c_rows, c_cols, elem_bytes, span_rows=None):

--- a/primus_turbo/flydsl/utils/gemm_helper.py
+++ b/primus_turbo/flydsl/utils/gemm_helper.py
@@ -786,6 +786,10 @@ class StoreCPerTensor:
         """Element address of the value at fragment (ti, tj), row ``i`` of this lane's four."""
         return (ti * 16 + (self.lane_id // 16) * 4 + i) * self.c_cols + base_col + tj * 16 + self.lane_id % 16
 
+    def _col_of(self, ti, i, tj, base_col):
+        """N coordinate of the value at fragment (ti, tj): what a column mask is taken over."""
+        return base_col + tj * 16 + self.lane_id % 16
+
     def _read_back(self, rsrc, ti, i, tj, base_row, base_col):
         """One beta=1 read-back load. ``trans`` swaps the fragment axes (row = N, col = M), so
         the element still lands at C[m, n] and the N bound moves with (ti, i) instead of tj."""
@@ -793,7 +797,7 @@ class StoreCPerTensor:
             n = base_row + ti * 16 + (self.lane_id // 16) * 4 + i  # base_row is the N origin here
             off = (tj * 16 + self.lane_id % 16) * self.c_cols + n
         else:
-            n = base_col + tj * 16 + self.lane_id % 16
+            n = self._col_of(ti, i, tj, base_col)
             off = self._row_col(ti, i, tj, base_col)
         return _buffer_ops.buffer_load(
             rsrc,
@@ -1111,18 +1115,59 @@ class StoreCPerTensorLineN(StoreCPerTensorPairN):
 
 class StoreCPerTensorQuadN(StoreCPerTensorPairN):
     """PairN for a kernel whose n-fragments arrived column-interleaved, so a lane already holds
-    the adjacent columns and one unmasked store folds them with no cross-lane step. The caller
-    owns the interleave; the tile must be column-safe."""
+    the adjacent columns and one store folds them with no cross-lane step. The caller owns the
+    interleave; a tile that is not column-safe needs N to be a whole number of runs, since the
+    mask a folded store can carry is one per run."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         assert self.n_tiles_b in (4, 8), "the interleave folds four or eight n-fragments"
-        assert self.col_safe, "a partial fold has no column mask"
 
     def _row_col(self, ti, i, tj, base_col):
         """The fold hands this lane a whole run of columns, so tj steps by one, not by a tile."""
         row = ti * 16 + (self.lane_id // 16) * 4 + i
         return row * self.c_cols + base_col + (self.lane_id % 16) * self.n_tiles_b + tj
+
+    def _col_of(self, ti, i, tj, base_col):
+        return base_col + (self.lane_id % 16) * self.n_tiles_b + tj
+
+    def prefetch(self, base_row, base_col):
+        """The fold gives a lane a contiguous run, so the beta=1 read-back rides the run the
+        store writes: one vector load per four columns instead of one per column, which fetched
+        the same line four times over."""
+        if not const_expr(self.beta_is_one):
+            return None
+        if self.rd_base is not None or self.rd_shift is not None:
+            return super().prefetch(base_row, base_col)
+        rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, self.out_bytes)
+        col0 = base_col + (self.lane_id % 16) * self.n_tiles_b
+        w = 4  # buffer_load's widest element count
+        mask = None if self.col_safe else col0 < self.c_cols
+        runs = [
+            [
+                [
+                    Vec(
+                        _buffer_ops.buffer_load(
+                            rsrc,
+                            (ti * 16 + (self.lane_id // 16) * 4 + i) * self.c_cols + col0 + h * w,
+                            vec_width=w,
+                            dtype=self.out_ty.ir_type,
+                            mask=mask,
+                        )
+                    )
+                    for h in range_constexpr(self.n_tiles_b // w)
+                ]
+                for i in range_constexpr(4)
+            ]
+            for ti in range_constexpr(self.n_tiles_a)
+        ]
+        return [  # _accum indexes [ti][tj][i] and takes the raw element
+            [
+                [_raw(runs[ti][i][tj // w][tj % w]) for i in range_constexpr(4)]
+                for tj in range_constexpr(self.n_tiles_b)
+            ]
+            for ti in range_constexpr(self.n_tiles_a)
+        ]
 
     def store(self, c_frag, base_row, base_col, prev=None):
         scale = self._scale()
@@ -1130,6 +1175,7 @@ class StoreCPerTensorQuadN(StoreCPerTensorPairN):
             prev = self.prefetch(base_row, base_col)
         rsrc = make_row_band_resource(self.c_base, base_row, self.c_rows, self.c_cols, 2)
         col0 = base_col + (self.lane_id % 16) * self.n_tiles_b
+        run_ok = None if self.col_safe else col0 < self.c_cols  # a run is whole in or whole out
         for ti in range_constexpr(self.n_tiles_a):
             row_local = ti * 16 + (self.lane_id // 16) * 4  # relative to base_row
             vecs = [
@@ -1146,6 +1192,7 @@ class StoreCPerTensorQuadN(StoreCPerTensorPairN):
                     Vec.from_elements(dw, fx.Int32).bitcast(self.out_ty),
                     rsrc,
                     ((row_local + i) * self.c_cols + col0) * 2,  # i32-small within band
+                    mask=run_ok,
                     cache_modifier=self.store_aux,
                     offset_is_bytes=True,
                 )


### PR DESCRIPTION
## Summary
- Kernel-tuning campaign on the FlyDSL dense FP8 tensorwise GEMM (`gemm_fp8_kernel.py`, `gemm_helper.py`) used by gpt-oss-20b's QKV and attention-output projections on MI355X (gfx950).
- K-aware macro-tile selection and NT-band scheduling improvements, measured on the campaign's six-shape NT benchmark: cumulative +3.22% (campaign score 1.2 -> 1.3) across all ten cells, `ok=true`, SNR within gate on every scored shape.
- End-to-end: ~0.3 samples/sec throughput improvement observed in real training runs.

## Test plan
- [x] Campaign benchmark (3 reps, best-of): all ten cells ok=true, SNR within the configured gate, deterministic across repeats.
- [x] Review round: no additional fixes required.
- [ ] End-to-end training throughput improvement reproduces outside this campaign's harness.