### PR TITLE
fix(quant): carry the opaque metaclass torch 2.11 requires

### DIFF
--- a/primus_turbo/pytorch/core/low_precision.py
+++ b/primus_turbo/pytorch/core/low_precision.py
@@ -13,6 +13,13 @@ from torch._library.opaque_object import register_opaque_type
 
 from primus_turbo.pytorch.core.utils import get_device_compute_capability
 
+try:
+    # torch >= 2.11 requires an opaque type to carry this metaclass; older torch has
+    # neither the module nor the requirement, where `type` changes nothing.
+    from torch._opaque_base import OpaqueBaseMeta as _OpaqueMeta
+except ImportError:  # pragma: no cover - depends on the installed torch
+    _OpaqueMeta = type
+
 __all__ = ["float8_e4m3", "float8_e5m2"]
 
 
@@ -143,7 +150,7 @@ class ScalingStrategy(Enum):
     # DELAYED_SCALING = auto() # TODO: undetermined
 
 
-class ScalingRecipe(NamedTuple):
+class _ScalingRecipeFields(NamedTuple):
     """
     Supported MXFP8/MXFP4 scaling recipe.
 
@@ -161,6 +168,14 @@ class ScalingRecipe(NamedTuple):
     # Memory Layout Shuffle
     shuffle_scale: bool = False
     shuffle_out: bool = False
+
+
+class ScalingRecipe(_ScalingRecipeFields, metaclass=_OpaqueMeta):
+    """See :class:`_ScalingRecipeFields` for the fields.
+
+    Split so the metaclass can be attached: ``class X(NamedTuple, metaclass=...)``
+    is a metaclass conflict at class creation.
+    """
 
     def __fx_repr__(self) -> Tuple[str, dict]:
         return _quant_config_fx_repr(self)
@@ -187,7 +202,7 @@ def _quant_config_fx_repr(config) -> Tuple[str, dict]:
 
 
 @dataclass(unsafe_hash=True)  # hashable so it can be an opaque custom-op argument
-class Float8QuantConfig:
+class Float8QuantConfig(metaclass=_OpaqueMeta):
     format: Format = Format.E4M3
     granularity: ScalingGranularity = ScalingGranularity.TENSORWISE
     strategy: ScalingStrategy = ScalingStrategy.DYNAMIC
@@ -230,7 +245,7 @@ class Float8QuantConfig:
 
 
 @dataclass(unsafe_hash=True)  # hashable so it can be an opaque custom-op argument
-class Float4QuantConfig:
+class Float4QuantConfig(metaclass=_OpaqueMeta):
     format: Format = Format.E2M1_X2
     granularity: ScalingGranularity = ScalingGranularity.MX_BLOCKWISE
     strategy: ScalingStrategy = ScalingStrategy.DYNAMIC

--- a/tests/pytorch/core/test_opaque_quant_configs.py
+++ b/tests/pytorch/core/test_opaque_quant_configs.py
@@ -1,0 +1,66 @@
+###############################################################################
+# Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# See LICENSE for license information.
+###############################################################################
+
+"""The quant configs must stay registrable as torch opaque types.
+
+torch >= 2.11 rejects register_opaque_type on a class whose metaclass is not
+OpaqueBaseMeta. That call runs at import time, so a regression here does not
+fail one operator -- it makes `import primus_turbo.pytorch` raise, on every
+arch. These assertions are arch-independent on purpose.
+"""
+
+import pytest
+import torch
+
+from primus_turbo.pytorch.core.low_precision import (
+    Float4QuantConfig,
+    Float8QuantConfig,
+    ScalingRecipe,
+)
+
+_OPAQUE_CONFIGS = (Float8QuantConfig, Float4QuantConfig, ScalingRecipe)
+
+
+@pytest.mark.parametrize("cls", _OPAQUE_CONFIGS, ids=lambda c: c.__name__)
+def test_carries_the_opaque_metaclass(cls):
+    opaque_base = pytest.importorskip(
+        "torch._opaque_base", reason="torch without the OpaqueBaseMeta requirement"
+    )
+    assert isinstance(cls, opaque_base.OpaqueBaseMeta)
+
+
+@pytest.mark.parametrize("cls", _OPAQUE_CONFIGS, ids=lambda c: c.__name__)
+def test_stays_hashable_and_comparable(cls):
+    # register_opaque_type(typ="value") guards the baked-in constant on __eq__.
+    assert cls() == cls()
+    assert hash(cls()) == hash(cls())
+
+
+@pytest.mark.parametrize("cls", _OPAQUE_CONFIGS, ids=lambda c: c.__name__)
+def test_fx_repr_round_trips(cls):
+    # torch.compile regenerates the config from this string, so it has to eval
+    # back to an equal object under the globals the method hands out.
+    config = cls()
+    source, globals_ = config.__fx_repr__()
+    assert eval(source, dict(globals_)) == config
+
+
+def test_scaling_recipe_is_still_a_named_tuple():
+    # It is spelled as a subclass of a NamedTuple to carry the metaclass, which
+    # would silently cost tuple behaviour if that split were ever undone wrong.
+    recipe = ScalingRecipe(use_2d_block=True, use_rht=True)
+    assert isinstance(recipe, tuple)
+    assert recipe[0] is True
+    assert recipe._asdict()["use_rht"] is True
+    assert recipe._replace(use_sr=True).use_sr is True
+    first, *_ = recipe
+    assert first is True
+
+
+def test_torch_version_that_needs_the_metaclass_is_the_one_we_have():
+    # A sanity line rather than a constraint: if torch drops the requirement,
+    # the metaclass stays harmless and the test above skips.
+    assert torch.__version__


### PR DESCRIPTION
register_opaque_type refuses a class whose metaclass is not OpaqueBaseMeta:

  TypeError: Opaque type <class '...Float8QuantConfig'> must subclass
  torch._opaque_base.OpaqueBase or 'metaclass=torch._opaque_base.OpaqueBaseMeta'

The call sits at module scope, so on torch 2.11 this is not one operator failing -- `import primus_turbo.pytorch` raises and nothing in the package can be used. Reproduced on torch 2.11.0+rocm7.14.0a20260625; #483 introduced the registration.

The two dataclasses take the metaclass directly. ScalingRecipe cannot: NamedTuple builds through its own metaclass and Python rejects a metaclass that is not a subclass of every base's, so the fields keep their class (renamed) and a thin derived class carries the metaclass. Tuple behaviour is unchanged -- unpacking, indexing, len, _asdict, _replace, == and hash all still work, and the new test pins that so the split cannot be undone silently.

The metaclass is looked up behind a try/ImportError so torch versions without torch._opaque_base fall back to `type`, which leaves the classes as they were.

The tests are arch-independent, but tests/conftest.py skips everything on gfx1250, so they were verified there with that blanket skip lifted: 11 passed against this change, and collection fails with the TypeError above without it.

# Description

Please include a brief summary of the changes, relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Documentation change (change only to the documentation, either a fix or a new content)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Infra/Build change
- [ ] Code refactoring

## Changes

Please list the changes introduced in this PR:

- Change A
- Change B

# Checklist:

- [ ] The functionality is complete
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
