### PR TITLE
fix(flydsl): cover all eligible MXFP4 dense quant rows

### DIFF
--- a/primus_turbo/flydsl/quantization/mxfp4_quant_kernel.py
+++ b/primus_turbo/flydsl/quantization/mxfp4_quant_kernel.py
@@ -277,12 +277,11 @@ def _finish_microblock(vbits, use_rht, seed=None):
 
 
 # ---- fused-dual tile geometry (shared by the 2D and batched-3D kernels) ----
-# Tile rows/cols for the fused dual. _TR drives the COL_OUT write granule
-# (_TR/8 i32 per feature's R-run): at _TR=64 that is 32 bytes, i.e. every byte of
-# the 265 MB colwise weight output leaves in a sub-cacheline burst. _TR must divide
-# both shipped N (5760 and 2880) and _TR*_TC/32 must divide BLK=256.
-# _TC also sets the K tail: ceil(2880/_TC)*_TC.
-_TR = 96  # tile rows (R dim)
+# Tile rows/cols for the fused dual. The 2D eligibility contract admits every
+# R divisible by 128, so its default row tile must divide 128. Batched weight
+# quantization temporarily selects the faster 96/128-row geometry per shape via
+# _pick_tile_geom below, then restores this safe 2D/fallback geometry.
+_TR = 64  # tile rows (R dim); covers every R accepted by dual_eligible
 _TC = 256  # tile cols (C dim)
 _TCW = _TC // 2  # 128 i32 words per tile row
 _NW = _TR * _TCW  # 8192 i32 words in LDS

--- a/tests/pytorch/ops/test_gemm_fp4.py
+++ b/tests/pytorch/ops/test_gemm_fp4.py
@@ -25,6 +25,41 @@ from tests.pytorch.test_utils import compute_snr
 torch.manual_seed(42)
 
 
+def test_gemm_fp4_dense_quant_tail_regression():
+    """Eligible dense shapes must not feed unwritten FlyDSL quant rows to GEMM."""
+    from primus_turbo.pytorch.core.low_precision import check_mxfp4_support
+
+    mxfp4_supported, reason = check_mxfp4_support()
+    if not mxfp4_supported:
+        pytest.skip(reason)
+    props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    if (props.major, props.minor) != (9, 5):
+        pytest.skip("FlyDSL MXFP4 GEMM requires gfx950")
+
+    torch.manual_seed(20260908)
+    a = torch.randn((128, 256), device="cuda", dtype=torch.bfloat16)
+    b = torch.randn((256, 256), device="cuda", dtype=torch.bfloat16)
+    reference = a @ b.T
+    config = Float4QuantConfig(
+        granularity=ScalingGranularity.MX_BLOCKWISE,
+        format=Format.E2M1_X2,
+        block_size=32,
+        scale_dtype=ScaleDtype.E8M0,
+        use_preshuffle=False,
+    )
+
+    GlobalBackendManager.set_gemm_backend(BackendType.FLYDSL)
+    GlobalBackendManager.set_auto_tune(False)
+    try:
+        actual = gemm_fp4(a, b, trans_a=False, trans_b=True, out_dtype=torch.bfloat16, config=config)
+        torch.cuda.synchronize()
+    finally:
+        GlobalBackendManager.reset()
+
+    assert torch.isfinite(actual).all()
+    assert compute_snr(reference, actual) > 10
+
+
 @pytest.mark.parametrize("m", [256, 512, 1024])
 @pytest.mark.parametrize("n", [256, 352, 1024, 2048])
 @pytest.mark.parametrize("k", [128, 160, 512, 1024])

