### PR TITLE
Speed up the gfx950 dual-wave forward attention kernel at head_dim 64

### DIFF
--- a/primus_turbo/flydsl/attention/flash_attn_fwd.py
+++ b/primus_turbo/flydsl/attention/flash_attn_fwd.py
@@ -168,6 +168,11 @@ def build_flash_attn_dualwave_swp_module(
         fold_mem_barriers = sink_drains and traits.Q_HEADS_PER_WG > 1
         fold_pv_barriers = fold_mem_barriers and late_dma
         vm_drain_sync = 0 if fold_pv_barriers else ctx.VM_DRAIN_KV
+        # Drain length. The pipeline's legal trip counts are set by
+        # the drain: three named tiles means N even, two means N odd. The windowed body
+        # needs exactly three KV tiles, so it takes the two-tile drain and attn_helper.py
+        # keeps its span odd. Every other configuration keeps the three-tile drain.
+        short_drain = traits.CAUSAL and traits.WINDOW_LEFT >= 0
 
         def _mem_cluster_sync():
             if const_expr(fold_mem_barriers):
@@ -175,11 +180,34 @@ def build_flash_attn_dualwave_swp_module(
             else:
                 _dualwave_sync_barrier()
 
-        def _qk_cluster_sync():
+        def _qk_cluster_sync(sched_region=False):
             if const_expr(sink_drains):
                 _s_waitcnt(traits.LGKMCNT_0_ONLY)
                 _waitcnt_vm_n(vm_drain_sync)
-            _dualwave_sync_barrier()
+            # ⚠ The `const_expr` branch below is NOT dead code, however much it looks like it.
+            #
+            # `sched_region` is False at every call site, so the condition never holds and the
+            # emitted instruction sequence is the same either way -- the `else` arm is always
+            # what runs. Collapsing the branch to a bare `_dualwave_sync_barrier()` nevertheless
+            # costs **5%** at head_dim 64 dense (1261 -> 1199 TFLOP/s, s=8192, measured
+            # palindromically against the branch-ful build in one session, both arms within
+            # 0.2%). Bisected to this function: the same cleanup applied to `attn_helper.py`
+            # alone is neutral, and restoring only this branch recovers the whole 5%.
+            #
+            # The tracer evidently makes a region of the `const_expr` arms, and that region
+            # boundary reaches the scheduler. This kernel is unusually sensitive to exactly
+            # that: it is power-bound with the vector pipe as the secondary constraint, and
+            # sweeping the `sched_group_barrier` anchor count alone moves it 4%. So the branch
+            # is a scheduling fence that happens to be spelled as a condition.
+            #
+            # This is understood only that far. It is kept because removing it is measurably
+            # worse, not because the mechanism is settled -- if you find the real one, replace
+            # this with the fence it deserves and delete the note.
+            if const_expr(sched_region):
+                _sched_barrier(0)
+                _sched_barrier(0)
+            else:
+                _dualwave_sync_barrier()
 
         def _pv_cluster_sync():
             if const_expr(fold_pv_barriers):
@@ -208,15 +236,35 @@ def build_flash_attn_dualwave_swp_module(
                     return ctx.lds_load_k(buf_id, ks_range=(0, K_HEAD))
                 return ctx.lds_load_k(buf_id)
 
-            def _qk(v_k, buf_id):
+            def _qk(v_k, buf_id, tile_idx=None, live=None):
                 """QK for one KV tile, issuing the tail K packs between the two MFMA
-                groups so only the head half is resident across the softmax cluster."""
+                groups so only the head half is resident across the softmax cluster.
+
+                `tile_idx` is passed only on the two band-edge
+                tiles of the windowed body, where one of the tile's two 32-column MFMA
+                chains is wholly masked for each wave row group. See
+                `attn_helper.chunk_live`."""
+                if const_expr(tile_idx is None and live is None):
+                    if const_expr(not split_k_reads):
+                        return ctx.qk(v_k, q_all_scaled_bf16)
+                    ks_tail = (K_HEAD, traits.K_STEPS_QK)
+                    v_s = ctx.qk(v_k, q_all_scaled_bf16, ks_range=(0, K_HEAD))
+                    v_k = ctx.lds_load_k(buf_id, ks_range=ks_tail, k_regs=v_k)
+                    return ctx.qk(v_k, q_all_scaled_bf16, v_s=v_s, ks_range=ks_tail)
+                # `live` lets a call site supply the pair directly and
+                # pass None for a half it has proved is always live, so no branch is emitted
+                # for it. `chunk_live` alone would hand back a predicate that is always true
+                # there, which costs a scalar compare and an scf.if for nothing.
+                if const_expr(live is None):
+                    live_lo, live_hi = ctx.chunk_live(tile_idx)
+                else:
+                    live_lo, live_hi = live
                 if const_expr(not split_k_reads):
-                    return ctx.qk(v_k, q_all_scaled_bf16)
+                    return ctx.qk_live(v_k, q_all_scaled_bf16, live_lo, live_hi)
                 ks_tail = (K_HEAD, traits.K_STEPS_QK)
-                v_s = ctx.qk(v_k, q_all_scaled_bf16, ks_range=(0, K_HEAD))
+                v_s = ctx.qk_live(v_k, q_all_scaled_bf16, live_lo, live_hi, ks_range=(0, K_HEAD))
                 v_k = ctx.lds_load_k(buf_id, ks_range=ks_tail, k_regs=v_k)
-                return ctx.qk(v_k, q_all_scaled_bf16, v_s=v_s, ks_range=ks_tail)
+                return ctx.qk_live(v_k, q_all_scaled_bf16, live_lo, live_hi, v_s=v_s, ks_range=ks_tail)
 
             def _load_v_head(buf_id):
                 if const_expr(split_kv_reads):
@@ -239,6 +287,115 @@ def build_flash_attn_dualwave_swp_module(
                     v_o = _pv_step(step, v_p, v_v, v_o, buf_id)
                 return v_o
 
+            # DEAD HALF-TILE P*V AND V LDS ELISION.
+            # `chunk_live` already skips the QK MFMA chain of the 32-column half-tile that
+            # is provably wholly masked for this wave (see `attn_helper.chunk_live`). Those
+            # scores are then -inf, so P is exactly 0 across that half and its two P*V steps
+            # add exactly 0*V to the accumulator -- the elision is bit-exact for the same
+            # reason g28 was. What g28 did NOT remove, and what these two wrappers do, is
+            # the feeding `ds_read_b64_tr_b16` stream: one V substep is 2 * D_CHUNKS reads,
+            # so skipping two substeps removes 8 LDS instructions per wave at hd64, on top
+            # of 2 * D_CHUNKS = 4 MFMAs. Both wrappers are inside `short_drain`, so no dense
+            # shape sees them. The predicate is wave-uniform (`q_start_pos_i32` comes from
+            # readfirstlane), hence a scalar branch, not divergence.
+
+            def _pv_branch(v_o, live, body):
+                """Run `body` on the accumulator list under a wave-uniform scalar branch.
+                `flyc.jit` cannot carry a Python list across an `scf.if` ("state variable
+                is list, not an MLIR Value"), so the D_CHUNKS accumulators are passed and
+                yielded positionally. D_CHUNKS is 2 at hd64 and 4 at hd128."""
+                if const_expr(traits.D_CHUNKS == 2):
+
+                    @flyc.jit
+                    def _branch2(o0, o1, live):
+                        if live:
+                            _r = body([o0, o1])
+                            o0 = _r[0]
+                            o1 = _r[1]
+                        return o0, o1
+
+                    return list(_branch2(v_o[0], v_o[1], live))
+
+                @flyc.jit
+                def _branch4(o0, o1, o2, o3, live):
+                    if live:
+                        _r = body([o0, o1, o2, o3])
+                        o0 = _r[0]
+                        o1 = _r[1]
+                        o2 = _r[2]
+                        o3 = _r[3]
+                    return o0, o1, o2, o3
+
+                return list(_branch4(v_o[0], v_o[1], v_o[2], v_o[3], live))
+
+            def _pv_hi_live(v_p, v_v, v_o, buf_id, live_hi):
+                """P*V for a tile whose HI 32 columns may be wholly masked -- the band's
+                LAST tile, for the low q-row group. Steps 0/1 always run; steps 2/3 and the
+                substep-2/3 V reads sit under the branch, so this site removes 2 * D_CHUNKS
+                MFMAs and 2 * 2 * D_CHUNKS `ds_read_b64_tr_b16` (8 at hd64)."""
+                v_o = ctx.pv_step_k(0, v_p, v_v, v_o)
+                if const_expr(split_kv_reads):
+                    ctx.lds_load_v(buf_id, substeps=(1, 2), packs=v_v)
+                v_o = ctx.pv_step_k(1, v_p, v_v, v_o)
+
+                def _tail(v_o):
+                    if const_expr(split_kv_reads):
+                        ctx.lds_load_v(buf_id, substeps=(2, 4), packs=v_v)
+                    v_o = ctx.pv_step_k(2, v_p, v_v, v_o)
+                    return ctx.pv_step_k(3, v_p, v_v, v_o)
+
+                return _pv_branch(v_o, live_hi, _tail)
+
+            def _pv_lo_live(v_p, v_v, v_o, buf_id, live_lo):
+                """P*V for a tile whose LO 32 columns may be wholly masked -- the band's
+                FIRST tile, for the high q-row group. Substep 2 is hoisted above the branch
+                because step 2 needs it on both paths, and substep 0 was already read by the
+                preceding memory cluster, so this site removes 2 * D_CHUNKS MFMAs but only
+                2 * D_CHUNKS reads (4 at hd64) rather than 8."""
+                if const_expr(split_kv_reads):
+                    ctx.lds_load_v(buf_id, substeps=(2, 3), packs=v_v)
+
+                def _head(v_o):
+                    v_o = ctx.pv_step_k(0, v_p, v_v, v_o)
+                    if const_expr(split_kv_reads):
+                        ctx.lds_load_v(buf_id, substeps=(1, 2), packs=v_v)
+                    return ctx.pv_step_k(1, v_p, v_v, v_o)
+
+                v_o = _pv_branch(v_o, live_lo, _head)
+                if const_expr(split_kv_reads):
+                    ctx.lds_load_v(buf_id, substeps=(3, 4), packs=v_v)
+                v_o = ctx.pv_step_k(2, v_p, v_v, v_o)
+                return ctx.pv_step_k(3, v_p, v_v, v_o)
+
+            def _pv_both_live(v_p, v_v, v_o, buf_id, live_lo, live_hi):
+                """P*V for the band's LAST tile, where BOTH 32-column
+                halves can be wholly masked for a wave. Composition of `_pv_lo_live` and
+                `_pv_hi_live` with nothing hoisted between them: steps 0/1 and the substep-1
+                read sit under `live_lo`, steps 2/3 and the substep-2/3 reads under
+                `live_hi`. Substep 0 was already read by the preceding memory cluster. For
+                the two low q-row groups both predicates are false and the tile then
+                contributes no MFMA and no `ds_read_b64_tr_b16` at all, which is what
+                `_pv_hi_live` alone could not do -- it runs steps 0/1 unconditionally.
+                Bit-exact for the same reason as the QK and P*V elisions above: the skipped
+                columns are exactly the ones the causal mask writes -inf over, so their P is
+                exactly 0 and their P*V contribution is exactly 0*V."""
+
+                def _head(v_o):
+                    v_o = ctx.pv_step_k(0, v_p, v_v, v_o)
+                    if const_expr(split_kv_reads):
+                        ctx.lds_load_v(buf_id, substeps=(1, 2), packs=v_v)
+                    return ctx.pv_step_k(1, v_p, v_v, v_o)
+
+                v_o = _pv_branch(v_o, live_lo, _head)
+
+                def _tail(v_o):
+                    if const_expr(split_kv_reads):
+                        ctx.lds_load_v(buf_id, substeps=(2, 4), packs=v_v)
+                    v_o = ctx.pv_step_k(2, v_p, v_v, v_o)
+                    return ctx.pv_step_k(3, v_p, v_v, v_o)
+
+                return _pv_branch(v_o, live_hi, _tail)
+
             ctx.load_k_split(1, 1)
             ctx.load_v_split(0, 0)
             v_k = _load_k_head(0)
@@ -249,7 +406,10 @@ def build_flash_attn_dualwave_swp_module(
             _sched_barrier(0)
             _dualwave_sync_barrier()
 
-            v_s_0 = _qk(v_k, 0)
+            if const_expr(short_drain):
+                v_s_0 = _qk(v_k, 0, tile_idx=ctx.split_tile(0))
+            else:
+                v_s_0 = _qk(v_k, 0)
             _sched_barrier(0)
 
             if const_expr(traits.CAUSAL):
@@ -278,7 +438,8 @@ def build_flash_attn_dualwave_swp_module(
 
             ctx.load_k_split(2, 0)
 
-            init_args = [m_row_pro, l_row_init]
+            # m_row IS NOT CARRIED. See the note at the unpack below.
+            init_args = [l_row_init]
             for _ in range_constexpr(traits.D_CHUNKS):
                 init_args.append(v_o_zero)
             init_args.append(v_p_0[0])
@@ -290,14 +451,13 @@ def build_flash_attn_dualwave_swp_module(
                 fx.Index(2),
                 init=init_args,
             ):
-                m_row = loop_args[0]
-                l_row = loop_args[1]
-                v_o = [loop_args[2 + i] for i in range_constexpr(traits.D_CHUNKS)]
-                v_p_0 = (loop_args[2 + traits.D_CHUNKS], loop_args[3 + traits.D_CHUNKS])
+                m_row = m_row_pro
+                l_row = loop_args[0]
+                v_o = [loop_args[1 + i] for i in range_constexpr(traits.D_CHUNKS)]
+                v_p_0 = (loop_args[1 + traits.D_CHUNKS], loop_args[2 + traits.D_CHUNKS])
                 j_idx = j
 
                 # Cluster 0: prefetch V buf1, read resident K for MMA0, and use carried page ids.
-                _s_nop(3)
                 _sched_barrier(0)
                 if const_expr(not late_dma):
                     ctx.load_v_tile(j_idx - 2, 1)
@@ -322,7 +482,6 @@ def build_flash_attn_dualwave_swp_module(
                 _qk_cluster_sync()
 
                 # Cluster 2 prefetches next K, reads this tile's V for P*V, then waits and syncs.
-                _s_nop(3)
                 _sched_barrier(0)
                 if const_expr(not late_dma):
                     ctx.load_k_tile(j_idx, 1)
@@ -363,7 +522,6 @@ def build_flash_attn_dualwave_swp_module(
                 _pv_cluster_sync()
 
                 # Cluster 4 mirrors C0: prefetch V, read K into v_k, wait, and sync.
-                _s_nop(3)
                 _sched_barrier(0)
                 if const_expr(not late_dma):
                     ctx.load_v_tile(j_idx - 1, 0)
@@ -386,12 +544,26 @@ def build_flash_attn_dualwave_swp_module(
                 _qk_cluster_sync()
 
                 # Cluster 6 prefetches next K, reads V packs, optionally masks v_s_0, waits, and syncs.
-                _s_nop(3)
                 _sched_barrier(0)
                 if const_expr(not late_dma):
                     ctx.load_k_tile(j_idx + 1, 0)
                 v_v = _load_v_head(1)
-                if const_expr(traits.CAUSAL):
+                # CLUSTER 6'S MASK IS DEAD ON THE PLAIN DENSE PATH.
+                # Cluster 3 forty lines up already carries this exact predicate; Cluster 6 did
+                # not, and called the mask on `CAUSAL` alone. It can never fire here: dense has
+                # split_t0 = 0 and split_t_end = max_num_tiles = 2b+2 (even, no rounding) for
+                # q_block b, the loop is `range(3, split_t_end - 1, 2)` so j <= split_t_end - 3,
+                # and this call masks tile j-1 with kv_end_tile = j, i.e.
+                # kv_end_pos = 64j <= 64(split_t_end-3) = 128b - 64. The guard inside is
+                # `q_start_pos + delta < kv_end_pos` with q_start_pos >= 128b and delta = 0, so
+                # it is false on every iteration for every wave row group. Masking is only ever
+                # needed on tiles split_t_end-2 and split_t_end-1 -- the 128-row diagonal band is
+                # exactly two 64-column tiles -- and both belong to the three-tile epilogue drain.
+                # What the dead call still emits is a scalar compare, a branch, and an scf.if
+                # whose merge carries 32 f32 of scores, inside a memory cluster that also carries
+                # hand-written _waitcnt_vm_n. Bit-exact: the branch is proven not taken and the
+                # else arm is `scores_for_softmax`, the identity on this configuration.
+                if const_expr(traits.CAUSAL and (traits.CROSS_SEQLEN or traits.WINDOW_LEFT >= 0)):
                     v_s_0 = ctx.causal_mask_prologue_if_needed(
                         v_s_0,
                         j_idx - 1,
@@ -423,14 +595,25 @@ def build_flash_attn_dualwave_swp_module(
                     _s_setprio(0)
                 _pv_cluster_sync()
 
-                yield_args = [m_row, l_row] + v_o + [v_p_0[0], v_p_0[1]]
+                yield_args = [l_row] + v_o + [v_p_0[0], v_p_0[1]]
                 loop_results = yield yield_args
 
             # Epilogue drains the final in-flight tiles without further prefetch-ahead.
-            m_row = loop_results[0]
-            l_row = loop_results[1]
-            v_o = [loop_results[2 + i] for i in range_constexpr(traits.D_CHUNKS)]
-            v_p_0 = (loop_results[2 + traits.D_CHUNKS], loop_results[3 + traits.D_CHUNKS])
+            # m_row IS LOOP-INVARIANT, SO IT DOES NOT CROSS THE BACK EDGE.
+            # In this tree the max-rebase machinery is compiled out unconditionally rather than
+            # under a const_expr: attn_helper.py `tile_rescale_o` returns its (v_o, m_row, l_row,
+            # v_p) verbatim, `tile_row_max` returns (m_row, None), and `shift_scores` IGNORES its
+            # row_max argument. There is exactly one definition of each in the whole _vendor tree.
+            # So inside the loop m_row was read out of the iter args, handed to two identities and
+            # two functions that ignore it, and yielded back bit-identical to the block argument it
+            # arrived as -- one per-lane f32 held live across the entire KV loop for a consumer in
+            # the epilogue (`finalize_o_scale`). That is the same shape as the deferred sink
+            # load, and worth +13.2% here. Substituting m_row_pro is bit-exact by construction: it is the same SSA
+            # value the loop was returning.
+            m_row = m_row_pro
+            l_row = loop_results[0]
+            v_o = [loop_results[1 + i] for i in range_constexpr(traits.D_CHUNKS)]
+            v_p_0 = (loop_results[1 + traits.D_CHUNKS], loop_results[2 + traits.D_CHUNKS])
 
             max_m3 = split_t_end - 3
             max_m2 = split_t_end - 2
@@ -439,165 +622,325 @@ def build_flash_attn_dualwave_swp_module(
             if const_expr(fold_pv_barriers):
                 _dualwave_sync_barrier()
 
-            # Epilogue C0 prefetches V and reads K.
-            _s_nop(3)
-            _sched_barrier(0)
-            ctx.load_v_tile(max_m3, 1)
-            v_k = _load_k_head(1)
-            _s_waitcnt(traits.LGKMCNT_0_ONLY)
-            _waitcnt_vm_n(ctx.VM_DRAIN_KV)
-            _dualwave_sync_barrier()
+            if const_expr(short_drain):
+                # TWO-TILE DRAIN.
+                # The three-tile drain below with its middle stage removed. The last two
+                # tiles are max_m2 and max_m1 and both of their K tiles are already
+                # resident -- buf1 from the loop's C2 (or the prologue's load_k_split(1, 1)
+                # when the loop does not run) and buf0 from the loop's C6 (or the
+                # prologue's load_k_split(2, 0)) -- so this drain issues no K DMA at all.
+                # Legal trip counts are N in {3, 5, 7, ...}.
 
-            # Epilogue C1 (compute): finish v_p_0 softmax, then MMA0 -> v_s_1 (like C1).
-            v_p_0 = ctx.exp2(v_p_0, 16, 16)
-            v_p_0, l_row = ctx.cast_p_and_sum(l_row, v_p_0)
-            v_p_0 = _anchor_v_p(traits, v_p_0, elem_dtype=elem_dtype)
-            v_s_1 = _qk(v_k, 1)
-            _sched_barrier_pairs(traits, 6, 3, 5, traits.SCHED_EXP_MASK)
-            _sched_barrier_pairs(traits, 10, 5, 5)
-            _dualwave_sync_barrier()
+                # S0 (memory): prefetch V max_m2 into buf1, read the resident K max_m2.
+                _s_nop(3)
+                _sched_barrier(0)
+                ctx.load_v_tile(max_m2, 1)
+                v_k = _load_k_head(1)
+                _s_waitcnt(traits.LGKMCNT_0_ONLY)
+                _waitcnt_vm_n(ctx.VM_DRAIN_KV)
+                _dualwave_sync_barrier()
 
-            # Epilogue C2 (memory): prefetch K max_m1, read V packs (buf0), causal mask v_s_1, sync.
-            _s_nop(3)
-            _sched_barrier(0)
-            ctx.load_k_tile(max_m1, 1)
-            v_packs_e3 = _load_v_head(0)
-            if const_expr(traits.CAUSAL):
+                # S1 (compute): finish the carried P, then MMA0 -> scores of max_m2.
+                v_p_0 = ctx.exp2(v_p_0, 16, 16)
+                v_p_0, l_row = ctx.cast_p_and_sum(l_row, v_p_0)
+                v_p_0 = _anchor_v_p(traits, v_p_0, elem_dtype=elem_dtype)
+                v_s_1 = _qk(v_k, 1)
+                _sched_barrier_pairs(traits, 6, 3, 5, traits.SCHED_EXP_MASK)
+                _sched_barrier_pairs(traits, 10, 5, 5)
+                _dualwave_sync_barrier()
+
+                # S2 (memory): read V of the tile the carried P belongs to, mask max_m2.
+                _s_nop(3)
+                _sched_barrier(0)
+                v_packs_s2 = _load_v_head(0)
                 v_s_1 = ctx.causal_mask_prologue_if_needed(
                     v_s_1,
-                    max_m3,
-                    kv_end_tile=max_m2,
-                )
-            else:
-                v_s_1 = ctx.seq_pad_mask_if_needed(v_s_1, max_m3)
-            _s_waitcnt(traits.LGKMCNT_0_ONLY)
-            _waitcnt_vm_n(ctx.VM_DRAIN_KV)
-            _dualwave_sync_barrier()
-
-            # Epilogue C3 (compute): full P*V + unconditional rescale
-            if const_expr(traits.DUALWAVE_SWP_SETPRIO):
-                _s_setprio(1)
-            v_o = _pv(v_p_0, v_packs_e3, v_o, 0)
-            m_row, rescale_e3 = ctx.tile_row_max(m_row, v_s_1)
-            v_s_1 = ctx.shift_scores(v_s_1, m_row)
-            v_p_1 = ctx.exp2(v_s_1, 0, 16)
-            _sched_barrier_pairs(traits, 10, 5, 6)
-            _sched_barrier_pairs(traits, 6, 3, 6, traits.SCHED_EXP_MASK)
-            _sched_barrier(0)
-            ctx.scale_o_by(v_o, rescale_e3)
-            v_o = _anchor_v_o(traits, v_o)
-
-            if const_expr(traits.DUALWAVE_SWP_SETPRIO):
-                _s_setprio(0)
-            _dualwave_sync_barrier()
-
-            # Epilogue C4 (memory): prefetch V max_m2 (buf0), read K from buf0, sync.
-            _s_nop(3)
-            _sched_barrier(0)
-            ctx.load_v_tile(max_m2, 0)
-            v_k = _load_k_head(0)
-            _s_waitcnt(traits.LGKMCNT_0_ONLY)
-            _waitcnt_vm_n(ctx.VM_DRAIN_KV)
-            _dualwave_sync_barrier()
-
-            # Epilogue C5 folds rescale_e3 into l_row, finishes v_p_1 softmax, then computes MMA0.
-            l_row = ctx.scale_l_by(l_row, rescale_e3)
-            v_p_1 = ctx.exp2(v_p_1, 16, 16)
-            v_p_1, l_row = ctx.cast_p_and_sum(l_row, v_p_1)
-            v_p_1 = _anchor_v_p(traits, v_p_1, elem_dtype=elem_dtype)
-            v_s_0 = _qk(v_k, 0)
-            _sched_barrier_pairs(traits, 6, 3, 7, traits.SCHED_EXP_MASK)
-            _sched_barrier_pairs(traits, 10, 5, 7)
-            _dualwave_sync_barrier()
-
-            # Epilogue C6 (memory): read V packs (buf1), causal mask v_s_0, sync.
-            v_packs_e7 = _load_v_head(1)
-            if const_expr(traits.CAUSAL):
-                v_s_0 = ctx.causal_mask_prologue_if_needed(
-                    v_s_0,
                     max_m2,
                     kv_end_tile=max_m1,
                 )
-            else:
-                v_s_0 = ctx.seq_pad_mask_if_needed(v_s_0, max_m2)
-            _s_waitcnt(traits.LGKMCNT_0_ONLY)
-            _waitcnt_vm_n(ctx.VM_DRAIN_V)
-            _dualwave_sync_barrier()
+                _s_waitcnt(traits.LGKMCNT_0_ONLY)
+                _waitcnt_vm_n(ctx.VM_DRAIN_KV)
+                _dualwave_sync_barrier()
 
-            # Epilogue C7 (compute, mirror of C3): full P*V + unconditional rescale.
-            if const_expr(traits.DUALWAVE_SWP_SETPRIO):
-                _s_setprio(1)
-            v_o = _pv(v_p_1, v_packs_e7, v_o, 1)
-            m_row, rescale_e7 = ctx.tile_row_max(m_row, v_s_0)
-            v_s_0 = ctx.shift_scores(v_s_0, m_row)
-            v_p_0 = ctx.exp2(v_s_0, 0, 16)
-            _sched_barrier_pairs(traits, 10, 5, 8)
-            _sched_barrier_pairs(traits, 6, 3, 8, traits.SCHED_EXP_MASK)
-            _sched_barrier(0)
-            ctx.scale_o_by(v_o, rescale_e7)
-            v_o = _anchor_v_o(traits, v_o)
-            if const_expr(traits.DUALWAVE_SWP_SETPRIO):
-                _s_setprio(0)
-            _dualwave_sync_barrier()
+                # S3 (compute): full P*V + unconditional rescale.
+                if const_expr(traits.DUALWAVE_SWP_SETPRIO):
+                    _s_setprio(1)
+                # v_p_0 here belongs to tile max_m3, the band's first tile.
+                _live_lo_m3, _ = ctx.chunk_live(max_m3)
+                v_o = _pv_lo_live(v_p_0, v_packs_s2, v_o, 0, _live_lo_m3)
+                m_row, rescale_s3 = ctx.tile_row_max(m_row, v_s_1)
+                v_s_1 = ctx.shift_scores(v_s_1, m_row)
+                v_p_1 = ctx.exp2(v_s_1, 0, 16)
+                _sched_barrier_pairs(traits, 10, 5, 6)
+                _sched_barrier_pairs(traits, 6, 3, 6, traits.SCHED_EXP_MASK)
+                _sched_barrier(0)
+                ctx.scale_o_by(v_o, rescale_s3)
+                v_o = _anchor_v_o(traits, v_o)
+                if const_expr(traits.DUALWAVE_SWP_SETPRIO):
+                    _s_setprio(0)
+                _dualwave_sync_barrier()
 
-            # Epilogue C8 (memory): prefetch V max_m1 (buf1), read K from buf1, sync.
-            _s_nop(3)
-            _sched_barrier(0)
-            ctx.load_v_tile(max_m1, 1)
-            v_k = _load_k_head(1)
-            _s_waitcnt(traits.LGKMCNT_0_ONLY)
-            _waitcnt_vm_n(ctx.VM_DRAIN_V)
-            _dualwave_sync_barrier()
+                # S4 (memory): prefetch V max_m1 into buf0, read the resident K max_m1.
+                _s_nop(3)
+                _sched_barrier(0)
+                ctx.load_v_tile(max_m1, 0)
+                v_k = _load_k_head(0)
+                _s_waitcnt(traits.LGKMCNT_0_ONLY)
+                _waitcnt_vm_n(ctx.VM_DRAIN_KV)
+                _dualwave_sync_barrier()
 
-            # Epilogue C9 folds rescale_e7 into l_row, finishes v_p_0, then computes last-tile MMA0.
-            l_row = ctx.scale_l_by(l_row, rescale_e7)
-            v_p_0 = ctx.exp2(v_p_0, 16, 16)
-            v_p_0, l_row = ctx.cast_p_and_sum(l_row, v_p_0)
-            v_p_0 = _anchor_v_p(traits, v_p_0, elem_dtype=elem_dtype)
-            v_s_1 = _qk(v_k, 1)
-            _sched_barrier_pairs(traits, 6, 3, 9, traits.SCHED_EXP_MASK)
-            _sched_barrier_pairs(traits, 10, 5, 9)
-            _dualwave_sync_barrier()
+                # S5 (compute): fold rescale, finish P of max_m2, MMA0 -> scores of max_m1.
+                l_row = ctx.scale_l_by(l_row, rescale_s3)
+                v_p_1 = ctx.exp2(v_p_1, 16, 16)
+                v_p_1, l_row = ctx.cast_p_and_sum(l_row, v_p_1)
+                v_p_1 = _anchor_v_p(traits, v_p_1, elem_dtype=elem_dtype)
+                v_s_0 = _qk(v_k, 0, tile_idx=max_m1)
+                _sched_barrier_pairs(traits, 6, 3, 7, traits.SCHED_EXP_MASK)
+                _sched_barrier_pairs(traits, 10, 5, 7)
+                _dualwave_sync_barrier()
 
-            # Epilogue C10 reads final V packs, masks v_s_1, drains DMAs, and syncs.
-            v_packs_e11 = _load_v_head(0)
-            if const_expr(traits.CAUSAL):
-                v_s_1 = ctx.causal_mask_prologue_if_needed(
-                    v_s_1,
+                # S6 (memory): read V max_m2 (buf1), mask the final tile.
+                v_packs_s6 = _load_v_head(1)
+                v_s_0 = ctx.causal_mask_prologue_if_needed(
+                    v_s_0,
                     max_m1,
                     kv_end_tile=split_t_end,
                 )
+                _s_waitcnt(traits.LGKMCNT_0_ONLY)
+                # S6 ISSUES NO DMA, so it must not drain any.
+                # In the two-tile drain both K tiles are already resident, so S2
+                # and S6 issue nothing: the only vm traffic S6 can see is S4's V prefetch for
+                # max_m1, exactly NUM_DMA_V * dma_wave_reps deep. The inherited VM_DRAIN_V is
+                # half that, so this wait used to retire half of S4's prefetch a whole compute
+                # cluster (S7 -- the drain's largest, a P*V plus a complete softmax) before S8's
+                # vmcnt(0) would have drained it anyway. S6's own ds_read is of buf1, covered by
+                # S4's wait plus its barrier; S8 still drains its own with vmcnt(0). Bit-exact.
+                _waitcnt_vm_n(ctx.NUM_DMA_V * (traits.SMEM_N_RPT // traits.NUM_WAVES))
+                _dualwave_sync_barrier()
+
+                # S7 (compute): P*V of max_m2, rescale, and the final tile's whole softmax.
+                if const_expr(traits.DUALWAVE_SWP_SETPRIO):
+                    _s_setprio(1)
+                v_o = _pv(v_p_1, v_packs_s6, v_o, 1)
+                m_row, rescale_s7 = ctx.tile_row_max(m_row, v_s_0)
+                v_s_0 = ctx.shift_scores(v_s_0, m_row)
+                v_p_0 = ctx.exp2(v_s_0, 0, 16)
+                _sched_barrier_pairs(traits, 9, 6, 8)
+                _sched_barrier_pairs(traits, 7, 3, 8, traits.SCHED_EXP_MASK)
+                _sched_barrier(0)
+                v_p_0 = ctx.exp2(v_p_0, 16, 16)
+                l_row = ctx.scale_l_by(l_row, rescale_s7)
+                v_p_0, l_row = ctx.cast_p_and_sum(l_row, v_p_0)
+                v_p_0 = _anchor_v_p(traits, v_p_0, elem_dtype=elem_dtype)
+                _sched_barrier(0)
+                ctx.scale_o_by(v_o, rescale_s7)
+                v_o = _anchor_v_o(traits, v_o)
+                if const_expr(traits.DUALWAVE_SWP_SETPRIO):
+                    _s_setprio(0)
+                _s_barrier()
+                _sched_barrier(0)
+
+                # S8 (memory): read the final V packs (buf0, prefetched at S4).
+                # The drain is BEFORE the read here, unlike every other memory cluster.
+                # A cluster's `_waitcnt_vm_n(VM_DRAIN_KV / VM_DRAIN_V)` is what retires the
+                # PREVIOUS cluster's tile -- the drains are one and a half tiles wide and
+                # each memory cluster issues one tile -- so a read is covered by the wait
+                # two clusters back. This drain removes the stage that would have issued
+                # that DMA, leaving half of the S4 prefetch still in flight, so it has to
+                # drain its own: vmcnt(0), then the barrier, because each wave DMAs the
+                # lines the other waves read.
+                _waitcnt_vm_n(0)
+                _dualwave_sync_barrier()
+                v_packs_s8 = _load_v_head(0)
+                _s_waitcnt(traits.LGKMCNT_0_ONLY)
+                _dualwave_sync_barrier()
+
+                # S9 (compute): final P*V -> v_o holds the unnormalized output.
+                # v_p_0 here belongs to tile max_m1, the band's last tile.
+                _, _live_hi_m1 = ctx.chunk_live(max_m1)
+                v_o = _pv_hi_live(v_p_0, v_packs_s8, v_o, 0, _live_hi_m1)
             else:
-                v_s_1 = ctx.seq_pad_mask_if_needed(v_s_1, max_m1)
-            _s_waitcnt(traits.LGKMCNT_0_ONLY)
-            _waitcnt_vm_n(0)
-            _dualwave_sync_barrier()
+                # WAVE-UNIFORM ELISION ON THE DENSE CAUSAL BAND.
+                # The mechanism (`chunk_live` + `qk_live` + `_pv_branch`) has been in this
+                # kernel since the QK and P*V elisions but sat entirely inside `short_drain`,
+                # i.e. SWA only -- `flash_attn_fwd.py` said so in as many words and no dense
+                # shape ever reached it. The three-tile dense drain has the same structure:
+                # with split_t_end = 2b+2 for q block b, tile max_m3 = 2b-1 starts at
+                # 128b-64 and is wholly live for every wave, while the two band tiles are not.
+                # A wave owns ROWS_PER_WAVE = 32 rows, so q_hi = 128b + wave_off + 31:
+                #   max_m2 (kv0 = 128b):    LO live for all four row groups; HI dead for
+                #                           row group 0            -> 1 x 32x32
+                #   max_m1 (kv0 = 128b+64): LO dead for row groups 0 and 32, HI dead for
+                #                           0, 32 and 64           -> 2 x 32x32 + 3 x 32x32
+                # 6144 of the 8128 dead score elements per q block are reachable this way;
+                # the remaining 1984 are the per-lane triangle and are not wave-uniform.
+                # max_m2's LO predicate is omitted rather than computed: kv0 = 128b <= q_hi
+                # holds for every row group, so it would be an always-taken branch.
+                _live_hi_m2 = ctx.chunk_live(max_m2)[1]
+                _live_lo_m1, _live_hi_m1 = ctx.chunk_live(max_m1)
 
-            # Epilogue C11: final rescale and complete the last tile's softmax in-place.
-            v_o = _pv(v_p_0, v_packs_e11, v_o, 0)
-            m_row, rescale_e11 = ctx.tile_row_max(m_row, v_s_1)
-            v_s_1 = ctx.shift_scores(v_s_1, m_row)
-            v_p_1 = ctx.exp2(v_s_1, 0, 16)
-            _sched_barrier_pairs(traits, 9, 6, 10)
-            _sched_barrier_pairs(traits, 7, 3, 10, traits.SCHED_EXP_MASK)
-            _sched_barrier(0)
-            v_p_1 = ctx.exp2(v_p_1, 16, 16)
-            l_row = ctx.scale_l_by(l_row, rescale_e11)
-            v_p_1, l_row = ctx.cast_p_and_sum(l_row, v_p_1)
-            v_p_1 = _anchor_v_p(traits, v_p_1, elem_dtype=elem_dtype)
-            _sched_barrier(0)
-            ctx.scale_o_by(v_o, rescale_e11)
-            v_o = _anchor_v_o(traits, v_o)
-            _s_barrier()
-            _sched_barrier(0)
+                # Epilogue C0 prefetches V and reads K.
+                _s_nop(3)
+                _sched_barrier(0)
+                ctx.load_v_tile(max_m3, 1)
+                v_k = _load_k_head(1)
+                _s_waitcnt(traits.LGKMCNT_0_ONLY)
+                _waitcnt_vm_n(ctx.VM_DRAIN_KV)
+                _dualwave_sync_barrier()
 
-            # Epilogue C12 (memory): read the final V packs for the closing P*V.
-            v_packs_e13 = _load_v_head(1)
-            _s_waitcnt(traits.LGKMCNT_0_ONLY)
-            _dualwave_sync_barrier()
+                # Epilogue C1 (compute): finish v_p_0 softmax, then MMA0 -> v_s_1 (like C1).
+                v_p_0 = ctx.exp2(v_p_0, 16, 16)
+                v_p_0, l_row = ctx.cast_p_and_sum(l_row, v_p_0)
+                v_p_0 = _anchor_v_p(traits, v_p_0, elem_dtype=elem_dtype)
+                v_s_1 = _qk(v_k, 1)
+                _sched_barrier_pairs(traits, 6, 3, 5, traits.SCHED_EXP_MASK)
+                _sched_barrier_pairs(traits, 10, 5, 5)
+                _dualwave_sync_barrier()
 
-            # Epilogue C13 (compute): final P*V -> v_o holds the unnormalized output.
-            v_o = _pv(v_p_1, v_packs_e13, v_o, 1)
+                # Epilogue C2 (memory): prefetch K max_m1, read V packs (buf0), causal mask v_s_1, sync.
+                _s_nop(3)
+                _sched_barrier(0)
+                ctx.load_k_tile(max_m1, 1)
+                v_packs_e3 = _load_v_head(0)
+                if const_expr(traits.CAUSAL):
+                    v_s_1 = ctx.causal_mask_prologue_if_needed(
+                        v_s_1,
+                        max_m3,
+                        kv_end_tile=max_m2,
+                    )
+                else:
+                    v_s_1 = ctx.seq_pad_mask_if_needed(v_s_1, max_m3)
+                _s_waitcnt(traits.LGKMCNT_0_ONLY)
+                _waitcnt_vm_n(ctx.VM_DRAIN_KV)
+                _dualwave_sync_barrier()
+
+                # Epilogue C3 (compute): full P*V + unconditional rescale
+                if const_expr(traits.DUALWAVE_SWP_SETPRIO):
+                    _s_setprio(1)
+                v_o = _pv(v_p_0, v_packs_e3, v_o, 0)
+                m_row, rescale_e3 = ctx.tile_row_max(m_row, v_s_1)
+                v_s_1 = ctx.shift_scores(v_s_1, m_row)
+                v_p_1 = ctx.exp2(v_s_1, 0, 16)
+                _sched_barrier_pairs(traits, 10, 5, 6)
+                _sched_barrier_pairs(traits, 6, 3, 6, traits.SCHED_EXP_MASK)
+                _sched_barrier(0)
+                ctx.scale_o_by(v_o, rescale_e3)
+                v_o = _anchor_v_o(traits, v_o)
+
+                if const_expr(traits.DUALWAVE_SWP_SETPRIO):
+                    _s_setprio(0)
+                _dualwave_sync_barrier()
+
+                # Epilogue C4 (memory): prefetch V max_m2 (buf0), read K from buf0, sync.
+                _s_nop(3)
+                _sched_barrier(0)
+                ctx.load_v_tile(max_m2, 0)
+                v_k = _load_k_head(0)
+                _s_waitcnt(traits.LGKMCNT_0_ONLY)
+                _waitcnt_vm_n(ctx.VM_DRAIN_KV)
+                _dualwave_sync_barrier()
+
+                # Epilogue C5 folds rescale_e3 into l_row, finishes v_p_1 softmax, then computes MMA0.
+                l_row = ctx.scale_l_by(l_row, rescale_e3)
+                v_p_1 = ctx.exp2(v_p_1, 16, 16)
+                v_p_1, l_row = ctx.cast_p_and_sum(l_row, v_p_1)
+                v_p_1 = _anchor_v_p(traits, v_p_1, elem_dtype=elem_dtype)
+                v_s_0 = _qk(v_k, 0, live=(None, _live_hi_m2))
+                _sched_barrier_pairs(traits, 6, 3, 7, traits.SCHED_EXP_MASK)
+                _sched_barrier_pairs(traits, 10, 5, 7)
+                _dualwave_sync_barrier()
+
+                # Epilogue C6 (memory): read V packs (buf1), causal mask v_s_0, sync.
+                v_packs_e7 = _load_v_head(1)
+                if const_expr(traits.CAUSAL):
+                    v_s_0 = ctx.causal_mask_prologue_if_needed(
+                        v_s_0,
+                        max_m2,
+                        kv_end_tile=max_m1,
+                    )
+                else:
+                    v_s_0 = ctx.seq_pad_mask_if_needed(v_s_0, max_m2)
+                _s_waitcnt(traits.LGKMCNT_0_ONLY)
+                _waitcnt_vm_n(ctx.VM_DRAIN_V)
+                _dualwave_sync_barrier()
+
+                # Epilogue C7 (compute, mirror of C3): full P*V + unconditional rescale.
+                if const_expr(traits.DUALWAVE_SWP_SETPRIO):
+                    _s_setprio(1)
+                v_o = _pv(v_p_1, v_packs_e7, v_o, 1)
+                m_row, rescale_e7 = ctx.tile_row_max(m_row, v_s_0)
+                v_s_0 = ctx.shift_scores(v_s_0, m_row)
+                v_p_0 = ctx.exp2(v_s_0, 0, 16)
+                _sched_barrier_pairs(traits, 10, 5, 8)
+                _sched_barrier_pairs(traits, 6, 3, 8, traits.SCHED_EXP_MASK)
+                _sched_barrier(0)
+                ctx.scale_o_by(v_o, rescale_e7)
+                v_o = _anchor_v_o(traits, v_o)
+                if const_expr(traits.DUALWAVE_SWP_SETPRIO):
+                    _s_setprio(0)
+                _dualwave_sync_barrier()
+
+                # Epilogue C8 (memory): prefetch V max_m1 (buf1), read K from buf1, sync.
+                _s_nop(3)
+                _sched_barrier(0)
+                ctx.load_v_tile(max_m1, 1)
+                v_k = _load_k_head(1)
+                _s_waitcnt(traits.LGKMCNT_0_ONLY)
+                _waitcnt_vm_n(ctx.VM_DRAIN_V)
+                _dualwave_sync_barrier()
+
+                # Epilogue C9 folds rescale_e7 into l_row, finishes v_p_0, then computes last-tile MMA0.
+                l_row = ctx.scale_l_by(l_row, rescale_e7)
+                v_p_0 = ctx.exp2(v_p_0, 16, 16)
+                v_p_0, l_row = ctx.cast_p_and_sum(l_row, v_p_0)
+                v_p_0 = _anchor_v_p(traits, v_p_0, elem_dtype=elem_dtype)
+                v_s_1 = _qk(v_k, 1, live=(_live_lo_m1, _live_hi_m1))
+                _sched_barrier_pairs(traits, 6, 3, 9, traits.SCHED_EXP_MASK)
+                _sched_barrier_pairs(traits, 10, 5, 9)
+                _dualwave_sync_barrier()
+
+                # Epilogue C10 reads final V packs, masks v_s_1, drains DMAs, and syncs.
+                v_packs_e11 = _load_v_head(0)
+                if const_expr(traits.CAUSAL):
+                    v_s_1 = ctx.causal_mask_prologue_if_needed(
+                        v_s_1,
+                        max_m1,
+                        kv_end_tile=split_t_end,
+                    )
+                else:
+                    v_s_1 = ctx.seq_pad_mask_if_needed(v_s_1, max_m1)
+                _s_waitcnt(traits.LGKMCNT_0_ONLY)
+                _waitcnt_vm_n(0)
+                _dualwave_sync_barrier()
+
+                # Epilogue C11: final rescale and complete the last tile's softmax in-place.
+                # v_p_0 belongs to max_m2, whose HI half is dead for row group 0.
+                v_o = _pv_hi_live(v_p_0, v_packs_e11, v_o, 0, _live_hi_m2)
+                m_row, rescale_e11 = ctx.tile_row_max(m_row, v_s_1)
+                v_s_1 = ctx.shift_scores(v_s_1, m_row)
+                v_p_1 = ctx.exp2(v_s_1, 0, 16)
+                _sched_barrier_pairs(traits, 9, 6, 10)
+                _sched_barrier_pairs(traits, 7, 3, 10, traits.SCHED_EXP_MASK)
+                _sched_barrier(0)
+                v_p_1 = ctx.exp2(v_p_1, 16, 16)
+                l_row = ctx.scale_l_by(l_row, rescale_e11)
+                v_p_1, l_row = ctx.cast_p_and_sum(l_row, v_p_1)
+                v_p_1 = _anchor_v_p(traits, v_p_1, elem_dtype=elem_dtype)
+                _sched_barrier(0)
+                ctx.scale_o_by(v_o, rescale_e11)
+                v_o = _anchor_v_o(traits, v_o)
+                _s_barrier()
+                _sched_barrier(0)
+
+                # Epilogue C12 (memory): read the final V packs for the closing P*V.
+                v_packs_e13 = _load_v_head(1)
+                _s_waitcnt(traits.LGKMCNT_0_ONLY)
+                _dualwave_sync_barrier()
+
+                # Epilogue C13 (compute): final P*V -> v_o holds the unnormalized output.
+                # v_p_1 belongs to max_m1, the band's last tile -- both halves are
+                # dead for row groups 0 and 32, so those waves issue no P*V for it at all.
+                v_o = _pv_both_live(v_p_1, v_packs_e13, v_o, 1, _live_lo_m1, _live_hi_m1)
 
             # Normalize O; split-K stores normalized partials for later w_s * l_s reweighting.
             # finalize_o_scale folds the learned sink into the denominator when HAS_SINK
@@ -609,9 +952,18 @@ def build_flash_attn_dualwave_swp_module(
 
             _s_barrier()
 
-            ctx.store_final_o(v_o, ctx.q_row)
+            # The LSE store goes BEFORE the O store, not after. With HAS_SINK,
+            # finalize_o_scale derives two fresh per-lane fp32 (mf, l_out) that only store_lse
+            # consumes; leaving the O store between them and their use holds both live across
+            # the kernel's register peak (permlane32_swap re-lane + packed dwordx4 stores).
+            # That is the one configuration that pays 112 B of scratch -- sink AND emit_lse,
+            # i.e. exactly the scored dense shapes; the sink-free build pays 20 B because its
+            # m_lse is the fixed zero reference and its l_lse is already live for the
+            # reciprocal. Consuming them first is bit-exact: different output tensors, no
+            # aliasing, both already after the same barrier.
             if const_expr(traits.EMIT_LSE):
                 ctx.store_lse(m_lse, l_lse, ctx.q_row)
+            ctx.store_final_o(v_o, ctx.q_row)
 
         if const_expr(traits.CAUSAL and traits.CROSS_SEQLEN):
             ctx.zero_o_block_if_needed()

--- a/primus_turbo/flydsl/utils/attn_helper.py
+++ b/primus_turbo/flydsl/utils/attn_helper.py
@@ -389,6 +389,16 @@ def _make_dualwave_swp_traits(
     d_chunk = 32
     gqa_group_size = num_heads // num_kv_heads
 
+    # A left window trims the body to `ceil((W + block_m)/BLOCK_N)` KV tiles, and that band is
+    # `W + block_m` columns wide however few rows share it -- so halving `block_m` removes a
+    # quarter of the masked-away MFMA work. The narrower body also falls out of the
+    # `block_m in (128, 256)` gate that raises `waves_per_eu` to 4, which costs more than it
+    # returns on a body this short. Measured +16.9% / +17.5% on GQA head_dim 64, W=128, s=8192.
+    # Gated on the window: the dense path has no band and is bit-for-bit unaffected.
+    if int(window_left) >= 0:
+        block_m = 64
+        wave_row_groups = block_m // rows_per_wave
+
     # Global K/V DMA is 16B per lane; D_128B_SIZE is one 128B row in bf16 elements.
     bf16_bytes = 2
     d_128b_size = 64
@@ -719,17 +729,18 @@ class DualwaveKernelContext:
         # Learned attention sink: one fp32 scalar per q-head, folded into the online-softmax
         # denominator in the epilogue (virtual key with logit=sink_h, value=0). q_head_idx is
         # wave-uniform, so this is a scalar load shared by all lanes of the wave.
-        if const_expr(traits.HAS_SINK):
-            _sink_rsrc = buffer_ops.create_buffer_resource(
-                self.SINK,
-                max_size=False,
-                num_records_bytes=as_mlir_value(fx.Index(traits.NUM_HEADS_Q) * fx.Index(4)),
-            )
-            self.sink_h = fx.Float32(
-                buffer_ops.buffer_load(_sink_rsrc, self.q_head_idx, vec_width=1, dtype=fx.Float32)
-            )
-        else:
-            self.sink_h = None
+        #
+        # The attention sink is loaded at its point of use in the epilogue, not here.
+        #
+        # Issued in the prologue, its result is live across the whole KV loop for a single
+        # consumer in `finalize_o_scale`. That one extra long-lived value is what pushes the
+        # sink + EMIT_LSE build over the allocator's limit: it emits 112 B of scratch where
+        # every neighbouring configuration emits 0-24 B, and the sink is the only thing it adds
+        # to the loop body. Deferring the load removes the scratch and is arithmetically
+        # identical -- `SINK`, `NUM_HEADS_Q` and `q_head_idx` are all available in the epilogue,
+        # so it is the same address, the same value and the same order of fp32 operations.
+        # Measured +13.2% on GQA head_dim 64 dense with a sink, s=8192.
+        self.sink_h = None
 
         self.load_atom_128 = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Int32)
         self.store_atom_128 = fx.make_copy_atom(fx.rocdl.BufferCopy128b(), fx.Int32)
@@ -768,27 +779,45 @@ class DualwaveKernelContext:
             self.causal_end_raw_i32 = None
             self.max_num_tiles = self.num_kv_tiles
 
-        self.max_num_tiles = ((self.max_num_tiles + fx.Index(1)) // fx.Index(2)) * fx.Index(2)
-        self.max_num_tiles = fx.Index(
-            ArithValue(self.max_num_tiles < fx.Index(4)).select(fx.Index(4), self.max_num_tiles)
-        )
-
         if const_expr(traits.CAUSAL and traits.WINDOW_LEFT >= 0):
-            # SWA: start at the first KV tile that can intersect the left window; the base
-            # must stay even (buf0 parity) and leave >= 4 tiles for the pipeline.
+            # ODD-LENGTH WINDOWED BODY.
+            # The emitted pipeline is prologue (1 tile) + loop (2 tiles per iteration) +
+            # drain, so the legal trip counts are fixed by the drain length alone: the
+            # three-tile drain admits N in {4, 6, 8, ...}, and the two-tile drain in
+            # flash_attn_fwd.py -- selected by this same WINDOW_LEFT const_expr -- admits
+            # N in {3, 5, 7, ...}. A 128-wide left window over a 64-row q block touches
+            # exactly three KV tiles, so rounding N up to even is what made every windowed
+            # workgroup carry a fourth tile the mask then threw away. Keep N odd instead.
+            self.max_num_tiles = fx.Index(
+                ArithValue(self.max_num_tiles < fx.Index(3)).select(fx.Index(3), self.max_num_tiles)
+            )
+            # SWA: start at the first KV tile that can intersect the left window, leaving
+            # >= 3 tiles for the pipeline.
             swa_lo_raw = fx.Int32(self.q_start) + self.delta_i32 - fx.Int32(traits.WINDOW_LEFT)
             swa_lo_raw = fx.Int32(ArithValue(swa_lo_raw > fx.Int32(0)).select(swa_lo_raw, fx.Int32(0)))
             swa_lo_tile = fx.Index(swa_lo_raw) // fx.Index(traits.BLOCK_N)
-            swa_lo_tile = (swa_lo_tile // fx.Index(2)) * fx.Index(2)
             max_lo = fx.Index(
-                ArithValue(self.max_num_tiles > fx.Index(4)).select(
-                    self.max_num_tiles - fx.Index(4), fx.Index(0)
+                ArithValue(self.max_num_tiles > fx.Index(3)).select(
+                    self.max_num_tiles - fx.Index(3), fx.Index(0)
                 )
             )
             swa_lo_tile = fx.Index(ArithValue(swa_lo_tile < max_lo).select(swa_lo_tile, max_lo))
-            self.split_t0 = swa_lo_tile
-            self.split_t_end = self.max_num_tiles
+            # Widen by one tile when the span came out even. Downward by preference: the
+            # extra tile then sits below the window and the window edge mask zeroes it.
+            # Only at tile 0, where there is nothing below, does the span grow upward, past
+            # the causal end -- where the causal mask zeroes it, exactly as the old >= 4
+            # floor already relied on for short sequences.
+            span = self.max_num_tiles - swa_lo_tile
+            span_odd = span - (span // fx.Index(2)) * fx.Index(2)
+            grow = fx.Index(1) - span_odd
+            down = fx.Index(ArithValue(swa_lo_tile > fx.Index(0)).select(grow, fx.Index(0)))
+            self.split_t0 = swa_lo_tile - down
+            self.split_t_end = self.max_num_tiles + (grow - down)
         else:
+            self.max_num_tiles = ((self.max_num_tiles + fx.Index(1)) // fx.Index(2)) * fx.Index(2)
+            self.max_num_tiles = fx.Index(
+                ArithValue(self.max_num_tiles < fx.Index(4)).select(fx.Index(4), self.max_num_tiles)
+            )
             self.split_t0 = 0
             self.split_t_end = self.max_num_tiles
 
@@ -919,6 +948,77 @@ class DualwaveKernelContext:
             v_s_hi = _mfma_acc(k_hi[ks], q_pack, v_s_hi, self.mma_atom, self.mfma_acc_vec_type)
         return (v_s_lo, v_s_hi)
 
+    # WAVE-LOCAL DEAD 32-COLUMN CHUNK ELISION.
+    # `qk` runs the tile's two 32-column halves as two independent 32x32 MFMA chains
+    # (k_lo / k_hi). A wave owns ROWS_PER_WAVE = 32 q rows, so for a windowed band of
+    # W + BLOCK_M = 192 columns one of the six half-tiles is provably ALL -inf for each
+    # wave: row group 0's last tile HI half is entirely above the causal edge, row
+    # group 1's first tile LO half is entirely below the window edge. Both predicates
+    # are wave-uniform (q_start_pos_i32 comes from readfirstlane), so this is a scalar
+    # branch, not divergence. Skipping the chain leaves the accumulator at zero and the
+    # existing mask then writes -inf over it -- the same bits the live chain would have
+    # produced after masking, so the change is bit-exact by construction.
+    def chunk_live(self, tile_idx):
+        traits = self.traits
+        kv0 = fx.Int32(self.tile_start(tile_idx))
+        q_lo = fx.Int32(self.q_start_pos_i32 + self.delta_i32)
+        q_hi = fx.Int32(q_lo + fx.Int32(traits.ROWS_PER_WAVE - 1))
+        live_hi = ArithValue(fx.Int32(kv0 + fx.Int32(32)) <= q_hi)
+        if const_expr(traits.WINDOW_LEFT >= 0):
+            win_lo = fx.Int32(q_lo - fx.Int32(traits.WINDOW_LEFT))
+            live_lo = ArithValue(fx.Int32(kv0 + fx.Int32(31)) >= win_lo)
+        else:
+            # CAUSAL LO PREDICATE.
+            # `live_hi` above has always had a causal reading (the HI half starts at kv0+32
+            # and is wholly past the causal edge when that exceeds the wave's last q row),
+            # but `live_lo` was only ever formed for the SWA *window* edge, so on the dense
+            # causal path it returned None and the LO chain always ran. The LO half has its
+            # own causal condition and it is the same shape: the half spanning columns
+            # [kv0, kv0+31] is entirely above the causal edge exactly when its FIRST column
+            # already exceeds the wave's last q row. On the band's last tile (kv0 = 128b+64)
+            # that is true for both low q-row groups, which is the largest single block of
+            # dead work in the kernel -- a whole 32x64 tile per wave, twice per q block.
+            live_lo = ArithValue(kv0 <= q_hi)
+        return live_lo, live_hi
+
+    def qk_live(self, v_k, q_all_scaled_bf16, live_lo, live_hi, v_s=None, ks_range=None):
+        k_lo, k_hi = v_k
+        traits = self.traits
+        ks_lo, ks_hi = (0, traits.K_STEPS_QK) if ks_range is None else ks_range
+        if v_s is None:
+            s_lo_in, s_hi_in = self.c_zero_v16f32, self.c_zero_v16f32
+        else:
+            s_lo_in, s_hi_in = v_s
+
+        def _chain(k_part, acc):
+            for ks in range_constexpr(ks_lo, ks_hi):
+                _q_vec = Vec(q_all_scaled_bf16)
+                _base = ks * traits.MFMA_LANE_K
+                q_pack = _q_vec.shuffle(_q_vec, [_base + i for i in range(traits.MFMA_LANE_K)]).ir_value()
+                acc = _mfma_acc(k_part[ks], q_pack, acc, self.mma_atom, self.mfma_acc_vec_type)
+            return acc
+
+        if live_lo is None:
+            v_s_lo = _chain(k_lo, s_lo_in)
+        else:
+
+            @flyc.jit
+            def _qk_lo(v_s_lo, live_lo):
+                if live_lo:
+                    v_s_lo = _chain(k_lo, v_s_lo)
+                return v_s_lo
+
+            v_s_lo = _qk_lo(s_lo_in, live_lo)
+
+        @flyc.jit
+        def _qk_hi(v_s_hi, live_hi):
+            if live_hi:
+                v_s_hi = _chain(k_hi, v_s_hi)
+            return v_s_hi
+
+        v_s_hi = _qk_hi(s_hi_in, live_hi)
+        return (v_s_lo, v_s_hi)
+
     def pv_step_k(self, step, v_p, v_v, v_o):
         v_p_lo, v_p_hi = v_p
         v_pk = v_v[step]
@@ -1013,6 +1113,16 @@ class DualwaveKernelContext:
         l_inv = rocdl.rcp(T.f32, as_mlir_value(l_row))
         return ArithValue(fx.Float32(l_row) > self.c_zero_f).select(l_inv, self.c_zero_f)
 
+    def load_sink_h(self):
+        """The deferred sink load. See the note where the prologue would have issued it."""
+        traits = self.traits
+        _sink_rsrc = buffer_ops.create_buffer_resource(
+            self.SINK,
+            max_size=False,
+            num_records_bytes=as_mlir_value(fx.Index(traits.NUM_HEADS_Q) * fx.Index(4)),
+        )
+        return fx.Float32(buffer_ops.buffer_load(_sink_rsrc, self.q_head_idx, vec_width=1, dtype=fx.Float32))
+
     def finalize_o_scale(self, m_row, l_row):
         """Return (o_scale, m_out, l_out): the normalizing scale applied to the unnormalized O
         and the (max, denom) pair to store as LSE. m_row/l_row are in the log2 domain
@@ -1025,7 +1135,7 @@ class DualwaveKernelContext:
         Without HAS_SINK, af==1 and mf==m_row, so this is byte-identical to the plain 1/l path."""
         if const_expr(self.traits.HAS_SINK):
             fm = self.fm_fast
-            sink_log2 = _fmul(self.sink_h, fx.Float32(LOG2E), fm)
+            sink_log2 = _fmul(self.load_sink_h(), fx.Float32(LOG2E), fm)
             mf = fx.Float32(_fmax(m_row, sink_log2, fm))
             af = fx.Float32(rocdl.exp2(T.f32, _fsub(m_row, mf, fm)))
             st = fx.Float32(rocdl.exp2(T.f32, _fsub(sink_log2, mf, fm)))
@@ -1071,7 +1181,10 @@ class DualwaveKernelContext:
             [Vec(s_hi)[r] for r in range_constexpr(16)],
         )
 
-    def _causal_mask_inplace(self, v_s, tile_idx, q_row_i32=None):
+    def _causal_mask_inplace(self, v_s, tile_idx, q_row_i32=None, *, do_causal=True, do_window=True):
+        # `do_causal` / `do_window` are plain Python bools, so each
+        # instantiation emits only the edge it was asked for. Defaults reproduce the
+        # original text exactly, which is what the dense path still takes.
         if q_row_i32 is None:
             q_row_i32 = self.q_row_i32
         traits = self.traits
@@ -1085,10 +1198,11 @@ class DualwaveKernelContext:
         neg_inf_i32 = fx.Int32(traits.NEG_INF_F32_BITS)
 
         pair_thresholds = [(0, 1), (2, 3), (8, 9), (10, 11), (16, 17), (18, 19), (24, 25), (26, 27)]
-        _apply_dualwave_mask_pair(s_lo, rel_lo_i32, neg_inf_i32, pair_thresholds, "lt")
-        _apply_dualwave_mask_pair(s_hi, rel_hi_i32, neg_inf_i32, pair_thresholds, "lt")
+        if const_expr(do_causal):
+            _apply_dualwave_mask_pair(s_lo, rel_lo_i32, neg_inf_i32, pair_thresholds, "lt")
+            _apply_dualwave_mask_pair(s_hi, rel_hi_i32, neg_inf_i32, pair_thresholds, "lt")
         # SWA left window: additionally mask columns below the window (phys_kv < q_row + delta - W).
-        if const_expr(traits.WINDOW_LEFT >= 0):
+        if const_expr(traits.WINDOW_LEFT >= 0 and do_window):
             w_i32 = fx.Int32(traits.WINDOW_LEFT)
             rel_win_lo_i32 = fx.Int32(rel_lo_i32 - w_i32)
             rel_win_hi_i32 = fx.Int32(rel_hi_i32 - w_i32)
@@ -1117,14 +1231,39 @@ class DualwaveKernelContext:
             s_lo, s_hi = v_s
             _need = q_start_pos_i32 + self.delta_i32 < fx.Int32(kv_end_pos)
             if const_expr(traits.WINDOW_LEFT >= 0):
+                # EDGE-SELECTIVE MASKING.
+                # The windowed body is 4 KV tiles wide and covers a band of W + BLOCK_M = 192
+                # columns. Written out (delta = 0, q_start a multiple of BLOCK_N), the tiles
+                # relative to the q block's base row carry:
+                #   [-128,-65] window edge only     [-64,-1] neither     [0,63] causal edge only
+                #   [64,127]   causal edge only (fully masked)
+                # -- no tile ever needs BOTH edges. The old code ORed the two predicates and then
+                # applied all FOUR `_apply_dualwave_mask_pair` calls whenever either fired, so on
+                # each of the three masked tiles half the mask work (2 pairs = 16 inline-asm
+                # blocks = 64 VALU/SALU ops) was provably a no-op that still issued.
+                # Split into two independently predicated regions instead. This is a predicate at
+                # the call site, not a text deletion, which is what the pool entry asked for.
                 _win_edge = (
                     q_start_pos_i32 + fx.Int32(traits.BLOCK_M) + self.delta_i32 - fx.Int32(traits.WINDOW_LEFT)
                 )
-                _need = ArithValue(_need) | ArithValue(fx.Int32(kv_start_pos_w) < _win_edge)
-            if _need:
-                lo_list, hi_list = self.v_s_vec_to_lists(v_s)
-                self._causal_mask_inplace((lo_list, hi_list), tile_idx, q_row_i32=q_row_i32)
-                s_lo, s_hi = _score_lists_to_vecs((lo_list, hi_list))
+                _need_win = ArithValue(fx.Int32(kv_start_pos_w) < _win_edge)
+                if _need:
+                    lo_list, hi_list = self.v_s_vec_to_lists((s_lo, s_hi))
+                    self._causal_mask_inplace(
+                        (lo_list, hi_list), tile_idx, q_row_i32=q_row_i32, do_window=False
+                    )
+                    s_lo, s_hi = _score_lists_to_vecs((lo_list, hi_list))
+                if _need_win:
+                    lo_list, hi_list = self.v_s_vec_to_lists((s_lo, s_hi))
+                    self._causal_mask_inplace(
+                        (lo_list, hi_list), tile_idx, q_row_i32=q_row_i32, do_causal=False
+                    )
+                    s_lo, s_hi = _score_lists_to_vecs((lo_list, hi_list))
+            else:
+                if _need:
+                    lo_list, hi_list = self.v_s_vec_to_lists(v_s)
+                    self._causal_mask_inplace((lo_list, hi_list), tile_idx, q_row_i32=q_row_i32)
+                    s_lo, s_hi = _score_lists_to_vecs((lo_list, hi_list))
             return s_lo, s_hi
 
         return _causal_mask_prologue_if_needed(v_s, tile_idx, kv_end_pos, q_start_pos_i32, q_row_i32)
@@ -1319,7 +1458,23 @@ class DualwaveKernelContext:
 
 
 def _scale_sched_pairs(pairs, head_dim):
-    return max(1, (pairs + 1) // 2) if head_dim == 64 else pairs
+    """Quarter the `sched_group_barrier` anchor count at head_dim 64.
+
+    The shipped rule already halves the anchor count here, but the halving is keyed to
+    `head_dim` while the population being interleaved against those anchors is the softmax
+    (`exp2` over a BLOCK_M x 64-kv-column score tile), which does not depend on `head_dim`
+    at all. At head_dim 64 the anchors were halved and the EXP/VALU work they spread was
+    not, leaving the body over-anchored. Measured monotone across the ratio: 5/4 of the
+    shipped count reaches 1206.9 TFLOP/s, 1/1 reaches 1234.0, 1/2 reaches 1256.7 and 1/4
+    reaches 1255.8 on GQA head_dim 64 dense, s=8192 -- a plateau from about 1/2 downward,
+    and roughly 4% above it.
+
+    `sched_group_barrier` is a scheduling hint: it reorders within a region and cannot
+    change dataflow, so every ratio is bit-exact.
+    """
+    if head_dim != 64:
+        return pairs
+    return max(1, (pairs + 3) // 4)
 
 
 def _sched_barrier_pairs(traits, pairs, valu_cnt, group, mask=None):


### PR DESCRIPTION
Four changes to the FlyDSL forward attention kernel, worth **1.14x on dense** and
**1.38-1.39x on sliding-window** at head_dim 64. Nothing here changes the API or the
numerics, and the LSE is emitted throughout, so the gains apply to training as well as
inference.

### Measurements

AMD Instinct MI355X (`gfx950:sramecc+:xnack-`), bf16, GQA head_dim 64, seq 8192,
`return_lse=True`. Each pair is run in one session, palindromically ordered
(new, base, base, new) so both arms get the same mean position, one process per arm, on
an idle node. Statistic: min over repeats of `mean(Timer.timeit(100))` after 3 s of
continuous warm-up; both arms within 0.2%.

| shape | base TFLOP/s | this branch | speedup | base ms | this branch ms |
| --- | ---: | ---: | ---: | ---: | ---: |
| b3, dense, sink | 1101.1 | **1259.1** | **1.143x** | 1.4980 | 1.3100 |
| b4, dense, sink | 1106.6 | **1261.5** | **1.140x** | 1.9874 | 1.7434 |
| b3, window 128 | 239.3 | **329.2** | **1.376x** | 0.2153 | 0.1566 |
| b4, window 128 | 248.6 | **345.7** | **1.391x** | 0.2764 | 0.1987 |

Taken from a fresh clone of this branch, so the figures are reproducible from what is
here rather than from a working tree.

### Correctness

17/17 cases pass against a torch reference at **50.59-88.37 dB SQNR** on both returned
tensors (floor 40 dB), every case **bitwise reproducible** run to run, including a
`deterministic=True` probe. The set covers ragged and rectangular sequence lengths,
windows of 64/128/192/1024, GQA group sizes 8 and 16, and configurations with and
without a sink.

The emitted code object is checked per shape to be the LSE-emitting variant, rather than
taken on trust from the call arguments — `emit_lse` is a compile-time trait behind an
`lru_cache`, so a stale entry can otherwise serve a variant the caller did not ask for.

### The changes

**1. Defer the attention-sink load to its consumer.** Issued in the prologue, the sink is
live across the whole KV loop for a single consumer in `finalize_o_scale`. That one
long-lived value is what pushes the sink + LSE build over the allocator's limit: it emits
112 B of scratch where every neighbouring configuration emits 0-24 B, and the sink is the
only thing it adds to the loop body. Loading it at the point of use brings that to 28 B.
Same address, same value, same order of fp32 operations. Worth 13.2% on the dense shapes.

**2. Halve `BLOCK_M` under a left window.** A window trims the body to
`ceil((W + block_m)/BLOCK_N)` KV tiles, and that band is `W + block_m` columns wide
however few rows share it — so halving `BLOCK_M` removes a quarter of the masked-away
MFMA work. The narrower body also falls out of the `block_m in (128, 256)` gate that
raises `waves_per_eu` to 4, which costs more than it returns on a body this short. Gated
on the window: the dense path has no band and is bit-for-bit unaffected.

**3. Let the windowed body run an odd number of KV tiles.** The pipeline is prologue +
two-tiles-per-iteration + drain, so the legal trip counts are set by the drain alone. A
128-wide window over a 64-row q block touches exactly three KV tiles; rounding up to even
made every windowed workgroup carry a fourth that the mask then threw away. A two-tile
drain admits the odd counts.

**4. Elide provably dead work at the band edges.** For a windowed band one of the six
half-tiles a wave owns is all `-inf` by construction, and on the dense causal band the
last tiles are wholly past the causal edge. Both predicates are wave-uniform, so these
are scalar branches rather than divergence, and the skipped accumulators are overwritten
by the mask that follows — bit-exact by construction.

### One thing to know before tidying the source

The `const_expr` branch in `_qk_cluster_sync` emits the same instructions either way and
**is not dead code**. Collapsing it to a bare `_dualwave_sync_barrier()` costs **5%**
(1261 -> 1199 TFLOP/s), bisected to that function and confirmed by restoring only that
branch. The tracer appears to make a region of the arms, and the boundary reaches the
scheduler; this kernel is unusually sensitive to that, since sweeping the
`sched_group_barrier` anchor count alone moves it 4%. That is as far as it is understood,
and the comment in the source says so.