--- a/tests/pytorch/ops/test_quantization.py
+++ b/tests/pytorch/ops/test_quantization.py
@@ -703,6 +703,56 @@ def test_quantize_mxfp4_with_trans(orig_dtype, dest_dtype, B, M, N, granularity,
     torch.testing.assert_close(colwise_ref, out_colwise, **get_tolerances(dest_dtype))
 
 
+def test_mxfp4_dense_dual_covers_every_eligible_row():
+    """A dense launch must not leave tail rows unwritten for an eligible shape."""
+    mxfp4_supported, reason = check_mxfp4_support()
+    if not mxfp4_supported:
+        pytest.skip(reason)
+
+    props = torch.cuda.get_device_properties(torch.cuda.current_device())
+    if (props.major, props.minor) != (9, 5):
+        pytest.skip("FlyDSL MXFP4 quantization requires gfx950")
+
+    from primus_turbo.flydsl.quantization import mxfp4_quant_kernel as kernel
+
+    torch.manual_seed(42)
+    x = torch.randn((128, 256), device="cuda", dtype=torch.bfloat16)
+    row_recipe = ScalingRecipe()
+    col_recipe = ScalingRecipe(use_rht=True)
+
+    assert kernel.dual_eligible(x.shape[0], x.shape[1], row_recipe, col_recipe)
+    assert x.shape[0] % kernel._TR == 0
+
+    fly = kernel.flydsl_dual_quant(
+        x,
+        turbo.float4_e2m1fn_x2,
+        row_recipe.use_rht,
+        col_recipe.use_rht,
+    )
+    hip = torch.ops.primus_turbo_cpp_extension.quantize_mxfp4_dual(
+        x,
+        turbo.float4_e2m1fn_x2,
+        128,
+        row_recipe.use_2d_block,
+        row_recipe.use_sr,
+        row_recipe.use_rht,
+        col_recipe.use_2d_block,
+        col_recipe.use_sr,
+        col_recipe.use_rht,
+        False,
+        False,
+        False,
+        False,
+    )
+    for actual, expected in zip(fly, hip):
+        torch.testing.assert_close(
+            actual.view(torch.uint8),
+            expected.view(torch.uint8),
+            rtol=0,
+            atol=0,
+        )
+
+
 @pytest.mark.parametrize("orig_dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize(
     "dest_dtype",


### PR DESCRIPTION
## Summary

This PR fixes incomplete row coverage in the FlyDSL dense dual MXFP4 quantization kernel. The bug could leave the final rows of the packed FP4 data and E8M0 scales uninitialized, causing NaN/Inf in downstream GEMMs during GPT-OSS-20B training.

## Root Cause

The dense kernel used `_TR = 96`, while its eligibility check accepts every shape with `R % 128 == 0`. The launch grid uses `R // _TR`, so an eligible row count is not always fully covered.

For the production shape `1024 × 4096`, only `10 × 96 = 960` rows were processed. The final 64 rows remained unwritten and could introduce NaN/Inf into downstream GEMMs. The collective timeouts observed after rank failures were a secondary effect.

## Fix

- Restore the dense/fallback row tile from `_TR = 96` to `_TR = 64`.
- Since every eligible row count is divisible by 128, the 64-row tile guarantees complete coverage.
- Keep the optimized batched 3D path unchanged; it can still select 96- or 128-row tiles through `_pick_tile_geom()`.
- Add targeted Quant and Quant-to-GEMM regression tests for row coverage, byte-exact HIP/FlyDSL parity, finite GEMM output, and SNR.

## Validation

Validation on MI355X/gfx950:

- New targeted Quant and GEMM regressions: **2 passed**
- Existing dual-quant parameterized suite: **128 passed**
- FlyDSL reproduction after the fix: **100 consecutive byte-exact runs**, with no unwritten sentinel values or non-finite outputs
- HIPBLASLt and AITER replays: **20 consecutive runs each passed**
- GPT-OSS-20B EP8 training: one complete iteration passed with finite loss and zero NaN iterations
- All **384/384** observed MXFP4 backend calls completed with finite output
- Ruff format, Ruff lint, and `git diff --check`: **passed**

## Performance Regression

Quant-only performance was compared on shapes fully computed by both versions:

| Shape | Before | After | Change |
|---|---:|---:|---:|
| `384 × 4096` | 9.008 μs | 9.026 μs | +0.20% |
| `768 × 4096` | 8.946 μs | 9.045 μs | +1.11% |
| `1152 × 4096` | 8.893 μs | 8.875 μs | -0.20% |
| `1536 × 4096` | 9.062 μs | 8.981 μs | -0.90% |

The aggregate latency change is approximately **+0.05%**, indicating no material performance regression.

The affected `1024 × 4096` case is excluded from the comparison because the old kernel skipped 64 rows, making its previous latency an invalid performance baseline.